### PR TITLE
fix(claude): detect sidebar nav menu structurally, not by English labels

### DIFF
--- a/src/chatbots/Claude.ts
+++ b/src/chatbots/Claude.ts
@@ -220,53 +220,67 @@ class ClaudeChatbot extends AbstractChatbot {
   }
 
   getSidebarConfig(sidebar: HTMLElement): SidebarConfig | null {
-    // Claude's sidebar structure (Jan 2025):
-    // - "New chat" is in its own container above the scrollable area
-    // - "Chats, Projects, Artifacts, Code" are in a flex column inside the scrollable area
-    // We want to insert our button after "Code" in that menu container
+    // Claude's sidebar groups "New chat" in its own container above the scrollable
+    // area, with the primary navigation (Chats, Projects, Artifacts, Code, ...) in a
+    // separate flex column. We append our voice-settings button after the last item
+    // in that navigation column.
+    //
+    // Claude restructures and *localizes* these labels frequently, so we identify the
+    // column structurally (a flex column of short-labelled link/button rows) rather
+    // than by hard-coded English label text. Known English labels are used only as a
+    // preference signal to disambiguate when more than one column looks menu-like
+    // (e.g. a recent-chats list); they are never required.
+    const NAV_LABEL_MAX_LEN = 30;
+    const KNOWN_LABELS = ["chats", "projects", "artifacts", "code"];
 
-    // Strategy: Find the container that has menu items like "Chats", "Projects", "Artifacts", "Code"
-    // These are direct children divs that contain anchor or button elements with those labels
-    const findMenuContainer = (): HTMLElement | null => {
-      // Look for a flex column container that has the navigation items
-      const candidates = Array.from(sidebar.querySelectorAll('div.flex.flex-col'));
-
-      for (const candidate of candidates) {
-        // Check if this container has children that look like menu items
-        const children = Array.from(candidate.children);
-        if (children.length < 3) continue;
-
-        // Look for recognizable menu items (Chats, Projects, Artifacts, Code)
-        const menuLabels = ['chats', 'projects', 'artifacts', 'code'];
-        const foundLabels = children.filter(child => {
-          const text = child.textContent?.toLowerCase().trim() || '';
-          return menuLabels.some(label => text === label);
-        });
-
-        // If we found at least 3 of the expected menu items, this is our container
-        if (foundLabels.length >= 3) {
-          return candidate as HTMLElement;
-        }
-      }
-
-      return null;
+    // A nav item is a row wrapping a link/button with a short, non-empty label.
+    // Recent-chats rows carry long free-text titles and are excluded by the length cap.
+    const isNavItem = (child: Element): boolean => {
+      const control = child.matches("a, button")
+        ? child
+        : child.querySelector("a, button");
+      if (!control) return false;
+      // Measure the control's own label (not the whole row, which may carry badges)
+      // and collapse whitespace so layout indentation cannot inflate the length.
+      const text = (control.textContent ?? "").replace(/\s+/g, " ").trim();
+      return text.length > 0 && text.length <= NAV_LABEL_MAX_LEN;
     };
 
-    const menuContainer = findMenuContainer();
+    const knownLabelCount = (container: Element): number =>
+      Array.from(container.children).filter((child) =>
+        KNOWN_LABELS.includes((child.textContent ?? "").toLowerCase().trim())
+      ).length;
 
-    if (!menuContainer) {
-      console.warn('[Claude] sidebar: Could not find menu container with navigation items');
+    const navColumns = (
+      Array.from(sidebar.querySelectorAll("div.flex.flex-col")) as HTMLElement[]
+    ).filter((column) => Array.from(column.children).filter(isNavItem).length >= 3);
+
+    // Claude nests the nav column inside outer flex columns that can themselves look
+    // menu-like; keep only the innermost qualifying columns so the button lands among
+    // the nav items rather than as a sibling of the whole column.
+    const candidates = navColumns.filter(
+      (column) => !navColumns.some((other) => other !== column && column.contains(other))
+    );
+
+    if (candidates.length === 0) {
+      console.warn(
+        "[Claude] sidebar: Could not find menu container with navigation items"
+      );
       return null;
     }
 
-    // Insert after "Code" which is typically the last item (position 4, 0-indexed)
-    // Count the actual children to determine insert position
-    const insertPosition = menuContainer.children.length;
+    // Prefer the column with the most recognised labels; otherwise keep document
+    // order (the primary nav sits above any recent-chats list). Sort is stable, so
+    // ties preserve the first-in-document candidate.
+    const menuContainer = candidates
+      .slice()
+      .sort((a, b) => knownLabelCount(b) - knownLabelCount(a))[0];
 
     return {
       buttonContainer: menuContainer,
-      buttonStyle: 'menu',
-      insertPosition: insertPosition,
+      buttonStyle: "menu",
+      // Append after the last existing nav item (#272: "after Code").
+      insertPosition: menuContainer.children.length,
     };
   }
 }

--- a/test/chatbots/ClaudeSidebarConfig.spec.ts
+++ b/test/chatbots/ClaudeSidebarConfig.spec.ts
@@ -24,6 +24,47 @@ beforeAll(async () => {
   ClaudeChatbot = module.ClaudeChatbot;
 });
 
+/**
+ * Build a Claude-like sidebar. Mirrors the real structure documented in #272:
+ * "New chat" sits in its own container above the scrollable area, while the
+ * primary navigation items live in a separate flex column inside it.
+ *
+ * `menuLabels` populates that nav column. `recentsTitles`, when given, adds a
+ * second flex column resembling the recent-chats list (long, free-text titles).
+ */
+function buildSidebar(menuLabels: string[], recentsTitles: string[] = []): string {
+  const navItems = menuLabels
+    .map((label) => `<div class="group"><a class="nav-link" href="/x">${label}</a></div>`)
+    .join("\n");
+  const recents = recentsTitles.length
+    ? `
+            <div class="flex flex-col gap-1" data-region="recents">
+              ${recentsTitles
+                .map((t) => `<div class="group"><a class="nav-link" href="/chat/uuid">${t}</a></div>`)
+                .join("\n              ")}
+            </div>`
+    : "";
+  return `
+    <aside>
+      <nav aria-label="Sidebar">
+        <div class="px-3 py-2">
+          <a data-testid="new-chat-button" href="/new">New chat</a>
+        </div>
+        <div class="flex-1 overflow-y-auto">
+          <div class="flex flex-col gap-1" data-region="menu">
+            ${navItems}
+          </div>${recents}
+        </div>
+      </nav>
+    </aside>
+  `;
+}
+
+function sidebarFrom(html: string, chatbot: InstanceType<typeof ClaudeChatbot>): HTMLElement {
+  const dom = new JSDOM(html);
+  return dom.window.document.querySelector(chatbot.getSidebarSelector()) as HTMLElement;
+}
+
 describe("Claude sidebar integration (GH-250/GH-252)", () => {
   let chatbot: InstanceType<typeof ClaudeChatbot>;
 
@@ -32,73 +73,93 @@ describe("Claude sidebar integration (GH-250/GH-252)", () => {
   });
 
   it("should find the sidebar via selector", () => {
-    const html = `
-      <aside>
-        <nav aria-label="Sidebar">
-          <div class="px-4 py-3">
-            <div class="flex flex-col gap-1">
-              <div class="nav-item">
-                <a data-testid="new-chat-button" class="nav-link">New chat</a>
-              </div>
-              <div class="nav-item">
-                <button class="nav-link">Search chats</button>
-              </div>
-              <div class="nav-item">
-                <a class="nav-link">Library</a>
-              </div>
-              <div class="nav-item">
-                <a class="nav-link">Codex</a>
-              </div>
-            </div>
-          </div>
-        </nav>
-      </aside>
-    `;
-
-    const dom = new JSDOM(html);
-    const selector = chatbot.getSidebarSelector();
-    const sidebar = dom.window.document.querySelector(selector);
+    const sidebar = sidebarFrom(buildSidebar(["Chats", "Projects", "Artifacts"]), chatbot);
     expect(sidebar).not.toBeNull();
   });
 
-  it("should provide menu configuration and tag the sidebar element", () => {
-    const html = `
-      <aside>
-        <nav aria-label="Sidebar">
-          <div class="px-4 py-3">
-            <div class="flex flex-col gap-1">
-              <div class="nav-item">
-                <a data-testid="new-chat-button" class="nav-link">New chat</a>
-              </div>
-              <div class="nav-item">
-                <button class="nav-link">Search chats</button>
-              </div>
-              <div class="nav-item">
-                <a class="nav-link">Library</a>
-              </div>
-              <div class="nav-item">
-                <a class="nav-link">Codex</a>
-              </div>
-            </div>
-          </div>
-        </nav>
-      </aside>
-    `;
-
-    const dom = new JSDOM(html);
-    const selector = chatbot.getSidebarSelector();
-    const sidebar = dom.window.document.querySelector(selector) as HTMLElement;
-    expect(sidebar).not.toBeNull();
+  it("provides a menu config and appends the button after the last nav item", () => {
+    const sidebar = sidebarFrom(buildSidebar(["Chats", "Projects", "Artifacts"]), chatbot);
 
     const config = chatbot.getSidebarConfig(sidebar);
     expect(config).not.toBeNull();
     expect(config?.buttonStyle).toBe("menu");
+    // The button is appended after the existing nav items (#272: "after Code").
+    expect(config?.buttonContainer.children.length).toBe(3);
     expect(config?.insertPosition).toBe(3);
-    expect(config?.buttonContainer.children.length).toBe(4);
+    expect(config?.buttonContainer.getAttribute("data-region")).toBe("menu");
   });
 
-  it("returns null when menu container cannot be determined", () => {
-    const html = `
+  it("finds the nav menu regardless of label language (i18n robustness)", () => {
+    // Claude localizes its sidebar labels; detection must not depend on English text.
+    const sidebar = sidebarFrom(
+      buildSidebar(["Unterhaltungen", "Projekte", "Artefakte"]),
+      chatbot
+    );
+
+    const config = chatbot.getSidebarConfig(sidebar);
+    expect(config).not.toBeNull();
+    expect(config?.buttonContainer.getAttribute("data-region")).toBe("menu");
+    expect(config?.buttonContainer.children.length).toBe(3);
+  });
+
+  it("selects the nav menu and ignores a recent-chats list of long titles", () => {
+    // A recent-chats column (free-text titles) must not be mistaken for the nav menu,
+    // even when the nav labels are localized so English-label matching cannot help.
+    const sidebar = sidebarFrom(
+      buildSidebar(
+        ["Unterhaltungen", "Projekte", "Artefakte"],
+        [
+          "How do I configure the WXT build for Firefox MV2 support?",
+          "Debugging the offscreen audio bridge handshake timeout",
+          "Why does the VAD clip the first word of my sentence",
+          "Notes on the dual-phase contextual transcription design",
+        ]
+      ),
+      chatbot
+    );
+
+    const config = chatbot.getSidebarConfig(sidebar);
+    expect(config).not.toBeNull();
+    expect(config?.buttonContainer.getAttribute("data-region")).toBe("menu");
+  });
+
+  it("selects the innermost nav column when wrapped in an outer flex column", () => {
+    // Claude nests the nav column inside outer flex columns that can themselves look
+    // menu-like. Detection must target the innermost column so the button is appended
+    // among the nav items, not as a sibling of the whole column. Localized + short
+    // labels here defeat the English-label tie-break, isolating the structural choice.
+    // Single-line markup keeps the inner column's textContent short so the OUTER
+    // column also qualifies — without innermost-preference the outer would be chosen.
+    const sidebar = sidebarFrom(
+      `<aside><nav aria-label="Sidebar"><div class="flex flex-col" data-region="outer"><div class="flex flex-col gap-1" data-region="menu"><div class="group"><a href="/x">Chat</a></div><div class="group"><a href="/x">Proj</a></div><div class="group"><a href="/x">Art</a></div></div><div class="group"><a href="/x">Foo</a></div><div class="group"><a href="/x">Bar</a></div></div></nav></aside>`,
+      chatbot
+    );
+
+    const config = chatbot.getSidebarConfig(sidebar);
+    expect(config).not.toBeNull();
+    expect(config?.buttonContainer.getAttribute("data-region")).toBe("menu");
+  });
+
+  it("prefers the nav menu over a recents list of short titles (localized, document order)", () => {
+    // Even when recent-chat titles are short enough to look like nav items and the
+    // labels are localized (no English-label tie-break), the nav column wins because
+    // it precedes the recents list in document order.
+    const sidebar = sidebarFrom(
+      buildSidebar(
+        ["Unterhaltungen", "Projekte", "Artefakte"],
+        ["VAD Bug", "Auth Flow", "CORS Fix", "WXT Setup"]
+      ),
+      chatbot
+    );
+
+    const config = chatbot.getSidebarConfig(sidebar);
+    expect(config).not.toBeNull();
+    expect(config?.buttonContainer.getAttribute("data-region")).toBe("menu");
+  });
+
+  it("returns null when no nav menu container is present", () => {
+    const sidebar = sidebarFrom(
+      `
       <aside>
         <nav aria-label="Sidebar">
           <div class="px-4 py-3">
@@ -106,11 +167,9 @@ describe("Claude sidebar integration (GH-250/GH-252)", () => {
           </div>
         </nav>
       </aside>
-    `;
-
-    const dom = new JSDOM(html);
-    const selector = chatbot.getSidebarSelector();
-    const sidebar = dom.window.document.querySelector(selector) as HTMLElement;
+      `,
+      chatbot
+    );
     expect(sidebar).not.toBeNull();
 
     const config = chatbot.getSidebarConfig(sidebar);


### PR DESCRIPTION
## Why

`npm test` was **red on `main`** (Wave 0 finding #1): `test/chatbots/ClaudeSidebarConfig.spec.ts` failed, which hollows out the entire merge gate (a "CI green" requirement is meaningless while main is red).

Root cause: commit #272 (`1b91c01`) rewrote `ClaudeChatbot.getSidebarConfig()` to locate the sidebar menu by matching direct-child text **exactly** against a hardcoded English list `['chats','projects','artifacts','code']` (≥3 required). That has two problems:

1. **It's a likely shipped regression, not just a stale test.** Any localized or relabelled Claude sidebar matches none of those labels → `getSidebarConfig` returns `null` → `decorateSidebar` silently skips (`bootstrap.ts:325-332`) → SayPi's voice-settings button never mounts. SayPi is i18n'd (`_locales/`), and Claude renames sidebar items often, so this is a real user-facing failure mode.
2. The test (written pre-#272 in #253) asserted the old contract and was never updated.

This is the gating fix for the whole autonomous loop, so it's PR 1.

## What changed

`getSidebarConfig()` now detects the nav column **structurally** instead of by English label text:

- A nav column is a `div.flex.flex-col` whose ≥3 direct children are short-labelled link/button rows (label measured on the control, whitespace-collapsed, ≤30 chars — long recent-chat titles are excluded).
- The known English labels are kept only as a **preference signal** to disambiguate when more than one column looks menu-like (e.g. a recents list) — they are never required, so localized sidebars work.
- **Innermost-column preference**: Claude nests the nav column inside outer flex columns that themselves look menu-like; we drop any candidate that contains another candidate, so the button lands among the nav items rather than as a sibling of the whole column.
- Appends after the last nav item, per #272's documented "after Code" intent.

## Tests (fail-first)

Rewrote/expanded `ClaudeSidebarConfig.spec.ts` (3 → 7 tests). New tests were confirmed RED against the current code before the fix:
- i18n/relabel robustness (German labels)
- ignores a recent-chats list of long titles
- selects the innermost nav column when nested (the ancestor/descendant trap)
- prefers the nav menu over a short-titled recents list via document order

## Verification

- `npm test`: **Jest 2/2; Vitest 72 files, 703 passed, 1 skipped, 0 failed** — restores the green baseline.
- `tsc --noEmit`: clean on the changed files.

## Review

Ran a two-lens adversarial subagent review (heuristic-correctness + regression-safety/test-integrity). Both returned APPROVE-WITH-NITS; their substantive findings were adopted in this PR: the innermost-column (ancestor/descendant) guard, measuring the control's own label + whitespace normalization, removal of a tautological assertion (`insertPosition` now asserts the concrete value), and the two extra edge-case tests. Speculative findings (deep `sr-only` handling, Tailwind class-coupling) are deferred to the live-DOM follow-up.

## Follow-up

⚠️ The detection logic could **not** be verified against the live Claude.ai DOM this session (browser inspection tool unavailable). #273 tracks a layer-4 real-site spot-check (capture the real DOM into a recorded fixture; confirm the button mounts correctly) — **to be completed before any store release**. Merging this to `main` does not ship to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
