### PR TITLE
Guard TTS stream closure until chunk sends finish

### DIFF
--- a/test/tts/InputBuffer.spec.ts
+++ b/test/tts/InputBuffer.spec.ts
@@ -86,12 +86,13 @@ describe('InputBuffer', () => {
     expect(ttsService.addTextToSpeechStream).toHaveBeenCalledWith(uuid, 'Hello world');
   });
 
-  it('should close buffer on endInput', () => {
+  it('should close buffer on endInput', async () => {
     inputBuffer.endInput();
     const closeAfterMs = 100;
     vi.advanceTimersByTime(closeAfterMs);
 
     expect(inputBuffer.hasEnded()).toBe(true);
+    await vi.runAllTicks();
     expect(ttsService.addTextToSpeechStream).toHaveBeenCalledWith(uuid, '');
   });
 


### PR DESCRIPTION
## Summary
- track pending chunk send promises in the input buffer so the end-of-stream marker is not sent until earlier flushes resolve
- add detailed logging around `/speak/{uuid}/stream` requests to highlight latency and unexpected failures
- update the input buffer unit test to await the async close flush path

## Testing
- npx vitest run test/tts/InputBuffer.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ddaa028550832aa0d77c6ee45c500a