### PR TITLE
fix(telemetry): only show the telemetry button after a voice turn records metrics

### DIFF
--- a/e2e/specs/telemetry-gate.e2e.ts
+++ b/e2e/specs/telemetry-gate.e2e.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "../fixtures/extension";
+
+/**
+ * Layer 3 guard (real built CSS): the telemetry button must NOT appear on the
+ * most-recent message unless that message recorded voice-turn metrics — i.e. it
+ * carries the `.has-telemetry` marker (set by MessageControls when a real
+ * `telemetry:updated` arrives). A non-call response (e.g. the greeting on a new
+ * chat) never gets the marker, so its telemetry button stays hidden — which also
+ * removes the awkward far-right positioning on the sparse greeting action bar.
+ *
+ * Pre-fix the show rule was `.present-messages .assistant-message:last-of-type
+ * .saypi-telemetry-button:has(svg) { display:flex }` — no marker required — so a
+ * last-of-type greeting showed it.
+ */
+test("telemetry button is hidden on the last message until it has recorded metrics (real build)", async ({
+  context,
+}) => {
+  const page = await context.newPage();
+  await page.goto("https://pi.ai/talk", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => document.body.classList.contains("pi"), {
+    timeout: 20_000,
+  });
+
+  const result = await page.evaluate(() => {
+    // The telemetry button CSS is scoped under html.desktop-view (SayPi adds this
+    // on desktop; the mock host doesn't), so recreate it as pi-call-button.e2e does.
+    document.documentElement.classList.add("desktop-view");
+
+    // Build the real telemetry context: a present-messages container whose
+    // last-of-type assistant message carries SayPi's controls + telemetry button.
+    const history = document.createElement("div");
+    history.className = "chat-history present-messages";
+    const msg = document.createElement("div");
+    msg.className = "assistant-message break-anywhere"; // last-of-type assistant message
+    const bar = document.createElement("div");
+    bar.className = "message-action-bar";
+    const ctrls = document.createElement("div");
+    ctrls.className = "saypi-tts-controls";
+    const tel = document.createElement("button");
+    tel.className = "saypi-telemetry-button";
+    tel.innerHTML = '<svg viewBox="0 0 768 768"><path d="M384 96 L384 384"></path></svg>';
+    ctrls.appendChild(tel);
+    bar.appendChild(ctrls);
+    msg.appendChild(bar);
+    history.appendChild(msg);
+    document.body.appendChild(history);
+
+    // Without recorded metrics (no marker) — must be hidden.
+    const hiddenDisplay = getComputedStyle(tel).display;
+
+    // Once a voice turn records metrics, MessageControls marks the message; the
+    // button then shows.
+    msg.classList.add("has-telemetry");
+    const shownDisplay = getComputedStyle(tel).display;
+
+    return { hiddenDisplay, shownDisplay };
+  });
+
+  expect(
+    result.hiddenDisplay,
+    `telemetry button must be hidden on a non-call response (was ${result.hiddenDisplay})`
+  ).toBe("none");
+  expect(
+    result.shownDisplay,
+    "telemetry button must show once the message has recorded metrics"
+  ).toBe("flex");
+});

--- a/src/TelemetryModule.ts
+++ b/src/TelemetryModule.ts
@@ -40,6 +40,42 @@ export interface TelemetryData {
 }
 
 /**
+ * Whether a voice turn has actually recorded performance metrics worth showing.
+ *
+ * The empty/initial telemetry — and the reset emitted at the very start of a turn
+ * (`speechStart` only) — does NOT count: there's nothing to visualise yet. A
+ * non-call response (e.g. the greeting on a new-chat page) never progresses past
+ * that, so it must not surface a telemetry button. We treat the turn as having
+ * recorded metrics once any duration metric is set, or any timestamp beyond the
+ * initial speech-start milestone exists.
+ */
+export function hasRecordedTelemetry(data: TelemetryData | null | undefined): boolean {
+  if (!data) return false;
+  if (
+    data.gracePeriod != null ||
+    data.transcriptionTime != null ||
+    data.transcriptionDelay != null ||
+    data.promptSubmission != null ||
+    data.completionResponse != null ||
+    data.streamingDuration != null ||
+    data.timeToTalk != null
+  ) {
+    return true;
+  }
+  const ts = data.timestamps || {};
+  // `speechStart` alone marks turn-start/reset; require a later milestone.
+  return !!(
+    ts.speechEnd ||
+    ts.transcriptionStart ||
+    ts.transcriptionEnd ||
+    ts.promptSubmission ||
+    ts.completionStart ||
+    ts.completionEnd ||
+    ts.audioPlaybackStart
+  );
+}
+
+/**
  * Module for collecting and storing performance telemetry data
  * Simplified to only track one message at a time (the current/most recent one)
  */

