### PR TITLE
fix(telemetry): show telemetry on the FIRST voice turn (don't reset on thread-creation)

### DIFF
--- a/src/chatbots/bootstrap.ts
+++ b/src/chatbots/bootstrap.ts
@@ -14,6 +14,7 @@ import { IconModule } from "../icons/IconModule";
 import { openSettings } from "../popup/popupopener";
 import { addChild } from "../dom/DOMModule";
 import getMessage from "../i18n";
+import { isPiNavigationAwayFromConversation } from "./piRouteUtils";
 
 export class DOMObserver {
   ttsUiMgr: ChatHistorySpeechManager | null = null;
@@ -119,13 +120,28 @@ export class DOMObserver {
       const currentUrl = window.location.href;
       if (currentUrl !== lastUrl) {
         logger.debug('Route changed:', lastUrl, '->', currentUrl);
+        const prevUrl = lastUrl;
         lastUrl = currentUrl;
 
-        // New thread / new chat = no active voice turn for the incoming view, so
-        // clear the current-turn telemetry (and its global marker). Without this,
-        // navigating from a thread that recorded telemetry into a new chat would
-        // leave the marker set and show a telemetry button on the greeting.
-        telemetryModule.resetTelemetry();
+        // Navigating AWAY from the current conversation (new chat or a different
+        // thread) = no active voice turn for the incoming view, so clear the
+        // current-turn telemetry (and its global marker); otherwise the greeting
+        // on a new chat would inherit the previous thread's telemetry button.
+        // But do NOT reset when the current conversation is merely assigned its
+        // thread id on first message (/talk -> /talk/<id>) — that would wipe the
+        // first turn's just-recorded metrics so its telemetry never shows.
+        try {
+          if (
+            isPiNavigationAwayFromConversation(
+              new URL(prevUrl).pathname,
+              new URL(currentUrl).pathname
+            )
+          ) {
+            telemetryModule.resetTelemetry();
+          }
+        } catch {
+          telemetryModule.resetTelemetry();
+        }
 
         // Start/stop observation based on whether the new path is chatable
         if (this.chatbot.isChatablePath(window.location.pathname)) {

--- a/src/chatbots/bootstrap.ts
+++ b/src/chatbots/bootstrap.ts
@@ -130,6 +130,8 @@ export class DOMObserver {
         // But do NOT reset when the current conversation is merely assigned its
         // thread id on first message (/talk -> /talk/<id>) — that would wipe the
         // first turn's just-recorded metrics so its telemetry never shows.
+        // Safe on non-Pi hosts: any path outside /talk/<id> returns true here
+        // (i.e. reset as before), so this is a no-op change for Claude/ChatGPT.
         try {
           if (
             isPiNavigationAwayFromConversation(

--- a/src/chatbots/piRouteUtils.ts
+++ b/src/chatbots/piRouteUtils.ts
@@ -1,0 +1,29 @@
+/**
+ * Whether a Pi route change is a navigation AWAY from the current conversation
+ * (new chat, or switching to a different thread) — as opposed to the current
+ * conversation simply being assigned its thread id when the first message is sent
+ * (`/talk` -> `/talk/<id>`).
+ *
+ * This matters for telemetry: we reset the current-turn telemetry on real
+ * navigation, but must NOT reset on thread-creation — otherwise the first voice
+ * turn of a new chat has its just-recorded metrics wiped the moment pi.ai swaps
+ * `/talk` for `/talk/<newId>`, so its telemetry button never appears (it only
+ * shows from the second turn on).
+ *
+ * @param oldPath previous URL pathname (e.g. "/talk" or "/talk/abc")
+ * @param newPath new URL pathname
+ */
+export function isPiNavigationAwayFromConversation(
+  oldPath: string,
+  newPath: string
+): boolean {
+  const threadId = (p: string): string | null => {
+    const m = p.match(/^\/talk\/([^/?#]+)/);
+    return m ? m[1] : null;
+  };
+  const oldId = threadId(oldPath);
+  const newId = threadId(newPath);
+  if (newId === null) return true; // -> new chat (/talk) or a non-thread page
+  if (oldId === null) return false; // /talk -> /talk/<id> = current thread just created
+  return newId !== oldId; // switched to a different existing thread
+}

--- a/test/chatbots/Pi-routeUtils.spec.ts
+++ b/test/chatbots/Pi-routeUtils.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { isPiNavigationAwayFromConversation } from "../../src/chatbots/piRouteUtils";
+
+/**
+ * Regression guard: the telemetry route-reset must NOT fire when the current
+ * conversation is merely assigned its thread id on the first message
+ * (`/talk` -> `/talk/<id>`). Firing there wiped the first voice turn's
+ * just-recorded metrics, so its telemetry button only appeared from turn 2 on.
+ */
+describe("isPiNavigationAwayFromConversation", () => {
+  it("is FALSE when the current conversation gets its thread id on first message", () => {
+    expect(isPiNavigationAwayFromConversation("/talk", "/talk/abc123")).toBe(false);
+  });
+
+  it("is TRUE when starting a new chat (back to /talk)", () => {
+    expect(isPiNavigationAwayFromConversation("/talk/abc123", "/talk")).toBe(true);
+  });
+
+  it("is TRUE when switching to a different thread", () => {
+    expect(isPiNavigationAwayFromConversation("/talk/abc123", "/talk/def456")).toBe(true);
+  });
+
+  it("is FALSE for a no-op same-thread change (e.g. query/hash)", () => {
+    expect(isPiNavigationAwayFromConversation("/talk/abc123", "/talk/abc123")).toBe(false);
+  });
+
+  it("is TRUE when navigating to a non-conversation page", () => {
+    expect(isPiNavigationAwayFromConversation("/talk/abc123", "/discover")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

You noticed the telemetry button appeared on the **second** conversation turn but not the **first** — that's a regression from #330's route-change telemetry reset.

#330 reset the current-turn telemetry on **any** URL change. But pi.ai assigns a thread id to a brand-new conversation when the first message is sent (`/talk` → `/talk/<id>`). So on turn 1: transcription records metrics → global `saypi-recent-telemetry` marker set → pi creates the thread → URL changes → my reset fires → **marker wiped right as the response arrives** → no telemetry button. Turn 2: URL is already `/talk/<id>`, no change, no reset → it shows.

## Fix

Only reset on a genuine navigation **away** from the conversation — a new chat (`/talk`) or a switch to a *different* thread — not when the current conversation merely gains its id. Extracted a pure, tested helper `isPiNavigationAwayFromConversation(oldPath, newPath)`:

| transition | reset? |
|---|---|
| `/talk` → `/talk/<id>` (thread created on 1st message) | **no** |
| `/talk/<id>` → `/talk` (new chat) | yes |
| `/talk/<A>` → `/talk/<B>` (switch thread) | yes |
| `/talk/<id>` → `/discover` | yes |

The new-chat / thread-switch reset that #330 added (so a greeting doesn't inherit a prior thread's telemetry) is preserved.

## Test (fail-first, L1)

`test/chatbots/Pi-routeUtils.spec.ts` pins the table above — the `/talk → /talk/<id>` case (the bug) asserts `false`. `npm test` green (Vitest 884 / Jest 2); e2e suite (9) green.

Will live-verify after merge: telemetry shows on the **first** voice turn of a new chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)