### PR TITLE
fix(telemetry): stop the telemetry:updated EventBus listener leak

### DIFF
--- a/src/dom/MessageElements.ts
+++ b/src/dom/MessageElements.ts
@@ -619,6 +619,13 @@ abstract class MessageControls {
   protected telemetryContainer: HTMLElement | null = null;
   private eventListeners: EventListener[] = []; // Added to track event listeners
 
+  // The last message is re-decorated on every token mutation while it streams,
+  // constructing a fresh MessageControls each time. Track which message elements
+  // already hold the telemetry listener so we register it at most once per element
+  // instead of leaking one listener per re-decoration.
+  private static elementsWithTelemetryListener = new WeakSet<HTMLElement>();
+  private addedTelemetryListener = false;
+
   constructor(
     protected message: AssistantResponse,
     protected ttsControls: TTSControlsModule
@@ -626,8 +633,13 @@ abstract class MessageControls {
     this.actionBar = this.messageControlsElement = null; // will be initialized in decorateControls()
     this.decorateControls(message);
 
-    if (this.message.isLastMessage()) {
-      // Listen for telemetry updates
+    if (
+      this.message.isLastMessage() &&
+      !MessageControls.elementsWithTelemetryListener.has(this.message.element)
+    ) {
+      // Listen for telemetry updates (once per message element)
+      MessageControls.elementsWithTelemetryListener.add(this.message.element);
+      this.addedTelemetryListener = true;
       EventBus.on("telemetry:updated", this.handleTelemetryUpdate);
       this.eventListeners.push({ event: "telemetry:updated", listener: this.handleTelemetryUpdate });
     }
@@ -665,6 +677,10 @@ abstract class MessageControls {
       EventBus.off(event, listener);
     });
     this.eventListeners = [];
+    if (this.addedTelemetryListener) {
+      MessageControls.elementsWithTelemetryListener.delete(this.message.element);
+      this.addedTelemetryListener = false;
+    }
     // Add any other specific cleanup for MessageControls here
   }
 

--- a/test/dom/MessageControls-telemetry-leak.spec.ts
+++ b/test/dom/MessageControls-telemetry-leak.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Avoid the MessageElements -> chatbots/Pi -> PiResponse -> MessageElements cycle
+// (same pattern as test/chatbots/ChatGPTAutoReadAloud.spec.ts).
+vi.mock("../../src/chatbots/Pi", () => ({ PiAIChatbot: class {} }));
+
+import { MessageControls } from "../../src/dom/MessageElements";
+import EventBus from "../../src/events/EventBus";
+
+/**
+ * Regression test for the `telemetry:updated` EventBus listener leak.
+ *
+ * While the last assistant message streams, the chat-history observer fires on
+ * every token mutation and re-decorates it, constructing a fresh MessageControls
+ * each time. Each instance added its own `telemetry:updated` listener (guarded
+ * only by isLastMessage()), and the prior instances were never torn down — so the
+ * listener count grew unbounded (observed: 350+ "listener leak detected" warnings).
+ *
+ * The fix registers the listener at most once per message element.
+ */
+class TestMessageControls extends MessageControls {
+  getActionBarSelector(): string {
+    return ".message-action-bar";
+  }
+  // Skip the DOM-heavy base decoration; we only exercise the listener lifecycle.
+  protected async decorateControls(_message: any): Promise<void> {
+    return;
+  }
+}
+
+function lastMessage(el: HTMLElement): any {
+  return { element: el, isLastMessage: () => true };
+}
+
+describe("MessageControls telemetry:updated listener", () => {
+  beforeEach(() => {
+    EventBus.removeAllListeners("telemetry:updated");
+  });
+
+  it("registers at most one listener per message element across re-decorations", () => {
+    const el = document.createElement("div");
+    const msg = lastMessage(el);
+    const tts: any = {};
+
+    // Simulate the streaming re-decoration loop (one MessageControls per mutation).
+    for (let i = 0; i < 60; i++) new TestMessageControls(msg, tts);
+
+    expect(EventBus.listenerCount("telemetry:updated")).toBe(1);
+  });
+
+  it("releases the listener on teardown so a later decoration can re-register", () => {
+    const el = document.createElement("div");
+    const tts: any = {};
+
+    const first = new TestMessageControls(lastMessage(el), tts);
+    expect(EventBus.listenerCount("telemetry:updated")).toBe(1);
+
+    first.teardown();
+    expect(EventBus.listenerCount("telemetry:updated")).toBe(0);
+
+    new TestMessageControls(lastMessage(el), tts);
+    expect(EventBus.listenerCount("telemetry:updated")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

On long / streaming threads SayPi flooded the extension error log with hundreds of `EventBus listener leak detected: N listeners added for "telemetry:updated"` warnings. Found during Layer 4 testing on pi.ai.

## Root cause

While the last assistant message streams, the chat-history observer fires on **every token mutation** and re-decorates it, constructing a fresh `MessageControls` each time. Each instance registered its own (instance-bound) `telemetry:updated` listener — guarded only by `isLastMessage()` — and the prior instances were never torn down. So the listener count grew unbounded: one per re-decoration (350+ on a long stream), plus needless DOM churn.

## Fix

Register the `telemetry:updated` listener **at most once per message element** (a `WeakSet` of elements that already hold it), and release it on `teardown()` so a later decoration can re-register. Caps the listener at one per distinct last-message element.

## Verification

- **Fail-first unit test** (`test/dom/MessageControls-telemetry-leak.spec.ts`): 60 re-decorations of the same last message → **1** listener (was 60); `teardown()` releases it so a later decoration re-registers.
- `npm test` green (jest + vitest, 803 passed / 1 skipped).

## Notes

- Pre-existing bug in `main` (not introduced by recent PRs); surfaced via the Layer 4 run.
- This caps the listener leak. The deeper item — a fresh `MessageControls`/`Response` constructed per mutation (DOM churn, likely contributing to Pi's React hydration warnings) — is a worthwhile follow-up but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
