### PR TITLE
fix(pi): reactively decorate the present-messages container (#309)

### DIFF
--- a/src/dom/ChatHistory.ts
+++ b/src/dom/ChatHistory.ts
@@ -45,6 +45,8 @@ type Observer = {
 class ChatHistoryRootElementObserver extends BaseObserver {
   speechSynthesis: SpeechSynthesisModule;
   oldMessageObserver: ChatHistoryOldMessageObserver | null = null;
+  recentMessageObserver: ChatHistoryOldMessageObserver | null = null;
+  private decoratedRecentContainer: Element | null = null;
   /* This class adds an id to the 2nd child of the element under observeration, whenever children are added to the element */
   constructor(
     private chatHistoryElement: HTMLElement,
@@ -108,6 +110,69 @@ class ChatHistoryRootElementObserver extends BaseObserver {
     }
   }
 
+  /**
+   * Ensure the most-recent / present-messages container is decorated and observed.
+   *
+   * Unlike the past container (which, once it becomes a direct child, keeps its
+   * slot), pi.ai mounts/repositions the present container AFTER the chat history
+   * is first decorated — and it transiently passes through the 2nd-child slot. The
+   * one-shot present setup in ChatHistorySpeechManager.registerPresentChatHistoryListener
+   * therefore resolves nothing at construction time and dies silently (its
+   * BaseObserver target is null), so the most-recent assistant message never gets
+   * its TTS/copy controls on thread load (#309).
+   *
+   * This re-resolves the recent container on every chat-history mutation and sets
+   * it up idempotently when it appears (or is replaced), symmetric with how the
+   * past container is handled reactively. No-op for chatbots whose recent selector
+   * is the whole chat-history element (Claude/ChatGPT), which decorate through the
+   * past path.
+   */
+  private ensureRecentMessages(): void {
+    const recentSelector = this.chatbot.getRecentChatHistorySelector();
+    if (!recentSelector) return;
+
+    const rootAncestor = findRootAncestor(this.chatHistoryElement);
+    let recentContainer: Element | null = null;
+    try {
+      recentContainer = rootAncestor.querySelector(recentSelector);
+    } catch (e) {
+      // Tolerate selector-invalid host classes (same defensiveness as BaseObserver).
+      return;
+    }
+    if (!recentContainer) return;
+    // Claude/ChatGPT: the recent selector resolves to the whole chat-history
+    // element, which is already handled via the past path — nothing to do here.
+    if (recentContainer === this.chatHistoryElement) return;
+    // Already set up for this exact element.
+    if (recentContainer === this.decoratedRecentContainer) return;
+
+    this.decoratedRecentContainer = recentContainer;
+    // The present container can transiently pass through the past slot and pick up
+    // a stray `past-messages` class; clear it so the two observers stay distinct.
+    recentContainer.classList.remove("past-messages");
+    recentContainer.classList.add("chat-history", "present-messages");
+    if (this.recentMessageObserver) {
+      this.recentMessageObserver.disconnect();
+    }
+    this.recentMessageObserver = new ChatHistoryOldMessageObserver(
+      this.chatHistoryElement,
+      `${recentContainer.tagName.toLowerCase()}.chat-history.present-messages`,
+      this.speechSynthesis,
+      this.chatbot
+    );
+    this.recentMessageObserver
+      .runOnce(recentContainer)
+      .then((messages) => {
+        if (messages.length > 0) {
+          logger.debug(`Found ${messages.length} recent assistant message(s)`);
+        }
+      });
+    this.recentMessageObserver.observe({
+      childList: true,
+      subtree: false,
+    });
+  }
+
   public async runOnce(): Promise<void> {
     // run once on the direct children of the root element
     for (const node of [...this.chatHistoryElement.children]) {
@@ -116,6 +181,7 @@ class ChatHistoryRootElementObserver extends BaseObserver {
         this.handleChatHistoryChild(child);
       }
     }
+    this.ensureRecentMessages();
   }
 
   protected async callback(mutations: MutationRecord[]): Promise<void> {
@@ -127,6 +193,14 @@ class ChatHistoryRootElementObserver extends BaseObserver {
         }
       }
     }
+    this.ensureRecentMessages();
+  }
+
+  public disconnect(): void {
+    super.disconnect();
+    // Also release the per-container child observers this root observer owns.
+    this.oldMessageObserver?.disconnect();
+    this.recentMessageObserver?.disconnect();
   }
 }
 

