### PR TITLE
fix(dom): invalid-selector SyntaxError on thread load (past-message observer)

### DIFF
--- a/src/dom/BaseObserver.ts
+++ b/src/dom/BaseObserver.ts
@@ -6,13 +6,7 @@ abstract class BaseObserver {
   private static warned: Set<string> = new Set();
 
   constructor(searchRoot: HTMLElement, protected selector: string) {
-    if (selector && searchRoot.matches?.(selector)) {
-      this.target = searchRoot;
-    } else if (selector) {
-      this.target = searchRoot.querySelector(selector);
-    } else {
-      this.target = null;
-    }
+    this.target = BaseObserver.resolveTarget(searchRoot, selector);
 
     this.observer = new MutationObserver(this.callback.bind(this));
 
@@ -22,6 +16,24 @@ abstract class BaseObserver {
         BaseObserver.warned.add(key);
         logger.debug(`Element with selector ${selector} not found (will retry later).`);
       }
+    }
+  }
+
+  // Resolve the element to observe, tolerating invalid selectors. The host DOM
+  // can yield class lists with selector-invalid characters (e.g. Tailwind's
+  // `lg:pb-8` or `min-h-[calc(100%-60px)]`), which would otherwise throw a
+  // SyntaxError from matches()/querySelector(). Never throws.
+  private static resolveTarget(
+    searchRoot: HTMLElement,
+    selector: string
+  ): Element | null {
+    if (!selector) return null;
+    try {
+      if (searchRoot.matches?.(selector)) return searchRoot;
+      return searchRoot.querySelector(selector);
+    } catch (e) {
+      logger.error(`BaseObserver received an invalid selector: "${selector}"`, e);
+      return null;
     }
   }
 

--- a/src/dom/ChatHistory.ts
+++ b/src/dom/ChatHistory.ts
@@ -87,9 +87,10 @@ class ChatHistoryRootElementObserver extends BaseObserver {
       }
       this.oldMessageObserver = new ChatHistoryOldMessageObserver(
         this.chatHistoryElement,
-        `${pastMessagesContainer.tagName}.${Array.from(
-          pastMessagesContainer.classList
-        ).join(".")}`,
+        // Identify the container by the stable classes we just added — NOT the
+        // host's volatile Tailwind classes, which contain selector-invalid chars
+        // (e.g. `lg:pb-8`, `min-h-[calc(100%-60px)]`) that throw from .matches().
+        `${pastMessagesContainer.tagName.toLowerCase()}.chat-history.past-messages`,
         this.speechSynthesis,
         this.chatbot
       );

--- a/test/dom/BaseObserver-invalid-selector.spec.ts
+++ b/test/dom/BaseObserver-invalid-selector.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { BaseObserver } from "../../src/dom/BaseObserver";
+
+/**
+ * Regression test for the uncaught SyntaxError on pi.ai thread load:
+ *
+ *   Failed to execute 'matches' on 'Element':
+ *   'DIV.pb-6.lg:pb-8.min-h-[calc(100%-60px)]...' is not a valid selector.
+ *
+ * ChatHistory built an observer selector by joining an element's full class list,
+ * including Pi's Tailwind classes (`lg:pb-8`, `min-h-[calc(100%-60px)]`) whose
+ * `:` `[` `]` `(` `)` `%` are invalid in an unescaped selector. The construction
+ * is fixed to use stable classes; BaseObserver is also hardened so an invalid
+ * selector can never throw (defense-in-depth).
+ */
+class TestObserver extends BaseObserver {
+  protected callback(): void {}
+  get resolvedTarget(): Element | null {
+    return (this as unknown as { target: Element | null }).target;
+  }
+}
+
+describe("BaseObserver invalid-selector handling", () => {
+  it("does not throw on a CSS-invalid selector built from host Tailwind classes", () => {
+    const root = document.createElement("div");
+    const invalid =
+      "DIV.pb-6.lg:pb-8.min-h-[calc(100%-60px)].sm:min-h-[calc(100%-120px)].chat-history.past-messages";
+    expect(() => new TestObserver(root, invalid)).not.toThrow();
+    expect(new TestObserver(root, invalid).resolvedTarget).toBeNull();
+  });
+
+  it("still resolves a valid selector", () => {
+    const root = document.createElement("div");
+    const child = document.createElement("div");
+    child.className = "chat-history past-messages";
+    root.appendChild(child);
+    const obs = new TestObserver(root, "div.chat-history.past-messages");
+    expect(obs.resolvedTarget).toBe(child);
+  });
+});


### PR DESCRIPTION
## Summary

On thread load (`pi.ai/talk/<id>`) the console logged an uncaught `SyntaxError` and past-message decoration silently broke:

```
Uncaught (in promise) SyntaxError: Failed to execute 'matches' on 'Element':
'DIV.pb-6.lg:pb-8.min-h-[calc(100%-60px)].sm:min-h-[calc(100%-120px)].chat-history.past-messages'
is not a valid selector.
  at new BaseObserver ... at ChatHistorySpeechManager.registerPastChatHistoryListener ...
```

## Root cause

`ChatHistory` built the old-message observer's selector by joining the container's **full class list** — including Pi's Tailwind classes (`lg:pb-8`, `min-h-[calc(100%-60px)]`) whose `:` `[` `]` `(` `)` `%` are invalid in an *unescaped* CSS selector. `BaseObserver`'s `.matches(selector)` threw, which aborted the `ChatHistoryOldMessageObserver` constructor — so past messages were never observed/decorated (and the throw surfaced as the uncaught rejection).

## Fix

1. **Build the selector from the stable classes SayPi controls** (`chat-history past-messages`) — which we just added to the container — instead of the host's volatile Tailwind classes. Also more robust to Pi DOM drift.
2. **Harden `BaseObserver`**: `resolveTarget()` tolerates an invalid selector (logs + returns `null`) rather than throwing — defense-in-depth against any future bad selector.

## Verification

- **Fail-first unit test** (`test/dom/BaseObserver-invalid-selector.spec.ts`): without the fix it throws the exact production `SyntaxError`; with the fix, passes.
- `npm test` green.
- **Live on a pi.ai thread**: no `SyntaxError`, SayPi loads, and past messages are decorated again (the crash had prevented the old-message observer from constructing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
