### PR TITLE
fix(i18n): label TTS quota as credits, not characters (#275)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -775,7 +775,7 @@
   },
   "ttsQuotaCharacters": {
     "message": "credits",
-    "description": "Unit for TTS quota (characters)."
+    "description": "Unit for the TTS quota (per-voice credits; key name retained for compatibility)."
   },
   "sttQuotaRemaining": {
     "message": "Speech Recognition",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -724,7 +724,7 @@
     "description": "Text to show when TTS quota is exhausted."
   },
   "ttsQuotaProgress": {
-    "message": "$remaining$ of $total$ characters remaining",
+    "message": "$remaining$ of $total$ credits remaining",
     "description": "Tooltip for the TTS quota progress bar.",
     "placeholders": {
       "remaining": {
@@ -734,6 +734,16 @@
       "total": {
         "content": "$2",
         "example": "1000"
+      }
+    }
+  },
+  "ttsCreditsRemaining": {
+    "message": "$credits$ credits remaining",
+    "description": "Text showing remaining TTS quota as a per-voice credit pool (saypi-api #181 Stage 2), not raw characters.",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
       }
     }
   },

--- a/entrypoints/settings/tabs/general/general.html
+++ b/entrypoints/settings/tabs/general/general.html
@@ -28,7 +28,7 @@
       <span class="label" data-i18n="ttsQuotaRemaining">Voice Generation</span>
       <span class="value" style="display: none">
         <span id="tts-quota-remaining-value" class="quota-remaining-value">0</span>
-        <span data-i18n="ttsQuotaCharacters">characters</span>
+        <span data-i18n="ttsQuotaCharacters">credits</span>
       </span>
     </div>
     <div class="progress-bar">

--- a/src/popup/status-subscription.js
+++ b/src/popup/status-subscription.js
@@ -247,12 +247,15 @@ function updateQuotaProgress(status, type = 'tts') {
     }
     percentageLabel.textContent = "100% used";
     
-    // Update quota percentage to show "0 credits remaining"
-    const quotaUnit = type === 'tts' ? 'characters' : 'seconds';
+    // Update quota percentage to show "0 ... remaining".
+    // TTS bills per-voice credits, not characters (#275); STT remains seconds.
     quotaPercentage.textContent = '';
     const remainingSpan = document.createElement('span');
     remainingSpan.className = 'text-muted-foreground';
-    remainingSpan.textContent = `0 ${quotaUnit} remaining`;
+    remainingSpan.textContent =
+      type === 'tts'
+        ? browser.i18n.getMessage('ttsCreditsRemaining', ['0'])
+        : `0 seconds remaining`;
     quotaPercentage.appendChild(remainingSpan);
     
     // Set tooltip for progress bar

