### PR TITLE
fix(transcription): repair dead server-merge continuity check (keys, not text)

### DIFF
--- a/src/TranscriptMergeService.ts
+++ b/src/TranscriptMergeService.ts
@@ -61,9 +61,13 @@ export class TranscriptMergeService {
     transcripts: Record<number, string>,
     cutoffTime: number
   ): Promise<string> {
-    const keys = this.sortTranscripts(transcripts).map((transcript) =>
-      parseInt(transcript)
-    );
+    // Continuity must be assessed over the segment SEQUENCE KEYS (1, 2, 3…), not
+    // the spoken text. Parsing the transcript text with parseInt() yields NaN for
+    // ordinary speech, which made isContinuous false for every multi-segment
+    // utterance and silently disabled the server /merge entirely.
+    const keys = Object.keys(transcripts)
+      .map(Number)
+      .sort((a, b) => a - b);
     const isContinuous = keys.every((value, index, array) => {
       // If it's the first element or keys are continuous
       return index === 0 || value === array[index - 1] + 1;

--- a/test/TranscriptMergeService-remote.spec.ts
+++ b/test/TranscriptMergeService-remote.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TranscriptMergeService } from "../src/TranscriptMergeService";
+
+// Exercises mergeTranscriptsRemote against the REAL service (only fetch is stubbed).
+// The continuity gate must be computed from the segment SEQUENCE KEYS (1, 2, 3…),
+// not from parseInt() of the spoken text — otherwise the server /merge never runs
+// for any real multi-segment utterance.
+
+const FAR_FUTURE_OFFSET_MS = 60_000; // well above the 2s averageResponseTime gate
+
+describe("TranscriptMergeService.mergeTranscriptsRemote", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const cutoff = () => Date.now() + FAR_FUTURE_OFFSET_MS;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ combined_transcript: "merged result" }),
+    });
+    (global as any).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (global as any).fetch;
+  });
+
+  it("POSTs to /merge and returns the combined transcript for consecutive segments of real speech", async () => {
+    const service = new TranscriptMergeService("http://api.example", "en-US");
+
+    const result = await service.mergeTranscriptsRemote(
+      { 1: "Hello there", 2: "how are you", 3: "today" },
+      cutoff()
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://api.example/merge",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(result).toBe("merged result");
+  });
+
+  it("does NOT call /merge when the segment keys are non-consecutive (a gap implies a discontinuity)", async () => {
+    const service = new TranscriptMergeService("http://api.example", "en-US");
+
+    // Keys 1 and 3 — segment 2 is missing, so the sequence is not continuous.
+    const result = await service.mergeTranscriptsRemote(
+      { 1: "Hello there", 3: "today" },
+      cutoff()
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toBe("");
+  });
+
+  it("does NOT call /merge for a single segment", async () => {
+    const service = new TranscriptMergeService("http://api.example", "en-US");
+
+    const result = await service.mergeTranscriptsRemote({ 1: "Hello there" }, cutoff());
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toBe("");
+  });
+
+  it("does NOT call /merge when there is not enough time remaining before cutoff", async () => {
+    const service = new TranscriptMergeService("http://api.example", "en-US");
+
+    // cutoff already passed → timeRemaining < averageResponseTime
+    const result = await service.mergeTranscriptsRemote(
+      { 1: "Hello there", 2: "how are you" },
+      Date.now() - 1
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toBe("");
+  });
+});

--- a/test/TranscriptMergeService-remote.spec.ts
+++ b/test/TranscriptMergeService-remote.spec.ts
@@ -75,4 +75,20 @@ describe("TranscriptMergeService.mergeTranscriptsRemote", () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(result).toBe("");
   });
+
+  it("judges continuity by the segment KEYS, not by numbers parsed from the text", async () => {
+    const service = new TranscriptMergeService("http://api.example", "en-US");
+
+    // Keys 1 and 5 are non-consecutive (segment missing), so this must NOT merge —
+    // even though the spoken text happens to start with consecutive numbers
+    // ("1 dog", "2 cats"). The old code parseInt()-ed the text → [1, 2] → wrongly
+    // continuous → POSTed. This pins the fix to read keys, not text.
+    const result = await service.mergeTranscriptsRemote(
+      { 1: "1 dog", 5: "2 cats" },
+      cutoff()
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toBe("");
+  });
 });


### PR DESCRIPTION
## What & why

`TranscriptMergeService.mergeTranscriptsRemote()` is supposed to call the server's optimistic `/merge` endpoint, which stitches the separate speech segments of one voice turn into a single clean prompt (repairing word-boundary errors, duplicated words across cuts, and capitalization/punctuation at the joins) before it's submitted to Pi.

It only does that when the segments form a *continuous* sequence — but it computed that continuity by `parseInt()`-ing the transcript **text**:

```js
const keys = this.sortTranscripts(transcripts).map((t) => parseInt(t)); // sortTranscripts returns VALUES
```

`sortTranscripts` returns the spoken text values (`["Hello there", "how are you", …]`), so `parseInt("Hello there")` is `NaN`. `isContinuous` is then false for every 2+-segment utterance (`NaN === NaN + 1` is false), the guard never passes, and the function returns `Promise.resolve("")`. **The server merge has been dead for every real multi-segment voice turn on pi.ai** — users always got the local naïve space-join instead.

The check was meant to run over the segment **sequence keys** (`1, 2, 3 …`), not the spoken text.

## Fix

Derive the continuity keys from the actual sequence keys:

```js
const keys = Object.keys(transcripts).map(Number).sort((a, b) => a - b);
```

Behaviour on a genuine gap (`{1, 3}`) or a single segment is unchanged (still no merge). Consecutive segments now correctly POST to `/merge`. The request body already sent the text values and is untouched.

## How it was found & verified

Surfaced by an adversarial code-audit of the pi.ai transcription path (2/2 verifier votes) during a Layer-4 exploration session, then confirmed against the real code (`mergeTranscriptsRemote` is live, called from `ConversationMachine.ts:531`).

Fail-first **L1** tests (`test/TranscriptMergeService-remote.spec.ts`) exercise the real service with only `fetch` stubbed:
- consecutive real-speech segments → `/merge` fires once and returns the merged transcript (**RED before the fix: 0 calls**);
- guards: non-consecutive keys, single segment, and insufficient-time-remaining → no merge.

`npm test` green (Jest 2/2, Vitest 98 files / 821 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
