### PR TITLE
fix(ui): stop call-button SVG churn destroying the countdown arc (#203)

### DIFF
--- a/src/buttons/CallButton.ts
+++ b/src/buttons/CallButton.ts
@@ -22,7 +22,7 @@ interface Segment {
     errorType?: string;
 }
 
-class CallButton {
+export class CallButton {
     private chatbot: Chatbot;
     private userPreferences: UserPreferenceModule;
     private sayPiActor: typeof StateMachineService.conversationActor;
@@ -526,54 +526,61 @@ class CallButton {
         }
     }
 
-    private updateCallButton(button: HTMLButtonElement | null, svgIconString: string, label: string, onClick: (() => void) | null, isActiveState: boolean) {
+    private updateCallButton(button: HTMLButtonElement | null, svgIconString: string, label: string, onClick: (() => void) | null, isActiveState: boolean, stateKey: string) {
         const callButton = button || this.element;
         if (!callButton) return;
 
-        // 1. Clear ALL previous children from the button.
-        while (callButton.firstChild) {
-            callButton.removeChild(callButton.firstChild);
+        // Only rebuild the SVG when the rendered icon/state actually changes. The call
+        // button's state subscription re-invokes these renderers many times during a
+        // call (listening substates oscillate as the user speaks/pauses/transcribes),
+        // and a full teardown+rebuild destroys and recreates the SVG — including
+        // #progress-ring — wiping the countdown-arc animation before it can render
+        // (#203). Skipping redundant same-state rebuilds lets the ring (and its
+        // .active countdown) persist; genuine icon changes still rebuild.
+        const alreadyRendered =
+            !!callButton.querySelector("svg") && callButton.dataset.callState === stateKey;
+
+        if (!alreadyRendered) {
+            // 1. Clear ALL previous children from the button.
+            while (callButton.firstChild) {
+                callButton.removeChild(callButton.firstChild);
+            }
+
+            // 2. Create the new SVG element from the icon string.
+            const newSvgElement = createSVGElement(svgIconString);
+            if (!newSvgElement || !(newSvgElement instanceof SVGElement)) {
+                console.error("Failed to create SVG element from string or invalid type:", svgIconString);
+                callButton.textContent = label; // Fallback: just show the label as text
+                delete callButton.dataset.callState;
+                return;
+            }
+
+            // 3. Create the segments group (first child) that segments draw into.
+            //    Original background is left in place; updateButtonSegments manages it.
+            const segmentsGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            segmentsGroup.setAttribute('id', 'saypi-segments-group');
+            newSvgElement.insertBefore(segmentsGroup, newSvgElement.firstChild);
+
+            // 4. Append the complete new SVG element directly to the button.
+            callButton.appendChild(newSvgElement);
+            callButton.dataset.callState = stateKey;
         }
 
-        // 2. Create the new SVG element from the icon string.
-        const newSvgElement = createSVGElement(svgIconString);
-        if (!newSvgElement || !(newSvgElement instanceof SVGElement)) {
-            console.error("Failed to create SVG element from string or invalid type:", svgIconString);
-            callButton.textContent = label; // Fallback: just show the label as text
-            return;
-        }
-
-        // ChatGPT theming is now applied only for the inactive call state in callInactive()
-
-        // 3. Original background is NOT removed here anymore. It will be handled by updateButtonSegments.
-
-        // 4. Create the segments group that will live inside the new SVG element.
-        const segmentsGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        segmentsGroup.setAttribute('id', 'saypi-segments-group');
-
-        // 5. Insert segmentsGroup as the first child of the new SVG element.
-        newSvgElement.insertBefore(segmentsGroup, newSvgElement.firstChild);
-
-        // 6. Append the complete new SVG element directly to the button.
-        callButton.appendChild(newSvgElement);
-
-        // 7. Set attributes and event listeners on the button itself.
+        // 5. Set attributes and event listeners on the button itself. Idempotent, so
+        //    run on every call to keep the label/handler/active-state current even
+        //    when the SVG rebuild was skipped.
         const finalLabel = this.overrideLabelForHost(label, isActiveState, callButton);
         callButton.setAttribute("aria-label", finalLabel);
-        if (onClick) {
-            callButton.onclick = onClick;
-        } else {
-            callButton.onclick = null;
-        }
+        callButton.onclick = onClick || null;
         callButton.classList.toggle("active", isActiveState);
 
-        // 8. Update internal state.
+        // 6. Update internal state.
         this.callIsActive = isActiveState;
 
-        // 9. Now that the SVG structure is in the DOM, draw/update the segments into the segmentsGroup.
+        // 7. Draw/update the segments into the segmentsGroup (reuses the existing group).
         this.updateButtonSegments();
 
-        // 10. Handle glow animation (primarily managed by state machine subscription).
+        // 8. Handle glow animation (primarily managed by state machine subscription).
         if (!this.callIsActive) {
             AnimationModule.stopAnimation("glow");
             this.glowColorUpdater.updateGlowColor(0);
@@ -584,7 +591,8 @@ class CallButton {
         const label = getMessage("callStarting");
         this.updateCallButton(button, callStartingIconSVG, label, () =>
             this.sayPiActor.send({ type: "saypi:hangup" }), // Use object syntax
-            false // Not fully active yet
+            false, // Not fully active yet
+            "starting"
         );
         // Glow might start here or wait for listening state?
     }
@@ -593,7 +601,8 @@ class CallButton {
         const label = getMessage("callInProgress");
         this.updateCallButton(button, hangupIconSVG, label, () =>
              this.sayPiActor.send({ type: "saypi:hangup" }),
-             true
+             true,
+             "active"
         );
         
         // Apply ChatGPT theming specifically for the active hangup.svg icon
@@ -618,7 +627,7 @@ class CallButton {
             const label = getMessage("callInterruptible");
             this.updateCallButton(button, interruptIconSVG, label, () => {
                  this.sayPiActor.send({ type: "saypi:interrupt" });
-            }, true); // Active state
+            }, true, "interruptible"); // Active state
              // AnimationModule.startAnimation("glow"); // Ensure glow is on -- Handled by subscription
         } else {
             // If hands-free interrupt is ON, just show the regular hangup icon
@@ -635,7 +644,8 @@ class CallButton {
         const label = getMessage("callNotStarted", nickname);
         this.updateCallButton(button, callIconSVG, label, () =>
                 this.sayPiActor.send({ type: "saypi:call" }),
-                false
+                false,
+                "inactive"
         );
         
         // Apply ChatGPT theming specifically for the inactive call.svg icon

--- a/test/buttons/CallButton-arc-rebuild.spec.ts
+++ b/test/buttons/CallButton-arc-rebuild.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the heavy module-level dependencies so CallButton imports cleanly in jsdom.
+vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
+vi.mock("../../src/AnimationModule", () => ({
+  default: { startAnimation: vi.fn(), stopAnimation: vi.fn() },
+}));
+vi.mock("../../src/StateMachineService", () => ({ default: { actor: null } }));
+vi.mock("../../src/buttons/GlowColorUpdater", () => ({
+  GlowColorUpdater: class {
+    updateGlowColor() {}
+  },
+}));
+
+import { CallButton } from "../../src/buttons/CallButton";
+
+/**
+ * #203 — the countdown arc never renders. Root cause (confirmed via live DOM
+ * monitoring on pi.ai): the call button's state subscription re-invokes the
+ * render methods many times during a call, and each call tore down + rebuilt the
+ * whole SVG — destroying #progress-ring (and the .active countdown animation
+ * applied to it) before it could show. The fix makes a redundant SAME-state
+ * render skip the SVG rebuild so the ring (and its countdown) persists.
+ */
+describe("CallButton — arc rebuild churn (#203)", () => {
+  let btn: HTMLButtonElement;
+  let cb: any;
+
+  beforeEach(() => {
+    btn = document.createElement("button");
+    document.body.appendChild(btn);
+    cb = Object.create(CallButton.prototype);
+    cb.element = btn;
+    cb.sayPiActor = { send: vi.fn() };
+    cb.segments = [];
+    cb.currentSegment = null;
+    cb.callIsActive = false;
+    cb.glowColorUpdater = { updateGlowColor: vi.fn() };
+    cb.chatbot = { getNickname: async () => "Pi", getID: () => "pi" };
+  });
+
+  it("preserves the #progress-ring (and its .active countdown) across a redundant same-state render", () => {
+    cb.callActive(btn);
+    const ring1 = btn.querySelector("#progress-ring") as SVGElement | null;
+    expect(ring1).toBeTruthy();
+
+    // Simulate the countdown being activated on the ring.
+    ring1!.classList.add("active");
+    (ring1 as any).dataset.marker = "m1";
+
+    // A redundant same-state render (the churn that wiped the arc).
+    cb.callActive(btn);
+
+    const ring2 = btn.querySelector("#progress-ring") as SVGElement | null;
+    expect(ring2).toBe(ring1); // same element, not recreated
+    expect(ring2!.classList.contains("active")).toBe(true); // countdown survives
+    expect((ring2 as any).dataset.marker).toBe("m1");
+  });
+
+  it("still rebuilds the SVG on a genuine state change (active -> inactive)", async () => {
+    cb.callActive(btn);
+    expect(btn.querySelector("#progress-ring")).toBeTruthy();
+    expect(btn.dataset.callState).toBe("active");
+
+    await cb.callInactive(btn);
+
+    expect(btn.dataset.callState).toBe("inactive");
+    // call.svg (inactive icon) has no progress ring.
+    expect(btn.querySelector("#progress-ring")).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Why

The countdown arc around the call button (the dynamic submit-wait feedback) stopped rendering — #203.

I reproduced and root-caused this **live** on pi.ai via DOM monitoring. During a single turn:

| | Capture 1 | Capture 2 |
|---|---|---|
| `#progress-ring` destroyed + recreated | 35× / 36× | 18× / 18× |
| `.active` countdown landed on a **live** ring | 0× | 1× |
| Arc actually rendered | no | no (wiped right after) |

The full static chain is intact (element, CSS, trigger, `VisualNotificationsModule` all present/wired). The arc never shows because the `#progress-ring` element is **destroyed and recreated 18–35 times per turn** — so the `.active` countdown is wiped almost instantly (and the ring reference cached in `VisualNotificationsModule` is constantly invalidated).

## Root cause

`CallButton.updateCallButton` unconditionally tore down (`while (firstChild) removeChild`) and rebuilt the **entire SVG** on every call. The call button's state subscription re-invokes the render methods many times during a call as the `listening` substates oscillate (speaking / pausing / transcribing) — each one a full SVG rebuild that recreates `#progress-ring` with no `.active`.

## Fix

Make `updateCallButton` **idempotent**: skip the SVG teardown/rebuild when the requested state is already rendered (tracked via `button.dataset.callState`), so the ring and its in-progress countdown animation persist. Genuine icon transitions (`starting`/`active`/`interruptible`/`inactive`) still rebuild. Label, onClick, the `active` class, segments, and glow handling still update on every call.

## Tests (fail-first)

`test/buttons/CallButton-arc-rebuild.spec.ts` (2 cases): a redundant same-state render preserves the **same** `#progress-ring` element and its `.active`/marker; a genuine `active → inactive` transition still rebuilds (ring gone). Both verified failing with the source fix stashed.

- `npm test`: Jest 2/2; Vitest **80 files, 753 passed, 1 skipped** (+2).
- `tsc`: clean on changed files.
- Adversarial review: **APPROVE** (guard correctness, behavior preservation, root-cause corroboration all verified).

## Verification status

Root cause **confirmed live** (DOM monitor) and the fix is unit-tested + reviewed. The final *visual* confirmation (arc now appears and animates) should be done with a dev build loaded — happy to drive that repro with the founder before release. `export class CallButton` is purely additive (only the factory functions are imported elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)