### PR TITLE
fix(ui): body-portal button tooltips (escape host overflow clipping)

### DIFF
--- a/src/buttons/CallButton.ts
+++ b/src/buttons/CallButton.ts
@@ -398,11 +398,8 @@ export class CallButton {
 
         addChild(container, button, position);
 
-        // ChatGPT uses overflow-clip on composer, so pseudo-element tooltips get clipped.
-        // For buttons marked with 'chatgpt-call-button', attach a portal-style tooltip to <body>.
-        if (button.classList.contains('chatgpt-call-button')) {
-            this.attachPortalTooltip(button);
-        }
+        // Tooltips (incl. this button's, which carries the `tooltip` class) are
+        // handled globally by the body-level portal in src/ui/Tooltip.ts.
 
         // Ensure segments drawn *after* initial SVG is added by callActive/callInactive
         this.updateButtonSegments();
@@ -411,65 +408,6 @@ export class CallButton {
             AnimationModule.startAnimation("glow");
         }
         return button;
-    }
-
-    // --- ChatGPT tooltip portal (avoids overflow clipping) ---
-    private tooltipEl: HTMLDivElement | null = null;
-    private hideTooltipBound: any;
-    private repositionTooltipBound: any;
-
-    private attachPortalTooltip(button: HTMLButtonElement) {
-        const show = () => {
-            const label = button.getAttribute('aria-label') || '';
-            if (!label) return;
-            if (!this.tooltipEl) {
-                this.tooltipEl = document.createElement('div');
-                this.tooltipEl.className = 'saypi-tooltip';
-                document.body.appendChild(this.tooltipEl);
-            }
-            this.tooltipEl.textContent = label;
-            this.tooltipEl.style.visibility = 'hidden';
-            this.tooltipEl.style.opacity = '0';
-            this.positionTooltip(button);
-            this.tooltipEl.style.visibility = 'visible';
-            this.tooltipEl.style.opacity = '1';
-        };
-
-        const hide = () => {
-            if (this.tooltipEl) {
-                this.tooltipEl.style.opacity = '0';
-                // remove after fade
-                const el = this.tooltipEl;
-                setTimeout(() => { if (el && el.parentElement) el.parentElement.removeChild(el); }, 120);
-                this.tooltipEl = null;
-            }
-            window.removeEventListener('scroll', this.repositionTooltipBound, true);
-            window.removeEventListener('resize', this.repositionTooltipBound, true);
-        };
-
-        this.hideTooltipBound = hide;
-        this.repositionTooltipBound = () => this.positionTooltip(button);
-
-        button.addEventListener('mouseenter', () => {
-            show();
-            window.addEventListener('scroll', this.repositionTooltipBound, true);
-            window.addEventListener('resize', this.repositionTooltipBound, true);
-        });
-        button.addEventListener('mouseleave', hide);
-        button.addEventListener('blur', hide);
-    }
-
-    private positionTooltip(button: HTMLButtonElement) {
-        if (!this.tooltipEl) return;
-        const rect = button.getBoundingClientRect();
-        const tooltip = this.tooltipEl;
-        tooltip.style.position = 'fixed';
-        tooltip.style.zIndex = '1000';
-        tooltip.style.left = `${rect.left + rect.width / 2}px`;
-        // place above with small gap
-        const gap = 10;
-        tooltip.style.top = `${Math.max(0, rect.top - gap)}px`;
-        tooltip.style.transform = 'translate(-50%, -100%)';
     }
 
     private overrideLabelForHost(baseLabel: string, isActiveState: boolean, button: HTMLButtonElement): string {

--- a/src/saypi.index.js
+++ b/src/saypi.index.js
@@ -20,6 +20,7 @@ import { ChatbotIdentifier } from "./chatbots/ChatbotIdentifier.ts";
 // Static imports for all modules (but conditionally execute)
 import { UniversalDictationModule } from "./UniversalDictationModule.ts";
 import { AIChatModule } from "./AIChatModule.ts";
+import { initTooltip } from "./ui/Tooltip.ts";
 
 // Conditional style imports
 import "./styles/claude.scss"; // scoped by chatbot flags, i.e. <body class="claude">
@@ -43,6 +44,9 @@ import "./styles/pi.scss"; // scoped by chatbot flags, i.e. <body class="pi">
   logger.debug("Initializing compatibility notification UI");
   const { CompatibilityNotificationUI } = await import(/* webpackMode: "eager" */ "./compat/CompatibilityNotificationUI.ts");
   CompatibilityNotificationUI.getInstance().initialize();
+
+  // Body-portal tooltips for SayPi buttons (escape host overflow/stacking clipping)
+  initTooltip();
 
   // Initialize progressive authentication prompt system (for chatbot overlay prompts)
   logger.debug("Initializing auth prompt system");

--- a/src/styles/chatgpt.scss
+++ b/src/styles/chatgpt.scss
@@ -59,29 +59,7 @@ body.chatgpt {
     }
   }
 
