### PR TITLE
fix(vad): stop the false "VAD disconnected — try reloading" alarm on idle SW recycle

### DIFF
--- a/src/vad/OffscreenVADClient.ts
+++ b/src/vad/OffscreenVADClient.ts
@@ -227,7 +227,12 @@ export class OffscreenVADClient implements VADClientInterface {
     this.isActive = true;
     this.statusIndicator.updateStatus(getMessage('vadStatusStarting'), getMessage('vadDetailActivatingMicrophone'));
     return new Promise((resolve) => {
-      this.callbacks.onStarted = (success, error) => resolve({ success, error });
+      this.callbacks.onStarted = (success, error) => {
+        // If the start never succeeded, the session isn't really active. Clear the
+        // flag so a later idle port recycle isn't misreported as a mid-call failure.
+        if (!success) this.isActive = false;
+        resolve({ success, error });
+      };
       this.sendMessage({ type: "VAD_START_REQUEST" });
     });
   }

--- a/src/vad/OffscreenVADClient.ts
+++ b/src/vad/OffscreenVADClient.ts
@@ -26,6 +26,9 @@ export class OffscreenVADClient implements VADClientInterface {
   private port: chrome.runtime.Port;
   private callbacks: VADClientCallbacks = {};
   private isPortConnected: boolean = true;
+  // Whether a VAD session is currently active (between start() and stop()/destroy()).
+  // Used to tell a genuine mid-call port loss apart from a routine idle recycle.
+  private isActive: boolean = false;
   private statusIndicator: VADStatusIndicator;
 
   constructor() {
@@ -156,10 +159,24 @@ export class OffscreenVADClient implements VADClientInterface {
     });
 
     this.port.onDisconnect.addListener(() => {
-      logger.warn("[SayPi OffscreenVADClient] Port disconnected from background script.");
-      this.statusIndicator.updateStatus(getMessage('vadStatusError'), getMessage('vadDetailVADServiceDisconnected'));
       this.isPortConnected = false;
-      this.callbacks.onError?.(getMessage('vadDetailVADServiceDisconnected'));
+      const wasActive = this.isActive;
+      this.isActive = false;
+
+      if (wasActive) {
+        // The port dropped mid-session (during a live call). This genuinely
+        // interrupts voice input, so surface it to the user and the error callback.
+        logger.warn("[SayPi OffscreenVADClient] Port disconnected during an active VAD session.");
+        this.statusIndicator.updateStatus(getMessage('vadStatusError'), getMessage('vadDetailVADServiceDisconnected'));
+        this.callbacks.onError?.(getMessage('vadDetailVADServiceDisconnected'));
+      } else {
+        // Idle disconnect: Chrome recycled the MV3 service worker / offscreen
+        // document while no call was active. This is expected and self-healing —
+        // initialize() transparently re-establishes the port on the next call —
+        // so don't alarm the user with a persistent "Try reloading" error.
+        logger.debug("[SayPi OffscreenVADClient] Port disconnected while idle; will reconnect on next use.");
+        this.statusIndicator.hide();
+      }
     });
   }
 
