### PR TITLE
fix(i18n): add three missing AudioInputMachine error keys (#318)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -637,6 +637,24 @@
     "message": "Failed to start voice recording",
     "description": "Error toast shown when the voice-detection client fails to start recording."
   },
+  "webAssemblyMemoryUnavailable": {
+    "message": "Voice detection can't start: WebAssembly memory is unavailable in this browser.",
+    "description": "Error thrown when the browser does not expose initial WebAssembly memory needed to run the voice-detection model."
+  },
+  "webAssemblyInsufficientMemory": {
+    "message": "Voice detection can't start: not enough WebAssembly memory for the voice model. $detail$",
+    "description": "Error thrown when the browser cannot allocate enough WebAssembly memory for the voice-detection model.",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "microphonePermissionDeniedError": {
+    "message": "Microphone permission was not granted. Please ensure you've allowed access in the prompt and in extension settings.",
+    "description": "Error toast shown when microphone permission was denied after the permission prompt flow."
+  },
   "submitModeControl": {
     "message": "Select when to submit your messages",
     "description": "The title (tooltip) of the control to select when messages should be submitted."

--- a/src/state-machines/AudioInputMachine.ts
+++ b/src/state-machines/AudioInputMachine.ts
@@ -335,7 +335,7 @@ async function setupRecording(completion_callback?: (success: boolean, error?: s
       const permissionGranted = await checkAndRequestMicrophonePermissionViaBackground();
 
       if (!permissionGranted) {
-        const errorMsg = getMessage("microphonePermissionDeniedError") || "Microphone permission was not granted. Please ensure you've allowed access in the prompt and in extension settings.";
+        const errorMsg = getMessage("microphonePermissionDeniedError");
         console.error("[AudioInputMachine] Microphone permission not granted after prompt flow.");
         EventBus.emit("saypi:ui:show-notification", {
           message: errorMsg,

--- a/test/i18n-audio-input-keys.spec.ts
+++ b/test/i18n-audio-input-keys.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Regression guard for #318: three keys referenced via getMessage(...) in
+ * AudioInputMachine had no entry in _locales/en/messages.json, so
+ * chrome.i18n.getMessage returned "" — producing `throw new Error("")` for the
+ * two WebAssembly checks and an English-only `|| fallback` for the mic
+ * permission error.
+ *
+ * Rather than enumerate just those three, this scans EVERY string-literal
+ * getMessage("…") key referenced in the file and asserts each one is defined in
+ * the en locale. That catches this whole class of dangling-key bug for this
+ * file going forward (including the #310 keys).
+ */
+const root = resolve(__dirname, "..");
+const en = JSON.parse(
+  readFileSync(resolve(root, "_locales/en/messages.json"), "utf8")
+);
+const src = readFileSync(
+  resolve(root, "src/state-machines/AudioInputMachine.ts"),
+  "utf8"
+);
+
+// Collect getMessage("literal" …) keys (ignore dynamic getMessage(variable) calls).
+const referencedKeys = Array.from(
+  src.matchAll(/getMessage\(\s*["'`]([A-Za-z0-9_]+)["'`]/g),
+  (m) => m[1]
+);
+const uniqueKeys = [...new Set(referencedKeys)];
+
+describe("#318 AudioInputMachine getMessage keys all exist in en locale", () => {
+  it("found getMessage(...) literal keys to check", () => {
+    expect(uniqueKeys.length).toBeGreaterThan(0);
+  });
+
+  it.each(["webAssemblyMemoryUnavailable", "webAssemblyInsufficientMemory", "microphonePermissionDeniedError"])(
+    "the previously-missing key %s now exists in en",
+    (key) => {
+      expect(en[key]?.message).toBeTruthy();
+    }
+  );
+
+  it("every literal getMessage key referenced in AudioInputMachine exists in en", () => {
+    const missing = uniqueKeys.filter((k) => !en[k]?.message);
+    expect(missing).toEqual([]);
+  });
+
+  it("webAssemblyInsufficientMemory carries the detail placeholder it is called with", () => {
+    // Called as getMessage("webAssemblyInsufficientMemory", `Required: …, Available: …`)
+    expect(en.webAssemblyInsufficientMemory?.placeholders).toBeTruthy();
+    expect(en.webAssemblyInsufficientMemory.message).toMatch(/\$\w+\$/);
+  });
+});


### PR DESCRIPTION
## Summary

Three `getMessage(...)` calls in `src/state-machines/AudioInputMachine.ts` referenced keys that **don't exist** in any `_locales/*/messages.json`. `chrome.i18n.getMessage` returns `""` for an unknown key, so:

| line | call | symptom on `main` |
|------|------|------|
| 240 | `throw new Error(getMessage("webAssemblyMemoryUnavailable"))` | **`Error("")`** — empty message |
| 244 | `throw new Error(getMessage("webAssemblyInsufficientMemory", "Required: …, Available: …"))` | **`Error("")`** — and the Required/Available detail was discarded |
| 338 | `getMessage("microphonePermissionDeniedError") \|\| "…English…"` | always fell back to hardcoded English (never localized) |

## Fix

Adds the three en keys. `webAssemblyInsufficientMemory` carries a `$detail$` placeholder so the `Required/Available` substitution is preserved. Drops the now-redundant English `||` literal at the permission site. en-only; the 31-locale MT pass is the founder-run `npm run translate` (mirrors #310/#275).

## Test (fail-first, L1)

`test/i18n-audio-input-keys.spec.ts` scans **every** string-literal `getMessage("…")` key in `AudioInputMachine.ts` and asserts each is defined in the en locale — so it guards this whole dangling-key class for the file (the #310 keys included), not just these three. Confirmed RED before the fix (5/6 failing), GREEN after.

- `npm test` green (Vitest 105 files / 863 passed / 1 skipped; Jest 2/2)
- `node tools/i18n/i18n-validate.cjs` clean (validates the new `$detail$` placeholder)

## Provenance

Surfaced by the independent reviewer of #316 (PR for #310) while confirming the voice-error toast keys. Pre-existing on `main`. The issue also suggests a stronger repo-wide guard (extend `i18n-validate.cjs` to flag any dangling literal `getMessage` key) — left as a follow-up in #318.

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)