### PR TITLE
Add descriptive text for speech-to-text presets

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -57,6 +57,18 @@
     "message": "Select your prefered transcription mode",
     "description": "The title (tooltip) of the control to select the prefered transcription mode."
   },
+  "mode_speed_description": {
+    "message": "Fastest response, but less accurate and may interrupt speech",
+    "description": "Description for the speed transcription mode."
+  },
+  "mode_balanced_description": {
+    "message": "Good balance of speed and accuracy for most uses",
+    "description": "Description for the balanced transcription mode."
+  },
+  "mode_accuracy_description": {
+    "message": "Highest accuracy, but slower transcription speed",
+    "description": "Description for the accuracy transcription mode."
+  },
   "lockButton": {
     "message": "Press to lock the screen",
     "description": "The title (tooltip) of the button to lock the screen against accidental touches."

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -35,6 +35,11 @@
       .control {
         margin-left: auto; /* align right */
       }
+      .description {
+        font-size: 0.875rem; /* Smaller font size for descriptions */
+        color: #4a5568; /* Gray color for descriptions */
+        margin-top: 0.25rem; /* Small margin above the description */
+      }
     </style>
   </head>
   <body class="flex items-center justify-center">
@@ -91,6 +96,16 @@
           data-i18n="mode_balanced"
         >
           balanced
+        </div>
+        <!-- Descriptions below each icon -->
+        <div class="description" data-i18n="mode_speed_description">
+          Fastest response, but less accurate and may interrupt speech
+        </div>
+        <div class="description" data-i18n="mode_balanced_description">
+          Good balance of speed and accuracy for most uses
+        </div>
+        <div class="description" data-i18n="mode_accuracy_description">
+          Highest accuracy, but slower transcription speed
         </div>
       </div>
       <div


### PR DESCRIPTION
Fixes #103

Add descriptive text for speech-to-text presets in the settings popup.

* Modify `src/popup/popup.html`:
  - Add descriptive text below each speech-to-text preset option (Speed, Balanced, Accuracy) using `data-i18n` attributes.
  - Include CSS to ensure descriptive text is in a smaller font than the labels for the presets.

* Update `_locales/en/messages.json`:
  - Add descriptive text for each speech-to-text preset option in the English locale bundle.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Pedal-Intelligence/saypi-userscript/issues/103?shareId=5a2df23c-dfd3-49a7-be62-34ea17984e1c).