### PR TITLE
Dictation: terminate on manual edits; preserve app-inserted updates; fix state accumulation

### DIFF
--- a/src/UniversalDictationModule.ts
+++ b/src/UniversalDictationModule.ts
@@ -342,8 +342,13 @@ export class UniversalDictationModule {
 
     // Listen for content changes to detect manual edits
     const handleContentChange = () => {
-      // Skip if we're currently updating from dictation
+      // Skip if we're currently updating from dictation (event-level debounce)
       if (isUpdatingFromDictation) {
+        return;
+      }
+      // Skip if this element is flagged as being updated programmatically by dictation
+      // The flag is set by the text insertion code and cleared on the next tick
+      if ((element as any).__dictationUpdateInProgress) {
         return;
       }
 

--- a/src/UniversalDictationModule.ts
+++ b/src/UniversalDictationModule.ts
@@ -387,6 +387,15 @@ export class UniversalDictationModule {
         markDictationUpdate();
       }
     });
+    
+    // Listen for dictation termination due to manual edit
+    EventBus.on("dictation:terminatedByManualEdit", (data) => {
+      if (data.targetElement === element && this.currentActiveTarget?.element === element) {
+        console.debug("Dictation terminated due to manual edit on element:", element);
+        // Clean up the active dictation state
+        this.stopDictation();
+      }
+    });
 
     // Button click handler - use mousedown for faster response
     const buttonClickHandler = (event: Event) => {

--- a/test/state-machines/DictationMachine-ManualEditTermination.spec.ts
+++ b/test/state-machines/DictationMachine-ManualEditTermination.spec.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { interpret } from 'xstate';
+import EventBus from '../../src/events/EventBus.js';
+
+// Mock dependencies
+vi.mock('../../src/TranscriptionModule', () => ({
+  uploadAudioWithRetry: vi.fn(() => Promise.resolve(1)),
+  isTranscriptionPending: vi.fn(() => false),
+  clearPendingTranscriptions: vi.fn(),
+  getCurrentSequenceNumber: vi.fn(() => 1),
+}));
+
+vi.mock('../../src/ConfigModule', () => ({
+  config: {
+    apiServerUrl: 'http://localhost:3000',
+  },
+}));
+
+vi.mock('../../src/prefs/PreferenceModule', () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({
+      getLanguage: vi.fn(() => Promise.resolve('en')),
+    }),
+  },
+}));
+
+vi.mock('../../src/error-management/TranscriptionErrorManager', () => ({
+  default: {
+    recordAttempt: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/TranscriptMergeService', () => ({
+  TranscriptMergeService: vi.fn().mockImplementation(() => ({
+    mergeTranscriptsLocal: vi.fn((transcripts) => {
+      return Object.keys(transcripts)
+        .sort((a, b) => parseInt(a) - parseInt(b))
+        .map(key => transcripts[key])
+        .join(' ');
+    }),
+  })),
+}));
+
+// Mock EventBus
+vi.spyOn(EventBus, 'emit');
+
+// Import the machine after mocks are set up
+import { createDictationMachine } from '../../src/state-machines/DictationMachine';
+
+describe('DictationMachine Manual Edit Termination', () => {
+  let service: any;
+  let inputElement: HTMLInputElement;
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Create an input element
+    inputElement = document.createElement('input');
+    inputElement.id = 'test-input';
+    inputElement.type = 'text';
+    inputElement.value = '';
+    document.body.appendChild(inputElement);
+    
+    // Create fresh machine for each test
+    const machine = createDictationMachine(inputElement);
+    service = interpret(machine);
+  });
+
+  afterEach(() => {
+    if (service) {
+      service.stop();
+    }
+    document.body.innerHTML = '';
+  });
+
+  it('should terminate dictation when manual edit is detected', async () => {
+    // Start the dictation machine
+    service.start();
+    
+    // Simulate starting dictation
+    service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+    service.send({ type: 'saypi:callReady' });
+    
+    // Verify we're in listening state
+    expect(service.state.value).toEqual(expect.objectContaining({ listening: expect.any(Object) }));
+    
+    // Set up transcription target mapping
+    service.state.context.transcriptionTargets[1] = inputElement;
+    
+    // Simulate transcription response
+    service.send({
+      type: 'saypi:transcribed',
+      text: 'Hello world',
+      sequenceNumber: 1,
+    });
+    
+    // Verify the input contains the transcription
+    expect(inputElement.value).toBe('Hello world');
+    expect(service.state.context.transcriptionsByTarget['test-input']).toEqual({
+      1: 'Hello world'
+    });
+    
+    // Simulate manual edit
+    inputElement.value = 'Hello world, edited!';
+    service.send({
+      type: 'saypi:manualEdit',
+      targetElement: inputElement,
+      newContent: 'Hello world, edited!',
+      oldContent: 'Hello world'
+    });
+    
+    // Verify dictation was terminated
+    expect(service.state.value).toBe('idle');
+    
+    // Verify transcription state was cleared
+    expect(service.state.context.transcriptionsByTarget['test-input']).toBeUndefined();
+    expect(service.state.context.transcriptions).toEqual({});
+    expect(service.state.context.accumulatedText).toBe('');
+    
+    // Verify termination event was emitted
+    expect(EventBus.emit).toHaveBeenCalledWith('dictation:terminatedByManualEdit', {
+      targetElement: inputElement,
+      reason: 'manual-edit'
+    });
+    
+    // Verify recording was stopped
+    expect(EventBus.emit).toHaveBeenCalledWith('audio:stopRecording');
+    expect(EventBus.emit).toHaveBeenCalledWith('audio:tearDownRecording');
+  });
+
+  it('should clear all transcriptions for the edited target', async () => {
+    // Start the dictation machine
+    service.start();
+    
+    // Simulate starting dictation
+    service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+    service.send({ type: 'saypi:callReady' });
+    
+    // Add multiple transcriptions
+    service.state.context.transcriptionTargets[1] = inputElement;
+    service.state.context.transcriptionTargets[2] = inputElement;
+    service.state.context.transcriptionTargets[3] = inputElement;
+    
+    service.send({
+      type: 'saypi:transcribed',
+      text: 'First part',
+      sequenceNumber: 1,
+    });
+    
+    service.send({
+      type: 'saypi:transcribed',
+      text: 'Second part',
+      sequenceNumber: 2,
+    });
+    
+    service.send({
+      type: 'saypi:transcribed',
+      text: 'Third part',
+      sequenceNumber: 3,
+    });
+    
+    // Verify all transcriptions are present
+    expect(service.state.context.transcriptionsByTarget['test-input']).toEqual({
+      1: 'First part',
+      2: 'Second part',
+      3: 'Third part'
+    });
+    
+    // Simulate manual edit
+    service.send({
+      type: 'saypi:manualEdit',
+      targetElement: inputElement,
+      newContent: 'Manually edited',
+      oldContent: inputElement.value
+    });
+    
+    // Verify all transcriptions were cleared
+    expect(service.state.context.transcriptionsByTarget['test-input']).toBeUndefined();
+    expect(service.state.context.transcriptions).toEqual({});
+    expect(service.state.context.initialTextByTarget['test-input']).toBeUndefined();
+  });
+
+  it('should handle manual edit when no transcriptions exist', async () => {
+    // Start the dictation machine
+    service.start();
+    
+    // Simulate starting dictation
+    service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+    service.send({ type: 'saypi:callReady' });
+    
+    // Simulate manual edit without any transcriptions
+    service.send({
+      type: 'saypi:manualEdit',
+      targetElement: inputElement,
+      newContent: 'Typed manually',
+      oldContent: ''
+    });
+    
+    // Should transition to idle without errors
+    expect(service.state.value).toBe('idle');
+    
+    // Verify termination event was still emitted
+    expect(EventBus.emit).toHaveBeenCalledWith('dictation:terminatedByManualEdit', {
+      targetElement: inputElement,
+      reason: 'manual-edit'
+    });
+  });
+
+  it('should handle manual edit during different states', async () => {
+    // Start the dictation machine
+    service.start();
+    
+    // Test manual edit during starting state
+    service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+    expect(service.state.value).toBe('starting');
+    
+    service.send({
+      type: 'saypi:manualEdit',
+      targetElement: inputElement,
+      newContent: 'Edit during starting',
+      oldContent: ''
+    });
+    
+    // Should transition to idle
+    expect(service.state.value).toBe('idle');
+    
+    // Start again and move to listening state
+    service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+    service.send({ type: 'saypi:callReady' });
+    expect(service.state.value).toEqual(expect.objectContaining({ listening: expect.any(Object) }));
+    
+    // Test manual edit during listening state
+    service.send({
+      type: 'saypi:manualEdit',
+      targetElement: inputElement,
+      newContent: 'Edit during listening',
+      oldContent: ''
+    });
+    
+    // Should transition to idle
+    expect(service.state.value).toBe('idle');
+  });
+
+  it('should terminate entire dictation session on manual edit', async () => {
+    // Create a second input element
+    const secondInput = document.createElement('input');
+    secondInput.id = 'second-input';
+    secondInput.type = 'text';
+    document.body.appendChild(secondInput);
+    
+    // Start the dictation machine
+    service.start();
+    
+    // Simulate starting dictation
+    service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+    service.send({ type: 'saypi:callReady' });
+    
+    // Add transcriptions for both targets
+    service.state.context.transcriptionTargets[1] = inputElement;
+    service.state.context.transcriptionTargets[2] = secondInput;
+    
+    service.send({
+      type: 'saypi:transcribed',
+      text: 'First input text',
+      sequenceNumber: 1,
+    });
+    
+    // Switch target
+    service.send({ type: 'saypi:switchTarget', targetElement: secondInput });
+    
+    service.send({
+      type: 'saypi:transcribed',
+      text: 'Second input text',
+      sequenceNumber: 2,
+    });
+    
+    // Verify both transcriptions exist
+    expect(service.state.context.transcriptionsByTarget['test-input']).toBeDefined();
+    expect(service.state.context.transcriptionsByTarget['second-input']).toBeDefined();
+    
+    // Simulate manual edit on first input
+    service.send({
+      type: 'saypi:manualEdit',
+      targetElement: inputElement,
+      newContent: 'Edited first',
+      oldContent: 'First input text'
+    });
+    
+    // SIMPLIFIED BEHAVIOR: Manual edit terminates entire dictation session
+    // This is cleaner and more predictable than trying to maintain partial state
+    expect(service.state.value).toBe('idle');
+    
+    // The edited target's transcriptions should be cleared
+    expect(service.state.context.transcriptionsByTarget['test-input']).toBeUndefined();
+    
+    // In the simplified approach, when dictation is terminated, 
+    // the session ends completely. Other targets' transcriptions may be preserved
+    // in the context but the dictation session itself is terminated.
+    // This prevents confusing state management issues.
+  });
+});

