### PR TITLE
fix(i18n): route AudioInputMachine voice-error toasts through i18n (#310)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -621,6 +621,22 @@
       }
     }
   },
+  "errorVoiceRecordingUnavailable": {
+    "message": "Voice recording not available",
+    "description": "Error toast shown when the voice-detection (VAD) client is unavailable, so recording cannot start."
+  },
+  "errorVadInitFailed": {
+    "message": "Failed to initialize voice detection",
+    "description": "Error toast shown when voice-activity detection fails to initialize."
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "message": "Failed to set up voice recording",
+    "description": "Error toast shown when an unexpected error occurs while setting up voice recording."
+  },
+  "errorVoiceRecordingStartFailed": {
+    "message": "Failed to start voice recording",
+    "description": "Error toast shown when the voice-detection client fails to start recording."
+  },
   "submitModeControl": {
     "message": "Select when to submit your messages",
     "description": "The title (tooltip) of the control to select when messages should be submitted."

--- a/src/state-machines/AudioInputMachine.ts
+++ b/src/state-machines/AudioInputMachine.ts
@@ -318,7 +318,7 @@ async function setupRecording(completion_callback?: (success: boolean, error?: s
       const errorMsg = "VAD client not available - this should not happen";
       console.error("[AudioInputMachine]", errorMsg);
       EventBus.emit("saypi:ui:show-notification", {
-        message: "Voice recording not available",
+        message: getMessage("errorVoiceRecordingUnavailable"),
         type: "text",
         seconds: 10,
         icon: "microphone-muted",
@@ -362,7 +362,7 @@ async function setupRecording(completion_callback?: (success: boolean, error?: s
       console.error("[AudioInputMachine] VAD initialization failed:", detailedErrorMsg);
       
       // Use short error message for notification (if available), otherwise fall back to detailed
-      const notificationMessage = initResult.error ? errorMsg : "Failed to initialize voice detection";
+      const notificationMessage = initResult.error ? errorMsg : getMessage("errorVadInitFailed");
       
       EventBus.emit("saypi:ui:show-notification", {
         message: notificationMessage,
@@ -381,7 +381,7 @@ async function setupRecording(completion_callback?: (success: boolean, error?: s
     const errorMsg = error.message || "Unknown error during recording setup";
     console.error("[AudioInputMachine] Error in setupRecording:", error);
     EventBus.emit("saypi:ui:show-notification", {
-      message: "Failed to set up voice recording",
+      message: getMessage("errorVoiceRecordingSetupFailed"),
       type: "text",
       seconds: 10,
       icon: "microphone-muted",
@@ -568,7 +568,7 @@ export const audioInputMachine = createMachine<
         if (!vadClient) {
           console.error("[AudioInputMachine] VAD client not available - cannot start recording");
           EventBus.emit("saypi:ui:show-notification", {
-            message: "Voice recording not available",
+            message: getMessage("errorVoiceRecordingUnavailable"),
             type: "text",
             seconds: 10,
             icon: "microphone-muted",
@@ -582,7 +582,7 @@ export const audioInputMachine = createMachine<
         if (!result.success) {
           console.error("[AudioInputMachine] Failed to start VAD:", result.error);
           EventBus.emit("saypi:ui:show-notification", {
-            message: "Failed to start voice recording",
+            message: getMessage("errorVoiceRecordingStartFailed"),
             type: "text",
             seconds: 10,
             icon: "microphone-muted",

--- a/test/i18n-voice-input-errors.spec.ts
+++ b/test/i18n-voice-input-errors.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Regression guard for #310: five voice-input error toasts in
+ * AudioInputMachine were emitted with literal English `message:` strings
+ * instead of going through `getMessage(...)`, so they appeared untranslated in
+ * all 31 non-English locales — unlike the sibling microphone-error path in the
+ * same file, which is correctly localized.
+ *
+ * Like the #275 guard, these assert against the real source and the real en
+ * locale (not mocks), so they catch a re-introduction of a hardcoded English
+ * toast on the live voice-input failure path.
+ */
+const root = resolve(__dirname, "..");
+const en = JSON.parse(
+  readFileSync(resolve(root, "_locales/en/messages.json"), "utf8")
+);
+const audioInputSrc = readFileSync(
+  resolve(root, "src/state-machines/AudioInputMachine.ts"),
+  "utf8"
+);
+
+// The English literals that used to be passed directly as toast `message:`.
+const HARDCODED_TOAST_LITERALS = [
+  "Voice recording not available",
+  "Failed to initialize voice detection",
+  "Failed to set up voice recording",
+  "Failed to start voice recording",
+];
+
+// The en keys the five emits should now resolve through.
+const REQUIRED_KEYS = [
+  "errorVoiceRecordingUnavailable",
+  "errorVadInitFailed",
+  "errorVoiceRecordingSetupFailed",
+  "errorVoiceRecordingStartFailed",
+];
+
+describe("#310 voice-input error toasts go through i18n", () => {
+  it.each(HARDCODED_TOAST_LITERALS)(
+    "AudioInputMachine no longer emits the hardcoded toast %j",
+    (literal) => {
+      expect(audioInputSrc).not.toContain(`"${literal}"`);
+    }
+  );
+
+  it.each(REQUIRED_KEYS)("en defines %s with a non-empty message", (key) => {
+    expect(en[key]?.message).toBeTruthy();
+  });
+
+  it("every voice-input toast emit references a getMessage(...) key", () => {
+    // Each of the four keys must actually be wired into the source, otherwise
+    // we'd pass the "no literal" check by deleting the toast entirely.
+    for (const key of REQUIRED_KEYS) {
+      expect(audioInputSrc).toContain(key);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Five voice-input error toasts in `AudioInputMachine.ts` were emitted with literal English `message:` strings instead of going through `getMessage(...)`, so they appeared **untranslated in all 31 non-English locales** — while the sibling microphone-error path in the same file (`getMessage(messageKey, detail)`) is correctly localized. This surfaced partially-translated error UX at the worst moment (when voice input just failed).

### Affected emits (now routed through i18n)

| line | was (literal) | now (key) |
|------|------|------|
| 321 | `"Voice recording not available"` | `errorVoiceRecordingUnavailable` |
| 365 | `"Failed to initialize voice detection"` | `errorVadInitFailed` |
| 384 | `"Failed to set up voice recording"` | `errorVoiceRecordingSetupFailed` |
| 571 | `"Voice recording not available"` | `errorVoiceRecordingUnavailable` |
| 585 | `"Failed to start voice recording"` | `errorVoiceRecordingStartFailed` |

`getMessage` was already imported. Added four en-locale keys; the 31-locale MT pass is the separate founder-run `npm run translate` (en is `default_locale`, so non-en falls back to en — no regression). Mirrors the established #275 i18n-copy fix pattern.

## Test (fail-first, L1)

`test/i18n-voice-input-errors.spec.ts` asserts against the **real source + real en locale** (not mocks): no hardcoded toast literal remains, all four keys exist with non-empty messages, and each key is actually wired into the source (so we can't pass by deleting a toast). Confirmed RED before the fix (9/9 failing), GREEN after.

- `npm test` green (Vitest 104 files / 857 passed / 1 skipped; Jest 2/2)
- `node tools/i18n/i18n-validate.cjs` clean

## Provenance

Found via the adversarial pi.ai-integration code audit (the Layer-4 session that produced #306/#307/#308). Clean, low-risk, en-only copy change.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)