### PR TITLE
fix(pi): decorate the most-recent assistant message on thread load (#309)

### DIFF
--- a/src/chatbots/Pi.ts
+++ b/src/chatbots/Pi.ts
@@ -115,11 +115,19 @@ class PiAIChatbot extends AbstractChatbot {
   }
 
   getPastChatHistorySelector(): string {
-    return "#saypi-chat-history :nth-child(2)"; // second child of the chat history container
+    // Direct-child combinator (`>`): the 2nd DIRECT child of the chat history
+    // container. Without `>`, the descendant combinator matches the first nested
+    // 2nd-child anywhere (e.g. an icon SVG element), not the container (#309).
+    return "#saypi-chat-history > :nth-child(2)";
   }
 
   getRecentChatHistorySelector(): string {
-    return "#saypi-chat-history :nth-child(3)"; // third child of the chat history container
+    // Direct-child combinator (`>`): the 3rd DIRECT child (the present/recent
+    // container holding the most-recent turn). The old descendant form
+    // ("#saypi-chat-history :nth-child(3)") matched an action-bar icon's
+    // <circle> SVG instead, so the recent container was never observed and the
+    // most-recent message went undecorated (#309).
+    return "#saypi-chat-history > :nth-child(3)";
   }
 
   getDiscoveryPanelSelector(): string {

--- a/test/chatbots/Pi-ChatHistorySelectors.spec.ts
+++ b/test/chatbots/Pi-ChatHistorySelectors.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { PiAIChatbot } from "../../src/chatbots/Pi";
+
+/**
+ * Regression guard for #309: the most-recent Pi assistant message never gets
+ * SayPi's TTS/copy controls on thread load.
+ *
+ * Root cause (confirmed on the live pi.ai DOM): pi.ai splits the chat history
+ * under #saypi-chat-history into direct children — a spacer (1st), the
+ * "past-messages" container (2nd), and the "present/recent" container (3rd)
+ * which holds the most-recent turn. getPastChatHistorySelector /
+ * getRecentChatHistorySelector were written with the DESCENDANT combinator
+ * ("#saypi-chat-history :nth-child(3)"), so querySelector returns the first
+ * DEEPLY-NESTED 3rd-child in document order — an action-bar icon's <circle> SVG
+ * inside an earlier message — instead of the 3rd DIRECT child. The present
+ * container is therefore never tagged/observed, and its (most-recent) message
+ * is left undecorated. (:nth-child(2) happened to resolve correctly by
+ * document-order luck; :nth-child(3) did not.)
+ *
+ * The selectors are documented as "second/third child of the chat history
+ * container", so the fix is the direct-child combinator ">".
+ *
+ * This test reconstructs the failing shape — including the SVG <circle> decoy
+ * that is a 3rd-child and precedes the present container in document order — and
+ * asserts the selectors resolve to the intended DIRECT-child containers.
+ */
+describe("Pi chat-history past/recent selectors (#309)", () => {
+  let chatbot: PiAIChatbot;
+  let chatHistory: HTMLElement;
+  let pastContainer: HTMLElement;
+  let presentContainer: HTMLElement;
+
+  const addAssistantMessageWithIconDecoy = (parent: HTMLElement) => {
+    // div.break-anywhere assistant message with an action bar whose icon SVG has
+    // a <circle> as its 3rd child — the exact decoy that hijacks a descendant
+    // ":nth-child(3)" match on the live site.
+    const msg = document.createElement("div");
+    msg.className = "break-anywhere";
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "path"));
+    svg.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "path"));
+    svg.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "circle")); // 3rd child
+    msg.appendChild(svg);
+    parent.appendChild(msg);
+    return msg;
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    chatbot = new PiAIChatbot();
+
+    chatHistory = document.createElement("div");
+    chatHistory.id = "saypi-chat-history";
+
+    // 1st child: a thin spacer (matches the live "relative shrink-0 h-1 z-30").
+    const spacer = document.createElement("div");
+    spacer.className = "relative shrink-0 h-1 z-30";
+    chatHistory.appendChild(spacer);
+
+    // 2nd child: past-messages container, with a message carrying the SVG decoy.
+    pastContainer = document.createElement("div");
+    pastContainer.className = "space-y-6";
+    addAssistantMessageWithIconDecoy(pastContainer);
+    chatHistory.appendChild(pastContainer);
+
+    // 3rd child: present/recent container, holding the most-recent message.
+    presentContainer = document.createElement("div");
+    presentContainer.className = "pb-6 lg:pb-8";
+    const recentMsg = document.createElement("div");
+    recentMsg.className = "break-anywhere";
+    presentContainer.appendChild(recentMsg);
+    chatHistory.appendChild(presentContainer);
+
+    document.body.appendChild(chatHistory);
+  });
+
+  it("getRecentChatHistorySelector resolves to the 3rd DIRECT child (present container), not a nested SVG", () => {
+    const recent = document.querySelector(chatbot.getRecentChatHistorySelector());
+    expect(recent).toBe(presentContainer);
+    // Guard against the descendant-combinator regression specifically.
+    expect(recent?.tagName.toLowerCase()).toBe("div");
+    expect(recent?.tagName.toLowerCase()).not.toBe("circle");
+  });
+
+  it("getPastChatHistorySelector resolves to the 2nd DIRECT child (past container)", () => {
+    const past = document.querySelector(chatbot.getPastChatHistorySelector());
+    expect(past).toBe(pastContainer);
+    expect(past?.tagName.toLowerCase()).toBe("div");
+  });
+
+  it("the present container actually holds the most-recent assistant message", () => {
+    // The behavioural point of #309: the message the observer must decorate
+    // lives in the container the recent-selector resolves to.
+    const recent = document.querySelector(
+      chatbot.getRecentChatHistorySelector()
+    ) as HTMLElement | null;
+    expect(recent).not.toBeNull();
+    expect(
+      recent!.querySelectorAll("div.break-anywhere:not(.justify-end)").length
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

On thread load, every Pi assistant message got SayPi's TTS/copy controls **except the most-recent one** — the message a user is most likely to want to copy or replay.

## Root cause (confirmed on the live pi.ai DOM)

pi.ai lays the chat history out as **direct children** of `#saypi-chat-history`:
1. a thin spacer (`relative shrink-0 h-1 z-30`)
2. the **past-messages** container (`space-y-6 …`) — holds the older turns
3. the **present/recent** container (`pb-6 lg:pb-8 …`) — holds the latest turn

`getPastChatHistorySelector` / `getRecentChatHistorySelector` used the **descendant** combinator (`#saypi-chat-history :nth-child(3)`), so `querySelector` returned the first deeply-nested 3rd-child in document order — an action-bar icon's `<circle>` SVG inside an earlier message — instead of the 3rd **direct** child. Live probe:

```
#saypi-chat-history :nth-child(3)    → <circle> (0 messages)   ❌
#saypi-chat-history > :nth-child(3)  → present container (1 msg) ✅
```

So the present container was never tagged `.chat-history present-messages` nor observed by `registerPresentChatHistoryListener`, and its (most-recent) message was never decorated. `:nth-child(2)` resolved correctly only by document-order luck; `:nth-child(3)` hit the SVG decoy.

Live evidence (an existing thread): 4 past messages all decorated (`hasTts:true`, `container:1`); the 1 most-recent message undecorated (`hasTts:false`, `isAssistantMsg:false`, `container:2`).

## Fix

Use the **direct-child combinator `>`** for both selectors — matching their own documented intent ("second/third child of the chat history container"). Minimal, Pi-only (Claude/ChatGPT use the whole container, unaffected).

## Test (fail-first, L2 contract)

`test/chatbots/Pi-ChatHistorySelectors.spec.ts` reconstructs the failing shape — spacer + past container (with a message carrying an SVG `<circle>` 3rd-child decoy) + present container — and asserts both selectors resolve to the intended **direct-child** containers (and the recent one isn't a `<circle>`). Confirmed RED before the fix (recent-selector matched the circle; past passed by luck — mirroring live), GREEN after.

- `npm test` green (Vitest 107 files / 868 passed / 1 skipped; Jest 2/2); existing `test/dom/ChatHistoryObserver.spec.ts` still green.

## Provenance

Root-caused this session against the live pi.ai DOM (founder handed over the browser) after #309 was filed as un-pinned. The earlier-suspected re-render/timing hypotheses were ruled out — it's a structural selector bug.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)