### PR TITLE
fix(telemetry): analytics config fails soft instead of aborting bootstrap (#292)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -116,10 +116,10 @@ Mixing them up is the single most confusing failure mode here:
   `.env.development.local` with the *public, non-secret* dev URLs
   (`VITE_API_SERVER_URL=https://api.saypi.ai`, etc.) so the compiled content
   script calls the real hostnames — which `--host-resolver-rules` then redirects.
-  These are **build-time** values baked into the bundle by WXT/Vite. The GA_*
-  values are non-secret placeholders that exist only because
-  `SessionAnalyticsMachine` validates analytics config at module load and would
-  otherwise throw and abort bootstrap. **Never put a secret here.**
+  These are **build-time** values baked into the bundle by WXT/Vite. **Never put
+  a secret here.** GA_* are deliberately omitted: telemetry fails soft (#292), so
+  building GA-less makes `decoration.e2e.ts` a regression guard — bootstrap must
+  still decorate the page with no analytics config.
 - **Shell / process env vars → the harness runtime.** `SAYPI_E2E_PI_PORT` and
   `SAYPI_E2E_API_PORT` are exported by `global-setup` *after* the mock servers
   bind ephemeral ports, and consumed by `launch-args.ts` to build

--- a/e2e/specs/decoration.e2e.ts
+++ b/e2e/specs/decoration.e2e.ts
@@ -5,6 +5,11 @@ import { test, expect } from "../fixtures/extension";
 // bootstrap survives absent telemetry config (analytics fails soft, not fatal).
 // If the SessionAnalyticsMachine module-load throw is ever reintroduced, the
 // bootstrap aborts before decoration and this spec goes red.
+// NOTE: this guard relies on SessionAnalyticsMachine being *eagerly* imported on
+// the bootstrap path (CallButton → StateMachineService → SessionAnalyticsMachine).
+// If that import ever becomes lazy/dynamic, a reintroduced throw could slip past
+// this spec — the unit-level module-load test in test/SessionAnalytics.spec.ts is
+// the backstop for that case.
 test("SayPi detects Pi and decorates the mock page", async ({ context, extensionId }) => {
   expect(extensionId).toMatch(/^[a-p]{32}$/);
   const page = await context.newPage();

--- a/e2e/specs/decoration.e2e.ts
+++ b/e2e/specs/decoration.e2e.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "../fixtures/extension";
 
+// This spec also guards #292: the e2e build ships NO GA_* config
+// (scripts/e2e-build.mjs), so a passing decoration here proves content-script
+// bootstrap survives absent telemetry config (analytics fails soft, not fatal).
+// If the SessionAnalyticsMachine module-load throw is ever reintroduced, the
+// bootstrap aborts before decoration and this spec goes red.
 test("SayPi detects Pi and decorates the mock page", async ({ context, extensionId }) => {
   expect(extensionId).toMatch(/^[a-p]{32}$/);
   const page = await context.newPage();

--- a/scripts/e2e-build.mjs
+++ b/scripts/e2e-build.mjs
@@ -10,25 +10,22 @@ const run = (cmd, args) =>
 // 1) Public, non-secret dev URLs so the src bundle has a real api host to call
 //    (host-resolver later redirects these hostnames to the local mocks).
 //    NEVER write secrets here; these match .env.example public defaults.
-//    The GA_* values are non-secret placeholders (mirroring .env.example's redacted
-//    form). They are required only because SessionAnalyticsMachine.ts validates the
-//    analytics config at MODULE LOAD and throws "GA_MEASUREMENT_ID is not set" when
-//    absent — that throw aborts the entire content-script bootstrap before SayPi
-//    decorates the page, so the harness needs them present (no analytics is actually
-//    sent: the host is sandboxed and the debug endpoint is a no-op).
+//
+//    GA_* are deliberately OMITTED. Telemetry must fail-soft: with no analytics
+//    config the extension still bootstraps and decorates the page, analytics just
+//    disables itself (#292). Building GA-less here makes the decoration spec a
+//    real regression guard for that — if the module-load throw is ever
+//    reintroduced, bootstrap aborts and `decoration.e2e.ts` goes red.
 const envFile = resolve(root, ".env.development.local");
 const desired = [
   "VITE_APP_SERVER_URL=https://app.saypi.ai",
   "VITE_API_SERVER_URL=https://api.saypi.ai",
   "VITE_AUTH_SERVER_URL=https://www.saypi.ai",
   "VITE_DEBUG_LOGS=true",
-  "VITE_GA_MEASUREMENT_ID=G-E2E0000000",
-  "VITE_GA_API_SECRET=e2e-no-secret",
-  "VITE_GA_ENDPOINT=https://www.google-analytics.com/debug/mp/collect",
   "",
 ].join("\n");
 writeFileSync(envFile, desired);
-console.log(`[e2e-build] wrote ${envFile} (public URLs only)`);
+console.log(`[e2e-build] wrote ${envFile} (public URLs only, GA omitted — #292 fail-soft guard)`);
 
 // 2) copy ONNX/WASM (npm prebuild hook is skipped when calling wxt directly)
 run("node", ["copy-onnx-files.js"]);

--- a/src/state-machines/SessionAnalyticsMachine.ts
+++ b/src/state-machines/SessionAnalyticsMachine.ts
@@ -8,6 +8,7 @@ import {
   AudibleNotificationsModule,
 } from "../NotificationsModule";
 import EventBus from "../events/EventBus";
+import { logger } from "../LoggingModule";
 
 interface ValidatedConfig {
   GA_MEASUREMENT_ID: string;
@@ -15,31 +16,48 @@ interface ValidatedConfig {
   GA_ENDPOINT: string;
 }
 
-function validateConfig(
+const REQUIRED_ANALYTICS_KEYS = [
+  "GA_MEASUREMENT_ID",
+  "GA_API_SECRET",
+  "GA_ENDPOINT",
+] as const;
+
+/**
+ * Resolve the analytics (Google Analytics) config without ever throwing.
+ *
+ * Telemetry is a non-essential, fire-and-forget concern, so a missing or blank
+ * GA_* value must NEVER abort content-script bootstrap (#292). When any required
+ * value is absent we log a loud warning (useful in dev) and return null; the
+ * caller then runs with analytics disabled while the rest of the extension —
+ * decoration, call button, voice — keeps working (graceful degradation).
+ */
+export function resolveAnalyticsConfig(
   config: Record<string, string | undefined>
-): ValidatedConfig {
-  if (!config.GA_MEASUREMENT_ID) {
-    throw new Error("GA_MEASUREMENT_ID is not set");
-  }
-  if (!config.GA_API_SECRET) {
-    throw new Error("GA_API_SECRET is not set");
-  }
-  if (!config.GA_ENDPOINT) {
-    throw new Error("GA_ENDPOINT is not set");
+): ValidatedConfig | null {
+  const missing = REQUIRED_ANALYTICS_KEYS.filter((key) => !config[key]);
+  if (missing.length > 0) {
+    logger.warn(
+      `[SessionAnalytics] Analytics disabled — missing config: ${missing.join(
+        ", "
+      )}. The extension will run normally without telemetry.`
+    );
+    return null;
   }
   return {
-    GA_MEASUREMENT_ID: config.GA_MEASUREMENT_ID,
-    GA_API_SECRET: config.GA_API_SECRET,
-    GA_ENDPOINT: config.GA_ENDPOINT,
+    GA_MEASUREMENT_ID: config.GA_MEASUREMENT_ID!,
+    GA_API_SECRET: config.GA_API_SECRET!,
+    GA_ENDPOINT: config.GA_ENDPOINT!,
   };
 }
 
-const valid_config = validateConfig(config);
-const analytics = new AnalyticsService(
-  valid_config.GA_MEASUREMENT_ID,
-  valid_config.GA_API_SECRET,
-  valid_config.GA_ENDPOINT
-);
+const analyticsConfig = resolveAnalyticsConfig(config);
+const analytics = analyticsConfig
+  ? new AnalyticsService(
+      analyticsConfig.GA_MEASUREMENT_ID,
+      analyticsConfig.GA_API_SECRET,
+      analyticsConfig.GA_ENDPOINT
+    )
+  : null;
 const userPreferences = UserPreferenceModule.getInstance();
 
 const MESSAGE_COUNT_THRESHOLD = 50; // number of messages to trigger the long running session prompt
@@ -193,7 +211,7 @@ const machine = createMachine<SessionContext, SessionEvent, SessionTypestate>(
       notifyEndSession: (context: SessionContext, event: EndSessionEvent) => {
         const durationInMillis = Date.now() - context.session_start_time;
         const durationInMinutes = durationInMillis / 1000 / 60;
-        analytics.sendEvent("session_ended", {
+        analytics?.sendEvent("session_ended", {
           session_id: context.session_id,
           engagement_time_msec: durationInMillis,
           message_count: context.message_count,
@@ -214,7 +232,7 @@ const machine = createMachine<SessionContext, SessionEvent, SessionTypestate>(
           context.last_message.talk_time_seconds * 1000;
         const rtf = processing_time_ms / speech_duration_ms;
 
-        analytics.sendEvent("message_sent", {
+        analytics?.sendEvent("message_sent", {
           session_id: context.session_id,
           engagement_time_msec: Date.now() - context.session_start_time,
           delay_msec: event.delay_ms,
@@ -229,7 +247,7 @@ const machine = createMachine<SessionContext, SessionEvent, SessionTypestate>(
         const transcriptionMode = await userPreferences.getCachedTranscriptionMode();
         const language = await userPreferences.getLanguage();
         const elapsed_ms = 0;
-        analytics.sendEvent("session_started", {
+        analytics?.sendEvent("session_started", {
           session_id: context.session_id,
           engagement_time_msec: elapsed_ms,
           transcription_mode: transcriptionMode,

--- a/test/SessionAnalytics.spec.ts
+++ b/test/SessionAnalytics.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression guard for #292: telemetry configuration must never abort
+ * content-script bootstrap. Analytics is a non-essential, fire-and-forget
+ * concern, so a missing/blank GA_* value must disable analytics gracefully
+ * rather than throw at module load (which previously bricked the entire
+ * content script — no decoration, no call button, no voice).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolveAnalyticsConfig } from "../src/state-machines/SessionAnalyticsMachine";
+
+const fullConfig = {
+  GA_MEASUREMENT_ID: "G-123",
+  GA_API_SECRET: "secret",
+  GA_ENDPOINT: "https://ga.example/collect",
+};
+
+describe("resolveAnalyticsConfig (#292 fail-soft telemetry)", () => {
+  it("returns the validated config when all GA values are present", () => {
+    expect(resolveAnalyticsConfig({ ...fullConfig })).toEqual(fullConfig);
+  });
+
+  it.each(["GA_MEASUREMENT_ID", "GA_API_SECRET", "GA_ENDPOINT"])(
+    "returns null (analytics disabled) without throwing when %s is missing",
+    (missingKey) => {
+      const cfg: Record<string, string | undefined> = { ...fullConfig };
+      delete cfg[missingKey];
+      expect(() => resolveAnalyticsConfig(cfg)).not.toThrow();
+      expect(resolveAnalyticsConfig(cfg)).toBeNull();
+    }
+  );
+
+  it("treats a blank string the same as missing", () => {
+    expect(
+      resolveAnalyticsConfig({ ...fullConfig, GA_MEASUREMENT_ID: "" })
+    ).toBeNull();
+  });
+});
+
+describe("SessionAnalyticsMachine module load (#292)", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("../src/ConfigModule");
+  });
+
+  it("does not throw at import when GA config is absent", async () => {
+    // Faithful reproduction: the bug threw "GA_MEASUREMENT_ID is not set" at
+    // module-load time, rejecting this dynamic import and aborting bootstrap.
+    vi.doMock("../src/ConfigModule", () => ({
+      config: {
+        appServerUrl: "https://app.example.com",
+        apiServerUrl: "https://api.example.com",
+        // GA_* deliberately absent — telemetry must disable, not abort bootstrap.
+      },
+    }));
+
+    await expect(
+      import("../src/state-machines/SessionAnalyticsMachine")
+    ).resolves.toHaveProperty("machine");
+  });
+});

--- a/test/SessionAnalytics.spec.ts
+++ b/test/SessionAnalytics.spec.ts
@@ -26,16 +26,20 @@ describe("resolveAnalyticsConfig (#292 fail-soft telemetry)", () => {
     (missingKey) => {
       const cfg: Record<string, string | undefined> = { ...fullConfig };
       delete cfg[missingKey];
-      expect(() => resolveAnalyticsConfig(cfg)).not.toThrow();
-      expect(resolveAnalyticsConfig(cfg)).toBeNull();
+      let result: unknown;
+      expect(() => {
+        result = resolveAnalyticsConfig(cfg);
+      }).not.toThrow();
+      expect(result).toBeNull();
     }
   );
 
-  it("treats a blank string the same as missing", () => {
-    expect(
-      resolveAnalyticsConfig({ ...fullConfig, GA_MEASUREMENT_ID: "" })
-    ).toBeNull();
-  });
+  it.each(["GA_MEASUREMENT_ID", "GA_API_SECRET", "GA_ENDPOINT"])(
+    "treats a blank %s the same as missing",
+    (blankKey) => {
+      expect(resolveAnalyticsConfig({ ...fullConfig, [blankKey]: "" })).toBeNull();
+    }
+  );
 });
 
 describe("SessionAnalyticsMachine module load (#292)", () => {


### PR DESCRIPTION
## Why

Telemetry config was a **fatal, hard dependency of the whole content-script bootstrap**. `SessionAnalyticsMachine.ts` ran `validateConfig(config)` at **module load** and threw `GA_MEASUREMENT_ID is not set` when any `GA_*` value was missing/blank. That module is pulled in by `StateMachineService` → `Button`/`Transcription`/`CallButton`/`Event` modules — all on the bootstrap path — so a missing GA var didn't just disable analytics, it **bricked the entire content script** (no decoration, no call button, no voice). That contradicts the project's "graceful degradation" pattern: a fire-and-forget telemetry concern should never be able to take down the product.

Not user-facing **today** (store builds always ship real `GA_*` values), but a build/env misconfiguration would silently disable the extension for everyone. It was surfaced as the **Layer 3 E2E harness's first real finding** (PR #289) — the harness had to inject placeholder `GA_*` or decoration failed outright.

Resolves #292.

## What

- **`SessionAnalyticsMachine.ts`** — replace the throwing `validateConfig` with a non-throwing `resolveAnalyticsConfig` that logs a loud (dev-visible) warning and returns `null` when config is absent. `analytics` becomes nullable; the 3 call sites use `analytics?.sendEvent(...)`. A missing telemetry key can no longer abort init.
- **`scripts/e2e-build.mjs`** — remove the `GA_*` placeholder workaround. The build now ships **no** analytics config, which turns `decoration.e2e.ts` into a genuine regression guard: if the module-load throw is ever reintroduced, bootstrap aborts and the spec goes red. (The placeholders only ever existed to paper over this bug — its own comment said so.)
- **`e2e/specs/decoration.e2e.ts` / `e2e/README.md`** — document that the spec now guards #292.

## Verification (test-harness layers)

- **Layer 1 (unit, fail-first TDD):** `test/SessionAnalytics.spec.ts` — `resolveAnalyticsConfig` returns `null` (no throw) for each missing/blank key, returns the config when complete; plus a module-load no-throw reproduction (mock `ConfigModule` with GA absent). Confirmed **red** first (`Error: GA_MEASUREMENT_ID is not set`), green after.
- **Required gate:** `npm test` → **86 files, 789 passed / 1 skipped**.
- **Layer 3 (headless E2E):** built the extension **GA-less** and ran the Playwright harness in real headless Chrome — `decoration` (4.4s) and `dictation-stt` (6.4s) both green. This is the end-to-end proof that bootstrap survives absent telemetry config.
- `tsc --noEmit`: no new errors introduced in the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)