--- a/test/state-machines/DictationMachine-PRDRequirements.spec.ts
+++ b/test/state-machines/DictationMachine-PRDRequirements.spec.ts
@@ -1,0 +1,448 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { interpret } from 'xstate';
+import EventBus from '../../src/events/EventBus.js';
+
+// Mock dependencies
+vi.mock('../../src/TranscriptionModule', () => ({
+  uploadAudioWithRetry: vi.fn(() => Promise.resolve(1)),
+  isTranscriptionPending: vi.fn(() => false),
+  clearPendingTranscriptions: vi.fn(),
+  getCurrentSequenceNumber: vi.fn(() => 0),
+}));
+
+vi.mock('../../src/ConfigModule', () => ({
+  config: {
+    apiServerUrl: 'http://localhost:3000',
+  },
+}));
+
+vi.mock('../../src/prefs/PreferenceModule', () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({
+      getLanguage: vi.fn(() => Promise.resolve('en')),
+    }),
+  },
+}));
+
+vi.mock('../../src/error-management/TranscriptionErrorManager', () => ({
+  default: {
+    recordAttempt: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/TranscriptMergeService', () => ({
+  TranscriptMergeService: vi.fn().mockImplementation(() => ({
+    mergeTranscriptsLocal: vi.fn((transcripts) => {
+      return Object.keys(transcripts)
+        .sort((a, b) => parseInt(a) - parseInt(b))
+        .map(key => transcripts[key])
+        .join(' ');
+    }),
+  })),
+}));
+
+// Mock EventBus
+vi.spyOn(EventBus, 'emit');
+
+// Import the machine and helper functions after mocks are set up
+import { createDictationMachine } from '../../src/state-machines/DictationMachine';
+import * as TranscriptionModule from '../../src/TranscriptionModule';
+
+describe('PRD Requirements - Dictation Text Merging', () => {
+  let service: any;
+  let inputElement: HTMLInputElement;
+  let sequenceCounter = 0;
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sequenceCounter = 0;
+    
+    // Mock sequence number generation
+    vi.mocked(TranscriptionModule.getCurrentSequenceNumber).mockImplementation(() => sequenceCounter);
+    vi.mocked(TranscriptionModule.uploadAudioWithRetry).mockImplementation(() => {
+      sequenceCounter++;
+      return Promise.resolve(sequenceCounter);
+    });
+    
+    // Create an input element
+    inputElement = document.createElement('input');
+    inputElement.id = 'test-input';
+    inputElement.type = 'text';
+    inputElement.value = '';
+    document.body.appendChild(inputElement);
+    
+    // Create fresh machine for each test
+    const machine = createDictationMachine(inputElement);
+    service = interpret(machine);
+  });
+
+  afterEach(() => {
+    if (service) {
+      service.stop();
+    }
+    document.body.innerHTML = '';
+  });
+
+  describe('Sequential Transcript Ordering', () => {
+    it('should maintain correct order even when responses arrive out of order', async () => {
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      // Set up target mappings for multiple sequences
+      service.state.context.transcriptionTargets[1] = inputElement;
+      service.state.context.transcriptionTargets[2] = inputElement;
+      service.state.context.transcriptionTargets[3] = inputElement;
+      
+      // Send transcriptions out of order
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Third',
+        sequenceNumber: 3,
+      });
+      
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'First',
+        sequenceNumber: 1,
+      });
+      
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Second',
+        sequenceNumber: 2,
+      });
+      
+      // Verify they're merged in the correct order
+      expect(inputElement.value).toBe('First Second Third');
+    });
+  });
+
+  describe('Initial Text Preservation', () => {
+    it('should preserve pre-existing content when dictation begins', async () => {
+      // Start with existing content
+      inputElement.value = 'Existing text';
+      
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      // Verify initial text is captured
+      expect(service.state.context.initialTextByTarget['test-input']).toBe('Existing text');
+      
+      // Add transcription
+      service.state.context.transcriptionTargets[1] = inputElement;
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'new dictation',
+        sequenceNumber: 1,
+      });
+      
+      // Verify existing text is preserved and new text is appended
+      expect(inputElement.value).toBe('Existing text new dictation');
+    });
+  });
+
+  describe('Smart Text Joining', () => {
+    it('should join text segments with appropriate spacing', async () => {
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      service.state.context.transcriptionTargets[1] = inputElement;
+      service.state.context.transcriptionTargets[2] = inputElement;
+      
+      // Test various joining scenarios
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Hello',
+        sequenceNumber: 1,
+      });
+      
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'world',
+        sequenceNumber: 2,
+      });
+      
+      // Should add space between segments
+      expect(inputElement.value).toBe('Hello world');
+    });
+    
+    it('should not add double spaces when segments already have spacing', async () => {
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      service.state.context.transcriptionTargets[1] = inputElement;
+      service.state.context.transcriptionTargets[2] = inputElement;
+      
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Hello ',  // Trailing space
+        sequenceNumber: 1,
+      });
+      
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'world',
+        sequenceNumber: 2,
+      });
+      
+      // Should not add extra space
+      expect(inputElement.value).toBe('Hello world');
+    });
+    
+    it('should normalize ellipsis characters', async () => {
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      service.state.context.transcriptionTargets[1] = inputElement;
+      
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Wait… let me think...',  // Unicode ellipsis and three dots
+        sequenceNumber: 1,
+      });
+      
+      // Ellipses should be normalized to spaces
+      expect(inputElement.value).toBe('Wait let me think');
+    });
+  });
+
+  describe('Multi-Target Support', () => {
+    it('should handle dictation switching between different input fields', async () => {
+      // Create second input
+      const secondInput = document.createElement('input');
+      secondInput.id = 'second-input';
+      secondInput.type = 'text';
+      document.body.appendChild(secondInput);
+      
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      // First target
+      service.state.context.transcriptionTargets[1] = inputElement;
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'First field text',
+        sequenceNumber: 1,
+      });
+      
+      // Switch to second target
+      service.send({ type: 'saypi:switchTarget', targetElement: secondInput });
+      
+      service.state.context.transcriptionTargets[2] = secondInput;
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Second field text',
+        sequenceNumber: 2,
+      });
+      
+      // Verify each field has its own content
+      expect(inputElement.value).toBe('First field text');
+      expect(secondInput.value).toBe('Second field text');
+      
+      // Verify separate transcription contexts
+      expect(service.state.context.transcriptionsByTarget['test-input']).toEqual({
+        1: 'First field text'
+      });
+      expect(service.state.context.transcriptionsByTarget['second-input']).toEqual({
+        2: 'Second field text'
+      });
+    });
+  });
+
+  describe('Manual Edit Detection & Handling', () => {
+    it('should terminate dictation when manual edit is detected', async () => {
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      service.state.context.transcriptionTargets[1] = inputElement;
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Dictated text',
+        sequenceNumber: 1,
+      });
+      
+      expect(inputElement.value).toBe('Dictated text');
+      
+      // Simulate manual edit
+      inputElement.value = 'Manually edited text';
+      service.send({
+        type: 'saypi:manualEdit',
+        targetElement: inputElement,
+        newContent: 'Manually edited text',
+        oldContent: 'Dictated text'
+      });
+      
+      // Verify dictation is terminated
+      expect(service.state.value).toBe('idle');
+      
+      // Verify termination event was emitted
+      expect(EventBus.emit).toHaveBeenCalledWith('dictation:terminatedByManualEdit', {
+        targetElement: inputElement,
+        reason: 'manual-edit'
+      });
+      
+      // Verify transcription state is cleared
+      expect(service.state.context.transcriptionsByTarget['test-input']).toBeUndefined();
+    });
+  });
+
+  describe('External Field Clearing Detection', () => {
+    it('should detect and handle when fields are cleared externally (chat platform issue)', async () => {
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      // First message
+      service.state.context.transcriptionTargets[1] = inputElement;
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'First message to chat',
+        sequenceNumber: 1,
+      });
+      
+      expect(inputElement.value).toBe('First message to chat');
+      
+      // Simulate chat platform clearing the field (external clear)
+      inputElement.value = '';
+      
+      // Second message should detect the clearing and start fresh
+      service.state.context.transcriptionTargets[2] = inputElement;
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Second message to chat',
+        sequenceNumber: 2,
+      });
+      
+      // Should only contain the second message, not accumulated
+      expect(inputElement.value).toBe('Second message to chat');
+      
+      // Verify state was properly reset
+      expect(service.state.context.transcriptionsByTarget['test-input']).toEqual({
+        2: 'Second message to chat'
+      });
+    });
+  });
+
+  describe('ContentEditable Support', () => {
+    it('should work with contenteditable elements', async () => {
+      // Create contenteditable div
+      const editableDiv = document.createElement('div');
+      editableDiv.id = 'editable-div';
+      editableDiv.contentEditable = 'true';
+      document.body.appendChild(editableDiv);
+      
+      const machine = createDictationMachine(editableDiv);
+      const editableService = interpret(machine);
+      editableService.start();
+      
+      editableService.send({ type: 'saypi:startDictation', targetElement: editableDiv });
+      editableService.send({ type: 'saypi:callReady' });
+      
+      editableService.state.context.transcriptionTargets[1] = editableDiv;
+      editableService.send({
+        type: 'saypi:transcribed',
+        text: 'ContentEditable text',
+        sequenceNumber: 1,
+      });
+      
+      expect(editableDiv.textContent).toBe('ContentEditable text');
+      
+      editableService.stop();
+    });
+  });
+
+  describe('Server-side Merging Support', () => {
+    it('should handle server-merged transcriptions', async () => {
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      // Set up multiple sequences that will be merged
+      service.state.context.transcriptionTargets[1] = inputElement;
+      service.state.context.transcriptionTargets[2] = inputElement;
+      service.state.context.transcriptionTargets[3] = inputElement;
+      
+      // First two transcriptions
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Part one',
+        sequenceNumber: 1,
+      });
+      
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Part two',
+        sequenceNumber: 2,
+      });
+      
+      // Server sends merged result
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Part one Part two Part three',
+        sequenceNumber: 3,
+        merged: [1, 2]  // Server merged sequences 1 and 2 into 3
+      });
+      
+      // Should use the server-merged result
+      expect(inputElement.value).toBe('Part one Part two Part three');
+      
+      // Verify merged sequences were removed from context
+      expect(service.state.context.transcriptions[1]).toBeUndefined();
+      expect(service.state.context.transcriptions[2]).toBeUndefined();
+      expect(service.state.context.transcriptions[3]).toBe('Part one Part two Part three');
+    });
+  });
+
+  describe('Error Recovery', () => {
+    it('should handle transcription failures gracefully', async () => {
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      // Simulate transcription failure
+      service.send({ type: 'saypi:transcribeFailed' });
+      
+      // Should transition to error state
+      expect(service.state.value).toEqual({ errors: 'transcribeFailed' });
+      
+      // Should recover to idle after timeout (simulated by advancing time)
+      // In real usage, this would happen after 3 seconds
+    });
+    
+    it('should handle empty transcriptions', async () => {
+      service.start();
+      service.send({ type: 'saypi:startDictation', targetElement: inputElement });
+      service.send({ type: 'saypi:callReady' });
+      
+      service.state.context.transcriptionTargets[1] = inputElement;
+      
+      // Send empty transcription
+      service.send({
+        type: 'saypi:transcribed',
+        text: '',
+        sequenceNumber: 1,
+      });
+      
+      // Should not crash or produce errors
+      expect(inputElement.value).toBe('');
+      
+      // Send non-empty transcription
+      service.state.context.transcriptionTargets[2] = inputElement;
+      service.send({
+        type: 'saypi:transcribed',
+        text: 'Valid text',
+        sequenceNumber: 2,
+      });
+      
+      // Should handle valid text normally
+      expect(inputElement.value).toBe('Valid text');
+    });
+  });
+});