--- a/test/dom/ChatHistoryObserver.spec.ts
+++ b/test/dom/ChatHistoryObserver.spec.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SpeechSynthesisModule } from "../../src/tts/SpeechSynthesisModule";
 import { TTSControlsModule } from "../../src/tts/TTSControlsModule";
-import { ChatHistoryMessageObserver } from "../../src/dom/ChatHistory";
+import {
+  ChatHistoryMessageObserver,
+  RootChatHistoryObserver,
+} from "../../src/dom/ChatHistory";
 import { JSDOM } from "jsdom";
 import { UserPreferenceModule } from "../../src/prefs/PreferenceModule";
 import { UserPreferenceModuleMock } from "../prefs/PreferenceModule.mock";
@@ -235,6 +238,78 @@ describe("ChatHistoryMessageObserver", () => {
           assistantResponseSelector
         );
       expect(withoutJustifyEnd.found).toBe(true); // should match without "justify-end"
+    });
+  });
+
+  describe("recent/present container reactive decoration (#309)", () => {
+    // Reproduces the live pi.ai thread-load layout: #saypi-chat-history has a
+    // spacer (1st child), a past-messages container (2nd), and a present/recent
+    // container (3rd) holding the most-recent turn. On a real thread the present
+    // container mounts AFTER the chat history is decorated, so the one-shot present
+    // setup misses it and the most-recent message is left undecorated. The
+    // RootChatHistoryObserver must pick it up reactively.
+    let saypiChatHistory: HTMLElement;
+    let chatbot: PiAIChatbot;
+    let observer: RootChatHistoryObserver;
+
+    beforeEach(() => {
+      chatbot = new PiAIChatbot();
+      saypiChatHistory = document.createElement("div");
+      saypiChatHistory.id = "saypi-chat-history";
+      saypiChatHistory.classList.add("chat-history");
+      document.body.appendChild(saypiChatHistory);
+    });
+
+    afterEach(() => {
+      observer?.disconnect();
+      saypiChatHistory?.remove();
+    });
+
+    it("decorates the most-recent message when the present container appears after the observer attaches", async () => {
+      // Keep the test focused on decoration: a non-SayPi provider skips the
+      // incomplete-speech branch (which reaches the real UserPreferenceModule
+      // singleton, unrelated to this behaviour) — same approach as the TTS
+      // resilience tests below.
+      vi.spyOn(speechSynthesisModule, "getActiveAudioProvider").mockResolvedValue(
+        audioProviders.None
+      );
+
+      observer = new RootChatHistoryObserver(
+        saypiChatHistory,
+        "#saypi-chat-history",
+        speechSynthesisModule,
+        chatbot,
+        false // don't auto-run; we drive the mutation sequence explicitly
+      );
+      observer.observe({ childList: true, subtree: false });
+
+      // Mount sequence AFTER observe() — mirrors pi.ai's deferred layout.
+      const spacer = document.createElement("div");
+      spacer.className = "relative shrink-0 h-1 z-30";
+      saypiChatHistory.appendChild(spacer);
+
+      const pastContainer = document.createElement("div");
+      pastContainer.className = "space-y-6";
+      pastContainer.appendChild(createAssistantMessage("an older message"));
+      saypiChatHistory.appendChild(pastContainer);
+
+      const presentContainer = document.createElement("div");
+      presentContainer.className = "pb-6 lg:pb-8";
+      const recentMessage = createAssistantMessage("the most recent message");
+      presentContainer.appendChild(recentMessage);
+      saypiChatHistory.appendChild(presentContainer);
+
+      // Allow the MutationObserver callbacks + async decoration to settle.
+      await new Promise((r) => setTimeout(r, 50));
+
+      // The most-recent message (in the present container) must be decorated.
+      expect(recentMessage.classList.contains("assistant-message")).toBe(true);
+      // And the past message must still be decorated (no regression to the past path).
+      expect(
+        pastContainer
+          .querySelector("div.break-anywhere")
+          ?.classList.contains("assistant-message")
+      ).toBe(true);
     });
   });
 

