### PR TITLE
Pi.ai integration fixes + native control-button styling (Layer 4 findings)

### DIFF
--- a/doc/autonomous-dev-loop.md
+++ b/doc/autonomous-dev-loop.md
@@ -203,6 +203,52 @@ unit-test the controller plus a `replaceI18n()` re-localization pass rather than
 trying to drive the popup. That is how the 2026-06-14 dictation mode-label fix was
 verified (`test/settings/tabs/DictationModeSelector.spec.ts`).
 
+## Verifying UI parity (check position + states, not just the property you changed)
+
+A real miss on this run: after resizing an injected icon I checked its *size*
+numerically and eyeballed the *resting* state — and shipped it visibly
+off-centre. Two lessons: a change aimed at one property (size) can break another
+(alignment), and the resting state (transparent background) hides alignment
+problems that only the hover/active background reveals.
+
+When decorating or restyling a host control, verify it the way the user sees it:
+
+1. **Position, not just size.** Assert the icon's *centre* matches the button's
+   centre (via `getBoundingClientRect`, and the glyph's via `getBBox`) — not only
+   its dimensions. An icon larger than the padding box won't centre unless the
+   button explicitly flex-centres it.
+2. **All interactive states.** Resting *and* hover *and* active (*and* dark). The
+   hover/active background is what exposes alignment, padding, radius and size
+   mismatches; the resting transparent state hides them.
+3. **Diff the whole box model against the native reference** — size, centre-offset,
+   padding, border-radius, hover fill — not just the one property you touched.
+4. **Re-verify the whole component after *every* change.** Don't assume a property
+   you didn't touch is still fine (resizing the icon is what broke its centring).
+
+A reusable parity probe — compare a SayPi button to a native reference:
+
+```js
+(() => {
+  const box = (el) => {
+    if (!el) return null;
+    const r = el.getBoundingClientRect(); const cs = getComputedStyle(el);
+    const svg = el.querySelector('svg'); let iconCentreOffset = null;
+    if (svg) { const s = svg.getBoundingClientRect();
+      iconCentreOffset = { dx: Math.round((s.x+s.width/2-(r.x+r.width/2))*10)/10,
+                           dy: Math.round((s.y+s.height/2-(r.y+r.height/2))*10)/10 }; }
+    return { size: Math.round(r.width)+'x'+Math.round(r.height), display: cs.display,
+             padding: cs.padding, radius: cs.borderRadius, iconCentreOffset };
+  };
+  return JSON.stringify({
+    saypi: box(document.getElementById('saypi-settingsButton')),
+    native: box(document.querySelector('[data-testid="nav-new-chat"]')),
+  }, null, 1);
+})()
+```
+
+`iconCentreOffset` near `{dx:0, dy:0}` means the glyph is centred; anything else is
+the class of bug missed on 2026-06-14. Run the probe in the hover state too.
+
 ## Staged-vs-released identity check
 
 The founder versions the staged dev build one patch ahead of the store release

--- a/doc/autonomous-dev-loop.md
+++ b/doc/autonomous-dev-loop.md
@@ -132,6 +132,77 @@ obs.observe(document.body, { subtree: true, childList: true, attributes: true })
 JSON.stringify(window.__probe.slice(-50));
 ```
 
+## Observability: see SayPi's own logs, and probe pitfalls (learned 2026-06-14)
+
+The biggest time-sink on the first real run was assuming the harness was dead
+because **no SayPi logs appeared**. They were there — just suppressed.
+
+- **Turn SayPi's logs on.** The logger is quiet by default *even in a `wxt dev`
+  build*: `logger.debug`/`info` emit nothing until debug mode is enabled. Enable it
+  per tab and reload: `localStorage.setItem('saypi:debug', 'true')` (or open the
+  page with `?saypi_debug=1`). After that the MCP `read_console_messages` *does*
+  capture the content script's isolated-world logs (prefixed `[SayPi DEBUG]`,
+  sourced from `content-scripts/saypi.js`). Until you do this, expect zero SayPi
+  output — that is not a broken harness.
+- **Arm capture *before* you reload.** MCP console/network tracking starts on the
+  *first* `read_console_messages` / `read_network_requests` call for a tab, resets
+  on navigation, and the buffer is small + deduped. Early-init logs are missed
+  unless you call the read tool once (to arm) and *then* reload — or rely on the
+  in-page buffer below.
+- **`javascript_tool` results can be silently blocked.** A call whose executed
+  code emits console output containing long digit runs (e.g. `Date.now()`
+  timestamps) returns `[BLOCKED: Cookie/query string data]` — the whole result is
+  redacted by a privacy filter. Install probes *silently* (no `console.log` from
+  injected code) and keep long numbers out of returned strings; prefer
+  `performance.now()|0` over `Date.now()` inside probes.
+- **`offsetParent` lies for `position:fixed` elements.** The call button is
+  `fixed`, so an `offsetParent`-based "visible?" check reports it hidden when it is
+  actually on screen. Use `getBoundingClientRect()` (non-zero box) or
+  `el.checkVisibility()` instead.
+- **Tooling:** in this environment `rg`'s colored output can mangle matched words —
+  read files with the Read tool or use `grep` / `rg --color=never -N`. `fd` is not
+  installed; use `find` / `rg --files`.
+
+Paste-once probe that enables logs and records main-world console + errors +
+unhandled rejections + DOM mutations (read any back later via `window.__cap` /
+`window.__probe`):
+
+```js
+(() => {
+  localStorage.setItem('saypi:debug','true'); // reload after this to capture init logs
+  if (!window.__cap) {
+    window.__cap = [];
+    for (const lvl of ['log','info','warn','error','debug']) {
+      const orig = console[lvl].bind(console);
+      console[lvl] = (...a) => { try { window.__cap.push({ lvl, n: performance.now()|0,
+        msg: a.map(x => { try { return typeof x==='string'?x:JSON.stringify(x); } catch { return String(x); } }).join(' ').slice(0,300) }); } catch {} return orig(...a); };
+    }
+    addEventListener('error', e => window.__cap.push({ lvl:'uncaught', msg:(e.message+' @ '+e.filename+':'+e.lineno).slice(0,300) }));
+    addEventListener('unhandledrejection', e => window.__cap.push({ lvl:'rejection', msg:String(e.reason&&(e.reason.stack||e.reason.message||e.reason)).slice(0,300) }));
+  }
+  if (!window.__probe) {
+    window.__probe = [];
+    new MutationObserver(ms => { for (const m of ms) window.__probe.push({ n:performance.now()|0, type:m.type, target:(m.target&&(m.target.id||(m.target.className&&String(m.target.className).slice(0,50))))||'' }); })
+      .observe(document.body, { subtree:true, childList:true, attributes:true });
+  }
+  return 'probes installed';
+})()
+```
+
+> The content script (isolated world) and `javascript_tool` (page main world) are
+> different JS contexts: the main-world `__cap` hook only catches main-world logs;
+> for SayPi's own logs use `read_console_messages` *with* `saypi:debug` enabled.
+
+## What the MCP can't reach (test it at Layer 2 instead)
+
+The extension **Settings page opens in its own browser window**, outside the MCP
+tab group — `tabs_context_mcp` never lists it and `computer`/`javascript_tool`
+can't drive it. The founder can screenshot it on request, but treat Settings-tab
+behaviour (e.g. the Dictation / Submit-mode selectors) as **Layer 1–2 territory**:
+unit-test the controller plus a `replaceI18n()` re-localization pass rather than
+trying to drive the popup. That is how the 2026-06-14 dictation mode-label fix was
+verified (`test/settings/tabs/DictationModeSelector.spec.ts`).
+
 ## Staged-vs-released identity check
 
 The founder versions the staged dev build one patch ahead of the store release

--- a/src/chatbots/Pi.ts
+++ b/src/chatbots/Pi.ts
@@ -72,8 +72,10 @@ class PiAIChatbot extends AbstractChatbot {
   }
 
   getAudioOutputButtonSelector(): string {
-    // audio button is the last button element in the audio controls container
-    return ".saypi-audio-controls > div > div.relative.flex.items-center.justify-end.self-end > button";
+    // Voice on/off button is the first button inside Pi's audio controls.
+    // Pi moved the buttons into an `inline-flex` wrapper and the row container
+    // dropped `items-center` (now `z-10`), so match the wrapper generically.
+    return ".saypi-audio-controls > div > div.relative.flex.justify-end.self-end > div > button";
   }
 
   getControlPanelSelector(): string {

--- a/src/popup/mode-selector.js
+++ b/src/popup/mode-selector.js
@@ -54,7 +54,9 @@
 			this.slider.value = String(index);
 			const v = this.values[index];
 			if (!v) return;
-			// label
+			// label — keep data-i18n in sync with the selected mode so a later
+			// re-localization pass (replaceI18n) doesn't revert it to the hard-coded key.
+			this.label.setAttribute('data-i18n', v.i18nLabelKey);
 			this.label.textContent = chrome.i18n.getMessage(v.i18nLabelKey);
 			// description visibility
 			const descriptions = this.container.querySelectorAll('.description');

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -39,6 +39,15 @@
   }
 }
 
+/* The dark-mode / theme switcher is a SayPi immersive-mode affordance: the chat
+   hosts ship their own native dark mode in the normal view, so the toggle belongs
+   in immersive mode only. Hide it explicitly outside immersive view rather than
+   relying on it collapsing to 0x0 — otherwise it reads as a broken/invisible
+   control in the normal control panel (e.g. on pi.ai). */
+html:not(.immersive-view) .theme-toggle-button {
+  display: none;
+}
+
 
 #saypi-lock-panel {
   /* lock panel is only displayed on mobile devices */

--- a/src/styles/pi.scss
+++ b/src/styles/pi.scss
@@ -21,13 +21,15 @@ html body.pi {
       height: 36px;
     }
 
-    /* Match Pi's native brown icon color */
+    /* Match Pi's icon colour via its own design token so we follow Pi's theme
+       (incl. light/dark) automatically. The rgb fallback keeps light mode correct
+       if Pi ever renames the token. */
     .saypi-control-button svg {
-      color: rgb(107, 98, 85);
-      stroke: rgb(107, 98, 85);
+      color: var(--color-text-secondary, rgb(101, 94, 85));
+      stroke: var(--color-text-secondary, rgb(101, 94, 85));
 
       path, line, circle, rect, polyline {
-        stroke: rgb(107, 98, 85);
+        stroke: var(--color-text-secondary, rgb(101, 94, 85));
       }
     }
 
@@ -36,10 +38,30 @@ html body.pi {
       display: none;
     }
 
-    /* Give settings button visible background to match enter button */
+    /* Focus + Voice-settings: match Pi's standalone icon buttons — transparent
+       with a hover/tap fill (Pi's tokens, so it tracks light/dark), Pi's icon
+       size, and Pi's icon-button radius. Replaces the old cream circle so the two
+       buttons read as one consistent, native-looking pair. */
+    #saypi-enter-button,
     #saypi-settingsButton {
-      background-color: rgb(237, 225, 209); /* bg-cream-550 */
-      border-radius: 50%;
+      background-color: transparent;
+      border-radius: 10px; /* Pi's icon-button radius (rounded-[10px]) */
+      transition: background-color 0.15s cubic-bezier(0.4, 0, 0.2, 1),
+        color 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+
+      &:hover {
+        background-color: var(--color-button-fill-hover, rgb(233, 221, 205));
+      }
+
+      &:active {
+        background-color: var(--color-button-fill-tap, rgb(228, 215, 198));
+      }
+
+      /* Match Pi's 20px icon size (SayPi's source SVGs are 24px+). */
+      svg {
+        width: 20px;
+        height: 20px;
+      }
     }
 
     /* Consistent spacing between SayPi buttons */
@@ -48,19 +70,10 @@ html body.pi {
     }
   }
 
-  /* Enter focus mode button specific sizing */
+  /* Enter focus mode button sizing (icon colour/size handled above) */
   #saypi-enter-button {
     width: 36px;
     height: 36px;
-
-    svg {
-      color: rgb(107, 98, 85);
-      stroke: rgb(107, 98, 85);
-
-      path, line, circle, rect, polyline {
-        stroke: rgb(107, 98, 85);
-      }
-    }
   }
 
   /* Message controls: size copy button to better match native thumbs up/down */
@@ -180,10 +193,11 @@ html body.pi {
       flex-shrink: 0; /* Prevent button from shrinking in flex container */
     }
 
-    /* Ensure SayPi toolbar buttons have visible background to match native neighbors */
+    /* Give SayPi toolbar buttons a visible resting background on mobile to match
+       native neighbours — via Pi's fill token so it tracks light/dark. */
     #saypi-enter-button,
     #saypi-settingsButton {
-      background-color: rgb(237, 225, 209); /* bg-cream-550 */
+      background-color: var(--color-fill-default, rgb(236, 225, 210));
     }
   }
 
@@ -233,3 +247,9 @@ html body.pi {
     }
   }
 }
+
+/* Dark mode is handled automatically: the SayPi control buttons above style
+   themselves with Pi's own design tokens (`--color-text-secondary`,
+   `--color-button-fill-*`, `--color-fill-default`), which Pi redefines under
+   `html.dark`. So SayPi's controls follow Pi's native light/dark theme with no
+   SayPi-specific dark rules. Verified live on pi.ai (light + dark) 2026-06-14. */

--- a/src/styles/pi.scss
+++ b/src/styles/pi.scss
@@ -46,6 +46,12 @@ html body.pi {
     #saypi-settingsButton {
       background-color: transparent;
       border-radius: 10px; /* Pi's icon-button radius (rounded-[10px]) */
+      /* Center the icon regardless of its size — the icons are intentionally
+         sized differently (and can exceed the padding box), so rely on flex
+         centering, not the default top-left block flow. */
+      display: flex;
+      align-items: center;
+      justify-content: center;
       transition: background-color 0.15s cubic-bezier(0.4, 0, 0.2, 1),
         color 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 

--- a/src/styles/pi.scss
+++ b/src/styles/pi.scss
@@ -57,10 +57,25 @@ html body.pi {
         background-color: var(--color-button-fill-tap, rgb(228, 215, 198));
       }
 
-      /* Match Pi's 20px icon size (SayPi's source SVGs are 24px+). */
-      svg {
-        width: 20px;
-        height: 20px;
+    }
+
+    /* Optical sizing — match the *visible* glyph to Pi's ~16px native icons, not
+       raw px. The source SVGs fill their viewBox very differently: the focus icon
+       fills ~75%, but the settings sliders fill only ~48% (its outer ring, hidden
+       on Pi, sets the 768 viewBox), so a uniform size makes settings look tiny.
+       Hence the deliberately different per-icon sizes. */
+    #saypi-enter-button svg {
+      width: 21px;
+      height: 21px;
+    }
+    #saypi-settingsButton svg {
+      width: 32px;
+      height: 32px;
+
+      /* The settings source SVG uses a light stroke relative to its large 768
+         viewBox; thicken the slider lines to match Pi's icon line weight. */
+      g {
+        stroke-width: 42;
       }
     }
 

--- a/test/chatbots/Pi-AudioControlsSelector.spec.ts
+++ b/test/chatbots/Pi-AudioControlsSelector.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { PiAIChatbot } from "../../src/chatbots/Pi";
+
+/**
+ * Contract test for Pi.ai's audio-output (voice on/off) button selector.
+ *
+ * Pi redesigned its audio controls: the voice on/off and voice-menu buttons
+ * moved inside an `inline-flex` wrapper, and the row container lost
+ * `items-center` (it now uses `z-10`). The old selector
+ *   `.saypi-audio-controls > div > div.relative.flex.items-center.justify-end.self-end > button`
+ * no longer matches, so SayPi never assigns `id="saypi-audio-output-button"`,
+ * which breaks AudioControlsModule.activateAudioOutput()/isAudioOutputEnabled()
+ * and SubmitErrorHandler (SayPi can't toggle Pi's voice during hands-free calls).
+ *
+ * Fixture captured live from pi.ai/talk on 2026-06-14.
+ */
+function buildPiAudioControls(): void {
+  document.body.innerHTML = `
+    <div class="undefined order-2 w-auto saypi-audio-controls">
+      <div class="relative flex flex-col-reverse">
+        <div class="relative z-10 flex justify-end self-end">
+          <div class="inline-flex h-9 min-h-9 items-stretch overflow-hidden rounded-[100px] bg-fill-default">
+            <button aria-label="Turn voice off" class="flex items-center justify-center">on/off</button>
+            <span class="flex shrink-0 items-center justify-center self-stretch"></span>
+            <button aria-label="Toggle voice menu" class="flex items-center justify-center">menu</button>
+          </div>
+        </div>
+      </div>
+      <div id="saypi-voice-menu"></div>
+    </div>`;
+}
+
+describe("Pi getAudioOutputButtonSelector", () => {
+  let chatbot: PiAIChatbot;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    chatbot = new PiAIChatbot();
+    buildPiAudioControls();
+  });
+
+  it("matches the voice on/off button in Pi's current audio-controls structure", () => {
+    const selector = chatbot.getAudioOutputButtonSelector();
+    const matched = document.querySelector(selector);
+
+    expect(matched).not.toBeNull();
+    // The audio-output button is the first (voice on/off) button, not the voice-menu toggle.
+    expect(matched?.getAttribute("aria-label")).toBe("Turn voice off");
+  });
+});

--- a/test/chatbots/Pi-DarkMode.spec.ts
+++ b/test/chatbots/Pi-DarkMode.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Regression guard for SayPi following Pi.ai's native light/dark theme.
+ *
+ * pi.scss used to hardcode light-mode colours (bg-cream-550, brown
+ * rgb(107,98,85) icons), so on Pi's dark UI SayPi's control buttons stayed light
+ * (most glaringly a bright cream settings circle). Rather than maintain a parallel
+ * `html.dark` colour set, the control buttons now style themselves with Pi's own
+ * design tokens (`--color-text-secondary`, `--color-button-fill-*`), which Pi
+ * redefines under `html.dark` — so they track Pi's theme automatically.
+ *
+ * Visual correctness is verified at Layer 4 (live, light + dark on real pi.ai);
+ * this guards that the token-based theming doesn't silently regress to hardcoded
+ * light colours.
+ */
+const piScss = readFileSync(
+  fileURLToPath(new URL("../../src/styles/pi.scss", import.meta.url)),
+  "utf8"
+);
+
+describe("Pi control buttons follow Pi's theme via design tokens (pi.scss)", () => {
+  it("colours the control-button icons with Pi's --color-text-secondary token", () => {
+    expect(piScss).toMatch(
+      /\.saypi-control-button svg[\s\S]*?color:\s*var\(--color-text-secondary/
+    );
+  });
+
+  it("uses Pi's fill tokens for the control-button hover state", () => {
+    expect(piScss).toMatch(/var\(--color-button-fill-hover/);
+  });
+
+  it("no longer hardcodes the light-mode cream settings-button background", () => {
+    // The old defect: a fixed bg-cream-550 (rgb(237,225,209)) circle that stayed
+    // light on Pi's dark UI. The settings button is now transparent + token hover.
+    expect(piScss).not.toMatch(/#saypi-settingsButton\s*\{[^}]*rgb\(237,\s*225,\s*209\)/);
+  });
+});

--- a/test/settings/tabs/DictationModeSelector.spec.ts
+++ b/test/settings/tabs/DictationModeSelector.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "../../../src/popup/mode-selector"; // IIFE: registers window.ModeSelector
+import { replaceI18n } from "../../../entrypoints/settings/shared/i18n";
+
+/**
+ * Regression test for the Dictation mode label showing the wrong mode.
+ *
+ * Observed live on pi.ai (2026-06-14): with the stored preference set to
+ * "accuracy", the slider and description correctly showed the accuracy mode,
+ * but the text label read "balanced".
+ *
+ * Root cause: ModeSelector.setIndex() updated the label's textContent but not
+ * its `data-i18n` attribute. The settings page localizes all `[data-i18n]`
+ * elements via replaceI18n() (on load / language change), which reset
+ * #sliderValue back to its hard-coded `data-i18n="mode_balanced"`. The
+ * descriptions survive because each has its own data-i18n; the single shared
+ * label does not.
+ */
+const MESSAGES: Record<string, string> = {
+  mode_speed: "speed",
+  mode_balanced: "balanced",
+  mode_accuracy: "accuracy",
+  mode_speed_description: "Fastest response, but less accurate. Prone to interrupting.",
+  mode_balanced_description: "Good balance of speed and accuracy for most uses.",
+  mode_accuracy_description:
+    "Highest accuracy, but slower transcription speed. Prone to hallucinations.",
+};
+
+const VALUES = [
+  { id: "speed", i18nLabelKey: "mode_speed", i18nDescriptionKey: "mode_speed_description" },
+  { id: "balanced", i18nLabelKey: "mode_balanced", i18nDescriptionKey: "mode_balanced_description" },
+  { id: "accuracy", i18nLabelKey: "mode_accuracy", i18nDescriptionKey: "mode_accuracy_description" },
+];
+
+function buildDictationDom(): void {
+  // Mirrors entrypoints/settings/tabs/dictation/dictation.html (label hard-codes mode_balanced).
+  document.body.innerHTML = `
+    <div id="preference-selector" class="mode-selector">
+      <div>
+        <div class="flex justify-between mb-2">
+          <span class="icon" slider-value="0" id="speed"><span class="icon-circle"></span></span>
+          <span class="icon active" slider-value="1" id="balanced"><span class="icon-circle"></span></span>
+          <span class="icon" slider-value="2" id="accuracy"><span class="icon-circle"></span></span>
+        </div>
+        <input type="range" min="0" max="2" value="1" id="customRange" />
+      </div>
+      <div id="sliderValue" data-i18n="mode_balanced">balanced</div>
+      <div class="description" data-i18n="mode_speed_description">x</div>
+      <div class="description" data-i18n="mode_balanced_description">x</div>
+      <div class="description" data-i18n="mode_accuracy_description">x</div>
+    </div>`;
+}
+
+describe("Dictation ModeSelector label", () => {
+  beforeEach(() => {
+    (chrome.i18n.getMessage as any) = vi.fn((key: string) => MESSAGES[key] ?? key);
+    (chrome.storage.local as any)._setState({ prefer: "accuracy" });
+    buildDictationDom();
+  });
+
+  it("stays in sync with the selected mode after the page re-localizes (replaceI18n)", async () => {
+    const selector = new (window as any).ModeSelector({
+      containerId: "preference-selector",
+      sliderId: "customRange",
+      labelId: "sliderValue",
+      storageKey: "prefer",
+      values: VALUES,
+    });
+    selector.init();
+    // ModeSelector reads the stored preference asynchronously, then calls setIndex().
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const label = document.getElementById("sliderValue")!;
+    const slider = document.getElementById("customRange") as HTMLInputElement;
+
+    // Precondition: stored "accuracy" preference was applied.
+    expect(slider.value).toBe("2");
+    expect(label.textContent).toBe("accuracy");
+
+    // The settings page localizes [data-i18n] elements; this can run after init.
+    replaceI18n();
+
+    // The label must still reflect the selected mode, not revert to "balanced".
+    expect(label.textContent).toBe("accuracy");
+  });
+});

--- a/test/ui/ThemeToggleImmersiveOnly.spec.ts
+++ b/test/ui/ThemeToggleImmersiveOnly.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The dark-mode / theme switcher is a SayPi *immersive-mode* affordance (the
+ * full-screen experience SayPi layers on top of the host). The chat hosts now
+ * ship their own native dark mode in the normal view, so the toggle belongs in
+ * immersive mode only.
+ *
+ * Previously it was added to the normal control panel and only hidden by
+ * accident (on Pi it collapsed to 0x0 for lack of the `mini` class), which read
+ * as a broken/invisible control. This guards that the toggle is *intentionally*
+ * hidden outside immersive view.
+ */
+const commonScss = readFileSync(
+  fileURLToPath(new URL("../../src/styles/common.scss", import.meta.url)),
+  "utf8"
+);
+
+describe("Theme toggle is immersive-only", () => {
+  it("hides the theme toggle outside immersive view", () => {
+    const normalized = commonScss.replace(/\s+/g, " ");
+    expect(normalized).toMatch(
+      /html:not\(\.immersive-view\) \.theme-toggle-button \{ display: none/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Polish + fixes for SayPi's integration on **pi.ai**, found and verified through the **Layer 4 dev-verify loop** (real pi.ai, hot-reload). Changes are unit/contract-tested where logic allows, and visually verified live.

## Changes

**Fixes**
- **Dictation mode label desync** — Settings → Dictation showed "balanced" even when the slider/description reflected a stored "speed"/"accuracy" preference. `ModeSelector.setIndex()` updated the label text but not its `data-i18n`, so the page's `replaceI18n()` pass reverted it. Now syncs the attribute. *(unit test)*
- **Pi audio-output selector drift** — Pi moved its voice on/off + menu buttons into an `inline-flex` wrapper (and the row dropped `items-center`), so `getAudioOutputButtonSelector()` no longer matched. SayPi never assigned `#saypi-audio-output-button`, silently breaking `AudioControlsModule` (couldn't toggle Pi's voice during hands-free calls) and `SubmitErrorHandler`. Selector updated. *(contract test + live)*

**Native styling / theming**
- **Control buttons now use Pi's design tokens** (`--color-text-secondary`, `--color-button-fill-*`) — transparent with a Pi hover fill and Pi's `rounded-[10px]`, replacing the off-brand cream circle. Because Pi redefines these tokens under `html.dark`, the buttons now **follow Pi's native light/dark theme automatically** (previously `pi.scss` had no dark rules, so SayPi's controls stayed light — a bright cream settings circle — on Pi's dark UI). *(regression test + live light/dark/hover)*
- **Optical icon sizing** — the Focus and Voice-settings glyphs are sized so the *visible* glyph matches Pi's ~16px native icons (the source SVGs fill their viewBoxes very differently), with line weight matched. Pi-scoped, so Claude's icon is untouched. *(live, against Pi's own icons)*
- **Theme toggle is now immersive-only** — the dark-mode switcher is a SayPi immersive-mode affordance (hosts ship native dark mode in the normal view). It was previously added to the normal control panel and only hidden by accident (0x0 for lack of `mini`), reading as a broken control; now hidden explicitly outside immersive view. *(test)*

**Docs**
- Layer 4 harness observability notes (enabling SayPi logs, MCP capture timing, the `javascript_tool` privacy-filter pitfall, `offsetParent` for fixed elements, and that Settings opens outside the MCP tab group).

## Verification
- `npm test` green: Jest 2 passed; Vitest 89 files, 789 passed / 1 skipped (5 new specs).
- Live on real pi.ai via the Layer 4 loop: audio-output button now assigned; control buttons match Pi in light, dark, and hover; dictation fix unit-verified (the Settings page isn't MCP-drivable).

## Notes
- A first-pass "fix" to make the theme toggle visible on pi.ai was **reverted** — its absence there is intentional (Pi has native dark mode); the switcher belongs in immersive mode.
- Pi styling uses Pi's CSS variables with rgb fallbacks, so light mode degrades safely if Pi renames a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
