### PR TITLE
fix(tts): tolerate powered_by="OpenAI" voices (unblocks saypi-api #215/#92)

### DIFF
--- a/src/tts/SpeechModel.ts
+++ b/src/tts/SpeechModel.ts
@@ -72,12 +72,25 @@ const audioProviders = {
   // function to get the provider from the text to speech engine name
   retrieveProviderByEngine: (powered_by: string): AudioProvider => {
     switch (powered_by) {
+      // OpenAI value-tier voices are synthesised and streamed by api.saypi.ai
+      // using the same ?voice_id= stream contract as ElevenLabs, so they are
+      // SayPi-served from the client's perspective (issue #215/#92 — the
+      // released extension previously threw on powered_by="OpenAI").
+      case "OpenAI":
       case "ElevenLabs":
         return audioProviders.SayPi;
       case "inflection.ai":
         return audioProviders.Pi;
       default:
-        throw new Error(`Provider powered by ${powered_by} not found.`);
+        // Every provider the API can serve streams from the SayPi domain. An
+        // unrecognised powered_by must NOT crash voice selection the way
+        // "OpenAI" did before this fix (#215/#92): treat any future API-added
+        // provider as SayPi-served and warn, rather than throwing into the
+        // synchronous setVoice / notifyAudioVoiceSelection call paths.
+        console.warn(
+          `Unrecognised TTS provider "${powered_by}"; treating as SayPi-served.`
+        );
+        return audioProviders.SayPi;
     }
   },
   retreiveProviderByVoice: (

--- a/test/tts/AudioProviders.spec.ts
+++ b/test/tts/AudioProviders.spec.ts
@@ -20,5 +20,28 @@ describe('audioProviders', () => {
     expect(audioProviders.getDefault().name).toBe('ChatGPT');
     spy.mockRestore();
   });
+
+  describe('retrieveProviderByEngine', () => {
+    it('maps OpenAI value-tier voices to the SayPi provider (issue #215/#92)', () => {
+      // OpenAI TTS is streamed from api.saypi.ai like ElevenLabs, so it is a
+      // SayPi-served voice from the client's perspective.
+      expect(audioProviders.retrieveProviderByEngine('OpenAI')).toBe(audioProviders.SayPi);
+    });
+
+    it('still maps the known ElevenLabs and inflection.ai engines', () => {
+      expect(audioProviders.retrieveProviderByEngine('ElevenLabs')).toBe(audioProviders.SayPi);
+      expect(audioProviders.retrieveProviderByEngine('inflection.ai')).toBe(audioProviders.Pi);
+    });
+
+    it('falls back to SayPi (and warns) instead of throwing on an unrecognised provider', () => {
+      // Regression guard for #215/#92: an unknown powered_by used to throw,
+      // crashing the synchronous voice-selection path. It must now degrade.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(() => audioProviders.retrieveProviderByEngine('SomeFutureProvider')).not.toThrow();
+      expect(audioProviders.retrieveProviderByEngine('SomeFutureProvider')).toBe(audioProviders.SayPi);
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
+    });
+  });
 });
 


### PR DESCRIPTION
## What

Make the userscript tolerate `powered_by="OpenAI"` voices so the API can re-enable OpenAI value-tier TTS without crashing the released extension. Unblocks saypi-api **#215 / #92**.

## Why

`audioProviders.retrieveProviderByEngine` (`src/tts/SpeechModel.ts`) switched only on `"ElevenLabs"` and `"inflection.ai"` and **threw** on anything else:

```ts
default:
  throw new Error(`Provider powered by ${powered_by} not found.`);
```

When `OPENAI_TTS_ENABLED=true` the API serves voices carrying `powered_by="OpenAI"`. That throw fires **synchronously** in three release-build paths the moment such a voice is touched:

- `PreferenceModule.setVoice` (`:840`) — selecting an OpenAI voice
- `AudioControlsModule.notifyAudioVoiceSelection` (`:71`, `:78`) — selection notification
- `SpeechSynthesisModule.getAudioProvider` (`:348`) — reload with a stored OpenAI preference

i.e. voice selection crashes. This is why `OPENAI_TTS_ENABLED` is currently forced `false` in production.

## Change

- Add an explicit `case "OpenAI": return audioProviders.SayPi;`. OpenAI voices are synthesised and streamed by `api.saypi.ai` using the same `?voice_id=` stream contract as ElevenLabs, so they are SayPi-served from the client's perspective. (This also satisfies `VoiceFactory.matchableFromVoiceRemote`'s existing `SayPi` branch — it builds a `SayPiVoice` — so no change is needed there.)
- Harden the `default` to **warn and fall back to SayPi** instead of throwing, so a *future* API-added provider can't crash an old extension build the same way this one did.
- Unit tests in `test/tts/AudioProviders.spec.ts` pin the OpenAI mapping, the existing ElevenLabs/inflection mappings (regression), and the no-longer-throwing default.

No `tier` field exists in the `/voices` contract, and the extra `model` field on OpenAI voices is ignored by the client's structural typing — so no further tolerance is needed. The powered-by badge renders from the already-committed `public/icons/logos/openai.svg`.

## ⚠️ Deployment ordering (mandatory)

This change is **additive and dormant** until the API serves OpenAI voices, so it is safe to merge ahead of any API change. But the kill switch must not be flipped until this is **live in users' browsers**:

1. Merge + **release** this extension build to the stores.
2. Confirm store rollout to users.
3. **Then** re-enable `OPENAI_TTS_ENABLED=true` on saypi-api.

Flipping the API switch before the new build rolls out would crash voice selection for everyone still on the old build.

## Test plan

```
npx vitest run test/tts/AudioProviders.spec.ts   # 5 passed
```

`tsc --noEmit` reports 152 pre-existing errors across unrelated files (`entrypoints/settings`, `ApiClient`, `AuthPromptController`, …) — this repo builds via wxt, not bare `tsc`. **Zero** of them are in the files this PR touches; verified `SpeechModel.ts` and `AudioProviders.spec.ts` are error-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
