### PR TITLE
ChatGPT: stabilize Read Aloud via dropdown shielding and minimize positioning (#206)

### DIFF
--- a/src/styles/chatgpt.scss
+++ b/src/styles/chatgpt.scss
@@ -72,4 +72,38 @@ body.chatgpt {
     white-space: nowrap;
     box-shadow: 0 4px 10px rgba(0,0,0,0.15);
   }
+
+  /* Invisible holder for temporarily relocated ChatGPT menu item
+     used to trigger Read Aloud outside the Radix popper. */
+  .saypi-relocated-voice-action {
+    position: absolute !important;
+    width: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+
+  /* Hide open Radix dropdown content we’ve flagged as hidden
+     (we do not toggle the popper's actual open state). */
+  [data-radix-popper-content-wrapper][data-saypi-hidden="true"],
+  [data-radix-menu-content][data-saypi-hidden="true"],
+  [data-radix-dropdown-menu-content][data-saypi-hidden="true"] {
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+
+  /* Minimize and soften the open menu while shielded. Keep it visible
+     so ChatGPT's playback context remains intact, but less distracting. */
+  [data-radix-popper-content-wrapper][data-saypi-shielded="true"],
+  [data-radix-menu-content][data-saypi-shielded="true"],
+  [data-radix-dropdown-menu-content][data-saypi-shielded="true"] {
+    opacity: 0.28 !important;
+    /* Position/transform is set inline when shielded so we can move it
+       to the bottom-right; keep transitions for a smooth effect. */
+    transition: opacity 120ms ease, transform 140ms ease !important;
+    transform-origin: var(--radix-popper-transform-origin, 50% 0%);
+    pointer-events: none !important; /* allow reading/clicks behind the menu */
+  }
 }


### PR DESCRIPTION
- Auto-activate Read Aloud from ellipsis dropdown without relocating item
- Add outside-dismiss shield (pointerdown/focusin/Escape capture) that re-dispatches events so page remains interactive
- Minimize and reposition open menu to bottom-right while playing; dim/scale; pass-through clicks
- Auto-close on stop using EventBus events (piStoppedSpeaking/piFinishedSpeaking/hangup) and state polling (responding.piSpeaking)
- Blur menu trigger on open/cleanup to avoid lingering focus ring
- Defer popper hiding; maintain focus on menu item during activation
- Add CSS for relocated holder and shielded/minimized menus
- Update tests: ChatGPTAutoReadAloud passes (focus maintained)
