### PR TITLE
Interrupting Pi without recording Pi

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "__MSG_appDescription__",
   "permissions": ["storage"],
   "host_permissions": ["https://api.saypi.ai/*"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saypi-userscript",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saypi-userscript",
-      "version": "1.6.7",
+      "version": "1.6.8",
       "dependencies": {
         "@ricky0123/vad-web": "^0.0.19",
         "@xstate/fsm": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saypi-userscript",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "type": "module",
   "scripts": {
     "prebuild": "node i18n-validate.cjs",

--- a/src/state-machines/SayPiMachine.ts
+++ b/src/state-machines/SayPiMachine.ts
@@ -814,7 +814,7 @@ const machine = createMachine<SayPiContext, SayPiEvent, SayPiTypestate>(
               },
               "saypi:interrupt": [
                 {
-                  target: "userInterrupting",
+                  target: "waitingForPiToStopSpeaking",
                   description: `The user has forced an interruption, i.e. tapped to interrupt Pi, during a call.`,
                   actions: "pauseAudio",
                   cond: "wasListening",
@@ -879,6 +879,14 @@ const machine = createMachine<SayPiContext, SayPiEvent, SayPiTypestate>(
               type: "clearPrompt",
             },
             description: "Pi's text response is being streamed to the page.",
+          },
+          waitingForPiToStopSpeaking: {
+            on: {
+              "saypi:piStoppedSpeaking": {
+                target: "userInterrupting",
+              },
+            },
+            description: "Interrupt requested. Waiting for Pi to stop speaking before recording.",
           },
           userInterrupting: {
             on: {

--- a/src/state-machines/SayPiMachine.ts
+++ b/src/state-machines/SayPiMachine.ts
@@ -886,6 +886,12 @@ const machine = createMachine<SayPiContext, SayPiEvent, SayPiTypestate>(
                 target: "userInterrupting",
               },
             },
+            after: {
+              500: {
+                target: "userInterrupting",
+                description: "Fallback transition after 500ms if piStoppedSpeaking event does not fire.",
+              },
+            },
             description: "Interrupt requested. Waiting for Pi to stop speaking before recording.",
           },
           userInterrupting: {


### PR DESCRIPTION
This PR resolves a problem where the last moments of Pi's speech might be accidentally recorded as user input after pressing the manual interrupt button.

The problem was caused by the conversational state machine (SayPiMachine.ts) entering the recording state while Pi's audio was still playing. Even though a request had already been made to pause the audio output, on some browsers (i.e. Firefox) the audio didn't stop before the state machine had transitioned. The live mic then picked up the audio output as input, and on those browsers with poor echo cancellation (i.e. Firefox) it reached the application and was transcribed as user input.

The solution was to introduce a new "holding state", `responding.waitingForPiToStopSpeaking`, that delays the transition to `recording.userInterrupting` until the audio output has stopped. A fallback mechanism ensure that the system always transitions to the target state after at most 500ms, in case the audio stop event is not received for some reason.