--- a/src/dom/MessageElements.ts
+++ b/src/dom/MessageElements.ts
@@ -17,7 +17,7 @@ import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { SpeechHistoryModule } from "../tts/SpeechHistoryModule";
 import { regenerateSpeech } from "./regenerateSpeech";
 import { MessageState } from "../tts/MessageHistoryModule";
-import telemetryModule, { TelemetryData } from "../TelemetryModule";
+import telemetryModule, { TelemetryData, hasRecordedTelemetry } from "../TelemetryModule";
 import { IconModule } from "../icons/IconModule";
 import { FailedSpeechUtterance } from "../tts/FailedSpeechUtterance";
 import { config } from "../ConfigModule";
@@ -933,6 +933,15 @@ abstract class MessageControls {
    * Handle telemetry updates from the TelemetryModule
    */
   private handleTelemetryUpdate = (event: { data: TelemetryData }): void => {
+    // Only reveal the telemetry button once a voice turn has actually recorded
+    // metrics for this (last) message. A non-call response — e.g. the greeting on
+    // a new-chat page — never emits a telemetry update with real data, so it never
+    // gets `has-telemetry` and its button stays hidden (the CSS show rule for the
+    // telemetry button requires `.assistant-message.has-telemetry`).
+    if (hasRecordedTelemetry(event.data)) {
+      this.safeAddClass("has-telemetry");
+    }
+
     // Update visualization if it's currently shown
     const container = this.message.element.querySelector(".saypi-telemetry-container") as HTMLElement;
     if (container && container.style.display !== "none") {

--- a/src/styles/messages.scss
+++ b/src/styles/messages.scss
@@ -89,6 +89,9 @@
 // `.has-telemetry` marker, set in MessageControls.handleTelemetryUpdate). A
 // non-call response (e.g. a greeting on a new chat) records no metrics, so it
 // never gets the marker and never shows a telemetry button.
+// (Mobile: these rules live under html.desktop-view; on mobile the whole
+// .saypi-tts-controls bar is hidden via mobile.scss, so no separate telemetry
+// hide rule is needed there.)
 .chat-history .assistant-message .saypi-telemetry-button
 {
   display: none;

--- a/src/styles/messages.scss
+++ b/src/styles/messages.scss
@@ -84,12 +84,16 @@
   }
 }
 
-// Hide telemetry button on all assistant messages except the last one
+// Telemetry button is hidden by default, and shown ONLY on the most-recent
+// message AND only once a voice turn has recorded metrics for it (the
+// `.has-telemetry` marker, set in MessageControls.handleTelemetryUpdate). A
+// non-call response (e.g. a greeting on a new chat) records no metrics, so it
+// never gets the marker and never shows a telemetry button.
 .chat-history .assistant-message .saypi-telemetry-button
 {
   display: none;
 }
-.present-messages .assistant-message:last-of-type .saypi-telemetry-button:has(svg)
+.present-messages .assistant-message:last-of-type.has-telemetry .saypi-telemetry-button:has(svg)
 {
   display: flex;
 }

--- a/test/TelemetryModule-hasRecorded.spec.ts
+++ b/test/TelemetryModule-hasRecorded.spec.ts
@@ -20,6 +20,7 @@ describe("hasRecordedTelemetry", () => {
   });
 
   it("is true once a duration metric is recorded", () => {
+    expect(hasRecordedTelemetry({ transcriptionTime: 400 })).toBe(true);
     expect(hasRecordedTelemetry({ transcriptionDelay: 250 })).toBe(true);
     expect(hasRecordedTelemetry({ completionResponse: 800 })).toBe(true);
     expect(hasRecordedTelemetry({ streamingDuration: 1200 })).toBe(true);

--- a/test/TelemetryModule-hasRecorded.spec.ts
+++ b/test/TelemetryModule-hasRecorded.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { hasRecordedTelemetry } from "../src/TelemetryModule";
+
+/**
+ * Guards the gate that keeps the telemetry button off non-call responses
+ * (e.g. the greeting on a new-chat page). A voice turn is only considered to have
+ * "recorded metrics" once it progresses past the initial/reset state — empty
+ * telemetry, or the speech-start-only reset emitted at turn start, must NOT count.
+ */
+describe("hasRecordedTelemetry", () => {
+  it("is false for empty / nullish telemetry", () => {
+    expect(hasRecordedTelemetry(undefined)).toBe(false);
+    expect(hasRecordedTelemetry(null)).toBe(false);
+    expect(hasRecordedTelemetry({})).toBe(false);
+    expect(hasRecordedTelemetry({ timestamps: {} })).toBe(false);
+  });
+
+  it("is false when only speechStart is set (turn just started / reset)", () => {
+    expect(hasRecordedTelemetry({ timestamps: { speechStart: 1000 } })).toBe(false);
+  });
+
+  it("is true once a duration metric is recorded", () => {
+    expect(hasRecordedTelemetry({ transcriptionDelay: 250 })).toBe(true);
+    expect(hasRecordedTelemetry({ completionResponse: 800 })).toBe(true);
+    expect(hasRecordedTelemetry({ streamingDuration: 1200 })).toBe(true);
+    expect(hasRecordedTelemetry({ timeToTalk: 500 })).toBe(true);
+  });
+
+  it("is true once a milestone beyond speechStart is timestamped", () => {
+    expect(
+      hasRecordedTelemetry({ timestamps: { speechStart: 1000, speechEnd: 1800 } })
+    ).toBe(true);
+    expect(
+      hasRecordedTelemetry({ timestamps: { transcriptionEnd: 2000 } })
+    ).toBe(true);
+    expect(
+      hasRecordedTelemetry({ timestamps: { completionStart: 2500 } })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

A non-call assistant response — e.g. the **greeting on a new-chat page** — was showing SayPi's telemetry button even though no call was active and there was no STT/TTS telemetry to record or show. On the sparse greeting action bar it also floated awkwardly to the far right.

(The far-right float: pi.ai's native copy button sits in a `.w-fit.pt-4` wrapper that `messages.scss` pushes `margin-left:auto`, and SayPi's trailing controls followed it. Removing the button on non-call responses removes that symptom too.)

## Root cause

Telemetry is a single **module-global current-turn record**, and the telemetry button was revealed purely by CSS on the *last present message* (`:last-of-type`), with **no check that a voice turn ever recorded metrics**. So any last message — including a greeting on load — showed it.

## Fix — gate on real recorded metrics

- `TelemetryModule` exports `hasRecordedTelemetry(data)`: `true` once a turn progresses past the empty/just-reset state (any duration metric, or any timestamp beyond the initial `speechStart` milestone).
- `MessageControls.handleTelemetryUpdate` marks the message `.has-telemetry` when a `telemetry:updated` event carries real metrics. A non-call response never emits such an update → never marked. (The listener is already registered only on the last message, so only it is marked.)
- `messages.scss` now requires `.assistant-message.has-telemetry` in the telemetry-button show rule.

Net: no metrics → no marker → no button (and no mis-positioning on the greeting bar). Telemetry still appears after **any voice turn that recorded metrics** (per your call — including TTS-off turns, which still have STT/VAD metrics), where the #326 native styling applies.

## Tests

- **L1** `test/TelemetryModule-hasRecorded.spec.ts`: empty / speech-start-only → `false`; a duration metric or a later timestamp → `true`.
- **L3 (fail-first)** `e2e/specs/telemetry-gate.e2e.ts`: against the **real built CSS**, a `:last-of-type` present assistant message *without* `.has-telemetry` keeps the telemetry button hidden; adding the marker shows it. Confirmed RED before the gate (was `flex`), GREEN after.
- Full e2e suite green (9/9); `npm test` green (Vitest 108 files/874; Jest 2/2).

Will live-verify on real pi.ai after merge (greeting shows no telemetry button; a real voice turn does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)