### PR TITLE
docs: add a 'choosing a test layer' guide to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,16 @@ WXT discovers entry points in **`entrypoints/`**; each is a thin shim that impor
 - **JSDOM** test environment for DOM manipulation testing
 - Mock implementations for Chrome extension APIs
 
+#### Choosing a test layer (prove it at the lowest layer that can)
+
+The testability net has four layers — reach for the cheapest one that can actually catch the bug:
+
+- **Layers 1–2 — unit / contract** (`npm test`; Jest + Vitest, JSDOM). Pure logic, XState machines, and `src/chatbots/` adapter contract tests against recorded DOM fixtures. The **required** merge gate. Default for any change with extractable logic. Can't catch real-browser or cross-context behavior.
+- **Layer 3 — headless E2E** (`npm run e2e:build && npm run test:e2e`; Playwright + real headless Chrome). Use when a change touches content-script **bootstrap/decoration**, the **offscreen ↔ service-worker ↔ VAD/STT** wiring, CSP, or anything needing a *real browser* but verifiable against a DOM you control. Fast, deterministic, **hermetic**, CI-able (currently **advisory**), and it **can drive the mic** via fake audio. Can't: real-host DOM fidelity, real auth, real network. See **[e2e/README.md](e2e/README.md)**.
+- **Layer 4 — real-site spot-check** (`node scripts/dev-rig.mjs` + Claude-in-Chrome). Use when you need fidelity to the *actual* pi.ai/Claude/ChatGPT DOM (which drifts and is **not** an API contract) or to confirm a fix on the live host. On-demand, **not** CI; needs the founder's browser (and the founder for mic-gated paths). Reach for it **after** Layer 3 is green, for real-host confirmation. See **[doc/autonomous-dev-loop.md](doc/autonomous-dev-loop.md)** (details below).
+
+Rule of thumb: if a controlled DOM can reproduce it, it belongs in Layer 3 (repeatable, in CI); reserve Layer 4 for what only the real host can show.
+
 #### Real-site verification (Layer 4 dev-verify loop)
 
 To verify a change in a real browser against the live hosts (pi.ai/Claude/ChatGPT),


### PR DESCRIPTION
Closes a documentation gap found while answering 'do the agent docs clearly say how/when to use both test layers?'

**Gap:** `CLAUDE.md` (auto-loaded every session) documented only the **Layer 4** real-site loop under Testing — a fresh agent session reading it would not learn that **Layer 3** (the headless E2E harness, PR #289) exists, nor when to choose which layer. (AGENTS.md already describes both layers and lists both runbooks; the gap was specifically the auto-loaded doc + the absence of a crisp decision guide.)

**Fix:** a concise "Choosing a test layer" guide covering all four layers — each with its run command, runbook pointer, and what it can/can't catch — plus a rule of thumb (prove it at the lowest layer that can; L3 for browser/wiring/mic against a controlled DOM; L4 for real-host confirmation only).

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)