### PR TITLE
fix(tts): make the regenerate-speech button degrade gracefully (#241/#268)

### DIFF
--- a/src/dom/MessageElements.ts
+++ b/src/dom/MessageElements.ts
@@ -15,6 +15,7 @@ import EventBus from "../events/EventBus";
 import { isMobileDevice } from "../UserAgentModule";
 import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { SpeechHistoryModule } from "../tts/SpeechHistoryModule";
+import { regenerateSpeech } from "./regenerateSpeech";
 import { MessageState } from "../tts/MessageHistoryModule";
 import telemetryModule, { TelemetryData } from "../TelemetryModule";
 import { IconModule } from "../icons/IconModule";
@@ -463,27 +464,21 @@ abstract class AssistantResponse {
       }
     }
 
-    // add event listener to regenerate speech
-    regenButton.addEventListener("click", async () => {
-      regenButton.disabled = true;
-      const speechSynthesis = SpeechSynthesisModule.getInstance();
-      const speechHistory = SpeechHistoryModule.getInstance();
-      speechSynthesis
-        .createSpeech(this.text, false)
-        .then((utterance) => {
-          speechSynthesis.speak(utterance);
-          this.decorateSpeech(utterance);
-          const charge = BillingModule.getInstance().charge(
-            utterance,
-            this.text
-          );
-          this.decorateCost(charge);
-          const speech = new AssistantSpeech(utterance, charge);
-          speechHistory.addSpeechToHistory(charge.utteranceHash, speech);
-          regenButton.remove();
-          this.safeRemoveClass("speech-incomplete");
-        });
-    });
+    // add event listener to regenerate speech (degrades gracefully on failure; #241/#268)
+    regenButton.addEventListener("click", () =>
+      regenerateSpeech(regenButton, this.text, (utterance) => {
+        const speechSynthesis = SpeechSynthesisModule.getInstance();
+        const speechHistory = SpeechHistoryModule.getInstance();
+        speechSynthesis.speak(utterance);
+        this.decorateSpeech(utterance);
+        const charge = BillingModule.getInstance().charge(utterance, this.text);
+        this.decorateCost(charge);
+        const speech = new AssistantSpeech(utterance, charge);
+        speechHistory.addSpeechToHistory(charge.utteranceHash, speech);
+        regenButton.remove();
+        this.safeRemoveClass("speech-incomplete");
+      })
+    );
   }
 
   async decorateCost(charge: UtteranceCharge): Promise<void> {
@@ -804,27 +799,24 @@ abstract class MessageControls {
       }
     }
 
-    // add event listener to regenerate speech
-    regenButton.addEventListener("click", async () => {
-      regenButton.disabled = true;
-      const speechSynthesis = SpeechSynthesisModule.getInstance();
-      const speechHistory = SpeechHistoryModule.getInstance();
-      speechSynthesis
-        .createSpeech(this.message.text, false)
-        .then((utterance) => {
-          speechSynthesis.speak(utterance);
-          this.decorateSpeech(utterance);
-          const charge = BillingModule.getInstance().charge(
-            utterance,
-            this.message.text
-          );
-          this.decorateCost(charge);
-          const speech = new AssistantSpeech(utterance, charge);
-          speechHistory.addSpeechToHistory(charge.utteranceHash, speech);
-          regenButton.remove();
-          this.safeRemoveClass("speech-incomplete");
-        });
-    });
+    // add event listener to regenerate speech (degrades gracefully on failure; #241/#268)
+    regenButton.addEventListener("click", () =>
+      regenerateSpeech(regenButton, this.message.text, (utterance) => {
+        const speechSynthesis = SpeechSynthesisModule.getInstance();
+        const speechHistory = SpeechHistoryModule.getInstance();
+        speechSynthesis.speak(utterance);
+        this.decorateSpeech(utterance);
+        const charge = BillingModule.getInstance().charge(
+          utterance,
+          this.message.text
+        );
+        this.decorateCost(charge);
+        const speech = new AssistantSpeech(utterance, charge);
+        speechHistory.addSpeechToHistory(charge.utteranceHash, speech);
+        regenButton.remove();
+        this.safeRemoveClass("speech-incomplete");
+      })
+    );
   }
 
   /**

--- a/src/dom/regenerateSpeech.ts
+++ b/src/dom/regenerateSpeech.ts
@@ -1,0 +1,54 @@
+import { SpeechSynthesisModule } from "../tts/SpeechSynthesisModule";
+import { SpeechUtterance } from "../tts/SpeechModel";
+
+/**
+ * Shared click handler for the "regenerate speech" button on assistant messages.
+ *
+ * Disables the button, obtains a fresh utterance for `text`, and hands it to
+ * `onUtterance` for message-specific decoration (speak, charge, history, button
+ * removal). If speech cannot be generated — most commonly because no voice is
+ * selected (voice off / signed out), but also on transient synthesis or network
+ * errors — the button is re-enabled so the user can retry, and the failure is
+ * logged rather than surfaced as an unhandled promise rejection that would leave
+ * the button stuck disabled. (#241/#268)
+ *
+ * The auto-TTS path already degrades to a silent placeholder (see
+ * SpeechSynthesisModule.createSpeechStream); this brings the explicit,
+ * user-triggered regenerate path to parity.
+ */
+export async function regenerateSpeech(
+  regenButton: HTMLButtonElement,
+  text: string,
+  onUtterance: (utterance: SpeechUtterance) => void | Promise<void>
+): Promise<void> {
+  regenButton.disabled = true;
+
+  let utterance: SpeechUtterance;
+  try {
+    utterance = await SpeechSynthesisModule.getInstance().createSpeech(
+      text,
+      false
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === "No voice selected") {
+      // Expected when voice is off or the user is signed out — not an error.
+      console.debug("[SayPi] Speech regeneration skipped: no voice selected");
+    } else {
+      console.warn("[SayPi] Speech could not be generated:", error);
+    }
+    // Re-enable so the user can retry instead of leaving the button stuck disabled.
+    regenButton.disabled = false;
+    return;
+  }
+
+  // Speech generated; run the caller's decoration. If that fails, recover the
+  // button too — but label it distinctly so a post-generation bug isn't reported
+  // as a generation failure.
+  try {
+    await onUtterance(utterance);
+  } catch (error) {
+    console.warn("[SayPi] Speech regenerated but post-processing failed:", error);
+    regenButton.disabled = false;
+  }
+}

