### PR TITLE
fix(prefs): remove vestigial /status/tts "beta paused" poll (#325)

### DIFF
--- a/src/prefs/PreferenceModule.ts
+++ b/src/prefs/PreferenceModule.ts
@@ -1,5 +1,4 @@
 import { config } from "../ConfigModule";
-import { callApi } from "../ApiClient";
 import { SpeechSynthesisModule } from "../tts/SpeechSynthesisModule";
 import AudioControlsModule from "../audio/AudioControlsModule";
 import EventBus from "../events/EventBus";
@@ -212,11 +211,6 @@ class UserPreferenceModule {
     });
 
     // keepSegments removed (dev-only via env)
-
-    // Network-dependent settings (not in chrome.storage)
-    this.isTTSBetaPaused().then((value) => {
-      this.cache.setCachedValue("isTTSBetaPaused", value);
-    });
   }
 
   private sanitizeVoicePreferences(preferences?: VoicePreferenceMap): VoicePreferenceMap {
@@ -916,32 +910,16 @@ class UserPreferenceModule {
 
   // --- Methods primarily using cache or other logic ---
 
-  public async isTTSBetaPaused(): Promise<boolean> { // This hits a network endpoint, not chrome.storage
-    const defaultStatus = false;
-    const statusEndpoint = `${config.apiServerUrl}/status/tts`;
-    try {
-      // Use ApiClient to encapsulate background routing and response handling
-      const response = await callApi(statusEndpoint, { method: 'GET', responseType: 'json' } as any);
-      const data = await response.json();
-      return data.beta.status === "paused";
-    } catch (error) {
-      console.warn("Unable to check TTS beta status. API server may be unavailable.", error);
-      return defaultStatus;
-    }
-  }
-
-  public getCachedIsTTSBetaPaused(): boolean {
-    return this.cache.getCachedValue("isTTSBetaPaused", false);
-  }
-
   public async getTextToSpeechEnabled(): Promise<boolean> {
     if (isSafari()) {
       return Promise.resolve(false);
     }
-    return Promise.all([
-      this.getStoredValue("enableTTS", true, 'local'), // Changed to 'local'
-      this.getCachedIsTTSBetaPaused(), 
-    ]).then(([enableTTS, ttsBetaPaused]) => enableTTS && !ttsBetaPaused);
+    // TTS is gated solely by the user's enableTTS preference. The historical
+    // "TTS beta paused" network check (GET /status/tts) was removed in #325: the
+    // beta ended over a year ago and the server no longer reports status "paused"
+    // (it can only return "active" or "unavailable"), so the gate had become a
+    // permanent no-op that polled the API on every page load.
+    return this.getStoredValue("enableTTS", true, 'local');
   }
   
   public setEnableTTS(enabled: boolean): Promise<void> {

--- a/test/UniversalDictationModule-ManualEdit.spec.ts
+++ b/test/UniversalDictationModule-ManualEdit.spec.ts
@@ -19,7 +19,6 @@ vi.mock('../src/prefs/PreferenceModule', () => ({
   UserPreferenceModule: {
     getInstance: () => ({
       getLanguage: vi.fn(() => Promise.resolve('en')),
-      isTTSBetaPaused: vi.fn(() => Promise.resolve(false)),
       getDiscretionaryMode: vi.fn(() => Promise.resolve(false)),
       getCachedDiscretionaryMode: vi.fn(() => false),
     }),

--- a/test/chatbots/ClaudeTextStream.spec.ts
+++ b/test/chatbots/ClaudeTextStream.spec.ts
@@ -73,8 +73,6 @@ vi.mock("../../src/prefs/PreferenceModule", () => {
       getInstance: () => ({
         reloadCache: vi.fn(),
         getLanguage: vi.fn().mockResolvedValue("en-US"),
-        isTTSBetaPaused: vi.fn().mockResolvedValue(false),
-        getCachedIsTTSBetaPaused: vi.fn().mockReturnValue(false),
         getCachedAutoSubmit: vi.fn().mockReturnValue(true),
         getCachedAllowInterruptions: vi.fn().mockReturnValue(true),
         getStoredValue: vi.fn().mockImplementation((key: string, defaultValue: any) => Promise.resolve(defaultValue)),

--- a/test/prefs/TtsStatusPoll.spec.ts
+++ b/test/prefs/TtsStatusPoll.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import EventBus from '../../src/events/EventBus';
+
+// The vestigial "TTS beta paused" gate fired GET ${apiServerUrl}/status/tts from
+// UserPreferenceModule's constructor (via reloadCache) on every content-script
+// load (issue #325). The server can only ever report beta.status "active" or
+// "unavailable" — never "paused" — so the gate was provably a no-op and the poll
+// pure waste. These tests pin: (1) construction must not poll /status/tts, and
+// (2) getTextToSpeechEnabled stays a pure function of the enableTTS preference.
+
+// Mock the API client so we can observe (and would-be-record) any /status/tts call.
+// vi.hoisted lets the mock fn exist before vi.mock's hoisted factory runs.
+const { callApiMock } = vi.hoisted(() => ({
+  callApiMock: vi.fn(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ beta: { status: 'active' } }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+  ),
+}));
+vi.mock('../../src/ApiClient', () => ({ callApi: callApiMock }));
+
+// Mock chrome.storage.local/sync for preference reads/writes (synchronous callbacks).
+// Include the runtime/storage listener surfaces the constructor touches so the test
+// does not lean on a production guard to stay quiet.
+const store: Record<string, any> = {} as any;
+// @ts-ignore
+global.chrome = {
+  storage: {
+    sync: {
+      get: (_keys: any, cb: (res: Record<string, any>) => void) => cb({}),
+    },
+    local: {
+      get: (keys: string[] | Record<string, any>, cb: (res: Record<string, any>) => void) => {
+        if (Array.isArray(keys)) {
+          const res: Record<string, any> = {};
+          keys.forEach((k) => (res[k] = store[k]));
+          cb(res);
+        } else {
+          cb(store);
+        }
+      },
+      set: (obj: Record<string, any>, cb?: () => void) => {
+        Object.assign(store, obj);
+        cb && cb();
+      },
+      remove: (k: string, cb?: () => void) => {
+        delete store[k];
+        cb && cb();
+      },
+    },
+    onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+  },
+  runtime: {
+    lastError: null,
+    onMessage: { addListener: vi.fn(), removeListener: vi.fn() },
+  },
+} as any;
+
+import { UserPreferenceModule } from '../../src/prefs/PreferenceModule';
+
+describe('TTS status poll (#325): no vestigial /status/tts on load', () => {
+  let reloadCacheRan: boolean;
+  const markReloadCacheRan = () => {
+    reloadCacheRan = true;
+  };
+
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k];
+    callApiMock.mockClear();
+    reloadCacheRan = false;
+    // reloadCache() emits userPreferenceChanged as it loads each cached pref; it is
+    // also exactly where the removed poll used to fire. Observing this event proves
+    // the constructor's async chain reached the poll site, so "no poll" is a real
+    // assertion rather than a premature/vacuous one.
+    EventBus.on('userPreferenceChanged', markReloadCacheRan);
+    // Force the singleton constructor to re-run under observation.
+    (UserPreferenceModule as any).instance = undefined;
+  });
+
+  afterEach(() => {
+    EventBus.off('userPreferenceChanged', markReloadCacheRan);
+  });
+
+  it('does not poll /status/tts when the preference module is constructed', async () => {
+    UserPreferenceModule.getInstance();
+
+    // Positive control: wait until the constructor's reloadCache() actually ran
+    // (so the absence of the poll below is meaningful, not a too-early read).
+    await vi.waitFor(() => expect(reloadCacheRan).toBe(true));
+
+    const polledUrls = callApiMock.mock.calls.map((c) => String(c[0]));
+    expect(polledUrls.some((u) => u.includes('/status/tts'))).toBe(false);
+  });
+
+  it('getTextToSpeechEnabled reflects the enableTTS preference (no network gate)', async () => {
+    const prefs = UserPreferenceModule.getInstance();
+    await vi.waitFor(() => expect(reloadCacheRan).toBe(true));
+
+    // Default: TTS enabled.
+    expect(await prefs.getTextToSpeechEnabled()).toBe(true);
+
+    // Disabling the preference disables TTS.
+    await prefs.setEnableTTS(false);
+    expect(await prefs.getTextToSpeechEnabled()).toBe(false);
+
+    // And it never consulted /status/tts to decide.
+    const polledUrls = callApiMock.mock.calls.map((c) => String(c[0]));
+    expect(polledUrls.some((u) => u.includes('/status/tts'))).toBe(false);
+  });
+});

--- a/test/tts/InputStream.spec.ts
+++ b/test/tts/InputStream.spec.ts
@@ -15,8 +15,6 @@ vi.mock("../../src/prefs/PreferenceModule", () => {
       getInstance: () => ({
         reloadCache: vi.fn(),
         getLanguage: vi.fn().mockResolvedValue("en-US"),
-        isTTSBetaPaused: vi.fn().mockResolvedValue(false),
-        getCachedIsTTSBetaPaused: vi.fn().mockReturnValue(false),
         getCachedAutoSubmit: vi.fn().mockReturnValue(true),
         getCachedAllowInterruptions: vi.fn().mockReturnValue(true),
         getStoredValue: vi.fn().mockImplementation((key, defaultValue) => Promise.resolve(defaultValue)),


### PR DESCRIPTION
## What

Every content-script load fired `GET ${apiServerUrl}/status/tts` from `UserPreferenceModule`'s constructor (`reloadCache` → `isTTSBetaPaused`). In aggregate this poll dominated saypi-api's production router log drain (~70% of a 1500-line sample, from 206 distinct IPs). This removes the fetch at the source.

Closes #325.

## Why it's safe to just delete the gate

The check had **become a permanent no-op**, so removing it is behavior-preserving by construction:

- The TTS beta GA'd over a year ago. The server (`saypi-api` `app.py:_build_tts_status_payload`) now computes `beta.status` as **only `"active"` or `"unavailable"`** — `"paused"` appears *nowhere* in the saypi-api codebase (it was a real kill-switch historically, removed in saypi-api #82).
- The client's `isTTSBetaPaused()` returned `data.beta.status === "paused"` (with `catch → false`). Since the server can never report `"paused"`, it **always resolved `false`**, so `getTextToSpeechEnabled()`'s `enableTTS && !ttsBetaPaused` always reduced to just `enableTTS`.

I verified the kill-switch claim against the live `saypi-api` source before touching anything, and an independent multi-lens review re-verified it (re-running the grep, enumerating every value `beta_status` can take).

## The change

- Removed the constructor poll, `isTTSBetaPaused()`, `getCachedIsTTSBetaPaused()`, and the now-dead `callApi` import.
- `getTextToSpeechEnabled()` now gates solely on the `enableTTS` preference; the **Safari short-circuit is preserved**, and the `enableTTS` source is unchanged (it was already read via `getStoredValue` — only the constant-`false` beta term was dropped).
- Sole caller (`PiVoiceMenu.ts:130`) keeps the same `Promise<boolean>` contract — unaffected.
- Dropped three stale `UserPreferenceModule` test mocks that stubbed the removed methods.

Per-user TTS availability is identical to before for every state (signed-in / signed-out / quota-exhausted / Firefox / Safari): old `= enableTTS && !ttsBetaPaused` with `ttsBetaPaused` provably always `false` ⇒ old `=` new `= enableTTS`. (Quota was never gated here — `beta.character_count/limit` were never read by this path.)

## Acceptance criteria

- ✅ `/status/tts` requests from the extension drop to **0 per page load** (the only client caller is gone).
- ✅ TTS continues to work for all users with no regression (the dropped term was a constant `true`).
- The router-drain share AC is a cross-repo/aggregate outcome (see umbrella **saypi-saas#157**, and **saypi-saas#159** for the separate `/metrics` poller) — out of scope for this repo's change.

## Verification (fail-first TDD)

- New `test/prefs/TtsStatusPoll.spec.ts` proves construction no longer polls `/status/tts`. Confirmed **RED** against the pre-fix code (`expected true to be false` ×2) and **GREEN** after. It stays non-vacuous via a positive control: it waits (`vi.waitFor`) for `reloadCache` to actually run — the exact site the poll lived — *before* asserting the poll's absence.
- Full suite green: **Jest 2/2, Vitest 108 files / 872 passed / 1 skipped**.

## Follow-up (deferred, out of scope)

The `previewStatusActive/Paused/Completed` i18n keys (`_locales/*/messages.json`) are the last dead residue of the beta-paused surface — zero code consumers, already dead before this change, and spread across 30+ locale files. Worth a separate behavior-neutral cleanup rather than ballooning this poll-focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)