### PR TITLE
A fix for issue #120, added a "userButtonInterrupting" state that moves to SayPi.listening after a short delay.

### DIFF
--- a/src/state-machines/SayPiMachine.ts
+++ b/src/state-machines/SayPiMachine.ts
@@ -814,7 +814,7 @@ const machine = createMachine<SayPiContext, SayPiEvent, SayPiTypestate>(
               },
               "saypi:interrupt": [
                 {
-                  target: "userInterrupting",
+                  target: "userButtonInterrupting",
                   description: `The user has forced an interruption, i.e. tapped to interrupt Pi, during a call.`,
                   actions: "pauseAudio",
                   cond: "wasListening",
@@ -938,6 +938,17 @@ const machine = createMachine<SayPiContext, SayPiEvent, SayPiTypestate>(
             ],
             description:
               "The user is speaking during Pi's response, and may wish to interrupt.",
+          },
+          userButtonInterrupting: {
+            after: {
+              "500": {
+                target: "#sayPi.listening",
+                description:
+                  "The user's speech will be picked up after a short delay",
+              },
+            },
+            description:
+              "The user has pressed an interrupt during Pi's response, and wants to speak or stop the response.",
           },
         },
       },


### PR DESCRIPTION
fix #120
 - Added a "userButtonInterrupting" state to the SayPiMachine, that is invoked when the user presses the interrupt button.

 - Now the behaviour should mean that the Pi speech will be halted immediately, and there should be no issues caused by a perception of "user finished speaking", which was invoked by the "userInterrupting" state.