### PR TITLE
fix(offscreen): keep live content-script ports across idle auto-shutdown (silent speech loss)

### DIFF
--- a/src/offscreen/offscreen_manager.ts
+++ b/src/offscreen/offscreen_manager.ts
@@ -113,13 +113,19 @@ class OffscreenManager {
     
     try {
       await browser.offscreen.closeDocument();
-      this.portMap.clear(); // Clear ports as the document is gone
+      // Do NOT clear portMap here. The content-script <-> service-worker ports are
+      // independent of the offscreen document's lifecycle and are still alive when
+      // the document is closed by the idle auto-shutdown (OFFSCREEN_AUTO_SHUTDOWN).
+      // They are removed per-tab by each port's onDisconnect handler when a tab
+      // actually disconnects. Clearing them here evicted live ports, so the next
+      // utterance's VAD_SPEECH_END could no longer be routed to the tab and was
+      // silently dropped until a full page reload.
       this.pendingAudioMessages.clear();
       logger.debug("[OffscreenManager] Offscreen document closed.");
     } catch (error) {
       logger.warn("[OffscreenManager] Error closing offscreen document:", error);
-      // Clear ports anyway since the document might be gone
-      this.portMap.clear();
+      // Same reasoning as above: the content-script ports outlive the offscreen
+      // document, so don't evict them here either.
       this.pendingAudioMessages.clear();
     }
   }

--- a/test/offscreen/offscreen-manager-auto-shutdown.spec.ts
+++ b/test/offscreen/offscreen-manager-auto-shutdown.spec.ts
@@ -20,6 +20,11 @@ function makePort(tabId: number): any {
 
 describe("OffscreenManager — auto-shutdown vs. live content-script ports", () => {
   beforeEach(() => {
+    // offscreenManager is a module-level singleton; reset its internal state so each
+    // test is hermetic (no reliance on distinct tab IDs or test ordering).
+    (offscreenManager as any).portMap.clear();
+    (offscreenManager as any).lastVadEventByTab.clear();
+
     // The shared wxt/browser mock has no offscreen API; provide one that reports a
     // document exists and closes cleanly (the auto-shutdown path).
     (browser as any).offscreen = {

--- a/test/offscreen/offscreen-manager-auto-shutdown.spec.ts
+++ b/test/offscreen/offscreen-manager-auto-shutdown.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { browser } from "wxt/browser";
+import { offscreenManager } from "../../src/offscreen/offscreen_manager";
+
+// Reproduces the silent-speech-loss bug: when the offscreen document is closed by
+// the 30s idle auto-shutdown (OFFSCREEN_AUTO_SHUTDOWN), the content-script <-> SW
+// VAD ports are still alive — but closeOffscreenDocument() used to clear them, so
+// the next utterance's VAD_SPEECH_END could no longer be routed to the tab.
+
+function makePort(tabId: number): any {
+  return {
+    name: "vad-content-script-connection",
+    sender: { tab: { id: tabId, title: "Pi" } },
+    onMessage: { addListener: vi.fn() },
+    onDisconnect: { addListener: vi.fn() },
+    postMessage: vi.fn(),
+    disconnect: vi.fn(),
+  };
+}
+
+describe("OffscreenManager — auto-shutdown vs. live content-script ports", () => {
+  beforeEach(() => {
+    // The shared wxt/browser mock has no offscreen API; provide one that reports a
+    // document exists and closes cleanly (the auto-shutdown path).
+    (browser as any).offscreen = {
+      hasDocument: vi.fn().mockResolvedValue(true),
+      closeDocument: vi.fn().mockResolvedValue(undefined),
+      createDocument: vi.fn().mockResolvedValue(undefined),
+      Reason: { USER_MEDIA: "USER_MEDIA", AUDIO_PLAYBACK: "AUDIO_PLAYBACK" },
+    };
+  });
+
+  afterEach(() => {
+    delete (browser as any).offscreen;
+  });
+
+  it("keeps a live content-script port when the offscreen document is auto-shut-down", async () => {
+    const port = makePort(42);
+    offscreenManager.registerContentScriptConnection(port);
+
+    // Simulate the idle auto-shutdown (closes the offscreen doc, NOT the tab/port).
+    await offscreenManager.closeOffscreenDocument();
+
+    // The next utterance's VAD result must still reach the content script.
+    offscreenManager.forwardMessageToContentScript(42, {
+      type: "VAD_SPEECH_END",
+      duration: 100,
+    });
+
+    expect(port.postMessage).toHaveBeenCalled();
+  });
+
+  it("still drops the port when the content script genuinely disconnects", () => {
+    const port = makePort(43);
+    offscreenManager.registerContentScriptConnection(port);
+
+    // Invoke the real per-tab onDisconnect handler (the legitimate eviction path).
+    const onDisconnect = port.onDisconnect.addListener.mock.calls[0][0];
+    onDisconnect();
+
+    offscreenManager.forwardMessageToContentScript(43, {
+      type: "VAD_SPEECH_END",
+      duration: 100,
+    });
+
+    expect(port.postMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What & why  (HIGH — silent data loss)

`OffscreenManager.closeOffscreenDocument()` cleared `portMap`. That method is called from **two paths with opposite invariants**:

1. the per-tab `port.onDisconnect` handler, when the **last** tab disconnects — here `portMap` is already empty, so the clear is a no-op;
2. the **30s idle auto-shutdown** (`media_coordinator` emits `OFFSCREEN_AUTO_SHUTDOWN` → `background.ts:1061` → `closeOffscreenDocument()`) — here the content-script ⇄ service-worker ports are **still alive**.

The CS⇄SW ports are independent of the offscreen document's lifecycle, so clearing them on auto-shutdown **evicts live ports**. The failure is silent and easy to hit on pi.ai: Pi's TTS plays through Pi's own `<audio>` element (the offscreen audio counter stays 0), so ~30s of "Pi is speaking" or a thinking pause trips the idle timer and the offscreen doc closes. The user's **next utterance** is captured and the VAD recreates the document, but the resulting `VAD_SPEECH_END` is routed via `portMap.get(tabId)` → `undefined` → *"No active port found"* and **dropped with no error**, until a full page reload.

## Fix

Remove the `portMap.clear()` from `closeOffscreenDocument()` (both the success and error paths). Ports are removed only by each port's `onDisconnect` handler when a tab genuinely disconnects. `pendingAudioMessages` — which *are* tied to the document — are still cleared.

## How it was found & verified

Surfaced by the adversarial code-audit of the pi.ai VAD/offscreen path (2/2 verifier votes, HIGH severity), confirmed against `background.ts:1059-1062` (the auto-shutdown caller) and the per-tab disconnect path (`offscreen_manager.ts:333`).

Fail-first **L2** test (`test/offscreen/offscreen-manager-auto-shutdown.spec.ts`): after `closeOffscreenDocument()` (auto-shutdown), a forwarded `VAD_SPEECH_END` still reaches the registered port (**RED before the fix**); a genuine `onDisconnect` still removes it.

`npm test` green (Jest 2/2, Vitest 98 files / 819 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
