### PR TITLE
fix(pi): observe present container subtree so SPA thread switches decorate (#309)

### DIFF
--- a/src/dom/ChatHistory.ts
+++ b/src/dom/ChatHistory.ts
@@ -167,9 +167,17 @@ class ChatHistoryRootElementObserver extends BaseObserver {
           logger.debug(`Found ${messages.length} recent assistant message(s)`);
         }
       });
+    // subtree:true is required for SPA thread-switching: pi.ai REUSES the present
+    // container element across threads (so the `decoratedRecentContainer` guard
+    // above skips a re-`runOnce`) and swaps the new thread's message in nested
+    // several levels deep. A direct-children-only (subtree:false) observer misses
+    // that deep content swap, leaving the most-recent message undecorated after an
+    // in-app navigation (it only worked on a full page load, where the container is
+    // a fresh element and `runOnce` fires). Decoration is idempotent, so the extra
+    // mutation traffic during streaming is a cheap no-op once a message is decorated.
     this.recentMessageObserver.observe({
       childList: true,
-      subtree: false,
+      subtree: true,
     });
   }
 

--- a/test/dom/ChatHistoryObserver.spec.ts
+++ b/test/dom/ChatHistoryObserver.spec.ts
@@ -311,6 +311,53 @@ describe("ChatHistoryMessageObserver", () => {
           ?.classList.contains("assistant-message")
       ).toBe(true);
     });
+
+    it("decorates a message swapped deep into a REUSED present container (SPA thread switch)", async () => {
+      vi.spyOn(speechSynthesisModule, "getActiveAudioProvider").mockResolvedValue(
+        audioProviders.None
+      );
+
+      observer = new RootChatHistoryObserver(
+        saypiChatHistory,
+        "#saypi-chat-history",
+        speechSynthesisModule,
+        chatbot,
+        false
+      );
+      observer.observe({ childList: true, subtree: false });
+
+      // Initial layout from a prior thread: the present container already exists
+      // (and is set up) with an inner wrapper, but no current-turn message yet.
+      const spacer = document.createElement("div");
+      spacer.className = "relative shrink-0 h-1 z-30";
+      saypiChatHistory.appendChild(spacer);
+
+      const pastContainer = document.createElement("div");
+      pastContainer.className = "space-y-6";
+      saypiChatHistory.appendChild(pastContainer);
+
+      const presentContainer = document.createElement("div");
+      presentContainer.className = "pb-6 lg:pb-8";
+      const innerWrapper = document.createElement("div"); // persists across SPA nav
+      innerWrapper.className = "space-y-6";
+      presentContainer.appendChild(innerWrapper);
+      saypiChatHistory.appendChild(presentContainer);
+
+      // Let ensureRecentMessages set up the recent observer on presentContainer.
+      await new Promise((r) => setTimeout(r, 30));
+
+      // SPA navigation to another thread: pi.ai REUSES the same presentContainer
+      // (so a re-runOnce is skipped) and swaps the new thread's most-recent message
+      // in NESTED inside the existing wrapper — i.e. the mutation target is the
+      // wrapper, not a direct child of presentContainer. A subtree:false observer
+      // never sees it.
+      const recentMessage = createAssistantMessage("most recent after SPA nav");
+      innerWrapper.appendChild(recentMessage);
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(recentMessage.classList.contains("assistant-message")).toBe(true);
+    });
   });
 
   describe("resilience to TTS failures (#268 / #241)", () => {


### PR DESCRIPTION
## Summary

Follow-up to #322/#323. Live re-verify (founder reloaded the `#323` build) showed the most-recent message is decorated on a **full page load** but **not** when switching threads via in-app **SPA navigation** (clicking a thread in the sidebar) — the common way users open a thread.

## Root cause (confirmed live)

On SPA navigation, pi.ai **reuses** the present container element across threads (it retains its `present-messages` class), so `ensureRecentMessages`'s `decoratedRecentContainer` guard correctly skips a re-`runOnce`. But the new thread's message is swapped in **nested several levels deep** inside the reused container (`present > … > div.space-y-6 > message`, observed at depth 4). `recentMessageObserver` was observing `{childList:true, subtree:false}`, so the deep swap — whose mutation target is an inner wrapper, not a direct child of the present container — was never seen.

Full page load worked only because the container is a fresh element there → `runOnce` fires and decorates synchronously.

Live evidence on the same thread:
- Full reload → most-recent decorated ✓
- SPA nav (sidebar click) → most-recent **undecorated** ✗ (present container reused, `present-messages` class retained, message at depth 4)

## Fix

Observe `subtree:true` on the recent container. This catches the deep content swap on SPA navigation while the existing `decoratedRecentContainer` guard still handles container *replacement* (re-setup + `runOnce`). Decoration is idempotent (`Observation.isNew && !decorated`), so the extra mutation traffic during streaming is a cheap no-op once a message is decorated. (This is the `subtree:false` nit the #323 reviewer flagged — now load-bearing for the SPA-nav case.)

## Test (fail-first, L2)

`test/dom/ChatHistoryObserver.spec.ts` adds a case: a message appended **into an existing nested wrapper** of an already-set-up (reused) present container must be decorated. Confirmed RED with `subtree:false` (`expected false to be true`), GREEN with `subtree:true`. The existing page-load case still passes.

- `npm test` green (Vitest 107 files / 870 passed / 1 skipped; Jest 2/2).
- Will live-verify SPA navigation on pi.ai after merge.

## Provenance

Found by live re-verification this session after #323 merged — full-load worked but SPA thread-switching still missed the most-recent message.

Refs #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)