### PR TITLE
Claude streaming improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/audio/capabilities-test.json
 .DS_Store
 source-code.zip
 doc/dom/claude/*
+doc/data/*

--- a/src/chatbots/Claude.ts
+++ b/src/chatbots/Claude.ts
@@ -252,7 +252,7 @@ class ClaudeTextBlockCapture extends ElementTextStream {
         const streamingInProgress = this.dataIsStreaming(claudeMessage);
         const streamingStarted = !wasStreaming && streamingInProgress;
         const streamingStopped = wasStreaming && !streamingInProgress;
-        const streamingText = this.getNestedText(element);
+        const streamingText = this.getNestedText(element).trimEnd(); // trim any trailing newline character from the text
         if (streamingStarted) {
           console.log("Claude started streaming.");
           // fire a new event to indicate that the streaming has started - this should not be necessary when streaming all data with subject.next(), but it's here since we only stream all data when the message is complete

--- a/src/chatbots/Claude.ts
+++ b/src/chatbots/Claude.ts
@@ -254,14 +254,12 @@ class ClaudeTextBlockCapture extends ElementTextStream {
         const streamingStopped = wasStreaming && !streamingInProgress;
         const streamingText = this.getNestedText(element).trimEnd(); // trim any trailing newline character from the text
         if (streamingStarted) {
-          console.log("Claude started streaming.");
           // fire a new event to indicate that the streaming has started - this should not be necessary when streaming all data with subject.next(), but it's here since we only stream all data when the message is complete
           EventBus.emit("saypi:llm:first-token", {text: streamingText, time: Date.now()});
           this.handleTextAddition(streamingText);
         } else if (streamingStopped) {
           this.handleTextAddition(streamingText, true);
           this.subject.complete();
-          console.log("Claude stopped streaming.");
         } else if (streamingInProgress) {
           this.handleTextAddition(streamingText);
         }
@@ -305,7 +303,6 @@ class ClaudeTextStream extends ClaudeTextBlockCapture {
     const unseenText = allText.replace(this._textProcessedSoFar, "");
     if (!unseenText) { return; } // some chunks may be empty, in which case we don't need to process them
 
-    console.log(`[ClaudeTextStream] sending text to buffer: "${unseenText}"`);
     this.subject.next(new AddedText(unseenText));
     this._textProcessedSoFar = allText;
   }

--- a/src/chatbots/Claude.ts
+++ b/src/chatbots/Claude.ts
@@ -301,6 +301,15 @@ class ClaudeTextStream extends ClaudeTextBlockCapture {
     super(element, options);
   }
 
+  override handleTextAddition(allText: string, isFinal: boolean = false): void {
+    const unseenText = allText.replace(this._textProcessedSoFar, "");
+    if (!unseenText) { return; } // some chunks may be empty, in which case we don't need to process them
+
+    console.log(`[ClaudeTextStream] sending text to buffer: "${unseenText}"`);
+    this.subject.next(new AddedText(unseenText));
+    this._textProcessedSoFar = allText;
+  }
+
 }
 
 function findAndDecorateCustomPlaceholderElement(

--- a/src/popup/popup-config.js
+++ b/src/popup/popup-config.js
@@ -1,10 +1,10 @@
 /**
- * Auto-generated from .env.production - DO NOT MODIFY DIRECTLY
+ * Auto-generated from .env - DO NOT MODIFY DIRECTLY
  * This file is regenerated on each build to ensure it uses the correct environment settings.
- * Generated on: 2025-04-10
+ * Generated on: 2025-04-15
  */
 const config = {
-  // Values from .env.production
+  // Values from .env
   apiBaseUrl: "https://api.saypi.ai",
   authServerUrl: "https://www.saypi.ai"
 };

--- a/src/tts/AudioStreamManager.ts
+++ b/src/tts/AudioStreamManager.ts
@@ -3,7 +3,7 @@ import { InputBuffer } from "./InputBuffer";
 import { SpeechSynthesisVoiceRemote, SpeechUtterance } from "./SpeechModel";
 
 const STREAM_TIMEOUT_MS = 19000; // end streams after prolonged inactivity (<= 20s)