### PR DESCRIPTION

Summary
- Simplifies manual-edit handling: terminate dictation immediately when the user types into the field for predictable, maintainable behavior
- Ensure app-inserted dictation updates do not trigger termination (guarded programmatic updates)
- Detect external field clearing (e.g., chat UIs) and prevent state accumulation/duplication

Why
- Reduces complexity and flakiness from reconciling manual edits mid-session
- Aligns with PRD goal of predictable behavior and data preservation
- Fixes the “state accumulation after chat submit/clear” bug

Key changes
- Manual edits terminate dictation
  - `src/state-machines/DictationMachine.ts`: on `saypi:manualEdit`, transition to `idle` and emit `dictation:terminatedByManualEdit`
- Preserve app-inserted dictation updates (don’t treat as manual edits)
  - `src/state-machines/DictationMachine.ts`: set per-element guard flag `__dictationUpdateInProgress` during insertion (cleared on next tick); still emits `dictation:contentUpdated` with source: "dictation"
  - `src/UniversalDictationModule.ts`: input handler now skips when guard flag is set or when `isUpdatingFromDictation` is true
- Prevent state accumulation after external clears
  - Improved detection in transcription handling: when field is externally cleared, reset target transcriptions cleanly before continuing

Implementation notes
- Maintains existing insertion strategies; guard is element-local and does not affect other elements
- Avoids overengineering (no heavy reconcilers/observers); simpler, testable, maintainable path forward
- Leaves room for future “continue after manual edit” behavior behind a feature flag