--- a/test/dom/regenerateSpeech.spec.ts
+++ b/test/dom/regenerateSpeech.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Control SpeechSynthesisModule.createSpeech so we can drive success/failure.
+const createSpeech = vi.fn();
+vi.mock('../../src/tts/SpeechSynthesisModule', () => ({
+  SpeechSynthesisModule: {
+    getInstance: () => ({ createSpeech }),
+  },
+}));
+
+import { regenerateSpeech } from '../../src/dom/regenerateSpeech';
+
+/**
+ * #241/#268 — the "regenerate speech" button must degrade gracefully. When speech
+ * cannot be generated (most often because no voice is selected — voice off or
+ * signed out), the button must be re-enabled so the user can retry, and the
+ * failure must not surface as an unhandled promise rejection that leaves the
+ * button stuck disabled.
+ */
+describe('regenerateSpeech (#241/#268)', () => {
+  let button: HTMLButtonElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    button = document.createElement('button');
+    button.disabled = false;
+  });
+
+  it('re-enables the button and resolves (no rejection) when no voice is selected', async () => {
+    createSpeech.mockRejectedValue(new Error('No voice selected'));
+    const onUtterance = vi.fn();
+
+    await expect(
+      regenerateSpeech(button, 'hello', onUtterance)
+    ).resolves.toBeUndefined();
+
+    expect(onUtterance).not.toHaveBeenCalled();
+    expect(button.disabled).toBe(false); // recovered — user can retry
+  });
+
+  it('re-enables the button on an unexpected synthesis error', async () => {
+    createSpeech.mockRejectedValue(new Error('Failed to synthesize speech'));
+
+    await expect(
+      regenerateSpeech(button, 'hello', vi.fn())
+    ).resolves.toBeUndefined();
+
+    expect(button.disabled).toBe(false);
+  });
+
+  it('disables the button and delegates the utterance to the caller on success', async () => {
+    const utterance = { id: 'u1' } as any;
+    createSpeech.mockResolvedValue(utterance);
+    const onUtterance = vi.fn();
+
+    await regenerateSpeech(button, 'hello', onUtterance);
+
+    expect(createSpeech).toHaveBeenCalledWith('hello', false);
+    expect(onUtterance).toHaveBeenCalledWith(utterance);
+    // On success the button stays disabled; the caller removes it after decorating.
+    expect(button.disabled).toBe(true);
+  });
+
+  it('recovers the button (no rejection) when post-generation decoration throws', async () => {
+    createSpeech.mockResolvedValue({ id: 'u1' } as any);
+    const onUtterance = vi.fn(() => {
+      throw new Error('decoration blew up');
+    });
+
+    await expect(
+      regenerateSpeech(button, 'hello', onUtterance)
+    ).resolves.toBeUndefined();
+
+    expect(button.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

The explicit **"regenerate speech"** button called `SpeechSynthesisModule.createSpeech(text, false)` inside `.then()` with **no `.catch()`**. When no voice is selected (voice off / signed out), `createSpeech` throws `"No voice selected"` → the button is left **stuck `disabled` forever** plus an unhandled promise rejection. (Same family as the live finding behind #279/#268.)

PR #279 fixed this for the **auto** TTS path (`createSpeechStream` returns a silent placeholder). This brings the **user-triggered** regenerate path to parity.

## What changed

The regen handler lived near-identically in two abstract classes (`AssistantResponse`, `MessageControls`) — so the bug existed twice. Extracted it into one small, unit-tested helper:

```ts
regenerateSpeech(regenButton, text, onUtterance)
```

- disables the button, generates speech, delegates success decoration to the caller's closure;
- on **generation** failure: re-enables the button so the user can retry; logs `"no voice selected"` at `debug` (expected state), other failures at `warn`;
- on **post-generation** (decoration) failure: also recovers the button, logged distinctly so a decoration bug isn't reported as a generation failure.

Both call sites now delegate to it; the success branch is preserved byte-for-byte (`decorateSpeech`/`decorateCost` stay fire-and-forget, ordering unchanged). The 429/quota path is untouched — `createSpeech` *resolves* with a `FailedSpeechUtterance` and flows through `onUtterance` exactly as before.

## Tests (fail-first)

New `test/dom/regenerateSpeech.spec.ts` — 4 cases: no-voice rejection → button re-enabled & no throw; unexpected synthesis error → re-enabled; success → utterance delegated; post-generation throw → button recovered. The two failure cases were confirmed failing against a no-`catch` version first.

- `npm test`: Jest 2/2; Vitest **79 files, 748 passed, 1 skipped** (+4).
- `tsc`: clean on changed files.

## Review

Adversarial review: APPROVE-WITH-NITS — verified success byte-equivalence, 429 path unchanged, no import cycle, correct button type. Nit applied: split generation vs post-generation failure logging (this PR's final form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)