-const BUFFER_TIMEOUT_MS = 1000; // flush buffers after inactivity
+const BUFFER_TIMEOUT_MS = 1500; // flush buffers after inactivity
 const START_OF_SPEECH_MARKER = " "; // In the first message, the text should be a space " " to indicate the start of speech (why?)
 
 export class AudioStreamManager {

--- a/src/tts/InputBuffer.ts
+++ b/src/tts/InputBuffer.ts
@@ -61,7 +61,7 @@ export class InputBuffer {
       throw new Error(`Cannot add text to a closed buffer: ${this.uuid}`);
     }
 
-    console.log(`[InputBuffer] adding text to buffer: "${text}"`);
+    console.debug(`[InputBuffer] adding text to buffer: "${text}"`);
 
     this.buffer += text;
     this.resetBufferTimeout();
@@ -96,7 +96,7 @@ export class InputBuffer {
         if (lastBreakIndex === this.buffer.length - 1) {
             // Case 1: Buffer ends with a break character. Flush the whole buffer.
             const textToFlush = this.buffer;
-            console.log(`[InputBuffer] flushing buffer due to end-text break: "${textToFlush}"`);
+            console.debug(`[InputBuffer] flushing buffer due to end-text break: "${textToFlush}"`);
             this.flushBuffer(textToFlush, "eos");
             this.buffer = "";
             // Clear potential timeout explicitly as buffer is empty
@@ -108,7 +108,7 @@ export class InputBuffer {
             // Case 2: Buffer contains a break, but not at the very end. Flush up to the break.
             const textToFlush = this.buffer.substring(0, lastBreakIndex + 1);
             const remainingText = this.buffer.substring(lastBreakIndex + 1);
-            console.log(`[InputBuffer] flushing buffer due to mid-text break: "${textToFlush}"`);
+            console.debug(`[InputBuffer] flushing buffer due to mid-text break: "${textToFlush}"`);
             this.flushBuffer(textToFlush, "eos");
             this.buffer = remainingText;
             // Timeout reset is handled in addText after this function returns, based on the updated buffer
@@ -125,11 +125,11 @@ export class InputBuffer {
     if (this.buffer.length > 0) {
       this.bufferTimeout = setTimeout(() => {
           if (this.buffer.length > 0) { // Double check buffer has content before flushing on timeout
-              console.log(`[InputBuffer] flushing buffer due to timeout: "${this.buffer}"`);
+              console.debug(`[InputBuffer] flushing buffer due to timeout: "${this.buffer}"`);
               this.flushBuffer(this.buffer, "timeout");
               this.buffer = "";
           } else {
-              console.log(`[InputBuffer] timeout occurred but buffer is empty.`);
+              console.debug(`[InputBuffer] timeout occurred but buffer is empty.`);
           }
       }, this.BUFFER_TIMEOUT_MS);
     } else {
@@ -187,7 +187,7 @@ export class InputBuffer {
     // Flush any remaining text before closing
     await this.flushBuffer(this.buffer, "close");
     this.buffer = ""; // Ensure buffer is empty after closing
-    console.log(`Buffer closed for UUID: ${this.uuid}`);
+    console.debug(`Buffer closed for UUID: ${this.uuid}`);
   }
 
   endInput(): void {
@@ -198,7 +198,7 @@ export class InputBuffer {
         console.error("Error ending input stream:", error);
       }
     } else {
-      console.log("Input stream already ended or not found");
+      console.debug("Input stream already ended or not found");
     }
   }
 

--- a/src/tts/TTSControlsModule.ts
+++ b/src/tts/TTSControlsModule.ts
@@ -34,8 +34,7 @@ export class TTSControlsModule {
     });
 
     EventBus.on("saypi:piWriting", (event: AssistantWritingEvent) => {
-      // short-circuit for block capture - remove this line to enable TTS streaming
-      return;
+      // full stream mode
       if (this.skipCurrent) {
         console.debug("Suppressing TTS generation due to skipCurrent flag");
         this.skipCurrent = false;
@@ -47,6 +46,7 @@ export class TTSControlsModule {
 
     EventBus.on("saypi:piStoppedWriting", (event: AssistantWritingEvent) => {
       // for Claude block capture, wait until all text is available before starting the audio output stream
+      return; // TODO: remove this line to switch between TTS streaming and TTS block capture
       if (this.skipCurrent) {
         console.debug("Suppressing TTS generation due to skipCurrent flag");
         this.skipCurrent = false;


### PR DESCRIPTION
Replace our block capture approach to monitoring Claude's output streams with a more sophisticated method that starts sending Claude's partial responses to the TTS service before it's finished streaming.

In principle, this should allow for significantly lower S2S/TTS latency since we don't have to wait the sometimes several seconds it takes for Claude to stream its full responses to the client (TTFT-TTLT) before starting to generate and stream the audio of those responses (TTFB).

In practice, I have not observed a noticeable improvement in latency. The reason for this isn't entirely clear, but is likely due to how the API server generates it responses and blocking behaviour on the single worker production dyno.