### PR TITLE
fix(ui): stop button tooltips being obscured (centre + z-index)

### DIFF
--- a/src/styles/desktop.scss
+++ b/src/styles/desktop.scss
@@ -58,30 +58,36 @@ html.desktop-view {
     }
   }
 
+  // Anchor the ::after tooltip to the button so it centres on it (not on some
+  // distant positioned ancestor).
+  .tooltip[aria-label] {
+    position: relative;
+  }
+
   .tooltip[aria-label]::after {
     content: attr(aria-label);
     position: absolute;
     top: 120%; // position the tooltip below the button
-    transform: translateX(-70%); // center the tooltip relative to the button
+    left: 50%;
+    transform: translateX(-50%); // centre the tooltip under the button
     white-space: nowrap;
     background: #24381b; // Pi primary text color (dark green)
     color: white;
     padding: 5px 10px;
     border-radius: 4px;
-    margin-left: 10px;
     opacity: 0;
     transition: opacity 0.3s;
     pointer-events: none;
     font-size: 1.2rem;
+    z-index: 1000; // sit above host chrome (e.g. Pi's z-999 sidebar)
   }
 
   @include meta.load-css("./chatgpt.scss");
-  
+
   // Show on hover (desktop)
   @media (hover: hover) {
     .tooltip[aria-label]:hover::after {
         opacity: 1;
-        z-index: 101;
     }
   }
 

--- a/src/styles/mobile.scss
+++ b/src/styles/mobile.scss
@@ -164,7 +164,7 @@ html.mobile-device .chat-message .message-hover-menu .saypi-cost-container {
 @media (hover: none) {
   .tooltip[aria-label]:active::after {
       opacity: 1;
-      z-index: 101;
+      z-index: 1000; // sit above host chrome (match desktop)
   }
 }
 

--- a/test/ui/TooltipPositioning.spec.ts
+++ b/test/ui/TooltipPositioning.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Regression guard for SayPi button tooltips being obscured.
+ *
+ * The base tooltip (`desktop.scss`, inherited by Pi + Claude) used to position
+ * the `::after` with `transform: translateX(-70%)` + `margin-left: 10px` — a crude
+ * off-centre hack that pushed a wide tooltip left until it crossed the host's
+ * sidebar boundary (Pi's sidebar is `z-[999]`) and got covered. Now it centres
+ * properly and carries a z-index above host chrome.
+ *
+ * Verified visually at Layer 4 (live, on real pi.ai).
+ */
+const desktopScss = readFileSync(
+  fileURLToPath(new URL("../../src/styles/desktop.scss", import.meta.url)),
+  "utf8"
+);
+
+describe("Button tooltip positioning (desktop.scss base)", () => {
+  it("centres the tooltip under the button (drops the old translateX(-70%) hack)", () => {
+    const norm = desktopScss.replace(/\s+/g, " ");
+    expect(norm).toContain("transform: translateX(-50%)");
+    expect(norm).not.toContain("translateX(-70%)");
+  });
+
+  it("renders the tooltip above host chrome (z-index over Pi's z-999 sidebar)", () => {
+    expect(desktopScss).toMatch(
+      /\.tooltip\[aria-label\]::after[\s\S]*?z-index:\s*1000/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

SayPi's button tooltips were getting **obscured** — e.g. the Pi "Voice settings" / "Enter Focus Mode" tooltips were clipped at the sidebar boundary. Found and fixed via the Layer 4 loop on real pi.ai.

## Root cause

The base tooltip (`desktop.scss`, scoped to `html.desktop-view`, **inherited by Pi and Claude**) positioned the `::after` with `transform: translateX(-70%)` + `margin-left: 10px` — a crude off-centre approximation. For a button near the host sidebar, that pushed the wide tooltip left until it crossed the sidebar (Pi's sidebar is `z-[999]`), where it was clipped/covered. ChatGPT already overrode this with proper centring; Pi and Claude inherited the broken base.

## Fix

- Centre the tooltip under its button: `left: 50%` + `transform: translateX(-50%)`, with the button `position: relative` so the `::after` anchors to it.
- Raise it above host chrome: `z-index: 1000` (over Pi's `z-999` sidebar); drop the stale `z-index: 101` that the hover/`:active` rules applied.
- Per-host **colours are unchanged** (Pi brown, Claude black/80, ChatGPT pill) — only positioning/stacking is corrected, so each host keeps its native look.

## Verification

- Live on real pi.ai: both the "Enter Focus Mode" and "Voice settings" tooltips now centre under their buttons and are fully visible (no sidebar clipping).
- Regression guard: `test/ui/TooltipPositioning.spec.ts`.
- `npm test` green (Vitest 803 passed / 1 skipped).

## Notes

- Claude/ChatGPT weren't re-verified live (no session this run), but ChatGPT was already correct and Claude inherits the same corrected base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
