### PR TITLE
claude: richer Voice menu (accent flags, gender icons, inline chips, subtle separators)

### DIFF
--- a/src/chatbots/ClaudeVoiceMenu.ts
+++ b/src/chatbots/ClaudeVoiceMenu.ts
@@ -247,11 +247,10 @@ export class ClaudeVoiceMenu extends VoiceSelector {
     name.classList.add("flex-1", "text-sm", "font-normal", "text-text-300");
     name.innerText = voice ? voice.name : getMessage("voiceOff");
     nameContainer.appendChild(name);
-    content.appendChild(nameContainer);
 
-    // Meta row (flag/accent / gender / price) – only shown when helpful
-    const meta = document.createElement("div");
-    meta.classList.add("flex", "items-center", "gap-2", "text-text-500", "text-xs", "pr-4");
+    // Chips inline to the right of the name to save vertical space
+    const chips = document.createElement("div");
+    chips.classList.add("flex", "items-center", "gap-2", "text-text-500", "text-xs", "pr-4");
     if (voice) {
       // Accent chip: show only the flag (no BCP tag text). If missing/invalid, omit entirely.
       const accentLocale = this.getVoiceLocale(voice);
@@ -263,7 +262,7 @@ export class ClaudeVoiceMenu extends VoiceSelector {
         flagImg.alt = accentLocale;
         flagImg.src = this.getFlagUrlForLocale(accentLocale);
         accentChip.appendChild(flagImg);
-        meta.appendChild(accentChip);
+        chips.appendChild(accentChip);
       }
       // Gender short tag
       if (this.showGender && voice.gender) {
@@ -273,7 +272,7 @@ export class ClaudeVoiceMenu extends VoiceSelector {
         const icon = gender.startsWith("M") ? marsSvgContent : gender.startsWith("F") ? venusSvgContent : "";
         if (icon) {
           addSvgToButton(genderChip, icon, "w-3", "h-3");
-          meta.appendChild(genderChip);
+          chips.appendChild(genderChip);
         }
       }
       // Price, if there are variations
@@ -281,12 +280,14 @@ export class ClaudeVoiceMenu extends VoiceSelector {
         const priceChip = document.createElement("span");
         priceChip.classList.add("inline-flex", "items-center", "opacity-80");
         priceChip.textContent = this.formatPrice(voice);
-        meta.appendChild(priceChip);
+        chips.appendChild(priceChip);
       }
     }
-    if (meta.childElementCount > 0) {
-      content.appendChild(meta);
+    if (chips.childElementCount > 0) {
+      nameContainer.appendChild(chips);
     }
+
+    content.appendChild(nameContainer);
 
     const description = document.createElement("div");
     description.classList.add("text-text-500", "pr-4", "text-xs", "overflow-hidden", "text-ellipsis", "max-w-[340px]");
@@ -317,6 +318,15 @@ export class ClaudeVoiceMenu extends VoiceSelector {
     item.appendChild(checkmarkContainer);
 
     item.addEventListener("click", () => this.handleVoiceSelection(voice, item));
+    
+    // Subtle divider under each item (removed for the last item later)
+    const divider = document.createElement('div');
+    divider.classList.add('saypi-voice-divider');
+    divider.style.height = '1px';
+    divider.style.marginTop = '6px';
+    divider.style.backgroundColor = 'rgba(0,0,0,0.06)';
+    item.appendChild(divider);
+
     return item;
   }
 
@@ -613,6 +623,9 @@ export class ClaudeVoiceMenu extends VoiceSelector {
       this.menuContent.appendChild(menuItem);
     });
 
+    // Add subtle separators for easier scanning
+    this.applyItemSeparators();
+
     // If we found a selected voice from the button, update the menu items to show selection
     if (currentSelectedVoice) {
       this.updateSelectedVoice(currentSelectedVoice);
@@ -624,6 +637,21 @@ export class ClaudeVoiceMenu extends VoiceSelector {
     }
 
     return !noVoicesAvailable;
+  }
+
+  // Add a faint bottom divider to each menu item except the last one
+  private applyItemSeparators(): void {
+    const items = Array.from(this.menuContent.querySelectorAll('[role="menuitem"]')) as HTMLElement[];
+    const lastIndex = items.length - 1;
+    items.forEach((el, idx) => {
+      const divider = el.querySelector('.saypi-voice-divider') as HTMLElement | null;
+      if (!divider) return;
+      if (idx === lastIndex) {
+        divider.remove();
+      } else {
+        // keep divider
+      }
+    });
   }
 
   private initializeVoiceSelector(chatbot: Chatbot): void {

--- a/src/dom/ChatHistory.ts
+++ b/src/dom/ChatHistory.ts
@@ -132,6 +132,9 @@ abstract class ChatHistoryMessageObserver extends BaseObserver {
   protected ttsControlsModule: TTSControlsModule;
   protected haltOnFirst: boolean = false; // stop searching after the first chat message is found
   protected messageHistory = MessageHistoryModule.getInstance();
+
+
+
   constructor(
     chatHistoryElement: HTMLElement,
     selector: string,
@@ -207,6 +210,7 @@ abstract class ChatHistoryMessageObserver extends BaseObserver {
         mutation.target instanceof Element
       ) {
         const mutatedElement = mutation.target as Element;
+
         this.findAndDecorateAssistantResponses(mutatedElement);
         this.findAndDecorateUserPrompts(mutatedElement);
       }

--- a/src/icons/lucide-globe.svg
+++ b/src/icons/lucide-globe.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+  stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+  class="lucide lucide-globe-icon lucide-globe">
+  <circle cx="12" cy="12" r="10" />
+  <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+  <path d="M2 12h20" />
+</svg>

--- a/src/icons/lucide-mars.svg
+++ b/src/icons/lucide-mars.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+  stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+  class="lucide lucide-mars-icon lucide-mars">
+  <path d="M16 3h5v5" />
+  <path d="m21 3-6.75 6.75" />
+  <circle cx="10" cy="14" r="6" />
+</svg>

--- a/src/icons/lucide-venus.svg
+++ b/src/icons/lucide-venus.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+  stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+  class="lucide lucide-venus-icon lucide-venus">
+  <path d="M12 15v7" />
+  <path d="M9 19h6" />
+  <circle cx="12" cy="9" r="6" />
+</svg>

--- a/src/tts/ChatHistoryManager.ts
+++ b/src/tts/ChatHistoryManager.ts
@@ -161,6 +161,7 @@ export class ChatHistorySpeechManager implements ResourceReleasable {
       childList: true,
       subtree: true,
       attributes: true,
+      attributeOldValue: true, // Enable tracking of old attribute values for debugging
     });
     this.observers.push(newMessagesObserver);
     return newMessagesObserver;

--- a/src/tts/SpeechModel.ts
+++ b/src/tts/SpeechModel.ts
@@ -255,6 +255,10 @@ interface SpeechSynthesisVoiceRemote extends SpeechSynthesisVoice {
   price_per_thousand_chars_in_usd: number; // price in USD per 1k characters
   price_per_thousand_chars_in_credits: number; // price in credits per 1k characters
   powered_by: string;
+  // Optional metadata for richer voice menus (may be omitted by server)
+  gender?: string;        // e.g., "F", "M" (or descriptive string)
+  accent?: string;        // e.g., "American", "British"
+  description?: string;   // short human-friendly description
 }
 
 interface MatchableVoice {


### PR DESCRIPTION
Enhances Claude’s voice picker with more voice options, and helps users compare and choose from a longer list of TTS voices without clutter:

- Accent flag chip (based on BCP‑47 `accent` with region) when accents vary
- Gender chip using Lucide icons (`mars`/`venus`) when genders vary
- Price chip (compact `$0.3/1k`) only when prices vary
- Chips are inline with the voice name (same row) to reduce vertical height
- Subtle divider between items for easier visual scanning
- Correct SVG handling so Lucide stroke icons render crisply (no accidental fill)

## User impact
- Faster scanning and easier differentiation between voices
- No new actions or settings; purely presentational improvements

## Implementation details
- Heuristics computed once per menu build to avoid noise:
  - Show accent only if more than one accent is present
  - Show gender only if more than one gender is present
  - Show price only if prices differ
- Accent expects a BCP‑47 tag in the `accent` field (e.g., `en-US`). We use the region subtag to display a flag from `src/icons/flags`.
- Gender icons are inline SVG (Lucide) to inherit `currentColor` and match other icons.
- Subtle 1px dividers are appended to each menu item except the last.

## Files changed
- `src/chatbots/ClaudeVoiceMenu.ts` — UI: chips inline with name, subtle dividers, flag lookup, heuristics
- `src/tts/VoiceMenu.ts` — fix `addSvgToButton` to preserve Lucide SVG attributes (stroke/fill/viewBox)
- `src/tts/SpeechModel.ts` — extend voice type with optional `gender?`, `accent?`, `description?`
- `src/icons/lucide-globe.svg` — Lucide globe asset
- `src/icons/lucide-mars.svg` — Lucide mars icon
- `src/icons/lucide-venus.svg` — Lucide venus icon

## Notes for server API
- Return `accent` as BCP‑47 (e.g., `en-US`, `en-GB`). We do not use a separate `locale` field.
- Suggested description length: ≤ ~60 chars, front‑load tone/feel.

## How to test
1. Build the extension (`npm run build`) and load the unpacked build.
2. Open Claude and the voice menu.
3. Verify:
   - Flags render for accents with region; no globe shown when accent missing/invalid.
   - Gender icons (♂/♀ via Lucide) appear only when genders vary across the list.
   - Price chip appears only if prices differ.
   - Chips render inline right of the name, above the description.
   - Subtle dividers appear between items (not after the last item).

## Screenshots
Light Theme
<img width="863" height="836" alt="saypi claude voices light theme" src="https://github.com/user-attachments/assets/154ff793-9182-4f8b-943b-966daa81557f" />


## Risks / compatibility
- No breaking changes in UI events or APIs.
- Flags resolve from `src/icons/flags` via `chrome.runtime.getURL` (already web‑accessible in the manifest; no duplication in `public/`).

## Follow‑ups
- Dark theme and theme switching polish (divider tone, secondary text contrast)
- Optional: per‑voice preview button
