### PR TITLE
fix(pi): reliably show telemetry button after a voice turn + apply native styling live

### DIFF
--- a/e2e/specs/pi-action-buttons.e2e.ts
+++ b/e2e/specs/pi-action-buttons.e2e.ts
@@ -30,6 +30,12 @@ test("SayPi's Pi action buttons are seamless with native (copy hidden, telemetry
   });
 
   const result = await page.evaluate(() => {
+    // The base telemetry CSS is scoped under html.desktop-view (SayPi adds this
+    // on desktop; the mock host doesn't). It MUST be present, otherwise the base
+    // rule never applies and this test would false-pass without exercising the
+    // real cascade (where the base 24px rule must be out-specified by pi.scss).
+    document.documentElement.classList.add("desktop-view");
+
     // pi.ai defines these theme variables; the mock host doesn't, so recreate
     // them so the extension's `var(--color-…)` references resolve to pi's values.
     document.documentElement.style.setProperty("--color-text-secondary", "#655E55");

--- a/e2e/specs/telemetry-gate.e2e.ts
+++ b/e2e/specs/telemetry-gate.e2e.ts
@@ -45,15 +45,19 @@ test("telemetry button is hidden on the last message until it has recorded metri
     history.appendChild(msg);
     document.body.appendChild(history);
 
-    // Without recorded metrics (no marker) — must be hidden.
+    // Without recorded metrics (no global marker) — must be hidden.
     const hiddenDisplay = getComputedStyle(tel).display;
 
-    // Once a voice turn records metrics, MessageControls marks the message; the
-    // button then shows.
-    msg.classList.add("has-telemetry");
+    // Once a voice turn records metrics, TelemetryModule sets the global body
+    // marker; the latest message's telemetry button then shows.
+    document.body.classList.add("saypi-recent-telemetry");
     const shownDisplay = getComputedStyle(tel).display;
 
-    return { hiddenDisplay, shownDisplay };
+    // Clearing the marker (turn reset / route change) hides it again.
+    document.body.classList.remove("saypi-recent-telemetry");
+    const reHiddenDisplay = getComputedStyle(tel).display;
+
+    return { hiddenDisplay, shownDisplay, reHiddenDisplay };
   });
 
   expect(
@@ -62,6 +66,10 @@ test("telemetry button is hidden on the last message until it has recorded metri
   ).toBe("none");
   expect(
     result.shownDisplay,
-    "telemetry button must show once the message has recorded metrics"
+    "telemetry button must show on the latest message while the turn has recorded metrics"
   ).toBe("flex");
+  expect(
+    result.reHiddenDisplay,
+    "telemetry button must hide again when the marker is cleared"
+  ).toBe("none");
 });

