### PR TITLE
fix(ui): make Claude button tooltip readable (was white-on-transparent)

### DIFF
--- a/src/styles/claude.scss
+++ b/src/styles/claude.scss
@@ -44,10 +44,15 @@ html body.claude {
     white-space: nowrap;
   }
 
-  /* Claude colour for the portal tooltip (.saypi-tooltip lives on <body>). */
+  /* Claude colour for the portal tooltip (.saypi-tooltip lives on <body>).
+     Use a literal dark fill, not Claude's `--black` token: the portal sits on
+     <body>, outside Claude's themed subtrees, where `--black` is undefined — an
+     unresolved var() computes to `transparent`, leaving white text invisible on
+     the light theme. Black/80 + white reads on both light and dark Claude. */
   .saypi-tooltip {
     font-size: 0.75rem; /* text-xs */
-    background-color: hsl(var(--black) / 0.8); /* bg-black/80 */
+    background-color: rgba(0, 0, 0, 0.8); /* bg-black/80 */
+    color: #fff;
   }
 
   .message-action-bar .saypi-tts-controls, .message-hover-menu .saypi-tts-controls {

--- a/test/ui/TooltipContrast.spec.ts
+++ b/test/ui/TooltipContrast.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Guards the contrast of the body-portal button tooltip (`.saypi-tooltip`).
+ *
+ * The tooltip is appended to <body> (to escape host overflow clipping), so it
+ * sits OUTSIDE the host's themed component subtrees. Any CSS custom property it
+ * references must therefore be defined at :root/body scope on that host — a
+ * host-scoped token won't resolve on the portal.
+ *
+ * Regression (claude.ai, light theme): the Claude override set
+ *   background-color: hsl(var(--black) / 0.8);
+ * but Claude defines no `--black` variable on <body>. An undefined `var()` is
+ * invalid at computed-value time and resolves to the property's *initial* value
+ * (`background-color: transparent`) — it does NOT fall back to the base rule's
+ * colour. The base `color: #fff` stayed, so the tooltip rendered as white text
+ * on a transparent box over Claude's light background — invisible.
+ *
+ * Live measurement on claude.ai/new (2026-06-15, light theme):
+ *   .saypi-tooltip computed -> background-color: rgba(0,0,0,0); color: rgb(255,255,255)
+ *
+ * Two invariants prevent this class of bug:
+ *   1. The base rule must pair a background-colour with a text colour.
+ *   2. No host override may use a bare `var(...)` (no comma fallback) for the
+ *      tooltip's background/text colour — a fallback keeps it readable even when
+ *      the host-scoped token is absent (see ChatGPT's `var(--x, rgba(...))`).
+ */
+const read = (p: string) =>
+  readFileSync(fileURLToPath(new URL(p, import.meta.url)), "utf8");
+
+const sheets: Record<string, string> = {
+  common: read("../../src/styles/common.scss"),
+  pi: read("../../src/styles/pi.scss"),
+  claude: read("../../src/styles/claude.scss"),
+  chatgpt: read("../../src/styles/chatgpt.scss"),
+  desktop: read("../../src/styles/desktop.scss"),
+  mobile: read("../../src/styles/mobile.scss"),
+};
+
+/** Extract the bodies of all bare `.saypi-tooltip { ... }` rules (not `.visible`). */
+function tooltipRuleBodies(css: string): string[] {
+  const bodies: string[] = [];
+  const re = /\.saypi-tooltip\s*\{([^}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(css)) !== null) bodies.push(m[1]);
+  return bodies;
+}
+
+/** A `var(` that has no comma before its matching close paren = no fallback. */
+function hasVarWithoutFallback(declaration: string): boolean {
+  const idx = declaration.indexOf("var(");
+  if (idx === -1) return false;
+  let depth = 0;
+  for (let i = idx + 3; i < declaration.length; i++) {
+    const ch = declaration[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth === 0) return true; // closed the var() with no comma seen
+    } else if (ch === "," && depth === 1) {
+      return false; // fallback present
+    }
+  }
+  return true;
+}
+
+describe("Body-portal tooltip stays readable across hosts", () => {
+  it("base .saypi-tooltip pairs a background colour with a text colour", () => {
+    const base = tooltipRuleBodies(sheets.common)[0];
+    expect(base, "common.scss should define a .saypi-tooltip rule").toBeTruthy();
+    expect(base).toMatch(/background-color\s*:/);
+    expect(base).toMatch(/(^|\s)color\s*:/);
+  });
+
+  it("no host tooltip override uses a var() colour without a fallback", () => {
+    for (const [host, css] of Object.entries(sheets)) {
+      for (const body of tooltipRuleBodies(css)) {
+        const colourDecls = body
+          .split(";")
+          .filter((d) => /(^|\s)(background-color|background|color)\s*:/.test(d));
+        for (const decl of colourDecls) {
+          expect(
+            hasVarWithoutFallback(decl),
+            `${host}.scss .saypi-tooltip colour uses a var() with no fallback (won't resolve on the <body> portal): "${decl.trim()}"`
+          ).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("the Claude override no longer references the undefined --black token", () => {
+    for (const body of tooltipRuleBodies(sheets.claude)) {
+      expect(body).not.toContain("--black");
+    }
+  });
+});


### PR DESCRIPTION
## What

On **claude.ai**, hovering SayPi's buttons (call button, etc.) showed an empty/invisible tooltip — white text on a near-transparent box over Claude's light theme.

![invisible tooltip](https://github.com/user-attachments/assets/placeholder)

## Why it happened

The body-portal tooltip's Claude override (`claude.scss`) set:

```scss
.saypi-tooltip { background-color: hsl(var(--black) / 0.8); }
```

But `.saypi-tooltip` is appended to `<body>` (to escape host `overflow:hidden` clipping), so it lives **outside** Claude's themed component subtrees — and Claude defines **no `--black` variable** at `:root`/`body` scope (its tokens are `--text-000`, `--bg-*`, …).

The CSS gotcha: an **undefined `var()` is invalid at computed-value time**, and the property resolves to its **initial value** (`background-color: transparent`) — it does *not* fall back to the lower-specificity base rule's `#24381b`. The base `color: #fff` stayed. Net result: white text on a transparent box → invisible. (The faint card in the screenshot is just the base `box-shadow`.)

## The fix

Use a literal dark fill (the documented `bg-black/80` intent) instead of the missing token, and set the text colour explicitly:

```scss
.saypi-tooltip {
  background-color: rgba(0, 0, 0, 0.8);
  color: #fff;
}
```

Readable on both light and dark Claude, and matches Claude's native dark tooltips. This mirrors the **ChatGPT** override, which already guards its `var()` with a fallback (`var(--radix-tooltip-bg, rgba(0,0,0,0.85))`) — Claude was the only host that referenced an undefined token with no fallback.

## Verification

**Layer 1/2:** new `test/ui/TooltipContrast.spec.ts` guards the bug *class*, not just this instance:
- the base `.saypi-tooltip` must pair a background colour with a text colour;
- **no** host override may use a bare `var()` colour without a comma-fallback (a host-scoped token can't resolve on the `<body>` portal);
- the Claude override no longer references `--black`.

Written fail-first (2 of 3 failed before the change). Full suite green after: vitest 817 passed / 1 skipped.

**Layer 4 (live dev-verify on claude.ai):** measured the real portal element before/after:

| | background-color | color | result |
|---|---|---|---|
| before | `rgba(0,0,0,0)` (transparent) | `#fff` | invisible |
| after | `rgba(0,0,0,0.8)` | `#fff` | dark pill, readable |

The call-button tooltip ("Start a hands-free conversation with Claude") renders as a dark pill with white text.

> Note: while verifying I hit a Layer 4 harness gap — the dev rig hot-reloads content-script **JS** but not the manifest-injected content-script **CSS** on SCSS saves, so a tab reload alone can't pick up CSS-only changes. Documenting that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)