### PR TITLE
test(e2e): verify host CSS against the real build at Layer 3 (no injection)

### DIFF
--- a/doc/autonomous-dev-loop.md
+++ b/doc/autonomous-dev-loop.md
@@ -110,40 +110,43 @@ secret.
    the rig restarted — reload the extension once, setup step 3.)
 4. **Assert** against the DOM (see the probe below).
 
-### CSS-only (SCSS) edits don't hot-reload (learned 2026-06-15)
+### CSS changes don't hot-reload — verify styles at Layer 3, never by injection (learned 2026-06-15)
 
-The rig hot-reloads content-script **JS** live from the dev server (HMR — the
-`.output` bundle isn't even rewritten), but content-script **CSS** is registered
-once from the last full build and HMR does **not** refresh it. So a `.ts`/`.js`
-edit reaches the page on a tab reload, but an SCSS-only edit does **not** — the
-page keeps serving the stale rule. Tell them apart with the output-mtime poll
-(step 2): after a CSS-only edit it won't advance, and `grep` the rule in
-`.output/chrome-mv3-dev/content-scripts/saypi.css` will still show the old value
-(the dev server on `:3001` *does* serve the fresh compiled SCSS — `curl -s
-"http://localhost:3001/@fs$(pwd)/src/styles/<host>.scss?direct"` — but that's not
-what the registered content script injects).
+**`wxt dev` cannot hot-reload content-script CSS.** It hot-reloads content-script
+**JS** live from the dev server, but a changed `.scss` never reaches the loaded
+extension. This is structural, not a stale watcher: WXT's `detectDevChanges`
+maps a changed file to the content-script step only if the file is in a JS
+chunk's `moduleIds` (`findEffectedSteps`). Content-script CSS is emitted as an
+*asset*, so an `.scss` edit matches nothing → it's classified **`no-change`** →
+no rebuild, no reload. (JS hot-reloads because it *is* in `moduleIds`.) The dev
+server on `:3001` serves the freshly-compiled SCSS on demand, but that is not
+what the manifest-injected content script uses, so the page keeps the old rule.
+Restarting the rig only "works" because the *initial* build re-reads source.
 
-To verify a CSS fix at Layer 4 anyway:
+**Do not inject CSS into the page to "verify" a style.** A rule you paste into
+the tab (even via `<style>` + `!important`) tests *your* rule, not the artifact
+the build system produced — it's a false signal. We hit exactly this trap and it
+masked nothing real.
 
-- **Quick value/visual check — inject the fixed rule into the test tab.** The
-  stale rule has equal specificity (same `body.<host> .saypi-tooltip` selector),
-  so use `!important` to win, then probe computed styles / screenshot:
+Instead, **verify CSS/visual contracts at Layer 3 against the real build** — it
+loads the actual `wxt build` output via `--load-extension`, so the browser
+injects the extension's real content-script CSS, autonomously and in CI. The
+pattern: navigate to the host mock (so the manifest CSS injects), let SayPi tag
+the body by host, create the element the shipped stylesheet targets, and assert
+its **computed** style. See `e2e/specs/tooltip-contrast.e2e.ts` (regression guard
+for the Claude tooltip contrast bug — confirmed fail-first by reverting the fix
+and rebuilding). The Claude host mock is wired the same way as Pi
+(`e2e/support/mock-claude-page.html`, `MAP claude.ai` in `launch-args.ts`,
+Host-routed in `mock-servers.ts`).
 
-  ```js
-  // via MCP javascript_tool, in the test tab
-  const s = document.createElement('style'); s.id = 'saypi-fix-verify';
-  s.textContent =
-    'body.claude .saypi-tooltip{background-color:rgba(0,0,0,0.8)!important;color:#fff!important}';
-  document.head.appendChild(s); // remove it again when done
-  ```
+Layer 1/2 SCSS-text assertions (`test/ui/TooltipContrast.spec.ts`,
+`test/ui/TooltipPositioning.spec.ts`) remain a fast first guard on the source,
+but the Layer 3 spec is what proves the *built* CSS renders correctly.
 
-- **True pipeline check — restart the rig** (rebuilds + re-registers the CSS) and
-  have the founder reload the extension once (setup step 3).
-
-Because the live CSS loop is unreliable, **prefer guarding CSS contracts at
-Layer 1/2**: text assertions over the SCSS source (e.g.
-`test/ui/TooltipContrast.spec.ts`, `test/ui/TooltipPositioning.spec.ts`) catch
-regressions in CI without depending on the rig.
+If you must spot-check a style on the **real** host (Layer 4), there is no live
+loop: rebuild (`npm run e2e:build`, or restart the rig) and have the founder
+reload the unpacked extension once, then assert computed styles on the page — but
+prefer Layer 3, which needs neither the founder nor the real host.
 
 ## The verification probe (buffered MutationObserver)
 
@@ -330,9 +333,10 @@ re-capture, not a contract violation.
   extension's baked origin is `localhost:3001`
   (`grep -ro "localhost:3001" .output/chrome-mv3-dev | head`). If the baked port
   differs, reload the extension once at `chrome://extensions`.
-- **A CSS/SCSS change won't appear (but JS changes do):** expected — content-script
-  CSS doesn't hot-reload. See *CSS-only (SCSS) edits don't hot-reload* under the
-  iterate-verify loop for how to verify a style fix at Layer 4.
+- **A CSS/SCSS change won't appear (but JS changes do):** expected and structural —
+  `wxt dev` never hot-reloads content-script CSS. Don't inject CSS to work around
+  it; verify styles at Layer 3 against the real build. See *CSS changes don't
+  hot-reload — verify styles at Layer 3* under the iterate-verify loop.
 - **Duplicate SayPi controls:** the store build is also active — disable it.
 - **Port busy / two servers:** re-run `node scripts/dev-rig.mjs`; it clears
   strays and waits for :3001 (and aborts with guidance if something else holds it).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -63,7 +63,7 @@ mock servers and a fake-mic device per run, so the specs run serially.
   context fixture (e2e/fixtures/extension.ts + launch-args.ts)
         │  chromium.launchPersistentContext with:
         │    --load-extension / --disable-extensions-except  -> the dev build
-        │    --host-resolver-rules  MAP pi.ai/api|www|app.saypi.ai/google-analytics.com
+        │    --host-resolver-rules  MAP pi.ai/claude.ai/api|www|app.saypi.ai/google-analytics.com
         │                           -> 127.0.0.1:<port>, then MAP * ~NOTFOUND (fail closed)
         │    --ignore-certificate-errors / --allow-insecure-localhost
         │    --use-fake-device-for-media-stream / --use-fake-ui-for-media-stream
@@ -75,6 +75,9 @@ mock servers and a fake-mic device per run, so the specs run serially.
      dictation-stt.e2e.ts fake mic (WAV) -> getUserMedia -> offscreen Silero-v5 VAD
                           -> onSpeechEnd -> SW POSTs /transcribe (mock echoes a
                           transcript) -> draft written into #saypi-prompt.value
+     tooltip-contrast.e2e.ts page.goto(https://claude.ai/new) -> body.claude ->
+                          the real built CSS renders .saypi-tooltip as an opaque
+                          dark pill (guards the host-CSS-var contrast bug)
 ```
 
 The pivotal trick is **`--host-resolver-rules`**: the extension is built with the
@@ -100,8 +103,9 @@ instead of silently calling the real internet.
 | `fixtures/audio/` | the fake-mic WAV clip + its [README](fixtures/audio/README.md) |
 | `support/global-setup.ts` | build guard + start mock servers + export ports |
 | `support/global-teardown.ts` | close mock servers |
-| `support/mock-servers.ts` | self-signed HTTPS Pi page + saypi-api (`/transcribe`, `/merge`, GA catch-all) |
+| `support/mock-servers.ts` | self-signed HTTPS page server (Host-routed Pi/Claude pages) + saypi-api (`/transcribe`, `/merge`, GA catch-all) |
 | `support/mock-pi-page.html` | minimal Pi.ai-shaped DOM the content script decorates |
+| `support/mock-claude-page.html` | minimal claude.ai stand-in (defines no `--black`) for the host-CSS contrast spec |
 | `support/transcribe-response.ts` | the STT contract: shape of the `/transcribe` response |
 | `support/manifest-guard.ts` | `assertDevManifest()` — refuses a non-static / production build |
 | `support/check-servers.mjs` | standalone sanity check for the mock servers |

--- a/e2e/fixtures/launch-args.ts
+++ b/e2e/fixtures/launch-args.ts
@@ -9,6 +9,8 @@ export interface LaunchArgsOptions {
 export function buildLaunchArgs(o: LaunchArgsOptions): string[] {
   const hostRules = [
     `MAP pi.ai 127.0.0.1:${o.piPort}`,
+    // claude.ai shares the page server; it serves the Claude mock by Host header.
+    `MAP claude.ai 127.0.0.1:${o.piPort}`,
     `MAP api.saypi.ai 127.0.0.1:${o.apiPort}`,
     `MAP www.saypi.ai 127.0.0.1:${o.apiPort}`,
     `MAP app.saypi.ai 127.0.0.1:${o.apiPort}`,

--- a/e2e/specs/tooltip-contrast.e2e.ts
+++ b/e2e/specs/tooltip-contrast.e2e.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "../fixtures/extension";
+
+/**
+ * Layer 3 regression guard for the Claude button-tooltip contrast bug.
+ *
+ * The body-portal tooltip (`.saypi-tooltip`) was invisible on claude.ai: the
+ * Claude override set `background-color: hsl(var(--black) / 0.8)`, but the portal
+ * lives on <body> where Claude defines no `--black`. An undefined var() computes
+ * to the property's initial value (`transparent`) — NOT the base rule's colour —
+ * so the box rendered transparent while the inherited `color:#fff` stayed: white
+ * text on nothing.
+ *
+ * This verifies the fix against the REAL BUILD, not an injected rule. We load the
+ * actual built extension (`.output/chrome-mv3-dev`, produced by `wxt build`) into
+ * Chrome via --load-extension, navigate to the claude.ai mock host (so Chrome
+ * injects the extension's real content-script CSS per the manifest match), let
+ * SayPi tag the body by host, then read the computed style of the element the
+ * shipped stylesheet targets. The mock page defines no `--black`, replicating
+ * claude.ai exactly.
+ *
+ * Before the fix this computes `rgba(0, 0, 0, 0)` (transparent) and the spec
+ * fails; after, `rgba(0, 0, 0, 0.8)` and it passes. Confirmed fail-first by
+ * temporarily reverting the fix in the source and rebuilding.
+ */
+test("Claude tooltip CSS renders an opaque, readable pill (real build)", async ({ context }) => {
+  const page = await context.newPage();
+  await page.goto("https://claude.ai/new", { waitUntil: "domcontentloaded" });
+
+  // SayPi tags <body> by host (ChatbotService.addChatbotFlags) — proves the
+  // content script and its CSS are live on claude.ai, and that the host-scoped
+  // `html body.claude .saypi-tooltip` override (not the base rule) is in effect.
+  await page.waitForFunction(() => document.body.classList.contains("claude"), {
+    timeout: 20_000,
+  });
+
+  // Create the element the shipped CSS targets and read its computed style. The
+  // colours come from the extension's real stylesheet — nothing is injected here.
+  const style = await page.evaluate(() => {
+    const el = document.createElement("div");
+    el.className = "saypi-tooltip";
+    el.textContent = "Start a hands-free conversation with Claude";
+    document.body.appendChild(el);
+    const cs = getComputedStyle(el);
+    const out = { backgroundColor: cs.backgroundColor, color: cs.color };
+    el.remove();
+    return out;
+  });
+
+  // Parse the background; the bug rendered it fully transparent (alpha 0).
+  const m = style.backgroundColor.match(/rgba?\(([^)]+)\)/);
+  expect(m, `unexpected background-color: "${style.backgroundColor}"`).not.toBeNull();
+  const [r, g, b, a = 1] = m![1].split(",").map((s) => parseFloat(s));
+
+  // Opaque enough to be visible (regression: alpha was 0).
+  expect(a, `tooltip background must be opaque, got "${style.backgroundColor}"`).toBeGreaterThan(0.5);
+  // A dark fill, so the white label reads against it.
+  expect(r + g + b, `tooltip background must be dark, got "${style.backgroundColor}"`).toBeLessThan(120);
+  // White text.
+  expect(style.color).toBe("rgb(255, 255, 255)");
+});

--- a/e2e/support/mock-claude-page.html
+++ b/e2e/support/mock-claude-page.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>Claude mock</title></head>
+  <!--
+    Minimal claude.ai stand-in for Layer 3. SayPi tags the body by host
+    (ChatbotService.addChatbotFlags → body.claude), so the host-scoped
+    content-script CSS (`html body.claude …`) applies here without needing full
+    decoration. Crucially this page defines NO `--black` custom property — that
+    mirrors real claude.ai (whose tokens are `--bg-*`, `--text-*`, …) and is the
+    exact condition under which `hsl(var(--black)/.8)` computed to `transparent`.
+  -->
+  <body>
+    <main id="mock-mount"></main>
+  </body>
+</html>

--- a/e2e/support/mock-servers.ts
+++ b/e2e/support/mock-servers.ts
@@ -7,7 +7,8 @@ import { buildTranscribeResponse } from "./transcribe-response.ts";
 // selfsigned@5 exposes an async `generate`; resolve once at module load (top-level await, ESM).
 const pems = await selfsigned.generate([{ name: "commonName", value: "saypi-e2e" }], { days: 1 });
 const tls = { key: pems.private, cert: pems.cert };
-const PAGE = readFileSync(resolve(import.meta.dirname, "mock-pi-page.html"), "utf8");
+const PI_PAGE = readFileSync(resolve(import.meta.dirname, "mock-pi-page.html"), "utf8");
+const CLAUDE_PAGE = readFileSync(resolve(import.meta.dirname, "mock-claude-page.html"), "utf8");
 
 export interface MockServers {
   piPort: number;
@@ -25,9 +26,14 @@ function extractSequenceNumber(body: Buffer): number {
 export async function startMockServers(): Promise<MockServers> {
   let hits = 0;
 
-  const piServer = https.createServer(tls, (_req, res) => {
+  // One page server backs both decorated hosts; the Host header picks the page.
+  // claude.ai and pi.ai both resolve here via --host-resolver-rules, and the
+  // content script injects per the manifest match for whichever URL is loaded.
+  const piServer = https.createServer(tls, (req, res) => {
+    const host = (req.headers.host ?? "").toLowerCase();
+    const page = host.includes("claude.ai") ? CLAUDE_PAGE : PI_PAGE;
     res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
-    res.end(PAGE);
+    res.end(page);
   });
 
   const apiServer = https.createServer(tls, (req, res) => {

--- a/test/e2e/launch-args.spec.ts
+++ b/test/e2e/launch-args.spec.ts
@@ -14,10 +14,12 @@ describe("buildLaunchArgs", () => {
     expect(args).toContain("--load-extension=/abs/.output/chrome-mv3-dev");
   });
 
-  it("redirects pi.ai and the saypi api/auth/app + GA hosts to local mocks", () => {
+  it("redirects pi.ai, claude.ai and the saypi api/auth/app + GA hosts to local mocks", () => {
     const rule = args.find((a) => a.startsWith("--host-resolver-rules="));
     expect(rule).toBeTruthy();
     expect(rule).toContain("MAP pi.ai 127.0.0.1:8443");
+    // claude.ai shares the page server (Host-routed to the Claude mock page).
+    expect(rule).toContain("MAP claude.ai 127.0.0.1:8443");
     expect(rule).toContain("MAP api.saypi.ai 127.0.0.1:8443");
     expect(rule).toContain("MAP www.saypi.ai 127.0.0.1:8443");
     expect(rule).toContain("MAP app.saypi.ai 127.0.0.1:8443");


### PR DESCRIPTION
## Why

While fixing the Claude tooltip contrast bug (#302) I "verified" it by **injecting CSS into the page** — which tests a rule I hand-wrote, not the artifact the build system produces. That's a false signal. This closes the testability gap so CSS/visual fixes are verified against real build output.

## Root cause of the gap

`wxt dev` **cannot hot-reload content-script CSS**. WXT's `detectDevChanges` maps a changed file to the content-script step only if it appears in a JS chunk's `moduleIds` (`findEffectedSteps`). Content-script CSS is emitted as an **asset**, so a changed `.scss` matches nothing → it's classified **`no-change`** → no rebuild, no reload. (JS hot-reloads precisely because it *is* in `moduleIds` — which is why a `.ts` fix earlier in the session reflected live but the `.scss` fix never did.) The Vite dev server serves the freshly-compiled SCSS on demand, but that is not what the manifest-injected content script uses. Net: the live Layer 4 loop can never reflect a CSS change — and my earlier "stale watcher" diagnosis (in the now-reverted doc) was wrong.

## Fix — verify CSS at Layer 3 against the real build

Layer 3 already builds the real extension (`wxt build -m development`) and loads it via `--load-extension`, so the browser injects the extension's **actual** content-script CSS — autonomously, hermetically, in CI. No founder, no `chrome://extensions`, no injection.

- **Claude mock host** — `e2e/support/mock-claude-page.html` (deliberately defines **no `--black`**, replicating claude.ai — the exact condition that made `hsl(var(--black)/.8)` compute to `transparent`), Host-routed in `mock-servers.ts`, `MAP claude.ai` added to `launch-args.ts`.
- **`e2e/specs/tooltip-contrast.e2e.ts`** — loads the built extension, navigates to the claude.ai mock so Chrome injects the real CSS, lets SayPi tag `body.claude`, then asserts the shipped stylesheet renders `.saypi-tooltip` as an **opaque dark pill with white text**.
- **`test/e2e/launch-args.spec.ts`** — guards the new host mapping (Layer 1).
- **`doc/autonomous-dev-loop.md`** — corrects the wrong "stale watcher" diagnosis, **removes the CSS-injection workaround entirely**, and points CSS verification at Layer 3.

## Verification (fail-first, against the real build)

```
# fix in place
npm run e2e:build && npx playwright test … tooltip-contrast   → ✓ passed
# revert the fix to hsl(var(--black)/.8), rebuild, re-run
                                                              → ✘ "tooltip background must be opaque, got rgba(0, 0, 0, 0)"
# restore fix, rebuild, re-run                                → ✓ passed
```

Full Layer 3 suite green (decoration, dictation-stt, tooltip-contrast); `test/e2e/launch-args.spec.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)