--- a/e2e/specs/telemetry-gate.e2e.ts
+++ b/e2e/specs/telemetry-gate.e2e.ts
@@ -2,15 +2,17 @@ import { test, expect } from "../fixtures/extension";
 
 /**
  * Layer 3 guard (real built CSS): the telemetry button must NOT appear on the
- * most-recent message unless that message recorded voice-turn metrics — i.e. it
- * carries the `.has-telemetry` marker (set by MessageControls when a real
- * `telemetry:updated` arrives). A non-call response (e.g. the greeting on a new
- * chat) never gets the marker, so its telemetry button stays hidden — which also
- * removes the awkward far-right positioning on the sparse greeting action bar.
+ * most-recent message unless the current voice turn recorded metrics — gated on
+ * the global `body.saypi-recent-telemetry` marker (toggled by
+ * TelemetryModule.emitUpdate when a real `telemetry:updated` carries recorded
+ * metrics). A non-call response (e.g. the greeting on a new chat) never triggers
+ * that marker, so its telemetry button stays hidden — which also removes the
+ * awkward far-right positioning on the sparse greeting action bar.
  *
- * Pre-fix the show rule was `.present-messages .assistant-message:last-of-type
- * .saypi-telemetry-button:has(svg) { display:flex }` — no marker required — so a
- * last-of-type greeting showed it.
+ * A global marker + CSS `:last-of-type` (rather than a per-message class) is
+ * immune to pi.ai's present-container re-render churn. Pre-fix the show rule was
+ * `.present-messages .assistant-message:last-of-type .saypi-telemetry-button:has(svg)`
+ * — no marker required — so a last-of-type greeting showed it.
  */
 test("telemetry button is hidden on the last message until it has recorded metrics (real build)", async ({
   context,

--- a/src/TelemetryModule.ts
+++ b/src/TelemetryModule.ts
@@ -280,6 +280,20 @@ export class TelemetryModule {
    * Emit an update event with the current telemetry data
    */
   private emitUpdate(): void {
+    // Reflect "the current voice turn has recorded metrics" as a single global
+    // body class. The telemetry button's show rule (messages.scss) gates on this
+    // marker + `:last-of-type`, so the button appears only on the most-recent
+    // message AND only after a voice turn recorded metrics — and never on a
+    // non-call response (greeting), which never emits a real telemetry update.
+    // A global marker (vs a per-message class) is immune to pi.ai's
+    // present-container re-render churn: the CSS `:last-of-type` always resolves
+    // to the live latest message, no matter how often it is re-decorated.
+    if (typeof document !== "undefined" && document.body) {
+      document.body.classList.toggle(
+        "saypi-recent-telemetry",
+        hasRecordedTelemetry(this.currentTelemetry)
+      );
+    }
     EventBus.emit("telemetry:updated", { data: this.currentTelemetry });
   }
 }

--- a/src/TelemetryModule.ts
+++ b/src/TelemetryModule.ts
@@ -288,6 +288,13 @@ export class TelemetryModule {
     // A global marker (vs a per-message class) is immune to pi.ai's
     // present-container re-render churn: the CSS `:last-of-type` always resolves
     // to the live latest message, no matter how often it is re-decorated.
+    //
+    // Cleared on turn start (saypi:userSpeaking -> resetTelemetry) and on route
+    // change (new chat / thread switch). Accepted tradeoff: a TYPED follow-up
+    // right after a voice turn fires no reset, so the marker persists and the
+    // (telemetry-less) text response would briefly show the button until the next
+    // voice turn or navigation. Pi is voice-first, so this is acceptable; the old
+    // per-message scheme avoided it but was unreliable against the churn above.
     if (typeof document !== "undefined" && document.body) {
       document.body.classList.toggle(
         "saypi-recent-telemetry",

--- a/src/chatbots/bootstrap.ts
+++ b/src/chatbots/bootstrap.ts
@@ -8,6 +8,7 @@ import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { ThemeManager } from "../themes/ThemeManagerModule";
 import { VoiceMenuUIManager } from "../tts/VoiceMenuUIManager";
 import { logger } from "../LoggingModule";
+import telemetryModule from "../TelemetryModule";
 import { AgentModeNoticeModule } from "../ui/AgentModeNoticeModule";
 import { IconModule } from "../icons/IconModule";
 import { openSettings } from "../popup/popupopener";
@@ -119,7 +120,13 @@ export class DOMObserver {
       if (currentUrl !== lastUrl) {
         logger.debug('Route changed:', lastUrl, '->', currentUrl);
         lastUrl = currentUrl;
-        
+
+        // New thread / new chat = no active voice turn for the incoming view, so
+        // clear the current-turn telemetry (and its global marker). Without this,
+        // navigating from a thread that recorded telemetry into a new chat would
+        // leave the marker set and show a telemetry button on the greeting.
+        telemetryModule.resetTelemetry();
+
         // Start/stop observation based on whether the new path is chatable
         if (this.chatbot.isChatablePath(window.location.pathname)) {
           this.startObservingDom();

--- a/src/dom/MessageElements.ts
+++ b/src/dom/MessageElements.ts
@@ -17,7 +17,7 @@ import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { SpeechHistoryModule } from "../tts/SpeechHistoryModule";
 import { regenerateSpeech } from "./regenerateSpeech";
 import { MessageState } from "../tts/MessageHistoryModule";
-import telemetryModule, { TelemetryData, hasRecordedTelemetry } from "../TelemetryModule";
+import telemetryModule, { TelemetryData } from "../TelemetryModule";
 import { IconModule } from "../icons/IconModule";
 import { FailedSpeechUtterance } from "../tts/FailedSpeechUtterance";
 import { config } from "../ConfigModule";
@@ -933,16 +933,10 @@ abstract class MessageControls {
    * Handle telemetry updates from the TelemetryModule
    */
   private handleTelemetryUpdate = (event: { data: TelemetryData }): void => {
-    // Only reveal the telemetry button once a voice turn has actually recorded
-    // metrics for this (last) message. A non-call response — e.g. the greeting on
-    // a new-chat page — never emits a telemetry update with real data, so it never
-    // gets `has-telemetry` and its button stays hidden (the CSS show rule for the
-    // telemetry button requires `.assistant-message.has-telemetry`).
-    if (hasRecordedTelemetry(event.data)) {
-      this.safeAddClass("has-telemetry");
-    }
-
-    // Update visualization if it's currently shown
+    // Telemetry-button visibility is driven by a single global body marker
+    // (`saypi-recent-telemetry`, toggled in TelemetryModule.emitUpdate) gated on
+    // `:last-of-type` in CSS — immune to pi.ai's present-container re-render churn.
+    // Here we only need to refresh an already-open visualization.
     const container = this.message.element.querySelector(".saypi-telemetry-container") as HTMLElement;
     if (container && container.style.display !== "none") {
       container.remove();

--- a/src/styles/messages.scss
+++ b/src/styles/messages.scss
@@ -85,10 +85,13 @@
 }
 
 // Telemetry button is hidden by default, and shown ONLY on the most-recent
-// message AND only once a voice turn has recorded metrics for it (the
-// `.has-telemetry` marker, set in MessageControls.handleTelemetryUpdate). A
-// non-call response (e.g. a greeting on a new chat) records no metrics, so it
-// never gets the marker and never shows a telemetry button.
+// message AND only while the current voice turn has recorded metrics — the
+// global `body.saypi-recent-telemetry` marker toggled in
+// TelemetryModule.emitUpdate. A non-call response (e.g. a greeting on a new
+// chat) records no metrics, so the marker is absent and no button shows. Using a
+// global marker + `:last-of-type` (rather than a per-message class) makes this
+// immune to pi.ai's present-container re-render churn — the latest message is
+// always resolved live.
 // (Mobile: these rules live under html.desktop-view; on mobile the whole
 // .saypi-tts-controls bar is hidden via mobile.scss, so no separate telemetry
 // hide rule is needed there.)
@@ -96,7 +99,7 @@
 {
   display: none;
 }
-.present-messages .assistant-message:last-of-type.has-telemetry .saypi-telemetry-button:has(svg)
+body.saypi-recent-telemetry .present-messages .assistant-message:last-of-type .saypi-telemetry-button:has(svg)
 {
   display: flex;
 }

--- a/src/styles/pi.scss
+++ b/src/styles/pi.scss
@@ -117,7 +117,12 @@ html body.pi {
       display: none;
     }
 
-    .saypi-telemetry-button {
+    /* `.saypi-tts-controls` ancestor included on purpose: the base telemetry
+       rule is `html.desktop-view .message-action-bar .saypi-tts-controls
+       .saypi-telemetry-button` (4 classes); without this ancestor our Pi rule
+       has fewer classes and LOSES the cascade (the button renders at the base
+       24px/0.6). With it, this rule outranks the base. */
+    .saypi-tts-controls .saypi-telemetry-button {
       width: 32px;
       height: 32px;
       margin: 0;

--- a/test/TelemetryModule-hasRecorded.spec.ts
+++ b/test/TelemetryModule-hasRecorded.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { hasRecordedTelemetry } from "../src/TelemetryModule";
+import { describe, it, expect, beforeEach } from "vitest";
+import telemetryModule, { hasRecordedTelemetry } from "../src/TelemetryModule";
 
 /**
  * Guards the gate that keeps the telemetry button off non-call responses
@@ -37,5 +37,27 @@ describe("hasRecordedTelemetry", () => {
     expect(
       hasRecordedTelemetry({ timestamps: { completionStart: 2500 } })
     ).toBe(true);
+  });
+});
+
+describe("TelemetryModule global telemetry marker (body.saypi-recent-telemetry)", () => {
+  const MARKER = "saypi-recent-telemetry";
+
+  beforeEach(() => {
+    telemetryModule.resetTelemetry();
+    document.body.classList.remove(MARKER);
+  });
+
+  it("is absent when there are no recorded metrics (reset state)", () => {
+    telemetryModule.resetTelemetry();
+    expect(document.body.classList.contains(MARKER)).toBe(false);
+  });
+
+  it("is set once the current turn records metrics, and cleared on reset", () => {
+    telemetryModule.updateTelemetryData({ completionResponse: 600 });
+    expect(document.body.classList.contains(MARKER)).toBe(true);
+
+    telemetryModule.resetTelemetry();
+    expect(document.body.classList.contains(MARKER)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

**Live (L4) verification of #326/#327 caught two issues their tests missed** — and a corrected test for each so this can't regress.

1. **Telemetry never reliably showed after a voice turn.** #327 marked the response via a per-message `telemetry:updated` listener, which races with pi.ai's present-container re-render churn (#324 `subtree:true` re-decorates the message repeatedly while telemetry events fire). The marker landed on a now-detached element, so the live latest response stayed unmarked → button hidden (intermittent). Verified live: a real voice turn left the latest response unmarked over a 9s watch.
2. **#326's native telemetry styling never applied live** (button rendered at the base **24px/opacity-0.6**, not 32px/16px). Specificity: the base rule `html.desktop-view .message-action-bar .saypi-tts-controls .saypi-telemetry-button` (4 classes) outranked `html body.pi .message-action-bar .saypi-telemetry-button` (3 classes). The #326 L3 test false-passed because it **omitted `html.desktop-view`**, so it never exercised the real cascade.

## Fixes

- **Global marker, churn-proof.** Replace the per-message `has-telemetry` with a single `body.saypi-recent-telemetry`, toggled in `TelemetryModule.emitUpdate` via `hasRecordedTelemetry()`. The CSS show rule gates on that marker + `:last-of-type` — CSS always resolves the live latest message, regardless of how often it's re-decorated. (Reverted #327's per-message marking.)
- **Clear on navigation.** bootstrap's route-change monitor now calls `telemetryModule.resetTelemetry()`, so moving from a thread that recorded telemetry into a new chat doesn't leave the greeting showing a telemetry button (the exact scenario originally reported).
- **Specificity fix.** pi.scss telemetry selector now includes the `.saypi-tts-controls` ancestor, out-specifying the base → renders native **32px/16px** live.

## Tests

- **L1/L2** `TelemetryModule-hasRecorded.spec.ts`: + the body marker toggles on recorded metrics and clears on reset.
- **L3** `telemetry-gate.e2e.ts`: rewritten around `body.saypi-recent-telemetry` (hidden → shown when marker set → hidden when cleared), real built CSS.
- **L3** `pi-action-buttons.e2e.ts`: now adds `html.desktop-view` so it exercises the real cascade — **fail-first proven** (telemetry 24px without the specificity fix, 32px with it).
- Full e2e suite green (9/9); `npm test` green (Vitest 109 files/878; Jest 2/2).

Will live-verify on real pi.ai after merge: greeting shows no telemetry; a real voice turn shows it, natively styled; navigating to a new chat clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)