### PR TITLE
test(layer4): detect stale dev builds (build-identity stamp + stalled-hot-reload warning)

### DIFF
--- a/doc/autonomous-dev-loop.md
+++ b/doc/autonomous-dev-loop.md
@@ -102,6 +102,26 @@ secret.
    ```
 
    or re-read the rig's background-task log for its `✔ Reloaded:` line.
+
+   **Confirm the *loaded* build, not just the on-disk one.** The content script
+   stamps the build identity onto `<html data-saypi-build="<sha>@<branch> <iso>">`
+   (`src/build-stamp.ts`, injected by a Vite `define` in `wxt.config.ts`). Read it
+   from the page's main world and compare to the current commit — this is the
+   **definitive** freshness check, because the on-disk mtime can be fresh while the
+   *page* still runs a stale build (e.g. its MV3 SW slept and never picked up the
+   reload):
+
+   ```js
+   document.documentElement.dataset.saypiBuild   // e.g. "0b65de4@main 2026-06-16T21:00:00Z"
+   ```
+   ```bash
+   git rev-parse --short HEAD                     # the sha it should match
+   ```
+
+   The rig also watches `src/` and prints a loud `⚠ hot-reload looks STALLED`
+   warning when an edit doesn't produce a rebuild within a few seconds — your cue
+   that the SW slept and the extension needs one reload (it can't reach the page to
+   know the SW is gone, so it flags the on-disk symptom).
 3. **Reload the test tab** via the MCP (`navigate` to the same URL), then read the
    DOM. With the SW connected WXT already reloads matching tabs itself; the MCP
    reload is a reliable belt-and-suspenders step and gives a clean point to assert.
@@ -328,11 +348,15 @@ re-capture, not a contract violation.
 
 ## Troubleshooting
 
-- **No hot-reload after an edit:** confirm the rig's background task is alive and
-  bound to :3001 (`lsof -nP -iTCP:3001 -sTCP:LISTEN`); confirm the loaded
-  extension's baked origin is `localhost:3001`
-  (`grep -ro "localhost:3001" .output/chrome-mv3-dev | head`). If the baked port
-  differs, reload the extension once at `chrome://extensions`.
+- **No hot-reload after an edit:** first check `<html data-saypi-build>` on the
+  page against `git rev-parse --short HEAD` — a mismatch (or a sha from an earlier
+  rig) means the *page* is stale even if `.output` looks fresh, so the SW slept;
+  reload the extension once at `chrome://extensions`. (The rig also prints a
+  `⚠ hot-reload looks STALLED` warning when an edit doesn't rebuild.) Then confirm
+  the rig's background task is alive and bound to :3001
+  (`lsof -nP -iTCP:3001 -sTCP:LISTEN`); confirm the loaded extension's baked origin
+  is `localhost:3001` (`grep -ro "localhost:3001" .output/chrome-mv3-dev | head`).
+  If the baked port differs, reload the extension once at `chrome://extensions`.
 - **A CSS/SCSS change won't appear (but JS changes do):** expected and structural —
   `wxt dev` never hot-reloads content-script CSS. Don't inject CSS to work around
   it; verify styles at Layer 3 against the real build. See *CSS changes don't

--- a/e2e/specs/decoration.e2e.ts
+++ b/e2e/specs/decoration.e2e.ts
@@ -25,4 +25,13 @@ test("SayPi detects Pi and decorates the mock page", async ({ context, extension
   await expect(page.locator(".saypi-prompt-container")).toHaveCount(1);
   await expect(page.locator("#saypi-prompt-controls-container")).toHaveCount(1);
   await page.waitForFunction(() => document.body.classList.contains("pi"));
+
+  // Build-identity stamp (src/build-stamp.ts): the dev/e2e content script writes
+  // <html data-saypi-build="<sha>@<branch> <iso>">. Asserting it here proves the
+  // Vite `define` for __SAYPI_BUILD_STAMP__ actually replaced the token in a real
+  // build (not the "dev" fallback) — durable CI coverage for the define, which no
+  // unit test can exercise. "@" is present only on a fully-populated real stamp.
+  const buildStamp = await page.evaluate(() => document.documentElement.dataset.saypiBuild);
+  expect(buildStamp).toBeTruthy();
+  expect(buildStamp).toMatch(/@/);
 });

--- a/scripts/dev-rig-lib.mjs
+++ b/scripts/dev-rig-lib.mjs
@@ -86,3 +86,21 @@ export function parseWxtPids(psOutput, repoPath) {
   }
   return pids;
 }
+
+/**
+ * Has hot-reload stalled? True when a source file was edited after the last
+ * build output, and more than `graceMs` has elapsed without the build catching
+ * up — the signature of a slept MV3 service worker that dropped its connection
+ * to the dev server (the build rebuilds on disk but never reaches the page, or
+ * doesn't rebuild at all). The grace window avoids false alarms while a normal
+ * rebuild (~1s) is still in flight.
+ *
+ * @param {{lastSrcEditMs:number, lastBuildMs:number, nowMs:number, graceMs?:number}} args
+ *   epoch-ms of the most recent src edit / build-output mtime / current time.
+ * @returns {boolean}
+ */
+export function isHotReloadStalled({ lastSrcEditMs, lastBuildMs, nowMs, graceMs = 8000 }) {
+  if (!lastSrcEditMs) return false; // no edit observed yet
+  if (lastBuildMs >= lastSrcEditMs) return false; // build caught up to the edit
+  return nowMs - lastSrcEditMs > graceMs; // edit is older than the grace window
+}

--- a/scripts/dev-rig.mjs
+++ b/scripts/dev-rig.mjs
@@ -16,8 +16,8 @@ import { execFileSync, spawn } from "node:child_process";
 import { createConnection } from "node:net";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve as resolvePath } from "node:path";
