### PR TITLE
Add client-side deduplication for streamed TTS text

### DIFF
--- a/src/tts/TextChunkDeduplicator.ts
+++ b/src/tts/TextChunkDeduplicator.ts
@@ -1,0 +1,87 @@
+export interface DeduplicatedChunk {
+  novelText: string;
+  removedText: string;
+  overlapLength: number;
+  leadingWhitespace: string;
+  originalChunk: string;
+  consumedEntireChunk: boolean;
+}
+
+const DEFAULT_CONTEXT_WINDOW = 400;
+const MIN_OVERLAP = 4;
+
+const TRAILING_WHITESPACE_REGEX = /\s+$/u;
+const LEADING_WHITESPACE_REGEX = /^\s+/u;
+
+export class TextChunkDeduplicator {
+  private history: string = "";
+
+  constructor(private readonly contextWindow: number = DEFAULT_CONTEXT_WINDOW) {}
+
+  deduplicate(chunk: string, pendingBuffer: string): DeduplicatedChunk | null {
+    if (!chunk) {
+      return null;
+    }
+
+    const context = this.buildContext(pendingBuffer);
+    if (!context) {
+      return null;
+    }
+
+    const trimmedChunk = chunk.replace(LEADING_WHITESPACE_REGEX, "");
+    if (!trimmedChunk) {
+      return null;
+    }
+
+    const leadingWhitespaceLength = chunk.length - trimmedChunk.length;
+    const leadingWhitespace = chunk.slice(0, leadingWhitespaceLength);
+
+    const overlapLength = this.findOverlap(context, trimmedChunk);
+    if (overlapLength < MIN_OVERLAP) {
+      return null;
+    }
+
+    const removedText = trimmedChunk.slice(0, overlapLength);
+    const novelText = trimmedChunk.slice(overlapLength);
+
+    return {
+      novelText,
+      removedText: leadingWhitespace + removedText,
+      overlapLength,
+      leadingWhitespace,
+      originalChunk: chunk,
+      consumedEntireChunk: novelText.length === 0,
+    };
+  }
+
+  registerProcessedText(text: string): void {
+    if (!text) {
+      return;
+    }
+    this.history = (this.history + text).slice(-this.contextWindow);
+  }
+
+  reset(): void {
+    this.history = "";
+  }
+
+  private buildContext(pendingBuffer: string): string {
+    const combined = `${this.history}${pendingBuffer}`;
+    if (!combined) {
+      return "";
+    }
+    return combined.replace(TRAILING_WHITESPACE_REGEX, "").slice(-this.contextWindow);
+  }
+
+  private findOverlap(context: string, chunk: string): number {
+    const maxOverlap = Math.min(context.length, chunk.length);
+    for (let length = maxOverlap; length > 0; length--) {
+      const contextSuffix = context.slice(-length);
+      const chunkPrefix = chunk.slice(0, length);
+      if (contextSuffix === chunkPrefix) {
+        return length;
+      }
+    }
+    return 0;
+  }
+}

--- a/test/tts/TextChunkDeduplicator.spec.ts
+++ b/test/tts/TextChunkDeduplicator.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { TextChunkDeduplicator } from "../../src/tts/TextChunkDeduplicator";
+
+describe("TextChunkDeduplicator", () => {
+  it("removes previously flushed overlap while preserving new content", () => {
+    const deduplicator = new TextChunkDeduplicator();
+    deduplicator.registerProcessedText("The answer is clear.");
+
+    const result = deduplicator.deduplicate(
+      "The answer is clear. We need to act.",
+      ""
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.novelText).toBe(" We need to act.");
+    expect(result!.consumedEntireChunk).toBe(false);
+  });
+
+  it("removes overlap against pending buffer content", () => {
+    const deduplicator = new TextChunkDeduplicator();
+
+    const result = deduplicator.deduplicate(
+      " But maybe that's the point.",
+      "But maybe that's"
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.novelText).toBe(" the point.");
+  });
+
+  it("handles whitespace variation at chunk boundaries", () => {
+    const deduplicator = new TextChunkDeduplicator();
+    deduplicator.registerProcessedText("Hello world");
+
+    const result = deduplicator.deduplicate(
+      " Hello world, how are you?",
+      ""
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.novelText).toBe(", how are you?");
+  });
+
+  it("supports partial word overlaps", () => {
+    const deduplicator = new TextChunkDeduplicator();
+
+    const result = deduplicator.deduplicate(
+      "incomplete sentence",
+      "incomp"
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.novelText).toBe("lete sentence");
+  });
+
+  it("preserves chunks that are entirely repeated", () => {
+    const deduplicator = new TextChunkDeduplicator();
+
+    const result = deduplicator.deduplicate(" little lamb,", "Mary had a little lamb,");
+
+    expect(result).not.toBeNull();
+    expect(result!.consumedEntireChunk).toBe(true);
+  });
+
+  it("keeps structural whitespace when it is meaningful", () => {
+    const deduplicator = new TextChunkDeduplicator();
+    deduplicator.registerProcessedText("Hello world");
+
+    const result = deduplicator.deduplicate("\nHello world again", "");
+
+    expect(result).not.toBeNull();
+    expect(result!.leadingWhitespace).toBe("\n");
+    expect(result!.novelText).toBe(" again");
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable TextChunkDeduplicator to detect and remove overlaps between streamed chunks
- integrate deduplication into the TTS InputBuffer and log overlap handling while preserving structural whitespace
- cover common and edge scenarios with new unit suites for the deduplicator and the InputBuffer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de88c90c14832a9ac48ca7da473ac6