--- a/src/popup/status-subscription.js
+++ b/src/popup/status-subscription.js
@@ -306,7 +306,11 @@ function updateQuotaProgress(status, type = 'tts') {
   // Format the remaining quota for display
   let remainingText;
   if (type === 'tts') {
-    remainingText = `${status.quota.remaining.toLocaleString()} characters remaining`;
+    // The TTS meter bills per-voice credits, not raw characters (saypi-api #181
+    // Stage 2 / #275). The figure is unchanged; only the unit label is "credits".
+    remainingText = browser.i18n.getMessage('ttsCreditsRemaining', [
+      status.quota.remaining.toLocaleString(),
+    ]);
   } else {
     // Convert seconds to minutes for STT
     const minutes = Math.floor(status.quota.remaining / 60);

--- a/test/i18n-tts-credits.spec.ts
+++ b/test/i18n-tts-credits.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Regression guard for #275: the TTS quota meter bills per-voice CREDITS, not
+ * raw characters (saypi-api #181 Stage 2). The remaining figure is numerically
+ * unchanged but its unit is credits, so the user-facing label must say
+ * "credits", not "characters".
+ *
+ * These tests assert against the real source and the real en locale (not mocks),
+ * so they catch a re-introduction of the "characters" wording on the live path.
+ */
+const root = resolve(__dirname, "..");
+const en = JSON.parse(
+  readFileSync(resolve(root, "_locales/en/messages.json"), "utf8")
+);
+const statusSubscriptionSrc = readFileSync(
+  resolve(root, "src/popup/status-subscription.js"),
+  "utf8"
+);
+
+describe("#275 TTS quota wording: credits, not characters", () => {
+  it("status-subscription.js renders the TTS remaining label via i18n, not a hardcoded 'characters' string", () => {
+    expect(statusSubscriptionSrc).not.toMatch(/characters remaining/i);
+    expect(statusSubscriptionSrc).toMatch(/ttsCreditsRemaining/);
+  });
+
+  it("en defines ttsCreditsRemaining and it says credits", () => {
+    expect(en.ttsCreditsRemaining?.message).toBeTruthy();
+    expect(en.ttsCreditsRemaining.message).toMatch(/credits/i);
+    expect(en.ttsCreditsRemaining.message).not.toMatch(/characters/i);
+  });
+
+  it("the en TTS quota progress tooltip no longer says characters", () => {
+    expect(en.ttsQuotaProgress.message).not.toMatch(/characters/i);
+  });
+});

--- a/test/i18n-tts-credits.spec.ts
+++ b/test/i18n-tts-credits.spec.ts
@@ -21,9 +21,19 @@ const statusSubscriptionSrc = readFileSync(
 );
 
 describe("#275 TTS quota wording: credits, not characters", () => {
-  it("status-subscription.js renders the TTS remaining label via i18n, not a hardcoded 'characters' string", () => {
+  it("status-subscription.js never labels a TTS quota unit as 'characters' (normal OR exhausted path)", () => {
+    // The original normal-path bug was a contiguous "characters remaining" string...
     expect(statusSubscriptionSrc).not.toMatch(/characters remaining/i);
-    expect(statusSubscriptionSrc).toMatch(/ttsCreditsRemaining/);
+    // ...but the exhausted-quota path built "0 characters remaining" by
+    // INTERPOLATION (`0 ${quotaUnit} remaining`, quotaUnit = 'characters'), which a
+    // contiguous-substring scan can't see. Guard the *quoted unit literal* directly:
+    // this file has no legitimate reason to contain "characters" as a string token.
+    expect(statusSubscriptionSrc).not.toMatch(/['"`]characters['"`]/);
+  });
+
+  it("renders BOTH live TTS quota labels (normal + exhausted) via ttsCreditsRemaining", () => {
+    const hits = statusSubscriptionSrc.match(/ttsCreditsRemaining/g) ?? [];
+    expect(hits.length).toBeGreaterThanOrEqual(2);
   });
 
   it("en defines ttsCreditsRemaining and it says credits", () => {


### PR DESCRIPTION
## Why

saypi-api **#181 Stage 2** ([PR #210](https://github.com/Pedal-Intelligence/saypi-api/pull/210)) switched the TTS meter to a **per-voice credit pool**. The remaining figure is numerically unchanged, but the **unit** is now credits — and the extension labelled it "characters remaining", which under-states spend for any non-flash voice (premium ~2×/char, OpenAI value ~0.05×/char).

Resolves #275.

## What

The TTS remaining label is rendered on **two** live paths in `src/popup/status-subscription.js`, both of which were hardcoded English "characters":
- **Normal path** — was `` `${n} characters remaining` `` → now `getMessage('ttsCreditsRemaining', [n])`.
- **Exhausted-quota path** (`remaining <= 0`) — was `0 ${quotaUnit} remaining` with `quotaUnit = 'characters'` → now `getMessage('ttsCreditsRemaining', ['0'])` for TTS (STT keeps seconds, out of scope).

Both now mirror the sibling STT branch (`getMessage('sttMinutesRemaining', ...)`), fixing the label and removing the hardcoded-English inconsistency.

- **`_locales/en/messages.json`** — added `ttsCreditsRemaining` (`"$credits$ credits remaining"`); relabelled the `ttsQuotaProgress` tooltip "characters"→"credits"; tidied the self-contradictory `ttsQuotaCharacters` description.
- **`entrypoints/settings/tabs/general/general.html`** — fixed the stale "characters" fallback text on the (hidden) `ttsQuotaCharacters` span.

Numerically unchanged: `JwtManager.getTTSQuotaDetails` reads the claim raw and the `> 0` gate is unaffected — display-only.

## Note on locales

`ttsQuotaProgress` **is** live (resolved via the computed key `getMessage(\`${type}QuotaProgress\`, ...)` — the progress-bar tooltip). The en relabel is correct; the other 31 locales still carry translated "characters" wording for both `ttsQuotaProgress` and the new `ttsCreditsRemaining` (which is en-only, so non-en falls back to en — `default_locale:"en"`, verified). Filling them needs the `translate-cli` + `OPENAI_API_KEY` pipeline (`npm run translate`) — a founder-run follow-up.

## Verification

- **Fail-first test** (`test/i18n-tts-credits.spec.ts`) — tests **real source + real en locale** (not mocks): no quoted `'characters'` unit literal survives (catches the *interpolated* exhausted-path bug — proven red against `origin/main`), both live render sites use `ttsCreditsRemaining`, and the en strings say credits.
- `npm test`: **86 files, 787 passed / 1 skipped**. `i18n-validate.cjs`: pass.
- Round-1 independent adversarial review caught a real BLOCKER (the exhausted path) + a wrong "dead code" claim; both addressed in `6717135`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)