Tests
- Updated tests to reflect new behavior (manual edit = terminate)
- Added comprehensive PRD coverage for ordering, initial text, smart joining, multi-target flows
- All tests green (233/233)
  - Updated: `test/state-machines/DictationMachine.spec.ts`
  - Updated: `test/state-machines/DictationMachine-OutOfOrder.spec.ts`
  - Added: `test/state-machines/DictationMachine-ManualEditTermination.spec.ts`
  - Added: `test/state-machines/DictationMachine-PRDRequirements.spec.ts`
  - Existing: `test/UniversalDictationModule-StateAccumulation.spec.ts` (now passes with improved clearing)

Files of interest
- `src/state-machines/DictationMachine.ts`
  - Add programmatic update guard around `setTextInTarget`
  - Transition to idle on `saypi:manualEdit`
  - Preserve `dictation:contentUpdated` emission
- `src/UniversalDictationModule.ts`
  - Input handler respects `__dictationUpdateInProgress` and `isUpdatingFromDictation`
  - Cleanup on `dictation:terminatedByManualEdit` event

PRD reference
- `scripts/PRD_dictation_text_merging.md`
- Approach intentionally favors simplicity and reliability over complex reconciliation (acceptable per PRD)

How to verify
1. Start dictation, speak text: field updates should not terminate dictation
2. While dictating, type any character: dictation terminates immediately
3. In a chat UI that clears the field on send: next dictation starts fresh without duplicating previous text
4. Switch targets mid-session: per-target buckets remain isolated and correct

Backward compatibility / risk
- Behavior change: manual edits now always end dictation (intentional)
- Low risk to non-dictation flows; change is scoped to dictation paths
- Guard is element-local; does not interfere with other inputs

Checklist
- [x] Behavior matches simplified PRD direction
- [x] Unit tests updated/added; all passing
- [x] No regression to insertion strategies or spacing/newline handling

Models and Agents
This feature was implemented initially by Claude Opus 4.1, given a PRD as input. There were still a few bugs after Opus had finished. 
At which point I switched to the just released GPT-5 model. Which finished the task admirably.