### PR TITLE
fix(dictation): insert transcribed text at the caret for input/textarea (#178)

### DIFF
--- a/src/state-machines/DictationMachine.ts
+++ b/src/state-machines/DictationMachine.ts
@@ -110,10 +110,22 @@ interface AudioSegment {
   refined?: boolean;  // Tracks if segment was included in a refinement (for O(n) incremental refinement)
 }
 
+/**
+ * Caret/selection offsets captured from an input/textarea at dictation start, so
+ * transcribed text can be inserted at that position rather than appended at the end
+ * (#178). For a collapsed caret, start === end. A non-collapsed range means the user
+ * had text selected; that range is replaced by the dictation.
+ */
+interface CaretRange {
+  start: number;
+  end: number;
+}
+
 interface DictationContext {
   transcriptions: Record<number, string>; // Global transcriptions for backwards compatibility
   transcriptionsByTarget: Record<string, Record<number, string>>; // Transcriptions grouped by target element ID
   initialTextByTarget: Record<string, string>; // Pre-existing text in each target when dictation started
+  caretRangeByTarget: Record<string, CaretRange>; // Caret/selection offset in each target when dictation started (#178; input/textarea only)
   isTranscribing: boolean;
   userIsSpeaking: boolean;
   timeUserStoppedSpeaking: number;
@@ -217,6 +229,72 @@ function smartJoinTwoTexts(firstText: string, secondText: string): string {
     // Add space if neither condition is met
     return firstText + " " + secondText;
   }
+}
+
+/**
+ * Capture the caret/selection offsets of an input/textarea so transcribed text can
+ * later be inserted at that position rather than appended at the end (#178).
+ *
+ * Returns undefined for contenteditable and other elements — insert-at-caret there
+ * is a follow-up; those targets continue to receive text appended at the end.
+ */
+function captureCaretRange(element?: HTMLElement): CaretRange | undefined {
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    try {
+      const start = element.selectionStart;
+      const end = element.selectionEnd;
+      if (start === null || end === null) return undefined;
+      return { start, end };
+    } catch (_) {
+      // selectionStart/End throw for input types that don't expose a selection
+      // (e.g. number, email); treat as "no caret captured".
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Compose the final field text while honoring the caret captured at dictation start
+ * (#178). The initial text is split at the caret into `before` and `after`; the
+ * dictated text is composed after `before` via `compose`, then `after` is re-attached.
+ *
+ * Returns the composed text and the caret offset to restore (the position just after
+ * the newly inserted text). When there is no caret to honor (`caretRange` undefined,
+ * e.g. contenteditable), it composes against the full initial text and returns no
+ * caret offset — preserving the previous append-at-end behavior.
+ *
+ * Note the regression-safety property: when the caret sits at the end of the initial
+ * text (`after === ""`), the result is identical to composing against the full
+ * initial text, so existing end-of-field behavior is unchanged.
+ */
+function composeFinalTextAtCaret(
+  initialText: string,
+  caretRange: CaretRange | undefined,
+  compose: (before: string) => string
+): { text: string; caretOffset?: number } {
+  if (!caretRange) {
+    return { text: compose(initialText) };
+  }
+
+  const len = initialText.length;
+  const start = Math.max(0, Math.min(caretRange.start, len));
+  const end = Math.max(start, Math.min(caretRange.end, len));
+  const before = initialText.slice(0, start);
+  const after = initialText.slice(end);
+
+  const composed = compose(before);
+  if (after === "") {
+    return { text: composed, caretOffset: composed.length };
+  }
+
+  // smartJoinTwoTexts appends `after` verbatim (with at most a single separating
+  // space before it), so the caret lands exactly where `after` begins.
+  const text = smartJoinTwoTexts(composed, after);
+  return { text, caretOffset: text.length - after.length };
 }
 
 function smartJoinTranscriptions(transcriptions: Record<number, string>): string {
@@ -438,11 +516,17 @@ function handleRefinementComplete(
   context.transcriptions[refinementKey] = combinedRefinement;
   context.transcriptionTargets[refinementKey] = targetElement;
 
-  // Calculate final text (initial + accumulated refinement)
+  // Calculate final text, inserting the refined dictation at the caret captured at
+  // dictation start (#178) rather than appending it at the end of the field.
   const initialText = context.initialTextByTarget[targetId] || "";
-  const finalText = smartJoinTwoTexts(initialText, combinedRefinement);
+  const caretRange = context.caretRangeByTarget[targetId];
+  const { text: finalText, caretOffset } = composeFinalTextAtCaret(
+    initialText,
+    caretRange,
+    (before) => smartJoinTwoTexts(before, combinedRefinement)
+  );
 
-  setTextInTarget(finalText, targetElement, true); // Replace all content
+  setTextInTarget(finalText, targetElement, true, caretOffset); // Replace all content
 
   // Update accumulated text if this is the current target
   if (targetElement === context.targetElement) {
@@ -735,7 +819,7 @@ function positionCursorAtEnd(element: HTMLElement): void {
 const textInsertionManager = TextInsertionManager.getInstance();
 
 // Helper function to set text in a specific target element
-function setTextInTarget(text: string, targetElement?: HTMLElement, replaceAll: boolean = false) {
+function setTextInTarget(text: string, targetElement?: HTMLElement, replaceAll: boolean = false, caretOffset?: number) {
   const target = targetElement || getTargetElement();
   if (!target) return;
 
@@ -759,8 +843,8 @@ function setTextInTarget(text: string, targetElement?: HTMLElement, replaceAll: 
   }
 
   // Get the appropriate strategy for this target element using the shared TextInsertionManager
-  const success = textInsertionManager.insertText(target, text, replaceAll);
-  
+  const success = textInsertionManager.insertText(target, text, replaceAll, caretOffset);
+
   if (success) {
     
     // Check what actually ended up in the target after insertion
@@ -780,6 +864,15 @@ function setTextInTarget(text: string, targetElement?: HTMLElement, replaceAll: 
     // Fallback: directly set value/textContent if no strategy is available
     if ((target as any).value !== undefined) {
       (target as any).value = text;
+      // Honor the requested caret offset for input/textarea (#178).
+      if (typeof caretOffset === "number" && typeof (target as any).setSelectionRange === "function") {
+        try {
+          const pos = Math.max(0, Math.min(caretOffset, ((target as any).value || "").length));
+          (target as any).setSelectionRange(pos, pos);
+        } catch (_) {
+          /* setSelectionRange unsupported for this input type; ignore */
+        }
+      }
     } else if ((target as any).textContent !== undefined) {
       (target as any).textContent = text;
     }
@@ -1133,10 +1226,23 @@ export function computeFinalText(
   // 1. Prefer text the server has already merged.
   if (mergedSequences.length > 0) {
     console.debug("Using server-merged text directly.");
-    return mergeServerCorrectedTranscriptions(
+    const serverMerged = mergeServerCorrectedTranscriptions(
       targetTranscriptions,
       mergedSequences
     );
+    // Preserve any pre-existing text (#178): when inserting at a caret, initialText
+    // is the slice *before* the caret and must not be discarded. Guard against
+    // double-inclusion when the merged text already contains it (e.g. initialText was
+    // re-read from a field that already held earlier dictation). Empty initialText
+    // falls through to the merged text unchanged via smartJoinTwoTexts.
+    const alreadyContainsInitial = Boolean(
+      initialText &&
+        (serverMerged === initialText ||
+          serverMerged.includes(initialText.trim()))
+    );
+    return alreadyContainsInitial
+      ? serverMerged
+      : smartJoinTwoTexts(initialText, serverMerged);
   }
 
   const mergedTranscript = mergeTargetTranscriptions(targetTranscriptions);
@@ -1171,6 +1277,7 @@ const machine = createMachine<DictationContext, DictationEvent, DictationTypesta
       transcriptions: {},
       transcriptionsByTarget: {},
       initialTextByTarget: {},
+      caretRangeByTarget: {},
       isTranscribing: false,
       userIsSpeaking: false,
       timeUserStoppedSpeaking: 0,
@@ -1230,6 +1337,22 @@ const machine = createMachine<DictationContext, DictationEvent, DictationTypesta
                     return updated;
                   }
                   return context.initialTextByTarget;
+                },
+                caretRangeByTarget: (context, event: DictationStartEvent) => {
+                  // Capture the caret/selection at dictation start so transcribed
+                  // text is inserted there rather than appended at the end (#178).
+                  if (event.targetElement) {
+                    const targetId = getTargetElementId(event.targetElement);
+                    const caretRange = captureCaretRange(event.targetElement);
+                    const updated = { ...context.caretRangeByTarget };
+                    if (caretRange) {
+                      updated[targetId] = caretRange;
+                    } else {
+                      delete updated[targetId];
+                    }
+                    return updated;
+                  }
+                  return context.caretRangeByTarget;
                 },
               }),
             ],
@@ -1653,9 +1776,11 @@ const machine = createMachine<DictationContext, DictationEvent, DictationTypesta
               });
               delete context.transcriptionsByTarget[targetId];
               
-              // Clear initial text for this target since field was cleared
+              // Clear initial text (and the now-meaningless caret offset) for this
+              // target since the field was cleared.
               delete context.initialTextByTarget[targetId];
-              
+              delete context.caretRangeByTarget[targetId];
+
               // Reset accumulated text if this is the current target
               if (originatingTarget === context.targetElement) {
                 context.accumulatedText = "";
@@ -1678,22 +1803,28 @@ const machine = createMachine<DictationContext, DictationEvent, DictationTypesta
           const initialText = storedInitialText !== undefined ? storedInitialText : currentFieldContent;
           const isUsingStoredInitialText = storedInitialText !== undefined;
 
-          // Get target-specific transcriptions for merging
-          const finalText = computeFinalText(
-            targetTranscriptions,
-            mergedSequences,
-            transcription,
+          // Insert the dictated text at the caret captured at dictation start (#178),
+          // composing it after the text before the caret and re-attaching the text
+          // after the caret. When no caret was captured (e.g. contenteditable) this
+          // composes against the full initial text — the previous append-at-end path.
+          const caretRange = context.caretRangeByTarget[targetId];
+          const { text: finalText, caretOffset } = composeFinalTextAtCaret(
             initialText,
-            isUsingStoredInitialText
+            caretRange,
+            (before) =>
+              computeFinalText(
+                targetTranscriptions,
+                mergedSequences,
+                transcription,
+                before,
+                isUsingStoredInitialText
+              )
           );
           console.debug(
             `Merged text for target ${targetId}: ${finalText}`
           );
 
-          // computeFinalText already includes initial text, so use finalText directly
-          
-          
-          setTextInTarget(finalText, originatingTarget, true); // true = replace all content
+          setTextInTarget(finalText, originatingTarget, true, caretOffset); // true = replace all content
 
           // Finally, handle server-side merging if present, after those sequences have been referenced in composing the final text
           if (mergedSequences.length > 0) {
@@ -1726,6 +1857,7 @@ const machine = createMachine<DictationContext, DictationEvent, DictationTypesta
       resetDictationState: assign({
         transcriptions: () => ({}),
         transcriptionsByTarget: () => ({}),
+        caretRangeByTarget: () => ({}),
         isTranscribing: false,
         userIsSpeaking: false,
         timeUserStoppedSpeaking: 0,
@@ -1791,7 +1923,16 @@ const machine = createMachine<DictationContext, DictationEvent, DictationTypesta
         }
           
         context.initialTextByTarget[targetId] = cleanedInitialText;
-        
+
+        // Capture the caret/selection in the new target so transcribed text is
+        // inserted at that position rather than appended at the end (#178).
+        const caretRange = captureCaretRange(event.targetElement);
+        if (caretRange) {
+          context.caretRangeByTarget[targetId] = caretRange;
+        } else {
+          delete context.caretRangeByTarget[targetId];
+        }
+
         console.log(`Captured initial text for target ${targetId}:`, JSON.stringify(cleanedInitialText));
         
         // Clear only global transcriptions, preserve target-specific mappings
@@ -1977,8 +2118,9 @@ const machine = createMachine<DictationContext, DictationEvent, DictationTypesta
           delete context.transcriptionsByTarget[targetId];
         }
         
-        // Clear initial text for this target
+        // Clear initial text (and the now-stale caret offset) for this target
         delete context.initialTextByTarget[targetId];
+        delete context.caretRangeByTarget[targetId];
 
         // Reset accumulated text if this is the current target
         if (event.targetElement === context.targetElement) {

--- a/src/text-insertion/TextInsertionManager.ts
+++ b/src/text-insertion/TextInsertionManager.ts
@@ -34,13 +34,16 @@ export class TextInsertionManager {
    * @param target The HTML element to insert text into
    * @param text The text to insert
    * @param replaceAll Whether to replace all existing text or append
+   * @param caretOffset Optional character offset to leave the caret at after
+   *   insertion (#178 insert-at-caret). Honored by input/textarea targets;
+   *   ignored by strategies that don't support it.
    * @returns true if insertion was successful, false otherwise
    */
-  insertText(target: HTMLElement, text: string, replaceAll: boolean = false): boolean {
+  insertText(target: HTMLElement, text: string, replaceAll: boolean = false, caretOffset?: number): boolean {
     try {
       const strategy = this.getStrategyForTarget(target);
       if (strategy) {
-        strategy.insertText(target, text, replaceAll);
+        strategy.insertText(target, text, replaceAll, caretOffset);
         return true;
       } else {
         console.warn('No text insertion strategy found for target:', target);

--- a/src/text-insertion/TextInsertionStrategy.ts
+++ b/src/text-insertion/TextInsertionStrategy.ts
@@ -6,7 +6,12 @@
 
 export interface TextInsertionStrategy {
   canHandle(target: HTMLElement): boolean;
-  insertText(target: HTMLElement, text: string, replaceAll: boolean): void;
+  /**
+   * @param caretOffset Optional character offset at which to leave the caret after
+   *   insertion. Supported by InputTextareaStrategy (#178 insert-at-caret); other
+   *   strategies may ignore it and fall back to positioning the caret at the end.
+   */
+  insertText(target: HTMLElement, text: string, replaceAll: boolean, caretOffset?: number): void;
 }
 
 /**
@@ -58,9 +63,9 @@ export class InputTextareaStrategy implements TextInsertionStrategy {
     return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
   }
 
-  insertText(target: HTMLElement, text: string, replaceAll: boolean): void {
+  insertText(target: HTMLElement, text: string, replaceAll: boolean, caretOffset?: number): void {
     const inputTarget = target as HTMLInputElement | HTMLTextAreaElement;
-    
+
     if (replaceAll) {
       inputTarget.value = text;
     } else {
@@ -69,6 +74,19 @@ export class InputTextareaStrategy implements TextInsertionStrategy {
 
     // Dispatch input event for framework compatibility
     inputTarget.dispatchEvent(new Event("input", { bubbles: true }));
+
+    // Position the caret at the requested offset (#178 insert-at-caret). Done after
+    // dispatching the input event so our position is the final state even if a
+    // framework listener moves the caret in response to the value change.
+    if (typeof caretOffset === "number") {
+      const pos = Math.max(0, Math.min(caretOffset, inputTarget.value.length));
+      try {
+        inputTarget.setSelectionRange(pos, pos);
+      } catch (_) {
+        // setSelectionRange throws for input types that don't support selection
+        // (e.g. number, email); safe to ignore — the caret stays at its default.
+      }
+    }
   }
 }
 

--- a/test/state-machines/DictationMachine-InsertAtCaret.spec.ts
+++ b/test/state-machines/DictationMachine-InsertAtCaret.spec.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { interpret } from 'xstate';
+import EventBus from '../../src/events/EventBus.js';
+
+// Mock dependencies (mirrors DictationMachine-OutOfOrder.spec.ts so the machine
+// can run headless without real audio/network/preferences).
+vi.mock('../../src/TranscriptionModule', () => ({
+  uploadAudioWithRetry: vi.fn(() => Promise.resolve(1)),
+  isTranscriptionPending: vi.fn(() => false),
+  clearPendingTranscriptions: vi.fn(),
+  getCurrentSequenceNumber: vi.fn(() => 1),
+}));
+
+vi.mock('../../src/ConfigModule', () => ({
+  config: {
+    apiServerUrl: 'http://localhost:3000',
+  },
+}));
+
+vi.mock('../../src/prefs/PreferenceModule', () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({
+      getLanguage: vi.fn(() => Promise.resolve('en')),
+    }),
+  },
+}));
+
+vi.mock('../../src/error-management/TranscriptionErrorManager', () => ({
+  default: {
+    recordAttempt: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/TranscriptMergeService', () => ({
+  TranscriptMergeService: vi.fn().mockImplementation(() => ({
+    mergeTranscriptsLocal: vi.fn((transcripts) => {
+      // Smart join identical to the production fallback for whitespace-free inputs.
+      const sortedKeys = Object.keys(transcripts)
+        .map(Number)
+        .sort((a, b) => a - b);
+
+      let result = '';
+      for (let i = 0; i < sortedKeys.length; i++) {
+        const segment = transcripts[sortedKeys[i]];
+        if (i === 0) {
+          result += segment;
+        } else {
+          const previousEndsWS = result.match(/\s$/);
+          const currentStartsWS = segment.match(/^\s/);
+          result += previousEndsWS || currentStartsWS ? segment : ' ' + segment;
+        }
+      }
+      return result;
+    }),
+  })),
+}));
+
+vi.spyOn(EventBus, 'emit');
+
+import { createDictationMachine } from '../../src/state-machines/DictationMachine';
+
+/**
+ * #178 — Dictation should insert transcribed text at the caret position, preserving
+ * text before and after, rather than always appending at the end of the field.
+ *
+ * Scope of this suite: <input> and <textarea> (selectionStart/selectionEnd). The
+ * worked example from the issue is: "Hello |world" + dictate "beautiful" ->
+ * "Hello beautiful |world".
+ *
+ * Note on the regression-safety property these tests also lock in: when the caret
+ * sits at the END of the field (the default after a programmatic value assignment,
+ * matching real browsers), insert-at-caret is byte-identical to the previous
+ * append-at-end behavior.
+ */
+describe('DictationMachine - Insert at Caret (#178)', () => {
+  let service: any;
+
+  const startOn = (element: HTMLElement) => {
+    service.start();
+    service.send('saypi:startDictation', { targetElement: element });
+    service.send('saypi:callReady');
+  };
+
+  const transcribe = (
+    element: HTMLElement,
+    text: string,
+    sequenceNumber: number = 1,
+    merged?: number[]
+  ) => {
+    service.state.context.transcriptionTargets[sequenceNumber] = element;
+    service.send('saypi:transcribed', {
+      text,
+      sequenceNumber,
+      ...(merged ? { merged } : {}),
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const machine = createDictationMachine();
+    service = interpret(machine);
+  });
+
+  afterEach(() => {
+    if (service) service.stop();
+  });
+
+  it('inserts dictated text at a collapsed caret in a textarea (the issue example)', () => {
+    const textarea = document.createElement('textarea');
+    textarea.id = 'caret-textarea';
+    textarea.value = 'Hello world';
+    // Caret between "Hello " and "world" (offset 6).
+    textarea.setSelectionRange(6, 6);
+    document.body.appendChild(textarea);
+
+    startOn(textarea);
+    transcribe(textarea, 'beautiful');
+
+    expect(textarea.value).toBe('Hello beautiful world');
+    // Caret should advance to just after the inserted text, before the preserved "world".
+    expect(textarea.selectionStart).toBe('Hello beautiful '.length);
+    expect(textarea.selectionEnd).toBe('Hello beautiful '.length);
+
+    document.body.removeChild(textarea);
+  });
+
+  it('inserts at the start of the field when the caret is at offset 0', () => {
+    const textarea = document.createElement('textarea');
+    textarea.id = 'caret-start-textarea';
+    textarea.value = 'world';
+    textarea.setSelectionRange(0, 0);
+    document.body.appendChild(textarea);
+
+    startOn(textarea);
+    transcribe(textarea, 'Hello');
+
+    expect(textarea.value).toBe('Hello world');
+    // Caret sits at the start of the preserved trailing text ("world"), after the
+    // smart-inserted separator — matching the issue's "Hello beautiful |world" example.
+    expect(textarea.selectionStart).toBe('Hello '.length);
+
+    document.body.removeChild(textarea);
+  });
+
+  it('replaces the selected range when a selection (not just a caret) is active', () => {
+    const textarea = document.createElement('textarea');
+    textarea.id = 'caret-selection-textarea';
+    textarea.value = 'Hello cruel world';
+    // Select "cruel" (offsets 6..11).
+    textarea.setSelectionRange(6, 11);
+    document.body.appendChild(textarea);
+
+    startOn(textarea);
+    transcribe(textarea, 'kind');
+
+    expect(textarea.value).toBe('Hello kind world');
+    expect(textarea.selectionStart).toBe('Hello kind'.length);
+
+    document.body.removeChild(textarea);
+  });
+
+  it('inserts at the caret in an <input> element too', () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.id = 'caret-input';
+    input.value = 'ab cd';
+    // Caret after "ab " (offset 3).
+    input.setSelectionRange(3, 3);
+    document.body.appendChild(input);
+
+    startOn(input);
+    transcribe(input, 'XX');
+
+    expect(input.value).toBe('ab XX cd');
+    expect(input.selectionStart).toBe('ab XX '.length);
+
+    document.body.removeChild(input);
+  });
+
+  it('preserves text before and after across out-of-order transcriptions', () => {
+    const textarea = document.createElement('textarea');
+    textarea.id = 'caret-ooo-textarea';
+    textarea.value = 'start end';
+    // Caret after "start " (offset 6), before "end".
+    textarea.setSelectionRange(6, 6);
+    document.body.appendChild(textarea);
+
+    startOn(textarea);
+
+    // Two dictated segments arrive out of order (seq 2 before seq 1).
+    transcribe(textarea, 'two', 2);
+    transcribe(textarea, 'one', 1);
+
+    // Final composed dictation is "one two", inserted at the caret.
+    expect(textarea.value).toBe('start one two end');
+    expect(textarea.selectionStart).toBe('start one two '.length);
+
+    document.body.removeChild(textarea);
+  });
+
+  it('preserves text before and after when the server merges sequences', () => {
+    // Acceptance criterion: "Out-of-order responses and server merges still produce
+    // correct final text" with before/after preserved. The server-merge branch must
+    // not discard the text before the caret.
+    const textarea = document.createElement('textarea');
+    textarea.id = 'caret-merge-textarea';
+    textarea.value = 'Hello world';
+    textarea.setSelectionRange(6, 6); // "Hello |world"
+    document.body.appendChild(textarea);
+
+    startOn(textarea);
+
+    // First fragment, then a server-merged correction that subsumes seq 1 into seq 2.
+    transcribe(textarea, 'foo', 1);
+    expect(textarea.value).toBe('Hello foo world');
+
+    transcribe(textarea, 'foo bar', 2, [1]);
+
+    expect(textarea.value).toBe('Hello foo bar world');
+    expect(textarea.selectionStart).toBe('Hello foo bar '.length);
+
+    document.body.removeChild(textarea);
+  });
+
+  it('keeps the caret at the insertion point across each live update', () => {
+    // The live phase replaces all content on every update; the caret must be
+    // re-restored to the insertion point each time, not jump to the end.
+    const textarea = document.createElement('textarea');
+    textarea.id = 'caret-live-textarea';
+    textarea.value = 'A Z';
+    textarea.setSelectionRange(2, 2); // "A |Z"
+    document.body.appendChild(textarea);
+
+    startOn(textarea);
+
+    transcribe(textarea, 'one', 1);
+    expect(textarea.value).toBe('A one Z');
+    expect(textarea.selectionStart).toBe('A one '.length);
+
+    transcribe(textarea, 'two', 2);
+    expect(textarea.value).toBe('A one two Z');
+    expect(textarea.selectionStart).toBe('A one two '.length);
+
+    document.body.removeChild(textarea);
+  });
+
+  it('appends at the end (unchanged behavior) when the caret is at the end of the field', () => {
+    const textarea = document.createElement('textarea');
+    textarea.id = 'caret-end-textarea';
+    textarea.value = 'Hello world';
+    // Default caret after a value assignment is the end; assert that explicitly.
+    expect(textarea.selectionStart).toBe('Hello world'.length);
+    document.body.appendChild(textarea);
+
+    startOn(textarea);
+    transcribe(textarea, 'again');
+
+    // Same result the pre-#178 append-at-end path produced.
+    expect(textarea.value).toBe('Hello world again');
+    expect(textarea.selectionStart).toBe('Hello world again'.length);
+
+    document.body.removeChild(textarea);
+  });
+});

--- a/test/state-machines/DictationMachine-computeFinalText.spec.ts
+++ b/test/state-machines/DictationMachine-computeFinalText.spec.ts
@@ -60,17 +60,33 @@ describe("computeFinalText (characterization)", () => {
         "unused-server-text",
         "any initial text"
       );
-      expect(result).toBe("the merged text");
+      // #178: pre-existing text (initialText) is now preserved before the server-merged
+      // text instead of being discarded. Previously this returned "the merged text".
+      expect(result).toBe("any initial text the merged text");
     });
 
-    it("ignores initialText and serverText entirely in the server-merge branch", () => {
+    it("preserves initialText (and still ignores serverText) in the server-merge branch", () => {
       const result = computeFinalText(
         { 1: "a", 2: "b", 3: "a b" },
         [1, 2],
         "serverText-ignored",
-        "initial-ignored"
+        "initial-kept"
       );
-      expect(result).toBe("a b");
+      // #178: initialText is preserved before the merged text; serverText stays unused.
+      // Previously this returned "a b" (initialText dropped).
+      expect(result).toBe("initial-kept a b");
+    });
+
+    it("does not duplicate initialText already contained in the server-merged text", () => {
+      // Guards the double-inclusion case: when initialText was re-read from a field
+      // that already held the dictation, it must not be prepended again.
+      const result = computeFinalText(
+        { 1: "redundant", 2: "hello there world" },
+        [1],
+        "",
+        "there world"
+      );
+      expect(result).toBe("hello there world");
     });
 
     it("trims surrounding whitespace from the server-merged result", () => {


### PR DESCRIPTION
## Why

Dictation always appended transcribed text at the **end** of the field, ignoring the user's caret. From #178:

> "Hello |world" + dictate "beautiful" → want "Hello beautiful |world"; currently the dictation lands after "world".

This builds directly on the de-risking groundwork (#281 characterization + #282 behavior-preserving refactor of `computeFinalText`).

## What changed

**Insert-at-caret for `<input>`/`<textarea>`.** The caret/selection is captured at dictation start (`caretRangeByTarget`). At compose time, the pre-existing text is split at the caret into `before`/`after`; the dictation is composed after `before` (through the existing `computeFinalText`/`smartJoinTwoTexts` paths), `after` is re-attached, and the caret is restored to the insertion point via `setSelectionRange`.

- `TextInsertionStrategy`/`TextInsertionManager`: new optional `caretOffset`; `InputTextareaStrategy` restores the caret. Other strategies ignore it.
- `DictationMachine`: `composeFinalTextAtCaret` helper threads `before`/`after` at the **live** and **refinement** write sites; `captureCaretRange` at start/switch; `caretRangeByTarget` cleaned up in lockstep with `initialTextByTarget` (external-clear, manual-edit, reset).

**Server-merge data-loss fix (found in adversarial review).** #178's acceptance criteria promote *"server merges still produce correct final text"* and *"pre-existing text preserved before and after"* to requirements. The server-merge branch of `computeFinalText` previously **discarded** pre-existing text entirely (a pre-existing bug the old empty-field test never caught). It now preserves it, guarded against double-inclusion. The affected characterization assertions are updated with comments documenting the deliberate change.

## Regression safety

When the caret sits at the **end** of the field (the default after a programmatic `value` set, matching real browsers — verified in jsdom), the composed output is **byte-identical** to the previous append-at-end path. So every existing dictation spec — which sets up pre-existing content via `.value=` (caret at end) — is unaffected.

## Tests (fail-first)

New `DictationMachine-InsertAtCaret.spec.ts` (8 cases): collapsed caret mid-field, caret at start, selection-replace, `<input>`, out-of-order, **server-merge before/after preservation**, multi-update caret restoration, and a caret-at-end regression guard. All failed before the fix, pass after.

- `npm test`: Jest 2/2; Vitest **78 files, 744 passed, 1 skipped** (+9).
- `tsc`: clean on changed files.

## Scope / follow-up

This covers **`<input>`/`<textarea>`** — the exact #178 repro. **Contenteditable** (Slate/ProseMirror/Lexical/Quill, which manage their own DOM across re-renders) keeps append-at-end for now and is a separate, higher-risk follow-up. Using **"Addresses #178"** rather than "Closes" so the contenteditable half can be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)