-import { readFileSync } from "node:fs";
-import { parseEnvMode, parseWxtPids } from "./dev-rig-lib.mjs";
+import { readFileSync, statSync, watch } from "node:fs";
+import { parseEnvMode, parseWxtPids, isHotReloadStalled } from "./dev-rig-lib.mjs";
 
 const PORT = Number(process.env.WXT_DEV_PORT ?? 3001);
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -76,6 +76,56 @@ async function waitForPortFree(port, timeoutMs = 10000) {
   return false;
 }
 
+function gitId() {
+  try {
+    const sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], { cwd: repoRoot, encoding: "utf8" }).trim();
+    const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: repoRoot, encoding: "utf8" }).trim();
+    return `${sha}@${branch}`;
+  } catch {
+    return "unknown";
+  }
+}
+
+// Warn when an edit doesn't reach a rebuild — the signature of a slept MV3 SW.
+// The page carries the loaded build's identity on <html data-saypi-build>; this
+// catches the on-disk side (edits that never rebuild) so a stale build is loud,
+// not a silent surprise discovered at verify time.
+function watchHotReload() {
+  const srcDir = resolvePath(repoRoot, "src");
+  const outTargets = [
+    resolvePath(repoRoot, ".output/chrome-mv3-dev/manifest.json"),
+    resolvePath(repoRoot, ".output/chrome-mv3-dev/content-scripts/saypi.js"),
+  ];
+  const buildMtimeMs = () => {
+    let newest = 0;
+    for (const f of outTargets) {
+      try { newest = Math.max(newest, statSync(f).mtimeMs); } catch { /* not built yet */ }
+    }
+    return newest;
+  };
+
+  let lastSrcEditMs = 0;
+  let warned = false;
+  try {
+    watch(srcDir, { recursive: true }, () => { lastSrcEditMs = Date.now(); warned = false; });
+  } catch (err) {
+    log(`hot-reload freshness watcher unavailable (${err.message}) — skipping staleness warnings`);
+    return;
+  }
+
+  setInterval(() => {
+    const lastBuildMs = buildMtimeMs();
+    if (lastBuildMs >= lastSrcEditMs) { warned = false; return; } // rebuild kept up
+    if (warned) return;
+    if (isHotReloadStalled({ lastSrcEditMs, lastBuildMs, nowMs: Date.now() })) {
+      warned = true;
+      log("⚠ hot-reload looks STALLED — you edited src but .output hasn't rebuilt.");
+      log("⚠ The MV3 service worker has likely slept. Reload the unpacked extension once");
+      log("⚠ at chrome://extensions, then re-test. (Confirm with: <html data-saypi-build>.)");
+    }
+  }, 3000).unref();
+}
+
 async function main() {
   log(`repo: ${repoRoot}`);
   ensureRemoteEnv();
@@ -91,7 +141,8 @@ async function main() {
 
   log(`starting wxt dev on :${PORT} (browser auto-launch disabled)`);
   log(`LOAD UNPACKED FROM: ${repoRoot}/.output/chrome-mv3-dev`);
-  log(`freshness: poll mtime of .output/chrome-mv3-dev after each edit`);
+  log(`building ${gitId()} — the loaded page carries this on <html data-saypi-build>`);
+  log(`freshness: watching src for stalled rebuilds; also compare data-saypi-build vs git HEAD`);
 
   const wxtBin = resolvePath(repoRoot, "node_modules/.bin/wxt");
   // stdin must be an OPEN pipe, not "inherit"/"ignore". After the first file change
@@ -110,6 +161,7 @@ async function main() {
   for (const sig of ["SIGTERM", "SIGINT"]) {
     process.on(sig, () => child.kill(sig));
   }
+  watchHotReload(); // warn if edits stop reaching the build (slept SW)
   child.on("exit", (code) => process.exit(code ?? 1)); // null code = signal-killed
 }
 

--- a/src/build-stamp.ts
+++ b/src/build-stamp.ts
@@ -1,0 +1,49 @@
+/**
+ * Build-identity stamp.
+ *
+ * `__SAYPI_BUILD_STAMP__` is replaced at build time by a Vite `define`
+ * (see wxt.config.ts) with the git short SHA, branch, and ISO build time. The
+ * content script writes it onto `<html data-saypi-build="...">` so the page's
+ * main world — and therefore an automation probe (Layer 4) — can read exactly
+ * which build is injected. This is what makes a stale dev build (e.g. one whose
+ * hot-reload silently stalled) detectable instead of a guess: compare the loaded
+ * stamp against the current `git rev-parse --short HEAD`.
+ */
+
+export interface BuildStamp {
+  sha: string;
+  branch: string;
+  time: string;
+}
+
+// Declared for TypeScript; substituted by Vite at build time. `typeof` keeps this
+// safe in the test/dev environment where the define is absent (no ReferenceError).
+declare const __SAYPI_BUILD_STAMP__: BuildStamp | undefined;
+
+export const BUILD_STAMP: BuildStamp =
+  (typeof __SAYPI_BUILD_STAMP__ !== "undefined" && __SAYPI_BUILD_STAMP__) || {
+    sha: "dev",
+    branch: "dev",
+    time: "",
+  };
+
+/** Compact, human-readable single-line representation, e.g. "0b65de4@main 2026-06-16T21:00:00Z". */
+export function formatBuildStamp(stamp: BuildStamp = BUILD_STAMP): string {
+  const ref =
+    stamp.branch && stamp.branch !== stamp.sha ? `${stamp.sha}@${stamp.branch}` : stamp.sha;
+  return `${ref} ${stamp.time}`.trim();
+}
+
+/**
+ * Record the build identity on the document root so it is readable from the
+ * page's main world (the content script runs in an isolated world, but the DOM
+ * is shared). Safe to call more than once.
+ */
+export function stampBuildOnDocument(
+  doc: Document = document,
+  stamp: BuildStamp = BUILD_STAMP
+): void {
+  const el = doc?.documentElement;
+  if (!el) return;
+  el.dataset.saypiBuild = formatBuildStamp(stamp);
+}

--- a/src/saypi.index.js
+++ b/src/saypi.index.js
@@ -4,6 +4,7 @@ import { logger } from "./LoggingModule.js";
 import { getJwtManager } from "./JwtManager.ts";
 import telemetryModule from "./TelemetryModule.ts";
 import { addUserAgentFlags } from "./UserAgentModule.ts";
+import { stampBuildOnDocument } from "./build-stamp.ts";
 
 // Import styles that are needed across all modes
 import "./styles/common.scss";
@@ -29,6 +30,10 @@ import "./styles/pi.scss"; // scoped by chatbot flags, i.e. <body class="pi">
 
 (async function () {
   "use strict";
+
+  // Record which build is injected on <html data-saypi-build="...">, readable
+  // from the page's main world so a Layer-4 probe can detect a stale dev build.
+  stampBuildOnDocument();
 
   // Determine the mode based on the centralized identifier helpers
   const chatbotType = ChatbotIdentifier.identifyChatbot();

--- a/src/saypi.index.js
+++ b/src/saypi.index.js
@@ -33,7 +33,8 @@ import "./styles/pi.scss"; // scoped by chatbot flags, i.e. <body class="pi">
 
   // Record which build is injected on <html data-saypi-build="...">, readable
   // from the page's main world so a Layer-4 probe can detect a stale dev build.
-  stampBuildOnDocument();
+  // Dev/e2e builds only — no need to expose build identity on production pages.
+  if (import.meta.env.DEV) stampBuildOnDocument();
 
   // Determine the mode based on the centralized identifier helpers
   const chatbotType = ChatbotIdentifier.identifyChatbot();

--- a/test/build-stamp.spec.ts
+++ b/test/build-stamp.spec.ts
@@ -13,6 +13,11 @@ describe("build-stamp", () => {
       const out = formatBuildStamp({ sha: "abc1234", branch: "feature/x", time: "2026-06-16T21:00:00Z" });
       expect(out).toContain("feature/x");
     });
+
+    it("collapses to the sha alone (no @branch, no trailing space) for the no-build fallback", () => {
+      // The fallback BUILD_STAMP is { sha: "dev", branch: "dev", time: "" }.
+      expect(formatBuildStamp({ sha: "dev", branch: "dev", time: "" })).toBe("dev");
+    });
   });
 
   describe("stampBuildOnDocument", () => {

--- a/test/build-stamp.spec.ts
+++ b/test/build-stamp.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { formatBuildStamp, stampBuildOnDocument, BUILD_STAMP } from "../src/build-stamp";
+
+describe("build-stamp", () => {
+  describe("formatBuildStamp", () => {
+    it("includes the short sha and the build time", () => {
+      const out = formatBuildStamp({ sha: "abc1234", branch: "main", time: "2026-06-16T21:00:00Z" });
+      expect(out).toContain("abc1234");
+      expect(out).toContain("2026-06-16T21:00:00Z");
+    });
+
+    it("appends the branch when it differs from the sha", () => {
+      const out = formatBuildStamp({ sha: "abc1234", branch: "feature/x", time: "2026-06-16T21:00:00Z" });
+      expect(out).toContain("feature/x");
+    });
+  });
+
+  describe("stampBuildOnDocument", () => {
+    beforeEach(() => {
+      delete document.documentElement.dataset.saypiBuild;
+    });
+
+    it("writes the formatted stamp to documentElement.dataset.saypiBuild (readable from the page's main world)", () => {
+      stampBuildOnDocument(document, { sha: "deadbee", branch: "main", time: "2026-06-16T00:00:00Z" });
+      expect(document.documentElement.dataset.saypiBuild).toContain("deadbee");
+    });
+
+    it("defaults to the live document and BUILD_STAMP", () => {
+      stampBuildOnDocument();
+      expect(document.documentElement.dataset.saypiBuild).toBeTruthy();
+    });
+  });
+
+  describe("BUILD_STAMP", () => {
+    it("exposes string sha/branch/time (falls back gracefully outside a build)", () => {
+      expect(typeof BUILD_STAMP.sha).toBe("string");
+      expect(typeof BUILD_STAMP.branch).toBe("string");
+      expect(typeof BUILD_STAMP.time).toBe("string");
+    });
+  });
+});

--- a/test/scripts/dev-rig-lib.spec.ts
+++ b/test/scripts/dev-rig-lib.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseEnvVars, parseEnvMode, parseWxtPids } from "../../scripts/dev-rig-lib.mjs";
+import { parseEnvVars, parseEnvMode, parseWxtPids, isHotReloadStalled } from "../../scripts/dev-rig-lib.mjs";
 
 describe("parseEnvVars", () => {
   it("ignores comments and trims inline comments", () => {
@@ -77,5 +77,36 @@ describe("parseWxtPids", () => {
 
   it("returns [] when nothing matches", () => {
     expect(parseWxtPids("12345 node /x/y/z\n", "/Users/rosscado/SayPi/saypi-userscript")).toEqual([]);
+  });
+});
+
+describe("isHotReloadStalled", () => {
+  const grace = 8000;
+
+  it("flags a stall when src was edited after the last build and the grace window has passed", () => {
+    // edited at 1000, last build at 500 (older), now is 1000+grace+1 → stalled
+    expect(
+      isHotReloadStalled({ lastSrcEditMs: 1000, lastBuildMs: 500, nowMs: 1000 + grace + 1, graceMs: grace })
+    ).toBe(true);
+  });
+
+  it("does not flag a stall while the build is at least as new as the last edit", () => {
+    // build caught up (>= edit) → hot-reload worked
+    expect(
+      isHotReloadStalled({ lastSrcEditMs: 1000, lastBuildMs: 1000, nowMs: 99999, graceMs: grace })
+    ).toBe(false);
+    expect(
+      isHotReloadStalled({ lastSrcEditMs: 1000, lastBuildMs: 2000, nowMs: 99999, graceMs: grace })
+    ).toBe(false);
+  });
+
+  it("does not flag a stall until the grace window elapses (a rebuild may still be in flight)", () => {
+    expect(
+      isHotReloadStalled({ lastSrcEditMs: 1000, lastBuildMs: 500, nowMs: 1000 + grace - 1, graceMs: grace })
+    ).toBe(false);
+  });
+
+  it("does not flag a stall when no source edit has been observed", () => {
+    expect(isHotReloadStalled({ lastSrcEditMs: 0, lastBuildMs: 0, nowMs: 99999, graceMs: grace })).toBe(false);
   });
 });

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,8 +9,9 @@ import { defineConfig } from "wxt";
 // commit so a stale dev build is detectable rather than a guess. Computed once
 // at config load; falls back gracefully outside a git checkout.
 function computeBuildStamp(): { sha: string; branch: string; time: string } {
+  const cwd = fileURLToPath(new URL(".", import.meta.url));
   const git = (args: string[]) =>
-    execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
   try {
     return {
       sha: git(["rev-parse", "--short", "HEAD"]),

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,7 +1,32 @@
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "wxt";
+
+// Build-identity stamp injected into the bundle as `__SAYPI_BUILD_STAMP__`
+// (see src/build-stamp.ts). Lets a loaded build be matched against the current
+// commit so a stale dev build is detectable rather than a guess. Computed once
+// at config load; falls back gracefully outside a git checkout.
+function computeBuildStamp(): { sha: string; branch: string; time: string } {
+  const git = (args: string[]) =>
+    execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  try {
+    return {
+      sha: git(["rev-parse", "--short", "HEAD"]),
+      branch: git(["rev-parse", "--abbrev-ref", "HEAD"]),
+      time: new Date().toISOString(),
+    };
+  } catch {
+    return { sha: "unknown", branch: "unknown", time: new Date().toISOString() };
+  }
+}
+const BUILD_STAMP = computeBuildStamp();
+
+const applyBuildStampDefine = (config: { define?: Record<string, any> }) => {
+  config.define ??= {};
+  config.define.__SAYPI_BUILD_STAMP__ = JSON.stringify(BUILD_STAMP);
+};
 
 // These constants are used for renaming CommonJS helper files generated during the build.
 // Chrome requires safe filenames for extension chunks, and specifically does not allow underscores in chunk names.
@@ -365,9 +390,11 @@ export default defineConfig((env) => {
     hooks: {
       "vite:build:extendConfig": (entrypoints, config) => {
         applyChunkFilePattern(config);
+        applyBuildStampDefine(config);
       },
       "vite:devServer:extendConfig": (config) => {
         applyChunkFilePattern(config);
+        applyBuildStampDefine(config);
       },
       "build:publicAssets": (_wxt: any, files: any[]) => {
         addLocalePublicAssets(files);


### PR DESCRIPTION
## Why

The biggest friction in the last Layer-4 session was that **hot-reload died silently**: the MV3 service worker slept, `.output` stopped rebuilding, and *nothing surfaced it*. The dev build that got reloaded was the stale pre-fix `main`, a VAD test hung on old code, and there was no way to tell the loaded build apart from the current one — the version string (`1.10.8`) is identical across commits. This adds two signals that make staleness visible instead of a guess.

## What

**Build-identity stamp**
- `wxt.config.ts` injects `__SAYPI_BUILD_STAMP__` (git short SHA + branch + ISO build time) via a Vite `define`, on both the build and dev-server hooks.
- `src/build-stamp.ts` exposes it and writes it to `<html data-saypi-build="<sha>@<branch> <iso>">`. The content script runs in an isolated world but the DOM is shared, so the **page's main world — and a Layer-4 probe — can read exactly which build is injected**. Bootstrap stamps it early. Falls back gracefully outside a build (tests) and outside a git checkout.
- "Is the loaded build current?" is now:
  ```js
  document.documentElement.dataset.saypiBuild   // "0b65de4@main 2026-06-16T21:00:00Z"
  ```
  vs `git rev-parse --short HEAD` — a definitive check (the on-disk mtime can be fresh while the *page* still runs a stale build).

**Stalled-hot-reload warning**
- `scripts/dev-rig-lib.mjs` gains the pure `isHotReloadStalled({lastSrcEditMs, lastBuildMs, nowMs, graceMs})`.
- `scripts/dev-rig.mjs` watches `src/` and prints a loud `⚠ hot-reload looks STALLED` warning when an edit doesn't rebuild within the grace window (the slept-SW signature), and logs the build identity at startup. The rig can't reach the page to know the SW is gone, so it flags the on-disk symptom.

## Verification

- **L1 unit tests**: `test/build-stamp.spec.ts` (format + DOM write + graceful fallback) and `test/scripts/dev-rig-lib.spec.ts` (the `isHotReloadStalled` predicate across all four branches).
- **End-to-end**: built the dev extension (`wxt build -m development`) and asserted the stamp value + `data-saypi-build` write land in the bundle and `__SAYPI_BUILD_STAMP__` is fully replaced (0 left).
- `npm test` green locally (Vitest 101 files / 839 passed; the build-stamp is non-test src, harmless in prod — just a SHA+time on `<html>`).
- Runbook (`doc/autonomous-dev-loop.md`) updated to lead with the `data-saypi-build` freshness check and the new warning.

Follow-up testability investment filed separately: an **L3 capability to exercise SW-recycle / port-disconnect / offscreen auto-shutdown** (the lifecycle where the recent #307/#308 bugs lived, currently only mockable at L1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
