### PR TITLE
insert at caret

### DIFF
--- a/scripts/research-advancing_caret_position.md
+++ b/scripts/research-advancing_caret_position.md
@@ -1,0 +1,141 @@
+# Advancing Caret Position After Programmatic Text Insertion
+
+When you insert text programmatically (e.g. for an autocomplete or dictation feature), you need to **manually update the caret (cursor) position** so that it ends up immediately after the newly inserted text. The exact approach differs slightly for plain text inputs vs. contenteditable elements or rich text editors, but there are reliable strategies that developers have used in production.
+
+## Text Inputs and Textareas (Plain Text Fields)
+
+For standard text `<input>` or `<textarea>` fields, you can insert text at the cursor and then use the element’s selection properties to place the caret right after the inserted text:
+
+1. **Determine the current selection/caret position:** Use the input’s `selectionStart` and `selectionEnd` properties. These give you the indices where the caret or selection begins and ends. For example:
+
+   ```js
+   const start = myField.selectionStart;
+   const end   = myField.selectionEnd;
+   ```
+2. **Insert the text at that position:** Update the value by slicing around the selection. For example:
+
+   ```js
+   const before = myField.value.substring(0, start);
+   const after  = myField.value.substring(end);
+   myField.value = before + newText + after;
+   ```
+
+   This replaces any selected text (if `start != end`) or inserts at the caret if no text was selected.
+3. **Move the caret to the end of the inserted text:** Set `selectionStart` and `selectionEnd` to the new caret index (which is `start + newText.length`). This will place a collapsed caret right after the inserted content. For example:
+
+   ```js
+   const newCaretPos = start + newText.length;
+   myField.selectionStart = myField.selectionEnd = newCaretPos;
+   ```
+4. **Ensure the field is focused:** The field must have focus for the selection change to take effect. If it isn’t already focused, call `myField.focus()` before setting the selection. (In practice, if the user was typing, the field is likely focused already.)
+
+Using the above method, the caret will reliably end up right after the inserted text. This approach works in all modern browsers. In fact, it’s the same technique used in popular answers on Stack Overflow and implemented in production code.
+
+> **Note:** A newer, convenient alternative is the `setRangeText()` method. This can replace the current selection with new text and automatically adjust the caret. For example: `myField.setRangeText(newText, start, end, 'end')` replaces the selection and puts the caret at the *end* of the inserted text. (Using `'end'` as the fourth parameter moves the caret to the end of the insertion. Other modes like `'select'` will highlight the inserted text instead.) This method is supported in all modern browsers except IE. Be aware, however, that directly manipulating `.value` or using `setRangeText` might reset the browser’s undo stack. If preserving undo/redo is important, you may prefer the older approach or simulate a native input event (described below).
+
+## Contenteditable Elements (Rich Text Divs)
+
+For contenteditable elements (like a `<div contenteditable="true">` or rich text editor content areas), the strategy is to use the **DOM Selection/Range API or execCommand** to insert content and then adjust the selection. Modern frameworks often handle this for you, but if you're inserting text externally, consider the following approaches:
+
+* **Try native insertion commands first:** Browsers support legacy commands that simulate typing. For example, focusing the contenteditable element and calling `document.execCommand('insertText', false, text)` will insert the given text at the current caret, and **the caret will automatically move to the end of the inserted text**. This is simple and preserves the user’s undo stack in many cases. If the text includes newline characters (`\n`), you can use `execCommand('insertHTML', false, ...)` with an HTML string where `\n` are replaced by `<br>` tags. For instance:
+
+  ```js
+  if (text.includes('\n')) {
+      document.execCommand('insertHTML', false, textWithBrs);
+  } else {
+      document.execCommand('insertText', false, text);
+  }
+  ```
+
+  Developers have found that using these commands on a focused contenteditable works reliably to insert text and advance the caret – even in complex editors like Gmail, ChatGPT, or Quill. (Despite being labeled “obsolete”, these commands are still supported in modern Chrome/Firefox as of 2025 and can be very handy.)
+
+* **If execCommand is unavailable or fails, use the Selection/Range API:** This gives fine-grained control:
+
+  1. Ensure the contenteditable element is focused (`target.focus()`), then get the current selection: `let sel = window.getSelection(); let range = sel.getRangeAt(0);`.
+
+  2. Delete any currently selected text in that range (`range.deleteContents()`), so insertion replaces the selection (or does nothing if caret is just collapsed).
+
+  3. **Insert the new text node or fragment** at the range. For plain text insertion, you can do:
+
+     ```js
+     range.insertNode(document.createTextNode(newText));
+     ```
+
+     If the text has multiple lines or needs HTML, you may create a document fragment containing text nodes and `<br>`s (or other elements) as needed and insert that node. For example, one technique is to construct an HTML fragment for the text (converting `\n` to `<br>` tags) and include a temporary marker element at the end.
+
+  4. **Move the caret to after the inserted content:** After insertion, the selection may still be highlighting the inserted nodes. To place the caret at the end, collapse the range to its end position. If you inserted a single text node, you can simply collapse the range:
+
+     ```js
+     range.collapse(false);  // collapse to end of range
+     sel.removeAllRanges();
+     sel.addRange(range);
+     ```
+
+     This leaves the caret blinking just after the newly inserted text.
+
+     If you inserted a more complex fragment (with multiple nodes or HTML), a robust method is the **marker element trick**: include an empty `<span>` (or similar) with a unique attribute at the end of your inserted fragment (e.g., `<span id="caret-marker"></span>`). After inserting the fragment, find that marker element in the DOM, create a new Range, and set its start and end **just after** the marker node. Then select this range and remove the marker element. For example:
+
+     ```js
+     // ... after inserting fragment which contains the marker:
+     const marker = target.querySelector('#caret-marker');
+     if (marker) {
+       const newRange = document.createRange();
+       newRange.setStartAfter(marker);
+       newRange.collapse(true);            // collapse to that position
+       sel.removeAllRanges();
+       sel.addRange(newRange);            // place caret
+       marker.remove();                   // cleanup marker node
+     }
+     ```
+
+     This reliably positions the cursor immediately after the inserted content, even if that content includes multiple nodes or line breaks. If for some reason the marker isn’t found (edge case), you can fall back to collapsing the original range as a safeguard.
+
+  5. (Optional) **Normalize `<br>`s if needed:** In some browsers, inserting HTML with line breaks can introduce extra `<br>` tags (for example, two `<br>` in a row). You can clean up redundant breaks by replacing occurrences of `(<br> *){2,}` with a single `<br>`. This step is mainly cosmetic/cleanup.
+
+  6. Finally, you may want to dispatch an `input` event on the contenteditable element (`target.dispatchEvent(new Event("input", { bubbles:true }))`). This is useful if the container has any listeners or frameworks expecting an input event after a DOM change.
+
+Using the Range API as above is a time-tested solution. It’s essentially what the well-known **Rangy** library or Tim Down’s classic Stack Overflow answers do: insert the node and then adjust the selection to follow it. In modern browsers you usually don’t even need a marker node if inserting a simple text node – collapsing the range to its end is enough to move the caret to after the new text. The marker technique is most useful when inserting HTML or when you want to be absolutely sure the caret goes *after* a group of inserted nodes.
+
+> **Tip:** Always make sure the contenteditable element is focused before manipulating or reading its selection. Browsers typically **ignore selection changes on an unfocused element**. Calling `element.focus()` (inside a `try/catch` in case it’s not focusable) is a common practice prior to selection/caret operations.
+
+## Handling Framework Editors (Lexical, Slate, etc.)
+
+Rich text editor frameworks like **Lexical**, **Slate**, **Quill**, etc. often manage their own internal representation of content. Directly manipulating the DOM might not suffice, because the framework could overwrite your changes or not register the new text in its internal state. Here are strategies proven to work:
+
+* **Simulate native input events (for Lexical, Slate, Draft.js, etc.):** Many modern editors respond to the `beforeinput` and `input` DOM events. A reliable approach is to dispatch those events as if the user typed the text. For example, for a Lexical editor (which uses a contenteditable under the hood), you can do:
+
+  ```js
+  const text = "your inserted text";
+  const beforeInputEvt = new InputEvent("beforeinput", {
+    bubbles: true, cancelable: true,
+    inputType: "insertText", data: text, composed: true
+  });
+  const notCanceled = target.dispatchEvent(beforeInputEvt);
+  if (notCanceled) {
+    const inputEvt = new InputEvent("input", {
+      bubbles: true, cancelable: false,
+      inputType: "insertText", data: text, composed: true
+    });
+    target.dispatchEvent(inputEvt);
+  }
+  ```
+
+  This sequence triggers the editor’s own event handlers for text insertion. Real-world developers have used this technique so that Lexical will recognize the programmatic insert as if it were typed, thereby updating its state and moving the cursor accordingly. Slate and Draft.js editors similarly listen for beforeinput events, so this approach can work for them as well. The benefit is that the editor’s normal behavior (including undo stack, formatting, etc.) is preserved. The caret will end up after the inserted text because the editor itself carries out the insertion.
+
+* **Use the editor’s API if available:** The most straightforward method (when you have access to the editor instance) is to call its official insertion command. For Slate (as of v0.5x), for example, you can do: `Transforms.insertText(editor, "your text")`. This inserts text at the current selection and moves the cursor to the end of that text in one operation. In other words, it's equivalent to how a user typing would behave: *if a range is selected, it’s replaced; otherwise text is inserted at the caret, and the caret moves after it*. Using the framework’s API ensures internal state consistency. Lexical has a similar concept (within a Lexical `editor.update()` callback you can insert nodes or text, or use commands). Always prefer these high-level commands when you can, as they handle selection movement automatically.
+
+* **Framework-specific hacks:** Some editors might require particular tricks. For example, Quill (a popular rich text editor) doesn’t expose a direct insert-at-cursor API for external scripts, but it’s known that focusing the editor and using `document.execCommand('insertText', false, text)` works – Quill intercepts that and updates its contents and caret as if the user typed the text. In fact, Quill’s documentation and community solutions often recommend using `execCommand('insertText')` or, for multiline content, `execCommand('insertHTML')`, to programmatically insert content while keeping Quill’s cursor position correct. Other frameworks might sync their contenteditable DOM on an `input` event, so firing an `input` event after inserting DOM nodes (as mentioned earlier) can help the framework pick up the change. Always check the framework’s recommendations or community forums – many have an official or de facto solution for programmatic text insertion.
+
+**Important:** Do *not* try to move the caret by synthesizing key presses (like sending Arrow-Right or End key events). Browsers do not apply "real" caret movement from synthetic keyboard events. In one example, a user attempted to dispatch an "End" key event after insertion, but it had no effect in Chrome. The reliable way to move the cursor is by using the selection/caret APIs as described above, or by letting the editor’s own logic handle it.
+
+## Summary
+
+To reliably advance the caret after programmatically inserting text:
+
+* **For plain text inputs/areas:** insert the text at the current selection and then update the `selectionStart`/`selectionEnd` to the end of the inserted text. This ensures the cursor lands immediately after your new text. (Remember to focus the field if not already focused.)
+* **For contenteditable elements:** either use `execCommand('insertText'/'insertHTML')` (quick and preserves undo) or manipulate the DOM Range: insert a text node/fragment at the caret and collapse the selection to its end. The "temporary marker element" technique is a robust way to position the caret after complex inserts.
+* **For specialized rich text editors:** use their high-level APIs or simulate native events so that the library’s own caret-handling takes place. This keeps the editor state in sync and the caret moving as expected.
+
+All of these methods have been used by real-world developers and in production code, and they work across modern Chrome and Firefox (desktop and mobile). By following these strategies, you can confidently insert text via script and have the cursor end up exactly where it needs to be – right after the inserted text – for a seamless user experience.
+
+**Sources:** The techniques above are drawn from well-established solutions in the web development community, including MDN documentation, Stack Overflow answers, and open-source code implementations, all of which demonstrate reliable caret positioning after programmatic text insertion. Each approach has been vetted in production scenarios to ensure the caret behaves just as if the user had typed the text themselves.

