### PR TITLE
fix(pi): three pi.ai composer integration bugs (stuck 'thinking', faint call button, taller editor)

### DIFF
--- a/e2e/specs/pi-call-button.e2e.ts
+++ b/e2e/specs/pi-call-button.e2e.ts
@@ -74,3 +74,56 @@ test("Pi call button has no vertical margin, so it doesn't inflate the composer 
     `margin-bottom must be 0 (was ${result!.marginBottom}); m-2's 8px inflates the composer`
   ).toBe("0px");
 });
+
+/**
+ * Bug: the ACTIVE (in-call) call button is "almost indistinguishable from the
+ * background".
+ *
+ * The intended active disc colour is grey #776d6d (hangup.svg). But while Pi is
+ * responding the button also gets the `disabled` class, and the shared rule
+ * `#saypi-callButton.disabled svg path.background` (common.scss) paints the disc
+ * `bg-cream-550` = rgb(245 238 223) — which on pi.ai's cream composer is the
+ * page background, so the disc renders cream-on-cream (invisible). (This is why
+ * the stuck-piThinking screenshot showed a near-invisible button: it was active
+ * AND disabled.)
+ *
+ * The fix pins the in-call (active) disc to the intended grey at full opacity on
+ * pi.ai, outranking the disabled→cream rule, so the active call button always
+ * reads as "in a call" — even mid-response.
+ *
+ * Fail-first: before the fix an active+disabled disc computes cream
+ * rgb(245, 238, 223); after, the intended grey rgb(119, 109, 109).
+ */
+test("Pi active call button keeps its visible grey disc even while disabled (real build)", async ({
+  context,
+}) => {
+  const page = await context.newPage();
+  await page.goto("https://pi.ai/talk", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => document.body.classList.contains("pi"), {
+    timeout: 20_000,
+  });
+  await page.waitForSelector("#saypi-callButton", { timeout: 20_000 });
+  // The disc is an SVG sub-path (visibility checks are unreliable on SVG paths),
+  // so wait for it to be attached, then read it inside evaluate.
+  await page.waitForFunction(
+    () => !!document.querySelector("#saypi-callButton svg path.background"),
+    { timeout: 20_000 }
+  );
+
+  const fill = await page.evaluate(() => {
+    const btn = document.getElementById("saypi-callButton")!;
+    // Reproduce the in-call-during-response state the user reported: the button
+    // is both active (hangup) and disabled (Pi responding).
+    btn.classList.add("active", "disabled");
+    const disc = btn.querySelector("svg path.background") as SVGElement | null;
+    if (!disc) return null;
+    return getComputedStyle(disc).fill;
+  });
+
+  expect(fill, "call button disc not found").not.toBeNull();
+  // Must be the intended grey #776d6d, not cream-on-cream (rgb(245, 238, 223)).
+  expect(
+    fill,
+    `active call disc must be the intended grey #776d6d, got "${fill}" (cream = invisible on pi's composer)`
+  ).toBe("rgb(119, 109, 109)");
+});

--- a/e2e/specs/pi-call-button.e2e.ts
+++ b/e2e/specs/pi-call-button.e2e.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "../fixtures/extension";
+
+/**
+ * Layer 3 guards for the SayPi call button on pi.ai, verified against the REAL
+ * built extension CSS (.output/chrome-mv3-dev via --load-extension) — not an
+ * injected rule. We navigate to the pi.ai mock host so Chrome injects the
+ * extension's real content-script stylesheet, let SayPi decorate the page (it
+ * creates #saypi-callButton and tags <body class="pi">), then assert computed
+ * styles on the shipped button.
+ */
+
+/**
+ * Bug: the prompt composer is ~16px taller with SayPi than native pi.ai.
+ *
+ * Root cause: Pi's getExtraCallButtonClasses() puts Tailwind `m-2` (0.5rem all
+ * sides) on #saypi-callButton. On desktop the button is in-flow
+ * (position:relative), so its 8px top+bottom margin makes it the tallest item in
+ * Pi's `items-center` prompt-controls row and inflates the rounded box by 16px.
+ * Pi's own submit button has margin 0. The fix neutralises the call button's
+ * vertical margin (desktop + Pi scoped) so it matches the native button.
+ *
+ * This reproduces Pi's host environment — the `.m-2` utility pi.ai ships and the
+ * `html.desktop-view` class SayPi sets on desktop — then reads the computed
+ * vertical margin off the real shipped button. Before the fix it is 8px (the
+ * bug); after, 0px. Horizontal spacing (margin-left) is preserved.
+ */
+test("Pi call button has no vertical margin, so it doesn't inflate the composer (real build)", async ({
+  context,
+}) => {
+  const page = await context.newPage();
+  await page.goto("https://pi.ai/talk", { waitUntil: "domcontentloaded" });
+
+  // Wait for SayPi to decorate: body tagged `pi` and the call button injected.
+  await page.waitForFunction(() => document.body.classList.contains("pi"), {
+    timeout: 20_000,
+  });
+  await page.waitForSelector("#saypi-callButton", { timeout: 20_000 });
+
+  const result = await page.evaluate(() => {
+    // Reproduce Pi's host environment (NOT the extension's CSS, which is real):
+    //  - desktop view: SayPi adds html.desktop-view on desktop, where the button
+    //    is in-flow and its margin affects layout.
+    //  - Pi's `m-2` utility (margin: 0.5rem) — Pi ships this; the e2e mock host
+    //    doesn't, so define it to recreate the live margin the fix must beat.
+    document.documentElement.classList.add("desktop-view");
+    const hostUtil = document.createElement("style");
+    hostUtil.textContent = ".m-2 { margin: 0.5rem; }";
+    document.head.appendChild(hostUtil);
+
+    const btn = document.getElementById("saypi-callButton");
+    if (!btn) return null;
+    const cs = getComputedStyle(btn);
+    return {
+      hasM2: btn.classList.contains("m-2"),
+      marginTop: cs.marginTop,
+      marginBottom: cs.marginBottom,
+      marginLeft: cs.marginLeft,
+    };
+  });
+
+  expect(result, "call button not found").not.toBeNull();
+  // Sanity: the shipped button really carries Pi's m-2 utility (else the test
+  // would trivially pass without exercising the cascade).
+  expect(result!.hasM2, "call button should carry Pi's m-2 class").toBe(true);
+
+  // The fix must zero the vertical margin so the button matches Pi's native
+  // (margin-0) submit button and the composer keeps its native height.
+  expect(
+    result!.marginTop,
+    `margin-top must be 0 (was ${result!.marginTop}); m-2's 8px inflates the composer`
+  ).toBe("0px");
+  expect(
+    result!.marginBottom,
+    `margin-bottom must be 0 (was ${result!.marginBottom}); m-2's 8px inflates the composer`
+  ).toBe("0px");
+});

