### PR TITLE
Shorten app description translations

### DIFF
--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Гласово въвеждане навсякъде, безпроблемни разговори с Pi, Claude и ChatGPT. Говори свободно — Pi се грижи за останалото."
+    "message": "Гласово въвеждане навсякъде. Лесни разговори с Pi, Claude и ChatGPT. Говори свободно."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Stemmeindtastning overalt, gnidningsfrie samtaler med Pi, Claude og ChatGPT. Tal frit – sig det, Pi klarer resten."
+    "message": "Stemmeindtastning overalt. Nem chat med Pi, Claude og ChatGPT. Tal frit."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Φωνητική πληκτρολόγηση παντού, απρόσκοπτες συνομιλίες με Pi, Claude και ChatGPT. Μίλα ελεύθερα—Το Pi θα αναλάβει τα υπόλοιπα."
+    "message": "Φωνητική πληκτρολόγηση παντού. Εύκολες συνομιλίες με Pi, Claude και ChatGPT. Μίλα ελεύθερα."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Escritura por voz en todas partes, conversaciones fluidas con Pi, Claude y ChatGPT. Habla libremente: Pi se encarga del resto."
+    "message": "Dictado por voz en todas partes. Charlas fáciles con Pi, Claude y ChatGPT. Habla libremente."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Hangalapú gépelés mindenhol, zökkenőmentes beszélgetések Pi-vel, Claude-dal és ChatGPT-vel. Beszélj bátran – a többit Pi intézi."
+    "message": "Hangalapú gépelés mindenhol. Könnyű beszélgetés Pi-vel, Claude-dal és ChatGPT-vel. Beszélj bátran."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Ketik suara di mana saja, obrolan lancar dengan Pi, Claude, dan ChatGPT. Bicara dengan bebas—Pi akan mengurus sisanya."
+    "message": "Dikte suara di mana saja. Obrolan mudah dengan Pi, Claude, dan ChatGPT. Bicara bebas."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Dettatura vocale ovunque, conversazioni fluide con Pi, Claude e ChatGPT. Parla liberamente—Pi si occupa del resto."
+    "message": "Dettatura vocale ovunque. Chat facili con Pi, Claude e ChatGPT. Parla liberamente."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Pengetikan suara di mana-mana, perbualan lancar dengan Pi, Claude, dan ChatGPT. Bersuara dengan bebas—Pi akan uruskan selebihnya."
+    "message": "Dikte suara di mana-mana. Sembang mudah dengan Pi, Claude dan ChatGPT. Bersuara bebas."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Digitação por voz em todos os lugares, conversas fluidas com Pi, Claude e ChatGPT. Fale à vontade—diga, Pi faz o resto."
+    "message": "Ditado por voz em todo lugar. Conversas fáceis com Pi, Claude e ChatGPT. Fale à vontade."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "எங்கும் குரல் டைப் செய்யவும், Pi, Claude, மற்றும் ChatGPT உடன் சீரான உரையாடல்கள் நடத்தவும். தமிழில் பேசுங்கள் — Pi மீதமுள்ளதை செய்வது."
+    "message": "எங்கும் குரல் தட்டச்சு. Pi, Claude, ChatGPT உடன் எளிய உரையாடல். சுதந்திரமாக பேசுங்கள்."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/tl/messages.json
+++ b/_locales/tl/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Pagsulat gamit ang boses saanman, tuloy-tuloy na usapan kasama sina Pi, Claude, at ChatGPT. Magsalita nang malaya—Si Pi ang bahala sa iba."
+    "message": "Voice typing saanman. Madaling usapan kasama sina Pi, Claude at ChatGPT. Magsalita nang malaya."
   },
   "appName": {
     "description": "The name of the application.",

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -17,7 +17,7 @@
   },
   "appDescription": {
     "description": "The description of the application.",
-    "message": "Nhập văn bản bằng giọng nói mọi lúc, trò chuyện mượt mà với Pi, Claude và ChatGPT. Nói tự nhiên—Pi sẽ lo phần còn lại."
+    "message": "Nhập bằng giọng nói mọi nơi. Trò chuyện dễ dàng với Pi, Claude và ChatGPT. Nói tự nhiên."
   },
   "appName": {
     "description": "The name of the application.",


### PR DESCRIPTION
Shorten `appDescription` in 12 locales to resolve i18n validation length errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-99c648a0-e27c-452e-b933-f42704eafb1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99c648a0-e27c-452e-b933-f42704eafb1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

