### PR TITLE
Fix for Issue #127 in package-extension.sh

### DIFF
--- a/package-extension.sh
+++ b/package-extension.sh
@@ -74,16 +74,19 @@ for BROWSER in "$@"; do
             EXT_DIR="dist/firefox-extension"
             ZIP_NAME="saypi.firefox.xpi"
             STORE_URL="https://addons.mozilla.org/en-US/firefox/"
+            WORKLET_FILE="public/vad.worklet.bundle.js"
             ;;
         chrome)
             EXT_DIR="dist/chrome-extension"
             ZIP_NAME="saypi.chrome.zip"
             STORE_URL="https://chrome.google.com/webstore/developer/dashboard"
+            WORKLET_FILE="public/vad.worklet.bundle.min.js"
             ;;
         edge)
             EXT_DIR="dist/chrome-extension"
             ZIP_NAME="saypi.edge.zip"
             STORE_URL="https://partner.microsoft.com/en-us/dashboard/microsoftedge/overview"
+            WORKLET_FILE="public/vad.worklet.bundle.min.js"
             ;;
     esac
 
@@ -111,7 +114,7 @@ for BROWSER in "$@"; do
     cp public/background.js "$PUBLIC_DIR"
     cp public/silero_vad.onnx "$PUBLIC_DIR"
     cp public/ort-wasm*.wasm "$PUBLIC_DIR"
-    cp public/vad.worklet.bundle*.js "$PUBLIC_DIR"
+    cp "$WORKLET_FILE" "$PUBLIC_DIR"
     cp public/audio/*.mp3 "$AUDIO_DIR"
 
     mkdir -p "$LOGOS_DIR"


### PR DESCRIPTION
Fix #127

Updated the package-extension.sh to have separate worklet paths for Firefox and Chrome/Edge. 