### PR TITLE
docs: install autonomous-engineering mandate; reconcile docs to WXT reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,54 @@
 # Repository Guidelines
 
+## Autonomous Engineering Mandate
+
+Since 2026-06-13, saypi-userscript is maintained as an **autonomously engineered product**: Claude Code agents run the full engineering loop under standing authorization from the founder (Ross Cadogan), the same operating model proven on saypi-api and saypi-saas. This section is the constitution for those sessions; the original bootstrap brief is `doc/autonomous-bootstrap.md`. It **complements** — does not replace — the Testing, Commit/PR, and Code-Review rules below.
+
+**Purpose.** Keep the extension improving for its users at founder-level quality and attention to detail — this repo *is* the product the customer touches. Velocity comes from tooling and discipline, never from lowering the bar; here the tooling that must be built first is the **testability net** (see Testability Investment).
+
+**Standing authorization (proceed without asking):**
+- Explore the codebase; bring `AGENTS.md`/`CLAUDE.md` to verified reality; remove dead cruft coherently.
+- Build the testability layers and their CI wiring — *additive* test/CI changes are explicitly yours to make.
+- Triage the backlog with adversarially-verified evidence; file issues per the Issue Authoring Standard.
+- Fix issues via fail-first TDD (see Testing Guidelines) in **isolated git worktrees**; open small, blast-radius-scoped PRs with full provenance (narrative why/what/verification, `Fixes #N`, Claude Code attribution).
+- Review every PR with independent subagent reviewers before merge (multi-lens for the high-blast-radius domains below). GitHub disallows self-approval, so post verdicts as PR comments.
+- Merge when gates pass; keep persistent operational memory across sessions.
+
+**Merge gate (default):** CI green (`npm test` — Jest **and** Vitest) **plus** a reviewer-subagent verdict on the PR. No flake exceptions until a specific chronic flake is documented in an issue with its exact signature.
+
+**High-blast-radius changes — multi-lens adversarial review + founder sign-off before merge:**
+- Auth / JWT (`src/JwtManager.ts`, OAuth/PKCE in `src/auth/`).
+- Request-contract changes with saypi-api that *require the server (saypi-api/saypi-saas) to also change* (new/changed fields/headers the server must parse, origin/CORS, auth). Backward-compatible *adoption* of a contract the server already supports is normal-gate.
+- MV2/MV3 manifest, permissions, or content-script injection scope (`wxt.config.ts`).
+
+**Hard guardrails (defense-in-depth):**
+- All changes via PR. Never push to `main`, force-push shared branches, or touch branches/issues/PRs that aren't yours.
+- Begin every commit/push command with `[ "$(git rev-parse --abbrev-ref HEAD)" = "<expected-branch>" ] || exit 1` in the same shell invocation. After `gh pr merge`, confirm `gh pr view --json state` is `MERGED`.
+- Never hand-edit generated artifacts: `.output/`, `dist/`, `public/` build output, `.wxt/`. Fix the generator or env input instead.
+- **Credentials (permanent boundary):** never read, copy, load, or echo `.env.production` or any secret; never run `npm run env:pull` against production. Copy only non-production env files into worktrees; never commit them.
+- Gate-weakening (removing/skipping/`.only` tests, relaxing CI triggers/required checks) and any edit to manifest generation, permissions, signing, or store-submission plumbing require founder sign-off.
+
+**Release is founder-only.** **Merging to `main` does NOT reach users.** Production artifacts come from `npm run build` / `build:firefox` and are submitted to the web stores (Chrome Web Store, Firefox AMO) by the founder — store-review-gated and effectively irreversible once users auto-update. Agents may run `npm run build*` *locally for verification only* and stage a release-ready changelog/checklist, but must **never** produce/submit a signed store artifact or load `.env.production` without explicit founder authorization. A bad release is higher, slower-to-reverse customer impact than a server deploy — treat it with more caution.
+
+**Testability Investment (the heart of the mandate).** Real behavior lives in third-party DOMs across two browsers and two manifest versions, so full cross-browser E2E is the *last* mile, not the first. Build toward it in layers, each paying off immediately: (1) extract unit-testable core logic out of DOM/Chrome-API coupling (lean on the XState machines in `src/state-machines/`; `@xstate/test` is a dependency); (2) contract-test the `src/chatbots/` platform adapters with **recorded real-DOM fixtures**; (3) headless E2E against a *local mock* chat page wired into CI (WXT ships `wxt/testing` `fakeBrowser`, purpose-built for this layer and not yet wired in); (4) reserve real-site E2E (Claude-in-Chrome) for periodic spot-checks, not a per-PR gate.
+
+**Escalate to the founder only for:** product/UX taste calls (what/whether to build), credentials/resources you lack, **store releases**, contract changes that require the server side to change, gate-weakening or release-machinery edits, irreversible actions, or anything risking customer trust. Otherwise proceed. End every session with a handoff: shipped / in-flight / waiting-on-human / built-but-unreleased.
+
+### Issue Authoring Standard
+- **Problem:** one-sentence summary of what's wrong.
+- **Scope:** which surfaces/flows are affected (and what's explicitly out of scope).
+- **Reproduction / verification:** precise, deterministic steps; expected vs actual.
+- **Acceptance criteria:** verifiable end states; avoid prescribing implementation.
+- **Notes/Hypotheses (optional):** clearly labelled as non-binding.
+
+Keep issues factual; exclude speculative root-cause or solution ideas from the body.
+
 ## Project Structure & Module Organization
-- `src/` TypeScript/ESM source. Entry: `src/saypi.index.js`; background/offscreen in `src/svc/` and `src/offscreen/`; UI in `src/popup/`, visuals in `src/styles/`, chatbot integrations in `src/chatbots/`.
-- `public/` Webpack output (e.g., `saypi.user.js`, `offscreen/*.js`, `permissions/*`). Do not edit generated files.
-- `test/` Tests mirror `src/`. Vitest: `*.spec.ts`; Jest: `*.test.js`. Common setup in `test/vitest.setup.js` and `test/jest.setup.js`.
-- `_locales/` i18n bundles; `scripts/` build helpers; `doc/` reference; `manifest.json` extension metadata.
+- `entrypoints/` WXT entry layer. `background.ts`, `saypi.content.ts`, and `saypi-universal.content.ts` are thin shims that import logic from `src/`; `entrypoints/offscreen/` and `entrypoints/settings/` (a substantial multi-file UI) hold their own entry-specific code; `entrypoints/permissions/` is a permissions-request page.
+- `src/` TypeScript/ESM source. Content-script bootstrapper: `src/saypi.index.js` (imported by `entrypoints/saypi.content.ts`); background/offscreen logic in `src/svc/` and `src/offscreen/`; shared settings styles/helpers in `src/popup/`; visuals in `src/styles/`; XState machines in `src/state-machines/`; chatbot integrations in `src/chatbots/`.
+- `.output/` WXT build output (`.output/chrome-mv3/`, `.output/firefox-mv2/`) — generated, git-ignored, never hand-edited. `public/` holds static assets copied verbatim by WXT (ONNX/WASM/icons), not build artifacts.
+- `test/` Tests mirror `src/` and `entrypoints/` (e.g. `test/settings/` ↔ `entrypoints/settings/`). Vitest: `*.spec.ts`; Jest: `*.test.js` only. Common setup in `test/vitest.setup.js` and `test/jest.setup.js`.
+- `_locales/` i18n bundles; `scripts/` build helpers; `doc/` reference. The manifest is generated by WXT from `wxt.config.ts` (the root `manifest.json` is legacy/unused by the WXT build).
 
 ## Build, Test, and Development Commands
 - `npm run dev` — WXT dev server for Chrome/Edge (MV3) with live reload; runs `predev` first.
@@ -60,8 +104,8 @@ When fixing bugs, follow this strict protocol:
 - PRs: clear description, linked issues, screenshots/GIFs for UI, passing tests, and updated docs/i18n when applicable.
 
 ## Security & Configuration Tips
-- Never commit secrets. Create local `.env` / `.env.production` from the templates (`.env.example`, `.env.production.example`) and fill in values such as `API_SERVER_URL`, `AUTH_SERVER_URL`.
-- `webpack` generates `src/popup/popup-config.js` from env — don’t edit it manually.
+- Never commit secrets. Create local `.env` / `.env.production` from the templates (`.env.example`, `.env.production.example`) and fill in values such as `API_SERVER_URL`, `AUTH_SERVER_URL`. (A 1Password flow exists via `npm run env:pull`; never run it against production.)
+- Env values reach the bundle via WXT/`import.meta.env`, validated by `scripts/validate-env.js` (run automatically before dev/build). There is no generated `popup-config.js`.
 - For HTTPS dev, set `CERT_DIR` with `localhost.pem` and `localhost-key.pem`.
 
 ## Assistant/Agent Docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build Commands
 
-- `npm run dev` - WXT dev server with live reload for Chromium targets (runs manifest update first)
+- `npm run dev` - WXT dev server (Chrome/Edge MV3) with live reload (`predev` runs env validation + ONNX copy first)
 - `npm run dev:firefox` - Firefox MV2 dev session (`wxt --browser firefox --mv2`; opens a temporary private profile)
-- `npm run build` - Production build (validates locale files, copies ONNX files, updates manifest)
+- `npm run build` - Production build via `wxt build` (`prebuild` validates env + i18n and copies ONNX; WXT generates the manifest)
 - `npm run build:firefox` - Build and package for Firefox
 - `npm test` - Run all tests (Jest + Vitest)
 - `npm run test:jest` - Run Jest tests only
 - `npm run test:vitest` - Run Vitest tests only  
 - `npm run test:vitest:watch` - Run Vitest in watch mode
 - `npm run copy-onnx` - Copy ONNX model files from dependencies
-- `npm run start` - Start development server
+- `npm run start` - Static file server (`node server.js`) for `public/` assets; not the WXT dev server (use `npm run dev`)
 - `npm run validate:env` - Validate local `.env` files (runs automatically before dev/build)
 
 ### Environment Setup
@@ -25,7 +25,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Architecture Overview
 
 ### Extension Type
-This is a Chrome/Firefox extension (manifest v3) that enhances voice interactions with AI chatbots (Pi.ai and Claude.ai).
+This is a browser extension built with **WXT** that enhances voice interactions with AI chatbots (Pi.ai, Claude.ai, ChatGPT). It targets Chrome/Edge (Manifest V3) and Firefox (Manifest V2).
 
 ### Browser Compatibility
 
@@ -44,9 +44,12 @@ For detailed browser and feature compatibility across different chatbot sites, s
 ### Key Components
 
 #### Entry Points
-- **src/saypi.index.js** - Main content script entry point that bootstraps the extension
-- **src/svc/background.ts** - Service worker handling extension lifecycle, auth, and message routing
-- **src/offscreen/** - Offscreen documents for audio processing under strict CSP
+WXT discovers entry points in **`entrypoints/`**; each is a thin shim that imports the real logic from `src/`.
+- **entrypoints/saypi.content.ts → src/saypi.index.js** - Main content script that bootstraps the extension on chatbot sites
+- **entrypoints/saypi-universal.content.ts** - Content script for universal dictation on all other sites
+- **entrypoints/background.ts → src/svc/background.ts** - Service worker handling extension lifecycle, auth, and message routing
+- **entrypoints/offscreen/ → src/offscreen/** - Single offscreen document for audio/VAD processing under strict CSP (Chrome/Edge only)
+- **entrypoints/settings/** - Extension settings page UI (shared styles/helpers in `src/popup/`)
 
 #### Core Systems
 
@@ -56,9 +59,9 @@ For detailed browser and feature compatibility across different chatbot sites, s
    - `Claude.ts`, `Pi.ts` - Chatbot-specific implementations with DOM selectors and UI integration
 
 2. **Audio Pipeline** (`src/audio/`)
-   - `AudioModule.js` - Main audio coordination and state management
+   - `AudioModule.js` - Main audio coordination and state management (interprets the audio XState actors)
    - `OffscreenAudioBridge.js` - Communication bridge between content script and offscreen audio processing
-   - `AudioInputMachine.ts`, `AudioOutputMachine.ts` - State machines for audio input/output flow
+   - **State machines** live in `src/state-machines/` (not `src/audio/`): `AudioInputMachine.ts`, `AudioOutputMachine.ts`, `AudioRetryMachine.ts`, plus `ConversationMachine.ts`, `DictationMachine.ts`, and others
    - **Dictation transcription**: Uses dual-phase approach (live streaming + refinement) - see [doc/DUAL_PHASE_TRANSCRIPTION.md](doc/DUAL_PHASE_TRANSCRIPTION.md)
 
 3. **Voice Activity Detection** (`src/vad/`)
@@ -68,7 +71,7 @@ For detailed browser and feature compatibility across different chatbot sites, s
 
 4. **Text-to-Speech** (`src/tts/`)
    - `TextToSpeechService.ts` - Core TTS management
-   - `ChatHistoryManager.ts` - Manages TTS for chat messages
+   - `ChatHistoryManager.ts` (exports `ChatHistorySpeechManager`) - Manages TTS for chat messages
    - `VoiceMenuUIManager.ts` - Voice selection UI components
 
 5. **DOM Management** (`src/dom/`)
@@ -98,41 +101,21 @@ For detailed browser and feature compatibility across different chatbot sites, s
 
 ### Build System
 
-- **Webpack** bundles TypeScript/JavaScript with multiple entry points
-- **Environment-specific configs** injected via webpack DefinePlugin
-- **Asset copying** for ONNX models, WASM files, and extension resources
-- **Minification enabled** in production builds to meet Firefox AMO 5MB file limit
-- **Code splitting** separates vendor libraries and enables on-demand loading
+- **WXT** (Vite/Rollup under the hood) builds the extension — there is **no Webpack**. `wxt build` produces the per-target output; `wxt --browser chrome` runs the dev server. Config: `wxt.config.ts`.
+- **Entry points** are defined in `entrypoints/`; the **manifest is generated** by WXT from `wxt.config.ts`, with per-target permissions (Chrome adds `offscreen`/`audio`/`identity`; Firefox MV2 omits `offscreen`).
+- **Environment values** are injected via WXT/`import.meta.env`, validated by `scripts/validate-env.js` (runs before dev/build).
+- **Asset copying** for ONNX models and VAD WASM (`npm run copy-onnx`) lands in `public/` (WXT's static `publicDir`) and is copied verbatim.
+- **Code splitting / minification** are handled by Vite/Rollup; minification keeps non-binary files under Firefox AMO's 5MB limit.
 
 #### Build Output
 
-The webpack build produces the following files in `/public`:
+`wxt build` emits to **`.output/<target>/`** (git-ignored) — e.g. `.output/chrome-mv3/` (MV3) and `.output/firefox-mv2/` (MV2). Each contains the generated `manifest.json`, `background.js`, `content-scripts/` (`saypi.js`, `saypi-universal.js`), hashed `chunks/`, and the HTML pages (`offscreen.html`, `settings.html`, `permissions.html`). Store-submission packaging (zipping the per-target `.output/` dir) is part of the founder-run release step.
 
-**Core bundles (8 files):**
-- `saypi.user.js` (450KB) - Main content script entry point
-- `background.js` (45KB) - Service worker
-- `common.bundle.js` (63KB) - Shared code across entry points
-- `vendor-onnx.bundle.js` (534KB) - ONNX runtime for ML inference
-- `vendor-xstate.bundle.js` (63KB) - XState state machine library
-- `vendor-vad.bundle.js` (18KB) - Voice Activity Detection library
-- `vendor-rxjs.bundle.js` (10KB) - RxJS reactive programming
-- `vendors.bundle.js` (29KB) - Other vendor libraries
+> `public/` is the static-asset **source** dir (ONNX/WASM/icons), **not** build output. To inspect actual artifacts, run a build and list `.output/`. Never hand-edit `.output/`, `dist/`, `.wxt/`, or generated files in `public/`.
 
-**Dynamic chunks (loaded on-demand):**
-- `793.js` (131KB) - AIChatModule (loads for Pi.ai, Claude.ai, ChatGPT)
-- `239.js` (33KB) - Supporting modules
-- `208.js`, `301.js`, `411.js`, `763.js` (126B each) - Tiny async chunks
-
-**Other resources:**
-- `lucide.min.js` (362KB) - Icon library for popup UI
-- `vad.worklet.bundle.min.js` (2.6KB) - Audio worklet processor
-- Offscreen scripts: `audio_handler.js`, `media_coordinator.js`, `media_offscreen.js`, `vad_handler.js`
-
-**Binary assets (not counted toward AMO 5MB limit):**
-- 4 WASM files (37MB total) - See [src/vad/README.md](src/vad/README.md) for why all 4 are required
-- 3 ONNX models (5MB total) - Silero VAD models for speech detection
-
-**Total package:** ~50MB (JavaScript: 1.8MB, well under Firefox AMO's 5MB non-binary file limit)
+**Binary assets (not counted toward AMO's 5MB non-binary limit):**
+- 4 WASM files - See [src/vad/README.md](src/vad/README.md) for why all 4 are required
+- 3 ONNX models - Silero VAD models for speech detection
 
 ### Testing
 

--- a/doc/autonomous-bootstrap.md
+++ b/doc/autonomous-bootstrap.md
@@ -1,0 +1,91 @@
+# Autonomous engineering — bootstrap prompt
+
+This document is the bootstrap prompt for running **saypi-userscript as an autonomously engineered
+product**, under the same mandate as saypi-api (`~/SayPi/saypi-api/AGENTS.md`) and saypi-saas.
+Paste its body as the first message of a fresh Claude Code session in this repo to start the
+initiative. It is kept in-repo so the mandate travels with the code, not a single machine.
+
+---
+
+You are taking on a standing mandate from me (Ross Cadogan, SayPi founder): make **saypi-userscript an autonomously engineered product**, the same way saypi-api has been run since June 9, 2026, and saypi-saas after it. The saypi-api experiment shipped ~30 merged PRs and 4 features to production in under two days of elapsed operation with zero deploy-caused downtime — by holding founder-level quality at agent speed. You are extending that operating model to the client.
+
+**This repo is the hard one, and we know why.** It is a browser extension: its real behavior lives in the DOM of third-party chat sites (Pi, Claude, ChatGPT, and more), across two browsers and two manifest versions (Chrome MV3, Firefox MV2). Full cross-browser, cross-platform end-to-end testing is genuinely hard to automate — that is the reason this initiative was sequenced last. **But E2E is the *last* mile, not the first.** An agent can deliver a great deal of durable value before that mile, and your first job is to build the testability that lets the autonomous loop run here at all. Do not start with a fix wave. Start with a **testability-investment wave**.
+
+## Your constitution
+
+Read `~/SayPi/saypi-api/AGENTS.md` **in full** before doing anything else — not just § "Autonomous Engineering Mandate" but its Agent Operating Rules, Bug Fix Protocol (Fail-First TDD), and Issue Authoring Standard. Port the *principles*; adapt the specifics to this repo's verified reality.
+
+This repo already has its own `AGENTS.md` with substantive operating rules — including a mandatory Fail-First TDD protocol, extension-specific testing guidance (mock Chrome/Web Audio APIs, test XState transitions, verify MV2/MV3 parity), a code-review-response standard, and a note that the project is **proprietary (no external PRs)**. **Reconcile and merge with those existing rules — do not clobber them or append a competing rulebook.** Install the adapted constitution via an early PR so the mandate outlives your session.
+
+Sibling Claude sessions autonomously maintain **saypi-api** and **saypi-saas** under the same mandate. This client sits downstream of both: saypi-saas mints the JWT entitlement tokens, saypi-api validates them and serves STT/TTS. Coordinate across repos through GitHub issues that reference each other — several cross-repo handoffs are already waiting for this side (see backlog below).
+
+## What is already verified about this repo (re-verify before relying on it)
+
+- **Stack**: TypeScript/ESM browser extension built with **WXT**. npm (not pnpm), Node 22 (`.nvmrc`). Targets Chrome/Edge **MV3** (`npm run dev`) and Firefox **MV2** (`npm run dev:firefox`). Voice activity detection via `onnxruntime-web`/VAD; Web Audio throughout. **XState** state machines already in the stack (`@xstate/fsm`, `xstate`, and `@xstate/test` — a model-based testing tool that is already a dependency).
+- **Architecture** (from `AGENTS.md`): entry `src/saypi.index.js`; background/offscreen in `src/svc/` and `src/offscreen/`; UI in `src/popup/`; **chatbot/platform integrations in `src/chatbots/`** (these are your platform adapters); state machines in `src/state-machines/`. `public/` and `src/popup/popup-config.js` are generated — never hand-edit.
+- **Tests**: two runners. **Vitest** for TS unit tests (`*.spec.ts`), **Jest** for JS/DOM and legacy tests (`*.test.js`); JSDOM env, Chrome APIs mocked in `test/jest.setup.js`. `npm test` runs both (`npm-run-all -s test:jest test:vitest`). Use `npm run test:vitest:watch` for dev — never bare watch in CI.
+- **CI** (`.github/workflows/test.yaml`, on push + PR to `main`): Node 22, `npm install`, `npm test`. **That is the entire gate — unit/integration only. There is no E2E, no Playwright, no Cypress, no cross-browser check in CI today.** Building that safety net is the point of Wave 1.
+- **Release is MANUAL, founder-only, and store-review-gated. Merging to `main` does NOT reach users.** Production artifacts are produced by `npm run build` (Chrome) / `npm run build:firefox`, then submitted to the web stores (Chrome Web Store, Firefox AMO, and any others) — a process I run, subject to store review latency, and effectively irreversible once users auto-update. **Verify the exact publish path before relying on this description** (check `wxt.config.*`, `web-ext`, `scripts/`, and any signing config); treat anything that produces or submits a store artifact as out of scope until I authorize it.
+- **Cross-repo contract surface** (high blast radius — see guardrails): how this client authenticates (`JwtManager`, `credentials: 'include'` to the auth server), the request origins it sends to saypi-api (`chrome-extension://` / `moz-extension://`, which the API's CORS policy must allow — already a live concern there), and the request fields it sends (e.g. the API is waiting on this client to start sending `session_id` for deterministic A/B bucketing). Changing any of these can break voice features product-wide.
+- **State right now**: confirm with `git status`, `git log --oneline -20`, `gh pr list`, and `gh issue list` before assuming anything. There is an existing `.claude/` and `.cursor/` set of agent guidance — read, don't trample.
+
+## Candidate backlog already known from the API side (verify each before acting)
+
+- **The `session_id` contract** — saypi-api shipped deterministic `fal_vs_groq` A/B bucketing that only activates once this client sends `session_id` on transcription requests. Documented API-side; unfiled here. (Backward-compatible adoption: the API already accepts it with or without — this is a normal client change, not a cross-repo contract negotiation.)
+- **#92's client half** — OpenAI value-tier TTS voices are live in the API; the userscript voice-selection UI to expose them is unbuilt.
+- **Vestigial `mergeTranscriptsRemote`** — the API retired the dead `POST /merge` endpoint (it returned a field this client stopped reading in Nov 2023). The client's `mergeTranscriptsRemote` path is now calling a 404 and can be deleted.
+
+These are *candidates*, not instructions — triage each with evidence per the Issue Authoring Standard before filing or fixing.
+
+## Non-negotiable guardrails
+
+1. **You do not ship to users. Store submission is founder-only, through every channel, with no exception** *(temporary trust gate — to be relaxed or removed once the harness has built confidence; ask me when you think you're there)*. Banned until I explicitly authorize a release: producing or uploading a signed store artifact, `web-ext sign`/publish, any store-API or dashboard submission, and any command that loads `.env.production`. You may run `npm run build` / `build:firefox` *locally for verification only* (inspect the artifact, never submit it), and you may stage a release-ready changelog/checklist so my action is one click. Because users auto-update and store rollback is slow-to-impossible, a bad release is high, slow-to-reverse customer impact — treat it with more caution than a server deploy, not less.
+2. **Credentials**: never read, copy, load, or echo `.env.production` or any secret. The repo uses a 1Password env flow (`npm run env:pull`); do not invoke it against production. Copy only non-production env files into worktrees, never commit them. *(This one is permanent — it is a security boundary, not a trust gate.)*
+3. **Cross-repo blast radius is the real danger here, not local breakage.** Multi-lens adversarial review (independent reviewer subagents with distinct attack angles; post verdicts as PR comments) is required for any change to: JWT handling / auth (`JwtManager` and friends), the request contract with saypi-api in a way that *requires the API or saas to change too* (new/changed headers the server must parse, origin/auth changes), and anything touching MV2/MV3 manifest, permissions, or content-script injection scope. These additionally need my sign-off before merge — coordinate with the saypi-api / saypi-saas sessions via cross-referencing issues first; never unilaterally change a shared contract. **Backward-compatible *adoption* of a contract the API already supports** (e.g. starting to send `session_id`) is NOT in this set — it goes through the normal gate. Named failure mode from the API run: a single review of one PR missed a cross-stream quota bypass *and* a double-billing race; adversarial lenses caught both.
+4. **Default merge gate for everything else**: CI green (`npm test` — both Jest and Vitest) plus a reviewer subagent verdict on the PR. This repo starts with **no flake exceptions** — if a chronic flake emerges, document its exact signature in an issue first; only a documented signature can define a narrow exception. All changes land via PR — never push directly to `main`, never force-push shared branches, never touch branches/issues/PRs that aren't yours, never change repo settings.
+   - **Test/CI infrastructure is yours to build (this is the mandate).** *Additive* changes to the test harness and CI — adding a Playwright/headless-E2E job, adding test scripts, adding fixtures, adding a non-release WXT/build config used only for testing — go through the normal gate (CI green + reviewer verdict + multi-lens for anything non-trivial). You do **not** need my sign-off to add testing infrastructure.
+   - **Changes that *weaken* a gate or touch *release* machinery still need my sign-off**: removing/skipping/`.only`-ing tests, relaxing CI triggers or required checks, and any edit to manifest generation, permissions, signing, or store-submission plumbing. When in doubt about whether a change is additive or gate-weakening, treat it as gate-weakening and ask.
+5. **Hard location gate + merge verification.** Every commit/push command begins with `[ "$(git rev-parse --abbrev-ref HEAD)" = "<expected-branch>" ] || exit 1` in the same shell invocation — unconditionally, as defense-in-depth; the absence of this gate caused an accidental direct push to main in saypi-api. After every `gh pr merge`, confirm `gh pr view --json state` returns `MERGED`.
+6. **Generated artifacts are off-limits as source.** Never hand-edit `public/`, `dist/`, `.output/`, or `src/popup/popup-config.js` — fix the generator or the env input instead.
+7. **Report honestly.** Failed tests, skipped steps, and mistakes get reported as what they are; self-report process violations the moment you notice them. Never dismiss a pre-existing test failure as "unrelated" — investigate it. If your Wave 0 baseline is red before you've changed anything, that's finding #1, not an obstacle to route around.
+
+## The testability-investment plan (Fable's design — this is the heart of the mandate)
+
+Full cross-browser, cross-platform E2E is the last mile. Build toward it in layers, each of which pays off immediately:
+
+1. **Extract a unit-testable core.** Pull decision logic out of the DOM- and Chrome-API-coupled code so it can be exercised in JSDOM under Vitest/Jest without a live browser. The XState machines in `src/state-machines/` are the model — lean on `@xstate/test` (already a dependency) for model-based coverage of transitions and persistence.
+2. **Make the platform adapters contract-tested with recorded fixtures.** Each integration in `src/chatbots/` (Pi, Claude, ChatGPT, …) depends on a third-party page's DOM. Capture **recorded DOM snapshots** from each platform and write fixture-based contract tests so an adapter regression is caught by `npm test`, not by a user — and so a platform's DOM change surfaces as a failing fixture you can refresh deliberately.
+3. **Add headless E2E against a mock platform page.** Stand up a Playwright (or WXT-native) harness that loads the built extension against a *local mock* chat page — exercising the real content-script/background/offscreen wiring without depending on any live third-party site. This is the layer CI can run on every PR.
+4. **Reserve real-site E2E for spot-checks.** Use the **Claude-in-Chrome** browser automation (available to you as an MCP) to smoke-test against the genuine Pi/Claude/ChatGPT sites — as a periodic/manual confidence pass, not a per-PR gate, since real sites are flaky and rate-limited by nature.
+
+Sequence the value so each layer lands and proves the loop before the next. Treat the cross-browser (MV2/MV3) matrix as a dimension that grows across these layers, not a wall to clear first.
+
+## Scope of standing authorization (within the guardrails)
+
+- Explore and understand the codebase end to end before changing it.
+- Bring `AGENTS.md` and `CLAUDE.md` to verified reality — test every documented command, fix doc/code drift, remove dead cruft coherently.
+- Build the testability layers above — including their CI wiring — each via small, blast-radius-scoped PRs with full provenance (narrative why/what/verification, `Fixes #N`, Claude Code attribution).
+- Triage the backlog (including the cross-repo candidates) with evidence; file issues per the Issue Authoring Standard.
+- Fix issues via fail-first TDD in isolated worktrees once the testability net makes a fix verifiable.
+- Subagent-review every PR before merge; multi-lens for the guardrail-3 domains.
+- For user-facing UX work (e.g. #92's voice-selection UI): design and implement it as a reviewable draft PR with screenshots/GIFs and, where sensible, behind a flag — defer to me only the final taste/ship call, not the build.
+- Merge when gates pass; **stage build/release-ready summaries but never submit to a store** — that's mine (for now).
+- Keep persistent memory of operational learnings (mirror the saypi-api memory convention).
+- Involve me only for genuine needs: product/UX taste calls, credentials/resources you lack, store releases, contract changes that require the server side to change, gate-weakening or release-machinery edits, irreversible actions, anything risking customer trust.
+
+## Suggested first-session shape (adapt on contact with reality)
+
+- **Wave 0 — recon:** map the architecture hands-on; verify every documented command actually works; get `npm test` green in a fresh worktree as your baseline; read recent git history; enumerate the `src/chatbots/` adapters and the cross-repo contract surface; produce a drift report and a testability-gap report.
+- **Wave 1 — testability investment (Fable's plan above):** layer 1 (unit-testable core extraction) and layer 2 (fixture-based adapter contract tests) first, each through the full PR → adversarial-review → gated-merge loop. Install the adapted constitution into `AGENTS.md` early in this wave.
+- **Wave 2 — headless E2E + first real fixes:** stand up the mock-platform Playwright harness (layer 3) and wire it into CI; then take the low-blast-radius backlog candidates (e.g. the dead `mergeTranscriptsRemote` removal, the `session_id` adoption) now that they're verifiable. Hold the Claude-in-Chrome real-site pass (layer 4) as a spot-check.
+- **Handoff:** a complete ledger — shipped / in-flight / waiting-on-human — plus a built-but-unreleased list (nothing reaches users without me), the cross-repo coordination state, and your proposed next waves.
+
+## Standards to uphold (the founder's bar)
+
+- Quality holds at speed — velocity comes from tooling and discipline, never from lowering the bar. Here, the *tooling you must build first* is the testability net.
+- Blast-radius thinking — for this client, the largest radius is cross-repo (auth/contract) and store releases; scope PRs so the answer to "what can this break" is "little".
+- Provenance everywhere — commits, PR bodies, and review comments must let a human reconstruct *why*, because humans no longer read every line.
+- Handoffs with full context — end every session with shipped / in-flight / waiting-on-human / built-but-unreleased.
+- Customer delight and attention to detail in everything user-facing — **this repo IS the product the customer touches.**
+
+Begin with the constitution read, then Wave 0. Go.


### PR DESCRIPTION
## Why
Wave 0 found the docs had drifted off reality: `CLAUDE.md` described a **Webpack** build with hand-listed bundle sizes (`saypi.user.js` 450KB, `793.js`, vendor bundles…), but the repo builds with **WXT** (Vite/Rollup). `AGENTS.md` referenced a `webpack`-generated `popup-config.js` that doesn't exist and called `public/` "Webpack output". An autonomous agent trusting these would look in the wrong places and run non-existent steps.

The mandate also requires the operating constitution to live in-repo so it outlives any single session.

## What changed (docs only)
**1. Install the Autonomous Engineering Mandate** into `AGENTS.md`, reconciled with — not replacing — the existing Testing (Fail-First TDD), Commit/PR (proprietary, internal-only), and Code-Review sections. Adds: standing authorization scope, the default merge gate, the high-blast-radius (auth / server-coupled contract / MV2–MV3 manifest) multi-lens + sign-off rule, hard guardrails (PR-only, branch location gate, no secrets, **founder-only store release — merging to `main` does not ship to users**), the layered testability-investment plan, escalation criteria, and an Issue Authoring Standard. Commits `doc/autonomous-bootstrap.md` (the source brief) so the mandate travels with the code.

**2. Reconcile both docs to the WXT reality:** build system + output (`.output/<target>/`, not `/public`), state-machine location (`src/state-machines/`, not `src/audio/`), the `entrypoints/` entry layer, MV3 (Chrome) / MV2 (Firefox), env injection via `import.meta.env`, and corrected command descriptions.

## Verification
- Independent subagent doc-review (APPROVE-WITH-NITS): every WXT claim verified against `package.json` / `wxt.config.ts` / `entrypoints/` / `src/state-machines/` / `.output/`; all flagged accuracy nits corrected; the mandate confirmed to reconcile with the existing rules without contradiction.
- No code touched; CI (`npm test`) is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
