### PR TITLE
1. Removal of css hiding settings button for Firefox Android

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "name": "__MSG_appName__",
   "version": "1.7.2",
   "description": "__MSG_appDescription__",
+  "options_page": "src/popup/popup.html",
   "permissions": [
     "storage",
     "cookies"

--- a/src/UserAgentModule.ts
+++ b/src/UserAgentModule.ts
@@ -17,16 +17,18 @@ export function isMobileDevice(): boolean {
 }
 
 export function addUserAgentFlags(): void {
-  const isFirefoxAndroid: boolean =
-    /Firefox/.test(navigator.userAgent) && /Android/.test(navigator.userAgent);
   const element: HTMLElement = document.documentElement;
 
-  if (isFirefoxAndroid) {
+  if (isFirefoxAndroid()) {
     element.classList.add("firefox-android");
   }
 
   addDeviceFlags(element);
   //addViewFlags(element); // redundant, as this is called in initMode
+}
+
+export function isFirefoxAndroid() : boolean {
+  return /Firefox/.test(navigator.userAgent) && /Android/.test(navigator.userAgent);
 }
 
 export function addDeviceFlags(element: HTMLElement): void {

--- a/src/styles/mobile.scss
+++ b/src/styles/mobile.scss
@@ -150,12 +150,6 @@ html.mobile-device .chat-message .message-hover-menu .saypi-cost-container {
     margin-left: 10px;
   }
 }
-
-/* hide the settings button on Firefox Android because the popup is not supported */
-html.firefox-android .saypi-control-panel .settings-button.mini {
-  display: none !important;
-}
-
 // Hide tooltip on touch devices after touch ends
 @media (hover: none) {
   .tooltip[aria-label]:active::after {

--- a/src/svc/background.ts
+++ b/src/svc/background.ts
@@ -1,4 +1,4 @@
-import { isFirefox } from "../UserAgentModule";
+import { isFirefox, isFirefoxAndroid } from "../UserAgentModule";
 import { config } from "../ConfigModule";
 import { jwtManager } from "../JwtManager";
 
@@ -193,7 +193,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === 'openPopup') {
     try {
       const isNotFirefox = !isFirefox();
-      if (isNotFirefox && chrome.action?.openPopup) {
+      if (isFirefoxAndroid()) {
+        chrome.runtime.openOptionsPage();
+      } else if (isNotFirefox && chrome.action?.openPopup) {
         // Default popup for Chrome on desktop
         chrome.action.openPopup();
       } else {


### PR DESCRIPTION
2. added options_page to manifest.json
3. opening the options page from background.ts if Firefox Android detected
4. added isFirefoxAndroid() convenience function to UserAgentModule.ts

 - tested on Firefox Android Nightly 138.0a1, Kiwi browser 132.0, and Firefox Linux desktop 136.0