--- a/src/chatbots/pi/PiResponse.ts
+++ b/src/chatbots/pi/PiResponse.ts
@@ -6,6 +6,8 @@ import {
   Completion,
   ElementTextStream,
   InputStreamOptions,
+  STREAM_TIMEOUT,
+  getNestedText,
 } from "../../tts/InputStream";
 import { UserPreferenceModule } from "../../prefs/PreferenceModule";
 import { TTSControlsModule } from "../../tts/TTSControlsModule";
@@ -107,96 +109,84 @@ export class PiMessageControls extends MessageControls {
 }
 
 export class PiTextStream extends ElementTextStream {
-  hiddenTextQueue: Queue<string> = new Queue();
-  additionalDelay: number = 0;
-  lastContentChange: number = Date.now();
+  // Endpointing window: complete once the rendered text stops changing.
+  private streamTimeoutMs: number | undefined;
+  // Extra endpointing delay accumulated from "saypi:tts:text:delay" events.
+  private additionalDelay: number = 0;
+  // The full rendered text already emitted, diffed against on each mutation.
+  private lastFullText: string = "";
+  private firstTokenEmitted: boolean = false;
 
   constructor(element: HTMLElement, options?: InputStreamOptions) {
     super(element, options);
-    EventBus.on("saypi:tts:text:delay", this.handleDelayEvent);
-  }
-
-  // Helper to check if a span is hidden
-  private isSpanHidden(span: HTMLSpanElement): boolean {
-    try {
-      if (span.style.display === "none" || span.style.opacity === "0") {
-        return true;
-      }
-      if (typeof window !== 'undefined' && window.getComputedStyle) {
-        const style = window.getComputedStyle(span);
-        return style.display === "none" || parseFloat(style.opacity) === 0;
-      }
-      return false;
-    } catch (e) {
-      console.error("Error checking if span is hidden", e);
-      return false;
+    this.streamTimeoutMs = options?.streamTimeout ?? STREAM_TIMEOUT;
+    // If the base already emitted the element's initial text, seed lastFullText
+    // so we don't re-emit it on the first mutation.
+    if (options?.includeInitialText) {
+      this.lastFullText = getNestedText(this.element);
     }
+    EventBus.on("saypi:tts:text:delay", this.handleDelayEvent);
+    // Re-arm the completion timer now that streamTimeoutMs is set (the base
+    // constructor armed it with the default before this ran).
+    this.resetStreamTimeout();
   }
 
-  /** Extend the stream timeout when a delay event is received. */
+  /** Endpointing window, extended by any received delay events. */
+  protected calculateStreamTimeout(): number {
+    return (this.streamTimeoutMs ?? STREAM_TIMEOUT) + (this.additionalDelay || 0);
+  }
+
+  /**
+   * pi.ai gives no explicit end-of-response marker, so complete the stream once
+   * the rendered text has been stable for the endpointing window. The base
+   * subscription re-arms this on every emitted chunk, so it fires only after
+   * streaming actually stops.
+   */
+  protected resetStreamTimeout(): void {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+    this.timeout = setTimeout(() => {
+      this.complete({ type: "eod", time: Date.now() });
+    }, this.calculateStreamTimeout());
+  }
+
+  /** Extend the endpointing window when a delay event is received. */
   handleDelayEvent = () => {
-    const delay = 1500;
-    this.additionalDelay += delay;
-    console.debug(`Received delay event. Adding ${delay}ms to timeout. Total additional delay: ${this.additionalDelay}ms`);
+    this.additionalDelay += 1500;
     this.resetStreamTimeout();
   };
 
-  private updateLastContentChange(): void {
-    this.lastContentChange = Date.now();
-  }
-
-  handleMutationEvent = (mutation: MutationRecord) => {
+  /**
+   * pi.ai streams a response by appending hidden `<span style="opacity:0">`
+   * word chunks (revealed later) and tweaking them via characterData — it does
+   * NOT append bare text nodes, and the first chunk arrives already nested in a
+   * container element. Rather than interpret each node mutation (the old, now
+   * broken approach), read the element's full rendered text on every mutation
+   * and emit the delta. This is robust to however the host nests or streams the
+   * text, and naturally handles appends, in-place edits, and nested containers.
+   */
+  handleMutationEvent = (_mutation: MutationRecord) => {
     if (this.closed()) {
       return;
     }
-
-    this.updateLastContentChange();
-
-    if (mutation.type === "childList") {
-      for (let i = 0; i < mutation.addedNodes.length; i++) {
-        const node = mutation.addedNodes[i];
-
-        if (node.nodeType === Node.ELEMENT_NODE) {
-          const element = node as HTMLElement;
-          if (element.tagName === "SPAN") {
-            const isHidden = this.isSpanHidden(element as HTMLSpanElement);
-            if (isHidden) {
-              if (this.hiddenTextQueue.isEmpty()) {
-                EventBus.emit("saypi:llm:first-token", { text: element.textContent || "", time: Date.now() });
-              }
-              this.hiddenTextQueue.enqueue(element.textContent || "");
-            }
-          }
-        } else if (node.nodeType === Node.TEXT_NODE) {
-          const textNode = node as Text;
-          const content = textNode.textContent || "";
-
-          const head = this.hiddenTextQueue.peek();
-          if (head) {
-            if (head.trim() === content.trim()) {
-              this.hiddenTextQueue.dequeue();
-            }
-          }
-          this.next(new AddedText(content || ""));
-
-          if (this.hiddenTextQueue.isEmpty()) {
-            console.debug("Stream completion detected - all hidden text has been added");
-            this.complete({ type: "eod", time: Date.now() });
-          }
-        }
+    const full = getNestedText(this.element);
+    if (full === this.lastFullText) {
+      return;
+    }
+    if (full.startsWith(this.lastFullText)) {
+      const delta = full.slice(this.lastFullText.length);
+      this.lastFullText = full;
+      if (!this.firstTokenEmitted && delta.trim().length > 0) {
+        this.firstTokenEmitted = true;
+        EventBus.emit("saypi:llm:first-token", { text: delta, time: Date.now() });
       }
-    } else if (mutation.type === "characterData") {
-      const textNode = mutation.target as Text;
-      const content = textNode.textContent || "";
-      const oldValue = mutation.oldValue || "";
-
-      const alreadyEmitted = this.emittedValues.some((value) => value.text === oldValue);
-      if (alreadyEmitted) {
-        this.next(new ChangedText(content, oldValue));
-        console.debug(`Text changed from "${oldValue}" to "${content}"`);
-      } else {
-        console.debug(`Skipping change event for "${content}" because the old value "${oldValue}" was not emitted`);
-      }
+      this.next(new AddedText(delta));
+    } else {
+      // Rare: earlier text was rewritten rather than appended to.
+      const previous = this.lastFullText;
+      this.lastFullText = full;
+      this.next(new ChangedText(full, previous));
     }
   };
 
@@ -204,13 +194,4 @@ export class PiTextStream extends ElementTextStream {
     super.complete(reason);
     EventBus.off("saypi:tts:text:delay", this.handleDelayEvent);
   }
-}
-
-class Queue<T> {
-  private items: T[] = [];
-  enqueue(item: T): void { this.items.push(item); }
-  dequeue(): T | undefined { return this.items.shift(); }
-  peek(): T | undefined { return this.items[0]; }
-  get size(): number { return this.items.length; }
-  isEmpty(): boolean { return this.items.length === 0; }
 }

--- a/src/state-machines/ConversationMachine.ts
+++ b/src/state-machines/ConversationMachine.ts
@@ -241,6 +241,16 @@ function getChatbotDefaultPlaceholder(): string {
 // Define a constant for the timeout (in milliseconds) for the user stopped speaking event
 const USER_STOPPED_TIMEOUT_MS = 10000;
 
+// Safety-net timeout for the piThinking state. piThinking normally exits the
+// moment Pi starts writing (saypi:piWriting) or speaking (saypi:piSpeaking).
+// Those signals depend on host-specific DOM detection (e.g. PiTextStream), which
+// can break if the chat host's response markup drifts — leaving the prompt
+// frozen on "$chatbot$ is thinking…" even though Pi has already answered. This
+// fallback guarantees the UI recovers (and the placeholder is restored) instead
+// of staying stuck forever. It is generous so it never fires during a normal,
+// promptly-detected response — it only rescues a genuine detection miss.
+const PI_THINKING_TIMEOUT_MS = 15000;
+
 const machine = createMachine<ConversationContext, ConversationEvent, ConversationTypestate>(
   {
     /** @xstate-layout N4IgpgJg5mDOIC5SwIYE8AKBLAxAV1jACcMiwAzYsAOwGMwBhACxWpggG0AGAXUVAAOAe1hYALliHV+IAB6IuAGhBoFAXzXLUmLADos1FLQkA3MDm0CsCAUSEBbAWIBKYFBDTc+SEMNESpGXkEAGYAdgAOAE5dMKiwrhCAFgAmADYAVgikjIzlVQQARkKUrl0IiOSoiOLqwviNLXRsfUNjLDMLdCsEWhQAG36vGT9xSWkfYKiU-MQopJiUrLCUsNyliK4wxpBtFoMjU3NLaysAZQE3AGsDKGGfUYCJ0GCk4ozYqLSojMSQjJKeRUiEKyRC5RCaTChQi0K4GTC4R2ez0fUGZzEKCIEjYXTQPTR-Vc7k8vBGIjGgUmiBySV0hSS2SyFSScTiQIKjI+SSSaRSqyihTShS4SUhyOaqIG-QxWJxUDxPRYbDwAnuggpTyCiAiM2BRS4P10v1h-0RaTSXEKGQlOl0hNl2NuiushIAYigsP1IOrfJrxtqEDy6QymRVsmyfrMilFwRkQlFEwDRTUE7aWg7MU7cbJYJixGBdChyAWiAAKUpcKsASjxGeljvlvceAepQYyIcZOXDrPiUf1yTKiZCgNWmUyNs0u0lun6WDzNGdJxsWAAKkwDDc2M3-VSXogQpDwWyq1lvmkkvDo4eMml6RUocVYVCkum9HOF9Ql91TlgLtdbh3fxW33UJ-mPeJTwic9Lw5A8SjCXQ3l+FYfhSSpKjfWd5wLL9cWXEx5ywAAjb0gMpZ45BBC0ImNM8akyflshCaNrXSWJoi+MIEiWQEsI-XDv3xawUDwCBJF6KRqDAYwfTJB5d0o4IhV5XQE15GDYziVixTKQ8X3U8JeUKficMXfCfwQUTxKEBAyFoKSZLEcitTbFTEMYnJRSrIVkmveNEMhBjqi83lTM-ISekIWBRCkKyYqwKBpM4eSNWAvcqKKC86QWfkeUfaD4mvHkh2tQoEjCS9QWtcLBLYXR7KEIhxIs4SEGVKBVRckDMpvCCEnhQqLyvfVK3BEJ4XWBMEyWV8pxRbCIvqxrmtuXRqCEMR-xQLcFWXAhiDdAx5yYSBtt27qMuCPrPgGs8vlg6N+VFXQLQWf4Ig7XUQlq8yoAamSmpa-6Nq2y4dsi6wDqIc7ANSv10qUkE-l0FIhQFVYrUtCInsNO9piieFvlKdJtnmmcBL+gGHNW+rodh1qenpsQhAES4IAZu54ZbK6dQZY10MiRkRTenHRvqRCCZU35knjNJfrw-6VuB3R6fB3aXQQZnWfZzmOEKbw0oowMajpDJBeyGouFFp6GUQ1JBRFaEYUteXybtSnFftKQzGzf6jFoPB7DwfoUHlHAICkQsDBMIQrkLexiBgAB5JwsHsHCsFoS6kYNLIkLCTIFmKVIlj1Ap0KFCE0gqBIR1WCIFbWhzqF9+Ui1oQPg9D8PiDsIhdAEHvyCa+xdETogU7TjO8yznPAxFDIYgZHIEWSa0qxY0aVnGypvi4TZWRSVkm-qlu27WgOg5DsPIYQMQiFYWBaCIEi5MNhHjbbeJwTR2FKkqomKEYQnoIg+LGUUjIJqWlZD9d2LRPbNx9sQduV9u630ZtYB+T8X5vw9F6d+5JEaBjRuxBM2QJy-GqFvCuw1dCCgWITSqKQvhwKaB7MyXtz4oMvp3a+Pc77YOoM-V+xFIAAFFHBiFJB-HmudSF3nIbyXIVDKhPU2HeN4CxIigjRhaMm7CEGcKQa3Hh9U0E33DrmfMhZiyljLCUKsXBawLUQWfZBfsO5d0sXDWRilAxKH1FwU--1uGeIsQInMeYw62JLMQMssA8DERnrFagAARMAoc0AuIpsY9xpjwl8PQU2bm-i3JvEQn-RES86hcDRteTe9JMh-FBJECak5DHvjyaEjx7dEnJPEOHeebZ9L9SgjBEaBQRzcXoQyQmpRCZZBCd7Ap7chEiJIoIx+wjcFiJSn44hbZ4x0iqWsQ8ADRTqKroeCqiRoJWzmp0xadUemrLWus3ZWycGiLAPg70+yiFf1Asc1GMJuLxhCBcpIT15gnMJqCGawp4QGOnBwparyL71Q+aIr5OyfkQEkU4GRgLXLAuSKC2EZzIXhEuQOOpd4WFVlWAsXU6EOmoqMei3QfcmqyjEAQblRB+6wBwNYmJRY4nll+DWOsXSuU8phvmAVCrYDDNAiwlI4IoR9iTAiTYNDEBLDiEhOZsIuKavFPAvQZBYDCGoMDTWHUuqlMOaBN41pPjfBlv8QErFrS0UvHXfkDI+TlSwjau1Dr9qEBhurXxJKeqvBuUhaY3ZzbRH+HBUIYpwSGiPtjTVCxw1wEjWtKwHrtIeQ1vmLcLqgWZVZHU+h2RpgHz-pCBp3xYjC0TPlaojcrUA1tVIFW5aNzUA1suKwAB1V+JSDn1teDxZtuU20wg7QOY+KRUaMjRo7NGYpi3DvtWWv8Na9qWXOCzNmZ1z1qsynya8FRt38kLvENGkJUiPI5daktI7T2c01lenWt6ALbgNgm3mQZ3iep+H8AESw-VbHoVsRI3YLyCjdk8iN-76rVrAxetqVgjpflgKdDmd662ksyuba8sZt0rHBSKeEmqOxHtLXhs9BHNZqwI-e4I8YjSfUTDUBE0JcjXnSLRBhsYJrWh9d+haOGT2ccA8uAwpYiCqmclRxNiAl6sl0HU3UuRRObHLgeJF9IJroX7YifK7HcP-XwxDTBCANN920-rBd1HgihsKMaNIkIFksITFmzNZRQTGbs8kMKg7lOjqwLOsYbmXMXV01BgKelIQFuthhyTMITWMjiPycISz4t-pU85pLc6q1-mvezZL87IO5xWE+kcsQxxilLqKeYjmqu6AAO6enlG6Jq2BVxCAxKzNTl76sgYo3xjLudAkFGCRV49KthspagGNkga4pvXsA2KgsEr7HSpyXaBLa1tujfGwd6bAg9bLYCdGdb2HKsq2hgASWoJp7Td9tY3sW65rmPm9MICy2pHLba8sLGvAmO89zg2lBbQOj7m21o-b+55tObmge6zvRBhSrrMq6mvFCJHpCIysjiP8DQU4NoQDgDIFELXAwAFoV7Rg5wsMo0rDRLxWMfC8KKFoHHaGYdnIy1gBdSPUdGw5yogP1AhcakJKrWxhNorCmY5S3Gl26izQY0ZGYVyhTIQpoghMN5lDnXweeXlzU4pe6bsjFGWcrA3JPF2Gq7emuIQW96y5VwUbXtEqyMeMiw2knvAa0xBptTmtvlKatopUZIuo1jMltuhekcQrdIu4lCOPNMvsxuTz73z8FEIB9YcHgEofDWGm3ZHn1obqjcWWWE+UKfEC87FgUDnsJjROKCrGX4Klu+9N4d4yJUA+8IEFB8P++r7NgINQgFhHrGUHxCEayoJlB1uIxWY-6-SM5iF71XiH5UvjlBKMVnk3EhRpBhebV6zSGQJgL9BafbysVtkNliJvcjZq8Ywm8t9pgV9OIER3JExlkFU+UCBF9j4W9zZEChVeUlVqCVV6CWFGCxRmDwhWCK55cisfhuIaVoh2VXFyCkCBCKCmpqDsU8FPR-l6CZklEsCWDcDhRwRkI-gRx3VFNcl5U+DFUw5lUbDqCM5aBxEbDdDApMDxCcCnpmDZlfhSg65pl+tgZF8B8edNVa8nFC5KgqwndLCrtPtT0K0J1QDP5wCc17ZU0sh00J9wtqp6FqheJDRphgEgiANz1F8sgm1cpohUNnp+wplBZrNRRERNhqh4xSjOMmsUi5FAxtEAtN4JoVhYR-Drx6gygWV+QgtUghYsMf0h0ON-pbtbg9sJtDsZtyib8oNVsDwEhaIosakShPoFg4iWhrs6YY1ft-s8cF9Njc5GRohXpD5GVrRRcEd0DYtERDwShEwtgGc1AgA */
@@ -843,6 +853,26 @@ const machine = createMachine<ConversationContext, ConversationEvent, Conversati
               "saypi:piWriting": {
                 target: "piWriting",
               },
+            },
+            after: {
+              [PI_THINKING_TIMEOUT_MS]: [
+                {
+                  target: "#conversation.listening",
+                  cond: {
+                    type: "wasListening",
+                  },
+                  description:
+                    "Fallback: Pi's response was never detected as written/spoken (e.g. host DOM drift broke completion detection). Recover the call's listening state instead of staying stuck on 'thinking', and restore the prompt placeholder via the exit action.",
+                },
+                {
+                  target: "#conversation.inactive",
+                  cond: {
+                    type: "wasInactive",
+                  },
+                  description:
+                    "Fallback when Pi was responding outside a call: return to inactive and restore the placeholder.",
+                },
+              ],
             },
             entry: [
               {

--- a/src/styles/desktop.scss
+++ b/src/styles/desktop.scss
@@ -24,6 +24,18 @@ html.desktop-view {
     margin-right: 0;
   }
 
+  /* Pi puts Tailwind `m-2` (0.5rem all sides) on the call button. On desktop the
+     button is in-flow (position:relative above), so its 8px top+bottom margin
+     makes it the tallest item in Pi's `items-center` prompt-controls row and
+     inflates the composer by 16px vs native (Pi's own submit button has margin
+     0). Zero the vertical margin so the box keeps Pi's native height. Scoped to
+     body.pi (m-2 is Pi-only) and to desktop-view (mobile keeps its own
+     position:fixed / margin:auto centering). Horizontal margin is left intact. */
+  body.pi #saypi-callButton {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
   .saypi-prompt-container {
     /* make room in the prompt text area for the call button */
     padding-right: 0;

--- a/src/styles/pi.scss
+++ b/src/styles/pi.scss
@@ -201,6 +201,20 @@ html body.pi {
     align-self: center;
   }
 
+  /* In-call (active) state: keep the hangup disc clearly visible — its intended
+     grey (#776d6d, from hangup.svg) at full opacity. While Pi is responding the
+     button also gets the `disabled` class, and the shared rule
+     `#saypi-callButton.disabled svg path.background` (common.scss) paints the
+     disc bg-cream-550 = rgb(245 238 223), which on pi.ai's cream composer is the
+     page background — so the active button renders cream-on-cream (invisible).
+     This pins the active disc to its grey and outranks that disabled rule, so the
+     in-call button always reads as "in a call", even mid-response. Transcription
+     segment wedges still hide it via inline fill-opacity:0, which outranks this. */
+  #saypi-callButton.active svg path.background {
+    fill: #776d6d;
+    fill-opacity: 1;
+  }
+
   /* Mobile-specific button sizing to match Pi's native buttons */
   @media (max-width: 768px) {
     #saypi-callButton {

--- a/src/tts/InputStream.ts
+++ b/src/tts/InputStream.ts
@@ -11,6 +11,12 @@ export function getNestedText(node: HTMLElement): string {
 export interface InputStreamOptions {
   includeInitialText?: boolean;
   delimiter?: string;
+  /**
+   * Endpointing window (ms): complete the stream when the rendered text has been
+   * stable for this long. Defaults to STREAM_TIMEOUT. Mainly used to keep tests
+   * fast; production uses the default.
+   */
+  streamTimeout?: number;
 }
 interface TextContent {
   text: string;

--- a/test/state-machines/ConversationMachine-piThinkingFallback.spec.ts
+++ b/test/state-machines/ConversationMachine-piThinkingFallback.spec.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { interpret } from 'xstate';
+
+// ---------------------------------------------------------------------------
+// Regression guard for the "Pi is thinking…" STUCK PLACEHOLDER bug.
+//
+// The `responding.piThinking` state sets the host prompt placeholder to the
+// "$chatbot$ is thinking..." message on entry and restores the native
+// placeholder (`clearPrompt` -> defaultPlaceholderText) on exit. Its ONLY exits
+// are `saypi:piWriting` and `saypi:piSpeaking`. With TTS output off, audio never
+// plays so `saypi:piSpeaking` never fires; and if pi.ai's streamed-response DOM
+// drifts out from under PiTextStream's detection, `saypi:piWriting` never fires
+// either. The machine then sits in piThinking forever — Pi's reply is rendered
+// by Pi itself, but SayPi's placeholder is frozen on "Pi is thinking…".
+//
+// This test reproduces that: drive the machine into responding.piThinking, then
+// let real wall-clock-equivalent time pass WITHOUT sending piWriting/piSpeaking,
+// and assert the machine recovers (leaves piThinking and restores the
+// placeholder) via a timeout fallback. Before the fix it stays stuck and this
+// fails; after adding the `after` fallback it passes.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../src/ConfigModule', () => ({
+  config: { apiServerUrl: 'http://api.example.com' },
+}));
+
+vi.mock('../../src/AnimationModule.js', () => ({
+  default: {
+    startAnimation: vi.fn(),
+    stopAnimation: vi.fn(),
+    stopAllAnimations: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/NotificationsModule', () => {
+  class NoopAudible {
+    static instance = new NoopAudible();
+    static getInstance() { return NoopAudible.instance; }
+    listeningStopped() {}
+    callStarted() {}
+    callEnded() {}
+  }
+  class NoopTextual { showNotification() {}; hideNotification() {}; }
+  class NoopVisual { listeningStopped() {}; listeningTimeRemaining() {}; }
+  return {
+    AudibleNotificationsModule: NoopAudible,
+    TextualNotificationsModule: NoopTextual,
+    VisualNotificationsModule: NoopVisual,
+  };
+});
+
+vi.mock('../../src/audio/AudioControlsModule', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    activateAudioOutput: vi.fn(),
+  })),
+}));
+
+vi.mock('../../src/WakeLockModule', () => ({
+  requestWakeLock: vi.fn(),
+  releaseWakeLock: vi.fn(),
+}));
+
+// i18n returns a distinct sentinel for the "thinking" message so we can tell it
+// apart from the restored (default) placeholder, which is "".
+vi.mock('../../src/i18n', () => ({
+  default: vi.fn(() => 'THINKING_MSG'),
+}));
+
+const fixedDelayMs = 200;
+vi.mock('../../src/TimerModule', () => ({
+  calculateDelay: vi.fn(() => fixedDelayMs),
+}));
+
+vi.mock('../../src/TranscriptionModule', () => ({
+  uploadAudioWithRetry: vi.fn(() => Promise.resolve(1)),
+  isTranscriptionPending: vi.fn(() => false),
+  clearPendingTranscriptions: vi.fn(),
+  getCurrentSequenceNumber: vi.fn(() => 1),
+}));
+
+vi.mock('../../src/TranscriptMergeService', () => ({
+  TranscriptMergeService: vi.fn().mockImplementation(() => ({
+    mergeTranscriptsLocal: (t: Record<number, string>) => Object.values(t).join(' '),
+    mergeTranscriptsRemote: vi.fn(() => Promise.resolve('merged')),
+  })),
+}));
+
+vi.mock('../../src/prefs/PreferenceModule', () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({
+      getLanguage: () => Promise.resolve('en'),
+      getDiscretionaryMode: () => Promise.resolve(false),
+      getCachedDiscretionaryMode: () => false,
+      getCachedAutoSubmit: () => true,
+      getCachedAllowInterruptions: () => true,
+      getCachedNickname: () => null,
+    }),
+  },
+}));
+
+import { createConversationMachine } from '../../src/state-machines/ConversationMachine';
+
+// Records every placeholder write so we can assert the restore happened.
+const setMessageCalls: string[] = [];
+const spyPrompt = {
+  setMessage(text: string) { setMessageCalls.push(text); },
+  setDraft(_: string) {},
+  setFinal(_: string) {},
+  getDraft() { return ''; },
+  getDefaultPlaceholderText() { return ''; },
+};
+// getPromptOrNull() resolves the prompt as chatbot.getPrompt(#saypi-prompt), so
+// return the single shared spy regardless of the element passed.
+const StubChatbot = {
+  getName: () => 'Pi',
+  getPrompt: (_el?: HTMLElement) => spyPrompt,
+  getContextWindowCapacityCharacters: () => 1_000_000,
+};
+
+function driveToPiThinking(service: any) {
+  service.send('saypi:call');
+  service.send('saypi:callReady');
+  service.send('saypi:userSpeaking');
+  const blob = new Blob(['a'], { type: 'audio/webm' });
+  service.send({ type: 'saypi:userStoppedSpeaking', duration: 800, blob });
+  vi.advanceTimersByTime(50);
+  service.send({
+    type: 'saypi:transcribed',
+    text: 'Good evening.',
+    sequenceNumber: 1,
+    pFinishedSpeaking: 0.2,
+    tempo: 0.86,
+  });
+  // Elapse the submission delay so the machine submits -> responding.piThinking
+  vi.advanceTimersByTime(fixedDelayMs + 5);
+}
+
+describe('ConversationMachine: piThinking never gets stuck (stuck-placeholder guard)', () => {
+  let service: any;
+
+  beforeEach(() => {
+    setMessageCalls.length = 0;
+    // getPromptOrNull() looks up #saypi-prompt in the DOM before delegating to
+    // the chatbot, so the element must exist for the prompt actions to run.
+    document.body.innerHTML = '<textarea id="saypi-prompt"></textarea>';
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1_000_000));
+    const machine = createConversationMachine(StubChatbot as any);
+    service = interpret(machine);
+    service.start();
+  });
+
+  afterEach(() => {
+    try { service?.stop(); } catch {}
+    vi.useRealTimers();
+  });
+
+  it('leaves piThinking and restores the placeholder when neither piWriting nor piSpeaking ever fires', () => {
+    driveToPiThinking(service);
+    expect(service.state.matches({ responding: 'piThinking' })).toBe(true);
+    // The thinking placeholder was written on entry.
+    expect(setMessageCalls).toContain('THINKING_MSG');
+
+    // Simulate a missed completion signal: Pi answers in the DOM but SayPi never
+    // observes piWriting/piSpeaking. Let a generous amount of time pass.
+    setMessageCalls.length = 0;
+    vi.advanceTimersByTime(20_000);
+
+    // The machine must NOT still be stuck thinking…
+    expect(service.state.matches({ responding: 'piThinking' })).toBe(false);
+    // …it should fall back to the call's listening state (the call was active).
+    expect(service.state.matches('listening')).toBe(true);
+    // …and the native placeholder must be restored (clearPrompt ran on exit).
+    expect(setMessageCalls).toContain('');
+  });
+});

