### PR TITLE
docs: note content-script CSS doesn't hot-reload in the dev rig (Layer 4)

### DIFF
--- a/doc/autonomous-dev-loop.md
+++ b/doc/autonomous-dev-loop.md
@@ -110,6 +110,41 @@ secret.
    the rig restarted — reload the extension once, setup step 3.)
 4. **Assert** against the DOM (see the probe below).
 
+### CSS-only (SCSS) edits don't hot-reload (learned 2026-06-15)
+
+The rig hot-reloads content-script **JS** live from the dev server (HMR — the
+`.output` bundle isn't even rewritten), but content-script **CSS** is registered
+once from the last full build and HMR does **not** refresh it. So a `.ts`/`.js`
+edit reaches the page on a tab reload, but an SCSS-only edit does **not** — the
+page keeps serving the stale rule. Tell them apart with the output-mtime poll
+(step 2): after a CSS-only edit it won't advance, and `grep` the rule in
+`.output/chrome-mv3-dev/content-scripts/saypi.css` will still show the old value
+(the dev server on `:3001` *does* serve the fresh compiled SCSS — `curl -s
+"http://localhost:3001/@fs$(pwd)/src/styles/<host>.scss?direct"` — but that's not
+what the registered content script injects).
+
+To verify a CSS fix at Layer 4 anyway:
+
+- **Quick value/visual check — inject the fixed rule into the test tab.** The
+  stale rule has equal specificity (same `body.<host> .saypi-tooltip` selector),
+  so use `!important` to win, then probe computed styles / screenshot:
+
+  ```js
+  // via MCP javascript_tool, in the test tab
+  const s = document.createElement('style'); s.id = 'saypi-fix-verify';
+  s.textContent =
+    'body.claude .saypi-tooltip{background-color:rgba(0,0,0,0.8)!important;color:#fff!important}';
+  document.head.appendChild(s); // remove it again when done
+  ```
+
+- **True pipeline check — restart the rig** (rebuilds + re-registers the CSS) and
+  have the founder reload the extension once (setup step 3).
+
+Because the live CSS loop is unreliable, **prefer guarding CSS contracts at
+Layer 1/2**: text assertions over the SCSS source (e.g.
+`test/ui/TooltipContrast.spec.ts`, `test/ui/TooltipPositioning.spec.ts`) catch
+regressions in CI without depending on the rig.
+
 ## The verification probe (buffered MutationObserver)
 
 Production builds strip `logger.debug`, and MCP console capture can miss events
@@ -295,6 +330,9 @@ re-capture, not a contract violation.
   extension's baked origin is `localhost:3001`
   (`grep -ro "localhost:3001" .output/chrome-mv3-dev | head`). If the baked port
   differs, reload the extension once at `chrome://extensions`.
+- **A CSS/SCSS change won't appear (but JS changes do):** expected — content-script
+  CSS doesn't hot-reload. See *CSS-only (SCSS) edits don't hot-reload* under the
+  iterate-verify loop for how to verify a style fix at Layer 4.
 - **Duplicate SayPi controls:** the store build is also active — disable it.
 - **Port busy / two servers:** re-run `node scripts/dev-rig.mjs`; it clears
   strays and waits for :3001 (and aborts with guidance if something else holds it).


### PR DESCRIPTION
## Why

While fixing the Claude tooltip contrast bug (#302) I tried to verify the CSS change live via the normal Layer 4 loop (edit → tab reload → assert) and it didn't take — the page kept serving the old rule. Investigation showed a real harness limitation worth recording:

The dev rig hot-reloads content-script **JS** live from the dev server (HMR — the `.output` bundle isn't even rewritten), but content-script **CSS** is registered once from the last full build and HMR does **not** refresh it. So `.ts`/`.js` edits reach the page on a tab reload; **SCSS-only edits do not**. (Confirmed: after the SCSS edit the dev output mtime didn't advance and `saypi.css` still held the old rule, while the dev server on `:3001` *did* serve the freshly-compiled SCSS.)

This explains why an earlier `.ts` fix in the same session reflected on a tab reload but the `.scss` fix didn't.

## What this adds

A subsection under the iterate-verify loop in `doc/autonomous-dev-loop.md`:
- how to detect it (output-mtime poll won't advance after a CSS-only edit);
- how to verify a style fix at Layer 4 anyway — inject the rule into the tab with `!important` (the stale rule has equal specificity), or restart the rig + founder extension reload for a true pipeline check;
- guidance to prefer guarding CSS contracts at Layer 1/2 (SCSS text assertions, e.g. `test/ui/TooltipContrast.spec.ts`, `test/ui/TooltipPositioning.spec.ts`).

Plus a Troubleshooting cross-reference.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)