--- a/src/state-machines/DictationMachine.ts
+++ b/src/state-machines/DictationMachine.ts
@@ -497,8 +497,17 @@ class InputTextareaStrategy implements TextInsertionStrategy {
       targetId: inputTarget.id || 'no-id'
     });
     
+    // Ensure focus so selection updates take effect
+    try { inputTarget.focus(); } catch (_) { /* ignore */ }
+
     if (replaceAll) {
       inputTarget.value = text;
+      // Place caret at the end of the inserted content
+      try {
+        const endPos = inputTarget.value.length;
+        (inputTarget as HTMLInputElement | HTMLTextAreaElement).selectionStart = endPos;
+        (inputTarget as HTMLInputElement | HTMLTextAreaElement).selectionEnd = endPos;
+      } catch (_) { /* ignore */ }
     } else {
       // Insert at caret/selection if available; otherwise append
       try {


### PR DESCRIPTION
- **dictation: insert at caret with smart spacing; contenteditable normalization; delta-based insertion vs replace-all for server merges and out-of-order\n\n- InputTextarea: caret-aware insertion with spacing and scroll/caret restore\n- ContentEditable: newline→<br>, caret insert, normalize consecutive <br>\n- Dictation handler: compute delta, insert at caret; replace-all on server merges, out-of-order, or whitespace-only CE\n- All tests passing (233)**
- **dictation: advance caret after programmatic insert for inputs/textareas (focus + selection to end on replace-all)\n\n- Apply best practice from research to ensure caret moves after inserts\n- Keep all tests green (233)**