--- a/test/tts/InputStream.spec.ts
+++ b/test/tts/InputStream.spec.ts
@@ -98,7 +98,7 @@ test(
   "ElementTextStream emits text as it is added",
   async () => {
     const element = document.createElement("div");
-    const stream = new PiTextStream(element);
+    const stream = new PiTextStream(element, { streamTimeout: 150 });
     const values: string[] = [];
     const promise = collectStreamValues(stream, values);
     await addText(element, "Hello ");
@@ -115,7 +115,7 @@ test(
   async () => {
     const element = document.createElement("div");
     document.body.appendChild(element);
-    const stream = new PiTextStream(element);
+    const stream = new PiTextStream(element, { streamTimeout: 150 });
     const values: string[] = [];
     const promise = collectStreamValues(stream, values);
 
@@ -144,7 +144,7 @@ test(
   async () => {
     const element = document.createElement("div");
     document.body.appendChild(element);
-    const stream = new PiTextStream(element); // no delimiter by default
+    const stream = new PiTextStream(element, { streamTimeout: 150 }); // no delimiter by default
     const values: string[] = [];
     const promise = collectStreamValues(stream, values);
 
@@ -168,7 +168,7 @@ test(
   async () => {
     const element = document.createElement("div");
     document.body.appendChild(element);
-    const stream = new PiTextStream(element);
+    const stream = new PiTextStream(element, { streamTimeout: 150 });
     const values: string[] = [];
     const promise = collectStreamValues(stream, values);
 
@@ -179,4 +179,49 @@ test(
     expect(values.join("")).toEqual(element.textContent);
   },
   timeoutCalc(2)
+);
+
+/**
+ * Regression guard for the "Pi is thinking…" stuck-placeholder bug.
+ *
+ * pi.ai's streamed-response DOM drifted: it still appends each word as a hidden
+ * `<span style="opacity:0">` but NO LONGER replaces those spans with bare text
+ * nodes (the `finishText` step above). The first word also arrives already
+ * nested inside an added container element. The old PiTextStream emitted only on
+ * bare-text-node additions and completed only when its hidden-span queue
+ * emptied, so against this markup it emitted nothing and never completed —
+ * `saypi:piWriting`/`saypi:piStoppedWriting` never fired and the conversation
+ * machine sat in `piThinking` forever.
+ *
+ * The stream must instead track the element's rendered text and complete on a
+ * stability timeout. `streamTimeout` keeps the test fast.
+ *
+ * Confirmed fail-first: against the pre-fix PiTextStream this never emits and
+ * never completes, so `promise` never resolves and the test times out.
+ */
+test(
+  "PiTextStream emits and completes for pi.ai's hidden-span stream with no text-node replacement (live model)",
+  async () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    const stream = new PiTextStream(element, { streamTimeout: 150 });
+    const values: string[] = [];
+    const promise = collectStreamValues(stream, values);
+
+    // First word arrives already nested inside an added container (as on live
+    // pi.ai), the rest as standalone hidden spans — and NONE are ever replaced
+    // by bare text nodes.
+    await new Promise((r) => setTimeout(r, intervalMillis));
+    const firstChunk = document.createElement("div");
+    firstChunk.innerHTML = '<span style="opacity:0">I\'m </span>';
+    element.appendChild(firstChunk);
+    await addText(element, "here ");
+    await addText(element, "for ");
+    await addText(element, "you.");
+    // Deliberately NO finishText() — the step pi.ai dropped.
+
+    await promise; // must still complete, via the stability timeout
+    expect(values.join("")).toBe("I'm here for you.");
+  },
+  4000
 );


### PR DESCRIPTION
Fixes three pi.ai integration regressions spotted on the live composer. Each was root-caused before fixing (fail-first TDD), and verified at the lowest layer that can catch it — with two confirmed live on pi.ai.

## 1. Prompt stuck on "Pi is thinking…" after Pi already answered
**Why:** "Pi is thinking…" is SayPi's own placeholder, set on the `responding.piThinking` state and cleared on exit. `piThinking` only exits on `saypi:piWriting`/`saypi:piSpeaking`. With TTS output off, `piSpeaking` never fires, leaving `piWriting` as the only exit — and `piWriting` depends on `PiTextStream` detecting Pi's streamed text. Capturing a live pi.ai response stream showed the host **dropped the hidden-span → bare-text-node replacement step**: it still appends each word as a hidden `<span style="opacity:0">` but never swaps it for a text node, and the first chunk now arrives nested in a container. The old parser emitted only on bare-text-node additions and completed only when its hidden-span queue emptied, so against the current DOM it emitted nothing and never completed — the machine sat in `piThinking` forever.

**Fix (two layers):**
- `PiTextStream` now **snapshot-diffs the element's rendered text** on each mutation (robust to spans/divs/text-nodes and nesting) and **completes on a stability timeout** (configurable `streamTimeout`; this also survives pi.ai re-rendering the element mid-stream, which the old queue approach did not).
- `ConversationMachine` gets an `after` **timeout fallback** out of `piThinking` (mirrors `waitingForPiToStopSpeaking`) so a future detection miss can never permanently freeze the UI — defence in depth.

## 2. Active (in-call) call button almost invisible
**Why:** the intended active disc colour is grey `#776d6d` (hangup.svg), but while Pi responds the button also gets `disabled`, and the shared rule `#saypi-callButton.disabled svg path.background` (common.scss) paints the disc `bg-cream-550` = pi.ai's cream composer background → cream-on-cream. (This is also why the stuck-`piThinking` screenshot showed a near-invisible button — it was active *and* disabled.)
**Fix:** pin the in-call (active) disc to its intended grey at full opacity on pi.ai, outranking the disabled→cream rule. Segment-progress wedges still hide it via inline `fill-opacity:0`, so the transcription display is unaffected.

## 3. Prompt composer ~16px taller than native
**Why:** Pi's `getExtraCallButtonClasses()` puts Tailwind `m-2` (0.5rem all sides) on the call button. On desktop it's in-flow, so its 8px top+bottom margin makes it the tallest item in pi's `items-center` controls row and inflates the box by 16px (measured live 86px→70px; pi's own submit button has margin 0).
**Fix:** zero the call button's vertical margin, scoped to `html.desktop-view body.pi` (m-2 is Pi-only; mobile keeps its `position:fixed`/`margin:auto` centring). Horizontal spacing preserved.

## Verification
- **Layer 1‑2 (required gate):** 848 Vitest + Jest pass, including new fail-first specs — `InputStream` live-model spec (hidden spans, no text-node replacement) and a `piThinking` fallback state-machine spec.
- **Layer 3 (real build, headless Chrome):** new `pi-call-button.e2e.ts` asserts the call button's computed vertical margin is `0` and the active disc computes grey `rgb(119,109,109)` — both fail-first-proven against the real `wxt build` output. Full suite 7/7 green.
- **Layer 4 (live pi.ai, build stamp `d6e5435@fix/pi-ui-integration`):** confirmed #2 (`marginTop: 0px`) and #3 (active disc `rgb(119,109,109)`) directly via computed styles; confirmed for #1 that SayPi observes new responses (decoration fires → `PiTextStream` created) and the response markup matches the captured hidden-span shape the L1‑2 parser test covers.

## Out of scope (discovered while verifying #1)
On the live host, pi.ai **re-renders/replaces the assistant message element after streaming**, which **wipes SayPi's TTS controls** off new responses (the controls are added, then removed by pi's reconciliation). This is a separate, pre-existing issue (not touched here) and does **not** affect bug #1 — the writing events fire during streaming and the new stability-timeout completes the stream even through the re-render. Worth a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)