-  /* Tooltip: compact black pill above the button, matching ChatGPT feel */
-  .tooltip[aria-label]::after {
-    content: attr(aria-label);
-    position: absolute;
-    top: -130%;
-    left: 50%;
-    transform: translateX(-50%);
-    white-space: nowrap;
-    background-color: rgba(0, 0, 0, 0.85);
-    color: #fff;
-    padding: 6px 8px;
-    border-radius: 9999px; /* pill */
-    font-size: 0.75rem; /* text-xs */
-    line-height: 1;
-    opacity: 0;
-    transition: opacity 0.15s ease-in-out;
-    pointer-events: none;
-    z-index: 1000;
-  }
-
-  @media (hover: hover) {
-    .tooltip[aria-label]:hover::after { opacity: 1; }
-  }
+  /* Tooltip handled by the body-level portal (.saypi-tooltip); styled below. */
 
   /* Subtle hover background using ::before overlay (composer-btn inspired) */
   #saypi-callButton {
@@ -153,21 +131,14 @@ body.chatgpt {
     --call-button-bg-hangup: color-mix(in srgb, var(--theme-secondary-btn-bg, var(--theme-user-msg-bg, #776d6d)) 85%, #000000 15%);
   }
 
-  /* Portal tooltip element appended to body to avoid overflow clipping */
+  /* ChatGPT colour/shape for the portal tooltip (structure is in common.scss).
+     Black pill for contrast in both themes. */
   .saypi-tooltip {
-    position: fixed;
-    /* Use black pill in both themes for contrast; allow host var override when available */
-    background-color: var(--radix-tooltip-bg, rgba(0,0,0,0.85));
+    background-color: var(--radix-tooltip-bg, rgba(0, 0, 0, 0.85));
     color: var(--radix-tooltip-fg, #fff);
+    border-radius: 9999px; /* pill */
     padding: 6px 8px;
-    border-radius: 9999px;
     font-size: 0.75rem;
-    line-height: 1;
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.12s ease-in-out;
-    white-space: nowrap;
-    box-shadow: 0 4px 10px rgba(0,0,0,0.15);
   }
 
   /* Invisible holder for temporarily relocated ChatGPT menu item

--- a/src/styles/claude.scss
+++ b/src/styles/claude.scss
@@ -44,10 +44,10 @@ html body.claude {
     white-space: nowrap;
   }
 
-  .tooltip[aria-label]::after {
+  /* Claude colour for the portal tooltip (.saypi-tooltip lives on <body>). */
+  .saypi-tooltip {
     font-size: 0.75rem; /* text-xs */
     background-color: hsl(var(--black) / 0.8); /* bg-black/80 */
-    top: -130%; /* position the tooltip above the button */
   }
 
   .message-action-bar .saypi-tts-controls, .message-hover-menu .saypi-tts-controls {

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -48,6 +48,31 @@ html:not(.immersive-view) .theme-toggle-button {
   display: none;
 }
 
+/* Portal tooltips for SayPi buttons — rendered on <body> and positioned with JS
+   (src/ui/Tooltip.ts) so they're never clipped by an overflow:hidden ancestor or
+   covered by host chrome (Pi's prompt box / z-[999] sidebar, ChatGPT's composer).
+   A CSS ::after tooltip can't escape its container; this can. Per-host colour is
+   overridden by `body.<host> .saypi-tooltip`. */
+.saypi-tooltip {
+  position: fixed;
+  z-index: 2147483000;
+  transform: translateX(-50%);
+  pointer-events: none;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.12s ease-in-out;
+  background-color: #24381b;
+  color: #fff;
+  padding: 5px 10px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  line-height: 1.2;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+.saypi-tooltip.visible {
+  opacity: 1;
+}
+
 
 #saypi-lock-panel {
   /* lock panel is only displayed on mobile devices */

--- a/src/styles/desktop.scss
+++ b/src/styles/desktop.scss
@@ -58,38 +58,11 @@ html.desktop-view {
     }
   }
 
-  // Anchor the ::after tooltip to the button so it centres on it (not on some
-  // distant positioned ancestor).
-  .tooltip[aria-label] {
-    position: relative;
-  }
-
-  .tooltip[aria-label]::after {
-    content: attr(aria-label);
-    position: absolute;
-    top: 120%; // position the tooltip below the button
-    left: 50%;
-    transform: translateX(-50%); // centre the tooltip under the button
-    white-space: nowrap;
-    background: #24381b; // Pi primary text color (dark green)
-    color: white;
-    padding: 5px 10px;
-    border-radius: 4px;
-    opacity: 0;
-    transition: opacity 0.3s;
-    pointer-events: none;
-    font-size: 1.2rem;
-    z-index: 1000; // sit above host chrome (e.g. Pi's z-999 sidebar)
-  }
+  // Button tooltips are rendered as a body-level portal (src/ui/Tooltip.ts +
+  // .saypi-tooltip in common.scss) so they're never clipped by an overflow:hidden
+  // ancestor — a CSS ::after tooltip couldn't escape Pi's prompt box / sidebar.
 
   @include meta.load-css("./chatgpt.scss");
-
-  // Show on hover (desktop)
-  @media (hover: hover) {
-    .tooltip[aria-label]:hover::after {
-        opacity: 1;
-    }
-  }
 
   @media only screen and (max-width:1200px){ // media query 
     @-moz-document url-prefix() { // target FF

--- a/src/styles/mobile.scss
+++ b/src/styles/mobile.scss
@@ -160,13 +160,8 @@ html.mobile-device .chat-message .message-hover-menu .saypi-cost-container {
 
 /* Allow settings button on Firefox Android (popup now opens as a tab) */
 
-// Hide tooltip on touch devices after touch ends
-@media (hover: none) {
-  .tooltip[aria-label]:active::after {
-      opacity: 1;
-      z-index: 1000; // sit above host chrome (match desktop)
-  }
-}
+// Tooltips are handled by the body-level portal (src/ui/Tooltip.ts); no
+// touch-device ::after rule needed.
 
 @include meta.load-css("./dark-mode.scss");
 @include meta.load-css("./focus-mode.scss");

--- a/src/styles/pi.scss
+++ b/src/styles/pi.scss
@@ -3,13 +3,11 @@
  */
 
 html body.pi {
-  /* Pi-specific tooltip styling to match native Pi tooltips */
-  .tooltip[aria-label]::after {
-    background: rgb(107, 98, 85); /* Pi's native tooltip brown/olive */
-    color: rgb(255, 255, 255);
+  /* Pi-native colour for the portal tooltip (.saypi-tooltip lives on <body>). */
+  .saypi-tooltip {
+    background-color: rgb(107, 98, 85); /* Pi's native tooltip brown/olive */
     font-size: 14px;
     padding: 4px 8px;
-    border-radius: 4px;
   }
 
   /* Pi-specific button sizing for control panel */

--- a/src/ui/Tooltip.ts
+++ b/src/ui/Tooltip.ts
@@ -1,0 +1,147 @@
+/**
+ * Body-portal tooltips for SayPi buttons.
+ *
+ * SayPi buttons live inside host containers that clip overflow (Pi's rounded
+ * prompt box, ChatGPT's composer) and sit beneath high z-index chrome (Pi's
+ * `z-[999]` sidebar). A CSS `::after` tooltip cannot escape an `overflow:hidden`
+ * ancestor, and z-index doesn't help with clipping — so tooltips were getting cut
+ * off (e.g. the call-button tooltip clipped by the prompt box). Instead we render
+ * a single tooltip element on `<body>`, positioned with JS relative to the hovered
+ * button, which escapes every clipping/stacking context.
+ *
+ * One delegated set of listeners covers every `.tooltip[aria-label]` button,
+ * current or future. Per-host colour comes from CSS (`.saypi-tooltip`, scoped by
+ * the host `body` class), so each host keeps its native look.
+ */
+
+export interface Rect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+export interface Size {
+  width: number;
+  height: number;
+}
+export interface Viewport {
+  width: number;
+  height: number;
+}
+export type Placement = "above" | "below";
+
+/**
+ * Compute where to place the tooltip. Returns the tooltip's horizontal CENTRE
+ * (`left`; the element is centred with `transform: translateX(-50%)`) and its
+ * `top`. Prefers placing the tooltip above the button and flips below when there
+ * isn't room; clamps the centre so the tooltip stays within the viewport.
+ */
+export function computeTooltipPosition(
+  anchor: Rect,
+  tooltip: Size,
+  viewport: Viewport,
+  gap = 8,
+  margin = 8
+): { left: number; top: number; placement: Placement } {
+  const half = tooltip.width / 2;
+  const centreX = anchor.left + anchor.width / 2;
+  const minX = margin + half;
+  const maxX = Math.max(minX, viewport.width - margin - half);
+  const left = Math.min(Math.max(centreX, minX), maxX);
+
+  let placement: Placement = "above";
+  let top = anchor.top - gap - tooltip.height;
+  if (top < margin) {
+    placement = "below";
+    top = anchor.bottom + gap;
+  }
+  return { left, top, placement };
+}
+
+const TOOLTIP_SELECTOR = ".tooltip[aria-label]";
+
+let tooltipEl: HTMLDivElement | null = null;
+let currentTarget: HTMLElement | null = null;
+let initialized = false;
+
+function getEl(): HTMLDivElement {
+  if (!tooltipEl || !tooltipEl.isConnected) {
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "saypi-tooltip";
+    tooltipEl.setAttribute("role", "tooltip");
+    document.body.appendChild(tooltipEl);
+  }
+  return tooltipEl;
+}
+
+function reposition(): void {
+  if (!currentTarget || !tooltipEl) return;
+  const r = currentTarget.getBoundingClientRect();
+  const { left, top, placement } = computeTooltipPosition(
+    r,
+    { width: tooltipEl.offsetWidth, height: tooltipEl.offsetHeight },
+    { width: window.innerWidth, height: window.innerHeight }
+  );
+  tooltipEl.style.left = `${Math.round(left)}px`;
+  tooltipEl.style.top = `${Math.round(top)}px`;
+  tooltipEl.dataset.placement = placement;
+}
+
+function showFor(target: HTMLElement): void {
+  const label = target.getAttribute("aria-label");
+  if (!label) return;
+  currentTarget = target;
+  const el = getEl();
+  el.textContent = label;
+  el.classList.remove("visible");
+  // Measure (offsetWidth/Height) and position on the next frame, once laid out.
+  requestAnimationFrame(() => {
+    if (currentTarget !== target) return;
+    reposition();
+    el.classList.add("visible");
+  });
+}
+
+function hide(): void {
+  currentTarget = null;
+  if (tooltipEl) tooltipEl.classList.remove("visible");
+}
+
+/**
+ * Install the delegated tooltip listeners once. Safe to call multiple times.
+ */
+export function initTooltip(): void {
+  if (initialized || typeof document === "undefined") return;
+  initialized = true;
+
+  document.addEventListener("pointerover", (e) => {
+    const target = (e.target as HTMLElement | null)?.closest?.(
+      TOOLTIP_SELECTOR
+    ) as HTMLElement | null;
+    if (target && target !== currentTarget) showFor(target);
+  });
+
+  document.addEventListener("pointerout", (e) => {
+    if (!currentTarget) return;
+    const related = e.relatedTarget as Node | null;
+    // Only hide when the pointer actually leaves the current button (not when it
+    // moves onto a child element of the button).
+    if (!related || !currentTarget.contains(related)) hide();
+  });
+
+  // Keep the tooltip aligned while the page scrolls or resizes.
+  window.addEventListener("scroll", reposition, true);
+  window.addEventListener("resize", reposition, true);
+  // Hide on focus changes (e.g. tabbing away).
+  document.addEventListener("focusout", hide, true);
+}
+
+/** Test-only reset of module state. */
+export function __resetTooltipForTests(): void {
+  if (tooltipEl?.parentElement) tooltipEl.parentElement.removeChild(tooltipEl);
+  tooltipEl = null;
+  currentTarget = null;
+  initialized = false;
+}

--- a/test/ui/Tooltip.spec.ts
+++ b/test/ui/Tooltip.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { computeTooltipPosition } from "../../src/ui/Tooltip";
+
+const rect = (left: number, top: number, width: number, height: number) => ({
+  left,
+  top,
+  width,
+  height,
+  right: left + width,
+  bottom: top + height,
+});
+
+describe("computeTooltipPosition", () => {
+  const viewport = { width: 1000, height: 800 };
+
+  it("centres above the button when there is room", () => {
+    const r = computeTooltipPosition(rect(400, 300, 40, 40), { width: 120, height: 30 }, viewport);
+    expect(r.placement).toBe("above");
+    expect(r.left).toBe(420); // 400 + 40/2
+    expect(r.top).toBe(262); // top - gap(8) - height(30)
+  });
+
+  it("flips below when there is no room above (button near the top)", () => {
+    const r = computeTooltipPosition(rect(400, 4, 40, 40), { width: 120, height: 30 }, viewport);
+    expect(r.placement).toBe("below");
+    expect(r.top).toBe(52); // bottom(44) + gap(8)
+  });
+
+  it("clamps the centre so a wide tooltip near the left edge stays on-screen", () => {
+    const r = computeTooltipPosition(rect(10, 300, 40, 40), { width: 200, height: 30 }, viewport);
+    expect(r.left).toBe(108); // margin(8) + half(100)
+  });
+
+  it("clamps the centre so a wide tooltip near the right edge stays on-screen", () => {
+    const r = computeTooltipPosition(rect(960, 300, 40, 40), { width: 200, height: 30 }, viewport);
+    expect(r.left).toBe(892); // viewport(1000) - margin(8) - half(100)
+  });
+});

--- a/test/ui/TooltipPositioning.spec.ts
+++ b/test/ui/TooltipPositioning.spec.ts
@@ -3,31 +3,41 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 /**
- * Regression guard for SayPi button tooltips being obscured.
+ * Guards that SayPi button tooltips are rendered as a body-level **portal**
+ * (`.saypi-tooltip`, positioned by src/ui/Tooltip.ts) rather than a CSS
+ * `::after` pseudo-element.
  *
- * The base tooltip (`desktop.scss`, inherited by Pi + Claude) used to position
- * the `::after` with `transform: translateX(-70%)` + `margin-left: 10px` — a crude
- * off-centre hack that pushed a wide tooltip left until it crossed the host's
- * sidebar boundary (Pi's sidebar is `z-[999]`) and got covered. Now it centres
- * properly and carries a z-index above host chrome.
- *
- * Verified visually at Layer 4 (live, on real pi.ai).
+ * The `::after` approach (even when centred) was clipped by the host's
+ * `overflow:hidden` containers (Pi's rounded prompt box) and couldn't be lifted
+ * out with z-index. The portal escapes all clipping/stacking contexts. This guard
+ * keeps us from regressing back to the clippable pseudo-element.
  */
-const desktopScss = readFileSync(
-  fileURLToPath(new URL("../../src/styles/desktop.scss", import.meta.url)),
-  "utf8"
-);
+const read = (p: string) =>
+  readFileSync(fileURLToPath(new URL(p, import.meta.url)), "utf8");
 
-describe("Button tooltip positioning (desktop.scss base)", () => {
-  it("centres the tooltip under the button (drops the old translateX(-70%) hack)", () => {
-    const norm = desktopScss.replace(/\s+/g, " ");
-    expect(norm).toContain("transform: translateX(-50%)");
-    expect(norm).not.toContain("translateX(-70%)");
+const common = read("../../src/styles/common.scss");
+const hostSheets = {
+  desktop: read("../../src/styles/desktop.scss"),
+  pi: read("../../src/styles/pi.scss"),
+  claude: read("../../src/styles/claude.scss"),
+  chatgpt: read("../../src/styles/chatgpt.scss"),
+  mobile: read("../../src/styles/mobile.scss"),
+};
+
+describe("Button tooltips use a body-level portal (not a clippable ::after)", () => {
+  it("defines the .saypi-tooltip portal base (position:fixed, high z-index) in common.scss", () => {
+    const norm = common.replace(/\s+/g, " ");
+    expect(norm).toMatch(/\.saypi-tooltip\s*\{[^}]*position:\s*fixed/);
+    // A high z-index so it sits above host chrome (e.g. Pi's z-[999] sidebar).
+    expect(norm).toMatch(/\.saypi-tooltip\s*\{[^}]*z-index:\s*\d{4,}/);
   });
 
-  it("renders the tooltip above host chrome (z-index over Pi's z-999 sidebar)", () => {
-    expect(desktopScss).toMatch(
-      /\.tooltip\[aria-label\]::after[\s\S]*?z-index:\s*1000/
-    );
+  it("no longer renders the clippable CSS ::after tooltip on any host", () => {
+    expect(common).not.toContain(".tooltip[aria-label]::after");
+    for (const [host, css] of Object.entries(hostSheets)) {
+      expect(css, `${host}.scss should not use ::after tooltips`).not.toContain(
+        ".tooltip[aria-label]::after"
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

After #297 centred the button tooltips, they were **still clipped** in several spots — most clearly the call-button tooltip cut off by Pi's rounded prompt box (`overflow:hidden`), and buttons near the sidebar. A CSS `::after` tooltip can't escape an `overflow:hidden` ancestor, and z-index doesn't help with clipping.

## Fix

Render tooltips as a single **body-level portal** (`.saypi-tooltip`), positioned with JS (`src/ui/Tooltip.ts`) relative to the hovered button — **above** by default, flipping **below** when there's no room, and clamped to the viewport. One delegated listener covers every `.tooltip[aria-label]` button (current and future). This generalises the portal that previously existed only for the ChatGPT call button; the per-host CSS `::after` tooltips are removed. Per-host colour is preserved (Pi brown, Claude black/80, ChatGPT pill) via `body.<host> .saypi-tooltip`.

## Verification

- **Unit test** for the positioning math (above/below flip + viewport clamp): `test/ui/Tooltip.spec.ts`.
- **Guard** that the clippable `::after` tooltips are gone and the portal base exists: `test/ui/TooltipPositioning.spec.ts`.
- **Live on pi.ai**: the call-button tooltip ("Start a hands-free conversation with Pi") now renders fully above the button, no longer clipped by the prompt box (screenshot in the thread).
- `npm test` green (809 passed / 1 skipped).

## Notes

- Removed the ChatGPT-only `attachPortalTooltip` from `CallButton` — the global manager covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
