### PR TITLE
fix(claude): verify sidebar detection against live DOM; harden tie-break (closes #273)

### DIFF
--- a/src/chatbots/Claude.ts
+++ b/src/chatbots/Claude.ts
@@ -221,9 +221,9 @@ class ClaudeChatbot extends AbstractChatbot {
 
   getSidebarConfig(sidebar: HTMLElement): SidebarConfig | null {
     // Claude's sidebar groups "New chat" in its own container above the scrollable
-    // area, with the primary navigation (Chats, Projects, Artifacts, Code, ...) in a
-    // separate flex column. We append our voice-settings button after the last item
-    // in that navigation column.
+    // area, with the primary navigation (Chats, Projects, Artifacts, Customize, …)
+    // in a separate flex column. We append our voice-settings button after the last
+    // item in that navigation column.
     //
     // Claude restructures and *localizes* these labels frequently, so we identify the
     // column structurally (a flex column of short-labelled link/button rows) rather
@@ -231,25 +231,35 @@ class ClaudeChatbot extends AbstractChatbot {
     // preference signal to disambiguate when more than one column looks menu-like
     // (e.g. a recent-chats list); they are never required.
     const NAV_LABEL_MAX_LEN = 30;
-    const KNOWN_LABELS = ["chats", "projects", "artifacts", "code"];
+    // Representative current labels (verified on the live Claude sidebar
+    // 2026-06-13: Chats / Projects / Artifacts / Customize). Only a soft
+    // preference hint to disambiguate when several columns look menu-like;
+    // never required, so localized/relabelled sidebars still work.
+    const KNOWN_LABELS = ["chats", "projects", "artifacts", "customize", "code"];
 
-    // A nav item is a row wrapping a link/button with a short, non-empty label.
-    // Recent-chats rows carry long free-text titles and are excluded by the length cap.
-    const isNavItem = (child: Element): boolean => {
+    // The visible label of a row's link/button control, whitespace-collapsed.
+    // Measured on the control (not the whole row, which may carry icons/badges
+    // whose text would otherwise inflate the length or defeat label matching).
+    const controlLabel = (child: Element): string | null => {
       const control = child.matches("a, button")
         ? child
         : child.querySelector("a, button");
-      if (!control) return false;
-      // Measure the control's own label (not the whole row, which may carry badges)
-      // and collapse whitespace so layout indentation cannot inflate the length.
-      const text = (control.textContent ?? "").replace(/\s+/g, " ").trim();
-      return text.length > 0 && text.length <= NAV_LABEL_MAX_LEN;
+      if (!control) return null;
+      return (control.textContent ?? "").replace(/\s+/g, " ").trim();
+    };
+
+    // A nav item is a row whose control has a short, non-empty label.
+    // Recent-chats rows carry long free-text titles and are excluded by the cap.
+    const isNavItem = (child: Element): boolean => {
+      const label = controlLabel(child);
+      return !!label && label.length <= NAV_LABEL_MAX_LEN;
     };
 
     const knownLabelCount = (container: Element): number =>
-      Array.from(container.children).filter((child) =>
-        KNOWN_LABELS.includes((child.textContent ?? "").toLowerCase().trim())
-      ).length;
+      Array.from(container.children).filter((child) => {
+        const label = controlLabel(child);
+        return label != null && KNOWN_LABELS.includes(label.toLowerCase());
+      }).length;
 
     const navColumns = (
       Array.from(sidebar.querySelectorAll("div.flex.flex-col")) as HTMLElement[]

--- a/test/chatbots/ClaudeSidebarConfig.spec.ts
+++ b/test/chatbots/ClaudeSidebarConfig.spec.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { JSDOM } from "jsdom";
+import { readFileSync } from "node:fs";
 
 vi.mock("../../src/dom/MessageElements", () => {
   class AssistantResponse {}
@@ -174,5 +175,57 @@ describe("Claude sidebar integration (GH-250/GH-252)", () => {
 
     const config = chatbot.getSidebarConfig(sidebar);
     expect(config).toBeNull();
+  });
+});
+
+describe("Claude sidebar — recorded live-DOM contract (closes #273)", () => {
+  let chatbot: InstanceType<typeof ClaudeChatbot>;
+
+  beforeEach(() => {
+    chatbot = new ClaudeChatbot();
+  });
+
+  // Snapshot distilled from the live Claude.ai sidebar captured 2026-06-13.
+  const liveHtml = readFileSync(
+    new URL("../fixtures/claude-sidebar.html", import.meta.url),
+    "utf-8"
+  );
+
+  it("finds the real nav menu (Chats/Projects/Artifacts/Customize) and appends after it", () => {
+    const sidebar = sidebarFrom(liveHtml, chatbot);
+    expect(sidebar).not.toBeNull();
+
+    const config = chatbot.getSidebarConfig(sidebar);
+    expect(config).not.toBeNull();
+    expect(config?.buttonStyle).toBe("menu");
+    // The live menu is nested in an outer scrollable column that also qualifies;
+    // innermost-preference must select the real menu, not the wrapper.
+    expect(config?.buttonContainer.getAttribute("data-region")).toBe("menu");
+    expect(config?.buttonContainer.children.length).toBe(4);
+    expect(config?.insertPosition).toBe(4);
+    // Assert on each row's control label (robust to future badge/icon siblings).
+    const labels = Array.from(config!.buttonContainer.children).map((c) =>
+      c.querySelector("a, button")?.textContent?.trim()
+    );
+    expect(labels).toEqual(["Chats", "Projects", "Artifacts", "Customize"]);
+    // The pre-#274 exact-English-label matcher (which expected "Code") returned
+    // null on this real DOM — verified live; this fixture guards the regression.
+  });
+
+  it("prefers the known-label nav menu over a preceding recents column even when nav rows carry count badges", () => {
+    // Hardening for the live finding that the known-label tie-break must read the
+    // control's label, not the whole row: nav rows here wrap a count badge OUTSIDE
+    // the link, so each row's textContent ("Chats3") is not an exact label. A
+    // recents column of short titles sits FIRST in document order, so document
+    // order alone would pick it — only a working known-label tie-break selects
+    // the real menu.
+    const sidebar = sidebarFrom(
+      `<aside><nav aria-label="Sidebar"><div class="flex flex-col gap-1" data-region="recents"><div class="group"><a href="#">VAD Bug</a></div><div class="group"><a href="#">Auth Flow</a></div><div class="group"><a href="#">CORS Fix</a></div></div><div class="flex flex-col gap-1" data-region="menu"><div class="group"><a href="#">Chats</a><span class="badge">3</span></div><div class="group"><a href="#">Projects</a><span class="badge">1</span></div><div class="group"><a href="#">Artifacts</a><span class="badge">7</span></div></div></nav></aside>`,
+      chatbot
+    );
+
+    const config = chatbot.getSidebarConfig(sidebar);
+    expect(config).not.toBeNull();
+    expect(config?.buttonContainer.getAttribute("data-region")).toBe("menu");
   });
 });

--- a/test/fixtures/claude-sidebar.html
+++ b/test/fixtures/claude-sidebar.html
@@ -1,0 +1,38 @@
+<!--
+  Recorded contract fixture for ClaudeChatbot.getSidebarConfig().
+
+  Distilled from the LIVE Claude.ai sidebar (https://claude.ai/new) captured
+  2026-06-13. Real class strings and nav labels are preserved; the chat-history
+  / profile sections and SVG icons are elided (kept PII-free and minimal).
+
+  The structure that matters: the primary navigation menu
+  (div.flex.flex-col.px-2.gap-px — Chats / Projects / Artifacts / Customize) is
+  nested inside an outer scrollable flex column that ALSO qualifies as menu-like.
+  On the live DOM this produced 2 candidate columns; detection must prefer the
+  innermost one and append after the last item. The pre-#274 exact-English-label
+  matcher returned null on this real DOM (it expected "Code", not "Customize"),
+  which is the regression PR #274 fixed and this fixture guards against.
+
+  data-region markers are test-only; production code never reads them.
+-->
+<aside>
+  <nav aria-label="Sidebar">
+    <div class="px-2 py-2">
+      <a data-testid="new-chat-button" href="#">New chat</a>
+    </div>
+    <div class="flex flex-col flex-grow align-center overflow-hidden min-h-0" data-region="outer">
+      <div class="flex flex-col px-2 gap-px" data-region="menu">
+        <div class="group"><a href="#">Chats</a></div>
+        <div class="group"><a href="#">Projects</a></div>
+        <div class="group"><a href="#">Artifacts</a></div>
+        <div class="group"><a href="#">Customize</a></div>
+      </div>
+      <!-- These two siblings are intentional: together with the inner menu they
+           give the outer column 3+ nav items, so it ALSO qualifies as a
+           candidate. That is what exercises the innermost-column preference —
+           do not remove them or the contract test becomes vacuous. -->
+      <div class="group"><a href="#">Recents</a></div>
+      <div class="group"><a href="#">Settings</a></div>
+    </div>
+  </nav>
+</aside>


### PR DESCRIPTION
Closes #273.

## Why
PR #274 reworked Claude's `getSidebarConfig()` to detect the sidebar nav menu structurally, but it shipped **unverified against the live Claude.ai DOM** (#273 tracked that gate). This PR does the layer-4 real-site spot-check and records the result as the project's first layer-2 contract fixture.

## Live verification (claude.ai/new, 2026-06-13)
Ran both the old and new detection logic against the real sidebar:
- Real selector `nav[aria-label="Sidebar"]` matches ✅
- Real labels: **Chats / Projects / Artifacts / Customize** (4th is "Customize", **not** "Code")
- `navColumns: 2 → candidates: 1` — the menu is nested in an outer scrollable flex column that also qualifies; the innermost-preference filter resolves correctly
- New heuristic selects the menu, `insertPosition: 4` (append) ✅
- **Old #272 logic `wouldFind: false`** → returned `null` on the live DOM → SayPi's voice button was **not mounting** in Claude's sidebar. Confirms #272 was a genuine user-facing regression that #274 fixed.

## Changes
1. **Recorded fixture** `test/fixtures/claude-sidebar.html` (distilled from the live DOM — real classes/labels/nesting, icons + PII elided) + a contract test asserting `getSidebarConfig` finds the real menu (labels, `insertPosition` 4, innermost selection). First layer-2 recorded-DOM adapter test.
2. **Hardened the known-label tie-break:** `knownLabelCount` now measures the row control's label via a shared `controlLabel` helper (also used by `isNavItem`), instead of the whole row's `textContent` — so a row with a count badge no longer defeats the menu-vs-recents preference (the live DOM exposed this). Refreshed `KNOWN_LABELS` with "customize". Fail-first test (badge rows + preceding recents column) confirmed RED before, GREEN after.

## Verification
- `npm test` green (Jest 2/2; Vitest 72 files, **705 passed, 1 skipped, 0 failed**); `tsc --noEmit` clean on changed files.
- Independent subagent review: APPROVE-WITH-NITS; both nits applied (assert on the control label; document the fixture's load-bearing siblings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
