### PR TITLE
fix(pi): bottom-align the telemetry button with native action-bar buttons

### DIFF
--- a/e2e/specs/pi-action-buttons.e2e.ts
+++ b/e2e/specs/pi-action-buttons.e2e.ts
@@ -68,6 +68,7 @@ test("SayPi's Pi action buttons are seamless with native (copy hidden, telemetry
 
     return {
       containerBg: csCtrls.backgroundColor,
+      ctrlsAlignSelf: csCtrls.alignSelf,
       copyDisplay: csCopy.display,
       telWidth: csTel.width,
       telHeight: csTel.height,
@@ -90,6 +91,15 @@ test("SayPi's Pi action buttons are seamless with native (copy hidden, telemetry
     result.containerBg,
     `controls container must be transparent (was ${result.containerBg})`
   ).toBe("rgba(0, 0, 0, 0)");
+
+  // Vertical alignment: the native action-bar buttons sit at the BOTTOM of the
+  // ~48px bar (their pt-4 top offset). Our controls zero that padding, so they
+  // must bottom-align explicitly to line the telemetry button up with native —
+  // otherwise it floats ~16px too high.
+  expect(
+    result.ctrlsAlignSelf,
+    `controls must bottom-align with native buttons (was ${result.ctrlsAlignSelf})`
+  ).toBe("flex-end");
 
   // Telemetry button: native size / radius / padding / full strength.
   expect(result.telWidth, "telemetry width must match native 32px").toBe("32px");

--- a/src/styles/pi.scss
+++ b/src/styles/pi.scss
@@ -103,12 +103,17 @@ html body.pi {
   .message-action-bar,
   .message-hover-menu {
     /* Seamless: drop the grouping "pill" so our controls sit inline with the
-       native buttons instead of inside a tinted rounded box. */
+       native buttons instead of inside a tinted rounded box. Zeroing the padding
+       also removes the `pt-4` top-offset that used to bottom-align us with the
+       native buttons (which sit at the bottom of the ~48px action bar via their
+       own pt-4), so bottom-align the controls explicitly to line our button up
+       with theirs. */
     .saypi-tts-controls {
       background-color: transparent;
       border-radius: 0;
       padding: 0;
       margin-top: 0;
+      align-self: flex-end;
     }
 
     /* pi.ai now has its own native Copy button — hide ours (also catches any left


### PR DESCRIPTION
## Summary

Live follow-up to #330: the telemetry button rendered **~16px too high**. pi.ai's native action-bar buttons sit at the **bottom** of the ~48px bar via their `pt-4` top offset; #326 zeroed the SayPi controls' padding (to drop the tinted pill), which also removed the `pt-4` that had bottom-aligned us — so the controls sat at the top.

## Fix

`align-self: flex-end` on `.saypi-tts-controls` (a flex child of the action bar), lining the telemetry button's vertical centre up with the native buttons. **Verified live**: telemetry centre `411 → 427`, matching native `427`.

## Test

`pi-action-buttons.e2e.ts` now asserts the controls' computed `align-self` is `flex-end` against the real built CSS. **Fail-first proven** (`auto` without the rule). Full e2e suite green (9/9); `npm test` green.

CSS-only, Pi-scoped. Will spot-check live after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)