--- a/test/vitest.setup.js
+++ b/test/vitest.setup.js
@@ -29,6 +29,7 @@ Object.defineProperties(global, {
   MutationObserver: { value: dom.window.MutationObserver },
   Node: { value: dom.window.Node },
   NodeList: { value: dom.window.NodeList },
+  Document: { value: dom.window.Document },
   Element: { value: dom.window.Element },
   HTMLElement: { value: dom.window.HTMLElement },
   HTMLInputElement: { value: dom.window.HTMLInputElement },


### PR DESCRIPTION
## Summary

Follow-on to #322. The selector fix there was **necessary but not sufficient** — the most-recent Pi assistant message was still undecorated on thread load (confirmed live on pi.ai with the built `#322` extension). This fixes the deeper, structural cause.

## Root cause (confirmed live)

`ChatHistorySpeechManager` handled the two history containers **asymmetrically**:
- The **past** container is decorated **reactively**: `RootChatHistoryObserver` observes `#saypi-chat-history` — a stable, always-resolvable target — and sets up the past container whenever it appears on a child mutation.
- The **present** container was set up **once** in the constructor (`registerPresentChatHistoryListener`), keyed on `.chat-history.present-messages`.

On a real thread, pi.ai mounts/repositions the present container **after** the chat history is first decorated (it even transiently passes through the 2nd-child slot, picking up a stray `past-messages` class). So `.chat-history.present-messages` doesn't exist at construction time. `BaseObserver` resolves its observe target **once** at construction; with the selector unresolved the target is `null` and `observe()` is a silent no-op — **the present observer never watches anything**, so the most-recent message never gets its controls.

Live experiments that pinned it (on the `#322` build):
- Manually tagging the present container `present-messages` → no decoration (nothing was waiting for it).
- Appending a fresh assistant node to the **past** container → decorated; to the **present** container → **not** decorated (no observer there).

## Fix

Make `RootChatHistoryObserver` also resolve and set up the recent/present container **reactively** (`ensureRecentMessages`), symmetric with the past container:
- Re-resolves the recent container on every chat-history mutation; sets it up idempotently when it appears or is replaced (robust to late appearance / repositioning).
- Clears the stray `past-messages` class off it.
- No-op for chatbots whose recent selector is the whole chat-history element (Claude/ChatGPT, decorated via the past path).
- Also disconnects both child observers on teardown (the existing `oldMessageObserver` leaked too).

The one-shot `registerPresentChatHistoryListener` is left as-is (harmless when its target is null; still drives live streaming on a fresh chat where the present container exists at construction time).

## Test (fail-first, L2)

`test/dom/ChatHistoryObserver.spec.ts` drives the **real** `RootChatHistoryObserver` through pi.ai's deferred mount sequence (spacer → past container → present container appearing **after** `observe()`) and asserts the most-recent message is decorated (and the past one still is). Confirmed RED before the fix (`expected false to be true`), GREEN after.

**Test-infra fix:** added the `Document` global to `test/vitest.setup.js` — `findRootAncestor` uses `instanceof Document`, and the setup defined `Element`/`HTMLElement` but not `Document`.

- `npm test` green (Vitest 107 files / 869 passed / 1 skipped; Jest 2/2).
- Will live-verify on pi.ai after merge (rebuild + reload) and report.

## Provenance

Root-caused live this session (founder handed over the browser) after #322 merged but the symptom persisted. Supersedes the "needs L3 mock" note on #309 — the defect is reproducible at L2 because it lives in the MutationObserver-driven observer coordination (JSDOM has MutationObserver).

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)