@@ -207,6 +224,7 @@ export class OffscreenVADClient implements VADClientInterface {
   }
 
   public start(): Promise<{ success: boolean, error?: string }> {
+    this.isActive = true;
     this.statusIndicator.updateStatus(getMessage('vadStatusStarting'), getMessage('vadDetailActivatingMicrophone'));
     return new Promise((resolve) => {
       this.callbacks.onStarted = (success, error) => resolve({ success, error });
@@ -215,6 +233,7 @@ export class OffscreenVADClient implements VADClientInterface {
   }
 
   public stop(): Promise<{ success: boolean, error?: string }> {
+    this.isActive = false;
     this.statusIndicator.updateStatus(getMessage('vadStatusStopping'), getMessage('vadDetailDeactivatingMicrophone'));
     return new Promise((resolve) => {
       this.callbacks.onStopped = (success, error) => resolve({ success, error });
@@ -223,6 +242,7 @@ export class OffscreenVADClient implements VADClientInterface {
   }
 
   public destroy(): void {
+    this.isActive = false;
     this.statusIndicator.updateStatus(getMessage('vadStatusShuttingDown'), getMessage('vadDetailReleasingVADResources'));
     this.sendMessage({ type: "VAD_DESTROY_REQUEST" });
     if (this.isPortConnected && this.port) {

--- a/test/vad/OffscreenVADClient-disconnect.spec.ts
+++ b/test/vad/OffscreenVADClient-disconnect.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Capture every VADStatusIndicator the client constructs so we can assert on it.
+const { indicatorInstances } = vi.hoisted(() => ({ indicatorInstances: [] as any[] }));
+
+vi.mock("../../src/LoggingModule", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../../src/i18n", () => ({
+  // Echo the message key back so assertions can match on it.
+  default: (key: string) => key,
+}));
+vi.mock("../../src/offscreen/media_coordinator", () => ({
+  sanitizeMessageForLogs: (m: any) => m,
+}));
+vi.mock("../../src/ui/VADStatusIndicator", () => ({
+  VADStatusIndicator: class {
+    updateStatus = vi.fn();
+    hide = vi.fn();
+    show = vi.fn();
+    destroy = vi.fn();
+    constructor() {
+      indicatorInstances.push(this);
+    }
+  },
+}));
+
+import { OffscreenVADClient } from "../../src/vad/OffscreenVADClient";
+
+const DISCONNECT_ERROR = ["vadStatusError", "vadDetailVADServiceDisconnected"];
+
+describe("OffscreenVADClient port disconnect", () => {
+  let ports: any[];
+
+  beforeEach(() => {
+    ports = [];
+    indicatorInstances.length = 0;
+    (global as any).chrome = {
+      runtime: {
+        connect: vi.fn(() => {
+          const port = {
+            onMessage: { addListener: vi.fn() },
+            onDisconnect: { addListener: vi.fn() },
+            postMessage: vi.fn(),
+            disconnect: vi.fn(),
+          };
+          ports.push(port);
+          return port;
+        }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete (global as any).chrome;
+  });
+
+  const triggerDisconnect = (portIndex = 0) => {
+    const listener = ports[portIndex].onDisconnect.addListener.mock.calls[0][0];
+    listener();
+  };
+
+  it("does NOT surface a 'try reloading' error when the idle port is recycled (no active call)", () => {
+    new OffscreenVADClient();
+    const indicator = indicatorInstances[0];
+
+    // The MV3 service worker / offscreen document is recycled while no call is
+    // active. Recovery is automatic on the next initialize(), so the user must
+    // not be told to reload.
+    triggerDisconnect();
+
+    expect(indicator.updateStatus).not.toHaveBeenCalledWith(...DISCONNECT_ERROR);
+    expect(indicator.hide).toHaveBeenCalled();
+  });
+
+  it("DOES surface the error when the port disconnects during an active VAD session", () => {
+    const client = new OffscreenVADClient();
+    const indicator = indicatorInstances[0];
+
+    client.start(); // user is in a call → session is active
+    triggerDisconnect();
+
+    expect(indicator.updateStatus).toHaveBeenCalledWith(...DISCONNECT_ERROR);
+  });
+
+  it("treats a disconnect after stop() as idle (quiet), not an error", () => {
+    const client = new OffscreenVADClient();
+    const indicator = indicatorInstances[0];
+
+    client.start();
+    client.stop(); // call ended → session no longer active
+    indicator.updateStatus.mockClear();
+    triggerDisconnect();
+
+    expect(indicator.updateStatus).not.toHaveBeenCalledWith(...DISCONNECT_ERROR);
+  });
+
+  it("self-heals: initialize() re-establishes the port after a disconnect", () => {
+    const client = new OffscreenVADClient();
+    expect((global as any).chrome.runtime.connect).toHaveBeenCalledTimes(1);
+
+    triggerDisconnect();
+    client.initialize();
+
+    expect((global as any).chrome.runtime.connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/vad/OffscreenVADClient-disconnect.spec.ts
+++ b/test/vad/OffscreenVADClient-disconnect.spec.ts
@@ -96,6 +96,36 @@ describe("OffscreenVADClient port disconnect", () => {
     expect(indicator.updateStatus).not.toHaveBeenCalledWith(...DISCONNECT_ERROR);
   });
 
+  it("treats a disconnect after a FAILED start() as idle (quiet), not an error", () => {
+    const client = new OffscreenVADClient();
+    const indicator = indicatorInstances[0];
+
+    client.start(); // optimistically marks the session active...
+    // ...but the offscreen reports the start failed, so it isn't really active.
+    const onMessage = ports[0].onMessage.addListener.mock.calls[0][0];
+    onMessage({
+      origin: "offscreen-document",
+      type: "OFFSCREEN_VAD_START_REQUEST_RESPONSE",
+      payload: { success: false, error: "mic denied" },
+    });
+    indicator.updateStatus.mockClear();
+    triggerDisconnect();
+
+    expect(indicator.updateStatus).not.toHaveBeenCalledWith(...DISCONNECT_ERROR);
+  });
+
+  it("treats a disconnect after destroy() as idle (quiet), not an error", () => {
+    const client = new OffscreenVADClient();
+    const indicator = indicatorInstances[0];
+
+    client.start();
+    client.destroy(); // session torn down
+    indicator.updateStatus.mockClear();
+    triggerDisconnect();
+
+    expect(indicator.updateStatus).not.toHaveBeenCalledWith(...DISCONNECT_ERROR);
+  });
+
   it("self-heals: initialize() re-establishes the port after a disconnect", () => {
     const client = new OffscreenVADClient();
     expect((global as any).chrome.runtime.connect).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## What & why

Discovered live on pi.ai during a Layer-4 session: a red **"VAD: Error — VAD service disconnected. Try reloading."** toast appears in normal use.

The offscreen VAD port's `onDisconnect` handler treated *any* port loss as a fatal, user-facing error:

```js
this.port.onDisconnect.addListener(() => {
  this.statusIndicator.updateStatus(getMessage('vadStatusError'),
                                    getMessage('vadDetailVADServiceDisconnected'));
  this.isPortConnected = false;
  ...
});
```

But in MV3 the service worker / offscreen document is recycled routinely whenever it's idle, which drops the port **even though no call is active** — and recovery is already automatic: `initialize()` transparently re-establishes the port on the next call. So the common case is: user isn't in a call → Chrome recycles the idle port → they're shown a scary, persistent "reload the page" error (the indicator is **on by default**) for something that self-heals and that they'd never have noticed otherwise. The advice to reload is simply wrong.

## Fix

Track whether a VAD session is actually active (`isActive`, set in `start()`, cleared in `stop()`/`destroy()`). On disconnect:

- **active session** (a live call) → keep surfacing the error + `onError` — this genuinely interrupts voice input;
- **idle** → stay quiet and hide the indicator; the existing lazy reconnect recovers on next use.

No behaviour change for a real mid-call failure; the noise on idle recycles is gone.

## Verification

Fail-first **L1** tests (`test/vad/OffscreenVADClient-disconnect.spec.ts`):
- idle disconnect, and disconnect-after-`stop()`, must **not** show the error (**RED before the fix**);
- an active-session disconnect **still** does (guards against over-suppression);
- `initialize()` re-establishes the port after a disconnect (self-heal characterization).

`npm test` green (Jest 2/2, Vitest 98 files / 821 passed).

> Note on Layer-4: the *bug* was observed live; re-confirming the *fixed* path on the real host would require forcing an MV3 SW recycle while keeping the same content script loaded, which isn't drivable from automation — so correctness is proven at L1, the layer that can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
