### PR TITLE
fix(tts): degrade gracefully when voice is off or synthesis fails (#241, #268)

### DIFF
--- a/src/dom/ChatHistory.ts
+++ b/src/dom/ChatHistory.ts
@@ -213,8 +213,19 @@ abstract class ChatHistoryMessageObserver extends BaseObserver {
       ) {
         const mutatedElement = mutation.target as Element;
 
-        this.findAndDecorateAssistantResponses(mutatedElement);
-        this.findAndDecorateUserPrompts(mutatedElement);
+        // Fire-and-forget: these run outside an awaited path, so a rejection
+        // here would be uncaught. Decoration (incl. TTS) must never crash the
+        // observer — log and move on.
+        this.findAndDecorateAssistantResponses(mutatedElement).catch((error) => {
+          logger.debug(
+            `Assistant response decoration failed on attribute change: ${error}`
+          );
+        });
+        this.findAndDecorateUserPrompts(mutatedElement).catch((error) => {
+          logger.debug(
+            `User prompt decoration failed on attribute change: ${error}`
+          );
+        });
       }
     }
   }
@@ -402,7 +413,19 @@ abstract class ChatHistoryMessageObserver extends BaseObserver {
           await message.decorateState(state);
         }
 
-        const speech = await this.streamSpeech(message);
+        let speech: StreamedSpeech | null = null;
+        try {
+          speech = await this.streamSpeech(message);
+        } catch (error) {
+          // A TTS failure (synthesis error for unauthenticated/over-quota users,
+          // or a voice-off race) must never abort message decoration or the
+          // surrounding observer cycle — fall through to the incomplete-speech
+          // state instead of rejecting (which would surface as an uncaught
+          // rejection and could derail prompt submission). See #268 / #241.
+          logger.debug(
+            `Speech unavailable for this message; continuing without it: ${error}`
+          );
+        }
         if (speech) {
           if (speech.utterance) {
             await message.decorateSpeech(speech.utterance);

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -245,10 +245,14 @@ class SpeechSynthesisModule {
 
     const preferedVoice: SpeechSynthesisVoiceRemote | null =
       await this.userPreferences.getVoice(chatbot);
-    if (!preferedVoice) {
-      throw new Error("No voice selected");
-    }
     const preferedLang = await this.userPreferences.getLanguage();
+    if (!preferedVoice) {
+      // Voice off, or the voice was cleared between the provider check and here
+      // (a race when toggling voice mid-response): degrade to a silent placeholder
+      // rather than throwing. The auto-TTS path must treat "no voice" as a no-op,
+      // not an uncaught rejection that aborts message decoration / submission.
+      return new SpeechPlaceholder(preferedLang, audioProviders.None);
+    }
     const uuid = generateUUID();
     const utterance = await this.audioStreamManager.createStream(
       uuid,
@@ -290,7 +294,10 @@ class SpeechSynthesisModule {
 
   speak(speech: SpeechUtterance, chatbot?: Chatbot): void {
     if (isPlaceholderUtterance(speech)) {
-      console.warn("Cannot speak a placeholder");
+      // Expected whenever voice is off (the auto-TTS path yields a placeholder):
+      // a no-op, not a warning. Debug-level so it doesn't spam the console
+      // on every voice-off turn. See #241.
+      console.debug("Skipping speak for placeholder utterance (voice off)");
       return;
     }
     if (isFailedUtterance(speech)) {

--- a/test/dom/ChatHistoryObserver.spec.ts
+++ b/test/dom/ChatHistoryObserver.spec.ts
@@ -276,6 +276,36 @@ describe("ChatHistoryMessageObserver", () => {
       );
       expect(observations.length).toBeGreaterThan(0);
     });
+
+    it("still shows the incomplete-speech indicator when a selected (SayPi) voice fails to synthesize (#268)", async () => {
+      const chatbot = new PiAIChatbot();
+      const observer = new FailingTtsObserver(
+        chatHistoryElement,
+        assistantResponseSelector,
+        speechSynthesisModule,
+        chatbot
+      );
+
+      // A voice IS selected (provider resolves to SayPi) but synthesis fails:
+      // the user must still get the incomplete-speech / regenerate affordance,
+      // not silence. Spy on decorateIncompleteSpeech so we don't execute its
+      // real body (which reaches the global UserPreferenceModule singleton).
+      vi.spyOn(speechSynthesisModule, "getActiveAudioProvider").mockResolvedValue(
+        audioProviders.SayPi
+      );
+      const incompleteSpy = vi
+        .spyOn(AssistantResponse.prototype, "decorateIncompleteSpeech")
+        .mockResolvedValue(undefined);
+
+      const assistantMessage = createAssistantMessage("Hello from the assistant");
+      chatHistoryElement.appendChild(assistantMessage);
+
+      const observations = await observer.findAndDecorateAssistantResponses(
+        chatHistoryElement
+      );
+      expect(observations.length).toBeGreaterThan(0);
+      expect(incompleteSpy).toHaveBeenCalled();
+    });
   });
 
   describe("findAssistantResponse", () => {

--- a/test/dom/ChatHistoryObserver.spec.ts
+++ b/test/dom/ChatHistoryObserver.spec.ts
@@ -10,6 +10,7 @@ import { AudioStreamManager } from "../../src/tts/AudioStreamManager";
 import { timeoutCalc } from "../tts/InputStream.spec";
 import { AssistantResponse } from "../../src/dom/MessageElements";
 import {
+  audioProviders,
   SayPiSpeech,
   SpeechSynthesisVoiceRemote,
   SpeechUtterance,
@@ -234,6 +235,46 @@ describe("ChatHistoryMessageObserver", () => {
           assistantResponseSelector
         );
       expect(withoutJustifyEnd.found).toBe(true); // should match without "justify-end"
+    });
+  });
+
+  describe("resilience to TTS failures (#268 / #241)", () => {
+    // Minimal concrete observer whose streamSpeech rejects, simulating a TTS
+    // synthesis failure (e.g. an unauthenticated user) or a voice-off race.
+    class FailingTtsObserver extends ChatHistoryMessageObserver {
+      protected streamSpeech(): Promise<never> {
+        return Promise.reject(new Error("Failed to synthesize speech"));
+      }
+      protected streamState(): Promise<null> {
+        return Promise.resolve(null);
+      }
+    }
+
+    it("does not propagate a TTS failure out of findAndDecorateAssistantResponses (no uncaught rejection, decoration continues)", async () => {
+      const chatbot = new PiAIChatbot();
+      const observer = new FailingTtsObserver(
+        chatHistoryElement,
+        assistantResponseSelector,
+        speechSynthesisModule,
+        chatbot
+      );
+
+      // Keep the test focused on the catch: a non-SayPi provider skips the
+      // incomplete-speech decoration branch (which reaches the real
+      // UserPreferenceModule singleton, unrelated to this behavior).
+      vi.spyOn(speechSynthesisModule, "getActiveAudioProvider").mockResolvedValue(
+        audioProviders.None
+      );
+
+      const assistantMessage = createAssistantMessage("Hello from the assistant");
+      chatHistoryElement.appendChild(assistantMessage);
+
+      // Must resolve (not reject) despite streamSpeech throwing, and still have
+      // processed/decorated the assistant message so the observer cycle continues.
+      const observations = await observer.findAndDecorateAssistantResponses(
+        chatHistoryElement
+      );
+      expect(observations.length).toBeGreaterThan(0);
     });
   });
 

--- a/test/tts/SpeechSynthesisModule.spec.ts
+++ b/test/tts/SpeechSynthesisModule.spec.ts
@@ -6,7 +6,7 @@ import { AudioStreamManager } from "../../src/tts/AudioStreamManager";
 import { mockVoices } from "../data/Voices";
 import { UserPreferenceModule } from "../../src/prefs/PreferenceModule";
 import { BillingModule } from "../../src/billing/BillingModule";
-import { audioProviders } from "../../src/tts/SpeechModel";
+import { audioProviders, isPlaceholderUtterance } from "../../src/tts/SpeechModel";
 
 describe("SpeechSynthesisModule", () => {
   let speechSynthesisModule: SpeechSynthesisModule;
@@ -157,6 +157,20 @@ describe("SpeechSynthesisModule", () => {
 
     expect(first).toBe(second);
     expect(audioStreamManagerMock.createStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a silent placeholder instead of throwing when no voice is selected (voice off)", async () => {
+    // Voice off (getVoice resolves null) must be a no-op for the auto-TTS path,
+    // not an uncaught "No voice selected" throw that aborts message decoration.
+    (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(null);
+
+    const utterance = await speechSynthesisModule.createSpeechStream(
+      { getID: () => "claude" } as any,
+      "message-voiceoff"
+    );
+
+    expect(isPlaceholderUtterance(utterance)).toBe(true);
+    expect(audioStreamManagerMock.createStream).not.toHaveBeenCalled();
   });
 
   it("keeps native audio for chatbots without a Say Pi voice selection", async () => {


### PR DESCRIPTION
## Why

#268 and #241 are two faces of the same defect: TTS for assistant messages runs *inside* DOM-mutation-driven decoration (`ChatHistory` observer → `findAndDecorateAssistantResponses` → `streamSpeech`), but the synthesis entry points **throw** on conditions that are normal or transient, and **nothing on the call chain catches them**. The rejection escapes as an uncaught promise, and because it aborts the decoration handler it can derail the user's prompt submission on the next turn.

## Live root-cause (claude.ai, store build, authenticated, voice off)

Verified with the founder driving the mic:
- A voice-off call **submits fine** and the auto-TTS path produces a **placeholder** — voice-off is *not* itself the error.
- **`No voice selected`** is the rare **race**: the provider check sees a voice, but it's cleared by the time `createSpeechStream` re-reads it (voice toggled mid-response, or a cold preference cache on the first turn).
- **`Failed to synthesize speech`** (#268) hits unauthenticated / over-quota users when a voice *is* selected.
- The trace also revealed a proactive `saypi:piWriting → speak` path that logged **`Cannot speak a placeholder`** as a *warning on every voice-off turn*.

(The race can't be hit reliably by hand — the window is a few ms at turn start — so the fix is defensive at the confirmed boundary rather than dependent on catching it live.)

## What changed

1. **`SpeechSynthesisModule.createSpeechStream`** — return a silent placeholder instead of throwing `No voice selected` when no voice is set. Voice off (and the toggle race) becomes a clean no-op. *(#241)*
2. **`ChatHistory.findAndDecorateAssistantResponses`** — `try/catch` around the `streamSpeech` await so a synthesis failure (#268) or any TTS error degrades to the existing incomplete-speech state instead of rejecting decoration and the observer cycle; `.catch` on the fire-and-forget attribute-mutation calls. **This decouples TTS failure from prompt submission.** *(#268, #241)*
3. **`SpeechSynthesisModule.speak`** — a placeholder is expected when voice is off, so log at `debug`, not `warn`. No more per-turn console noise. *(#241)*

## Tests (fail-first)

Both confirmed **RED** before the fix:
- `createSpeechStream` returns a placeholder (not throw) when no voice is selected.
- `findAndDecorateAssistantResponses` resolves and keeps decorating when `streamSpeech` rejects (no uncaught rejection).

## Verification

- `npm test`: **Jest 2/2; Vitest 75 files, 714 passed, 1 skipped** (+2 tests).
- `tsc --noEmit`: clean on the changed files.
- ⚠️ Final in-browser verification needs a **dev build** of this branch (the fix isn't in the store extension). Merging to `main` does not ship.

## Out of scope (flagged for follow-up)

- #268's **"disable the voice selector when unauthenticated"** — a product/UX call, intentionally not bundled.
- The explicit **regen-speech button** (`createSpeech:197`) still throws on voice-off with no `.catch` — a distinct, lower-frequency path.
- An auth-aware **pre-check** to skip predictably-doomed TTS calls for unauthenticated users (touches auth-state reading) — deferred.

## Unrelated findings surfaced during the live trace (for triage)

- **TTS stalls after "Thinking"** with a real voice — it synthesized Claude's thinking indicator then never narrated the answer (block-capture path; plausibly ~#238).
- **~3953 credits charged for a 1-word utterance** — looks like live corroboration of saypi-api #211 (flash-weighted pre-flight over-spend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
