### PR TITLE
feat(telemetry): refresh the Performance Metrics visualization

### DIFF
--- a/src/dom/MessageElements.ts
+++ b/src/dom/MessageElements.ts
@@ -16,6 +16,7 @@ import { isMobileDevice } from "../UserAgentModule";
 import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { SpeechHistoryModule } from "../tts/SpeechHistoryModule";
 import { regenerateSpeech } from "./regenerateSpeech";
+import { readableSegmentLabel } from "./colorUtils";
 import { MessageState } from "../tts/MessageHistoryModule";
 import telemetryModule, { TelemetryData } from "../TelemetryModule";
 import { IconModule } from "../icons/IconModule";
@@ -1312,7 +1313,9 @@ abstract class MessageControls {
         segmentElem.style.backgroundColor = segment.color;
         segmentElem.style.borderRadius = "3px";
         segmentElem.style.boxShadow = "0 1px 2px rgba(0,0,0,0.1)";
-        
+        // Legible time labels regardless of how light the segment colour is.
+        const lbl = readableSegmentLabel(segment.color);
+
         // For Pi Speaks segment, extend to the right edge
         if (segment.metricKey === 'speechPlayback') {
           // Make the segment extend to the right edge of the chart
@@ -1331,8 +1334,8 @@ abstract class MessageControls {
             endTimeLabel.style.top = "50%";
             endTimeLabel.style.transform = "translateY(-50%)";
             endTimeLabel.style.fontSize = "9px";
-            endTimeLabel.style.color = "#fff";
-            endTimeLabel.style.textShadow = "0 0 2px rgba(0,0,0,0.5)";
+            endTimeLabel.style.color = lbl.color;
+            endTimeLabel.style.textShadow = lbl.textShadow;
             segmentElem.appendChild(endTimeLabel);
           } else {
             // For regular segments, check if there's enough width for both labels
@@ -1346,8 +1349,8 @@ abstract class MessageControls {
               middleLabel.style.top = "50%";
               middleLabel.style.transform = "translate(-50%, -50%)";
               middleLabel.style.fontSize = "9px";
-              middleLabel.style.color = "#fff";
-              middleLabel.style.textShadow = "0 0 2px rgba(0,0,0,0.5)";
+              middleLabel.style.color = lbl.color;
+              middleLabel.style.textShadow = lbl.textShadow;
               middleLabel.style.whiteSpace = "nowrap"; // Prevent text wrapping
               
               // For very small segments, show label outside the segment instead of inside
@@ -1368,8 +1371,8 @@ abstract class MessageControls {
               startTime.style.top = "50%";
               startTime.style.transform = "translateY(-50%)";
               startTime.style.fontSize = "9px";
-              startTime.style.color = "#fff";
-              startTime.style.textShadow = "0 0 2px rgba(0,0,0,0.5)";
+              startTime.style.color = lbl.color;
+              startTime.style.textShadow = lbl.textShadow;
               startTime.style.whiteSpace = "nowrap"; // Prevent text wrapping
               segmentElem.appendChild(startTime);
               
@@ -1381,8 +1384,8 @@ abstract class MessageControls {
               endTime.style.top = "50%";
               endTime.style.transform = "translateY(-50%)";
               endTime.style.fontSize = "9px";
-              endTime.style.color = "#fff";
-              endTime.style.textShadow = "0 0 2px rgba(0,0,0,0.5)";
+              endTime.style.color = lbl.color;
+              endTime.style.textShadow = lbl.textShadow;
               endTime.style.whiteSpace = "nowrap"; // Prevent text wrapping
               segmentElem.appendChild(endTime);
             }

--- a/src/dom/MessageElements.ts
+++ b/src/dom/MessageElements.ts
@@ -963,7 +963,7 @@ abstract class MessageControls {
         key: 'voiceActivityDetection',
         label: 'Grace Period',
         value: telemetryData.transcriptionDelay,
-        color: '#2979FF', // Brighter blue to make it more noticeable
+        color: '#83996a', // Brighter blue to make it more noticeable
         explanation: 'Intentional delay between receiving final transcription and submitting prompt to LLM - allows for detecting if user is truly finished speaking'
       });
     } else {
@@ -977,7 +977,7 @@ abstract class MessageControls {
           key: 'voiceActivityDetection',
           label: 'Grace Period',
           value: calculatedGracePeriod,
-          color: '#2979FF', // Brighter blue to make it more noticeable
+          color: '#83996a', // Brighter blue to make it more noticeable
           explanation: 'Intentional delay between receiving final transcription and submitting prompt to LLM - allows for detecting if user is truly finished speaking'
         });
       } else {
@@ -987,7 +987,7 @@ abstract class MessageControls {
           key: 'voiceActivityDetection',
           label: 'Grace Period',
           value: 0,
-          color: '#2979FF', // Brighter blue to make it more noticeable
+          color: '#83996a', // Brighter blue to make it more noticeable
           explanation: 'Intentional delay between receiving final transcription and submitting prompt to LLM - allows for detecting if user is truly finished speaking'
         });
       }
@@ -1000,7 +1000,7 @@ abstract class MessageControls {
         key: 'transcriptionDuration',
         label: 'Transcription',
         value: telemetryData.transcriptionTime,
-        color: '#DB4437', // Red
+        color: '#bd6b52', // Red
         explanation: 'Time taken to transcribe speech to text'
       });
     } else if (timestamps.transcriptionStart && timestamps.transcriptionEnd) {
@@ -1011,7 +1011,7 @@ abstract class MessageControls {
         key: 'transcriptionDuration',
         label: 'Transcription',
         value: calculatedTranscriptionTime,
-        color: '#DB4437', // Red
+        color: '#bd6b52', // Red
         explanation: 'Time taken to transcribe speech to text (calculated from timestamps)'
       });
     }
@@ -1022,7 +1022,7 @@ abstract class MessageControls {
         key: 'streamingDuration',
         label: 'Pi writes',
         value: telemetryData.streamingDuration,
-        color: '#F4B400', // Yellow/Gold
+        color: '#6a82a3', // Yellow/Gold
         explanation: 'Time taken to stream the text response'
       });
     }
@@ -1034,7 +1034,7 @@ abstract class MessageControls {
         key: 'speechPlayback',
         label: 'Pi Speaks: 5+s',
         value: 5000, // Just a small duration to make it visible - this is just a marker
-        color: '#0F9D58', // Green
+        color: '#9a7aa0', // Green
         explanation: 'Point when Pi begins speaking the response (continues beyond timeline)'
       });
     }
@@ -1045,7 +1045,7 @@ abstract class MessageControls {
         key: 'completionResponse',
         label: 'LLM Wait Time',
         value: telemetryData.completionResponse,
-        color: '#673AB7', // Purple
+        color: '#4f8a8b', // Purple
         explanation: 'Time waiting for Pi to formulate a response'
       });
     }
@@ -1056,7 +1056,7 @@ abstract class MessageControls {
         key: 'timeToTalk',
         label: 'Time to Talk',
         value: telemetryData.timeToTalk,
-        color: '#3F51B5', // Indigo
+        color: '#c2a14d', // Indigo
         explanation: 'Time from start of response to start of audio playback'
       });
     }
@@ -1080,7 +1080,7 @@ abstract class MessageControls {
       key: 'totalTime',
       label: 'Speech to Speech',
       value: totalTime,
-      color: '#9E9E9E', // Gray
+      color: '#857a6e', // Gray
       explanation: 'Total time from end of user speech to beginning of Pi\'s audio response'
     });
     
@@ -1103,13 +1103,21 @@ abstract class MessageControls {
     const container = document.createElement("div");
     container.className = "saypi-telemetry-container";
     
-    // Add title
-    const title = document.createElement("h4");
-    title.textContent = "Performance Metrics";
-    title.style.margin = "0 0 10px 0";
-    title.style.fontSize = "14px";
-    title.style.fontWeight = "bold";
-    container.appendChild(title);
+    // Header: "Performance" title + the total turn time as a subtle pill.
+    const header = document.createElement("div");
+    header.className = "saypi-telemetry-header";
+    const title = document.createElement("span");
+    title.className = "saypi-telemetry-title";
+    title.textContent = "Performance";
+    header.appendChild(title);
+    if (totalTime > 0) {
+      const total = document.createElement("span");
+      total.className = "saypi-telemetry-total";
+      total.textContent = `${(totalTime / 1000).toFixed(2)}s`;
+      total.title = "Total voice-turn time (you stopped speaking → Pi responds)";
+      header.appendChild(total);
+    }
+    container.appendChild(header);
 
     // Create chart container
     const chartContainer = document.createElement("div");
@@ -1166,7 +1174,7 @@ abstract class MessageControls {
     timeScale.style.height = "24px";
     timeScale.style.marginLeft = "160px"; // Space for labels
     timeScale.style.marginBottom = "5px";
-    timeScale.style.borderBottom = "1px solid #ccc";
+    timeScale.style.borderBottom = "1px solid rgba(0, 0, 0, 0.12)";
     
     // Determine appropriate tick interval based on timeline length
     let tickInterval = 1; // Default: show every second
@@ -1187,7 +1195,7 @@ abstract class MessageControls {
       tickMark.style.bottom = "0";
       tickMark.style.width = "1px";
       tickMark.style.height = "6px";
-      tickMark.style.backgroundColor = "#888";
+      tickMark.style.backgroundColor = "rgba(0, 0, 0, 0.35)";
       
       const tickLabel = document.createElement("div");
       tickLabel.className = "tick-label";
@@ -1288,8 +1296,8 @@ abstract class MessageControls {
       timelineColumn.style.flex = "1";
       timelineColumn.style.position = "relative";
       timelineColumn.style.height = "100%";
-      timelineColumn.style.backgroundColor = "#f5f5f5";
-      timelineColumn.style.border = "1px solid #e0e0e0";
+      timelineColumn.style.backgroundColor = "rgba(0, 0, 0, 0.04)";
+      timelineColumn.style.border = "1px solid rgba(0, 0, 0, 0.08)";
       timelineColumn.style.borderRadius = "4px";
       
       // Add segments within this row
@@ -1423,8 +1431,8 @@ abstract class MessageControls {
       timelineColumn.style.flex = "1";
       timelineColumn.style.position = "relative";
       timelineColumn.style.height = "100%";
-      timelineColumn.style.backgroundColor = "#f5f5f5";
-      timelineColumn.style.border = "1px solid #e0e0e0";
+      timelineColumn.style.backgroundColor = "rgba(0, 0, 0, 0.04)";
+      timelineColumn.style.border = "1px solid rgba(0, 0, 0, 0.08)";
       timelineColumn.style.borderRadius = "4px";
       
       // Add gap segments
@@ -1534,7 +1542,7 @@ abstract class MessageControls {
       const colorBox = document.createElement("div");
       colorBox.style.width = "12px";
       colorBox.style.height = "12px";
-      colorBox.style.backgroundColor = "#E0E0E0";
+      colorBox.style.backgroundColor = "#dcd3c7";
       colorBox.style.marginRight = "5px";
       colorBox.style.borderRadius = "2px";
       colorBox.style.border = "1px dashed #aaa";
@@ -1834,7 +1842,7 @@ abstract class MessageControls {
           start: currentSegment.end,
           end: nextSegment.start,
           duration: nextSegment.start - currentSegment.end,
-          color: '#E0E0E0', // Light gray
+          color: '#dcd3c7', // Light gray
           explanation: `Time between end of ${currentProcess.label} and start of ${nextProcess.label}`
         };
         

--- a/src/dom/colorUtils.ts
+++ b/src/dom/colorUtils.ts
@@ -1,0 +1,29 @@
+/**
+ * Pick a readable time-label colour for a segment of background colour `bgHex`,
+ * choosing white or near-black by whichever yields higher WCAG contrast. The
+ * muted telemetry palette has light members (sage, gold) where white labels read
+ * poorly; this gives each segment a legible label without hardcoding per-colour.
+ * Returns the colour plus a matching text-shadow (a soft dark halo behind white
+ * text only — pointless behind dark text).
+ */
+export function readableSegmentLabel(bgHex: string): {
+  color: string;
+  textShadow: string;
+} {
+  const m = /^#?([0-9a-f]{6})$/i.exec(bgHex.trim());
+  if (!m) return { color: "#fff", textShadow: "0 0 2px rgba(0,0,0,0.5)" };
+  const int = parseInt(m[1], 16);
+  const chan = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const L =
+    0.2126 * chan((int >> 16) & 0xff) +
+    0.7152 * chan((int >> 8) & 0xff) +
+    0.0722 * chan(int & 0xff);
+  const contrastWhite = 1.05 / (L + 0.05);
+  const contrastBlack = (L + 0.05) / 0.05;
+  return contrastBlack > contrastWhite
+    ? { color: "#222", textShadow: "none" }
+    : { color: "#fff", textShadow: "0 0 2px rgba(0,0,0,0.5)" };
+}

--- a/src/styles/messages.scss
+++ b/src/styles/messages.scss
@@ -353,11 +353,15 @@ body.saypi-recent-telemetry .present-messages .assistant-message:last-of-type .s
 }
 
 // Dark mode support
-.dark-mode, [data-theme="dark"] {
+// `html.dark` covers Claude/ChatGPT's dark themes (they don't use .dark-mode /
+// [data-theme]); the translucent base already degrades fine on dark, but this
+// gives those hosts the intended explicit dark card + legible text.
+.dark-mode, [data-theme="dark"], html.dark {
   .saypi-telemetry-container {
     background-color: #2a2a2a;
     border-color: #444;
-    
+    color: #ddd;
+
     button {
       background-color: #444;
       color: #ddd;

--- a/src/styles/messages.scss
+++ b/src/styles/messages.scss
@@ -137,28 +137,59 @@ body.saypi-recent-telemetry .present-messages .assistant-message:last-of-type .s
 
 // Telemetry visualization styles
 .saypi-telemetry-container {
-  margin-top: 10px;
-  padding: 10px;
-  background-color: #f5f5f5;
-  border-radius: 5px;
+  margin-top: 12px;
+  padding: 14px 16px;
+  // Theme-neutral translucent surface: a soft raised card that reads on both
+  // pi's warm cream and Claude/ChatGPT's darker surfaces without clashing. This
+  // is a debugging view, so it stays understated rather than fully host-styled.
+  background-color: rgba(127, 127, 127, 0.07);
+  border: 1px solid rgba(127, 127, 127, 0.18);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   width: 100%;
-  border: 1px solid #ddd;
   box-sizing: border-box;
-  
+  // Pi-native text colour where available (tracks light/dark), neutral elsewhere.
+  color: var(--color-text-secondary, #6b6255);
+
+  // Header: title on the left, total turn time as a subtle pill on the right.
+  .saypi-telemetry-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+
+    .saypi-telemetry-title {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      opacity: 0.7;
+    }
+    .saypi-telemetry-total {
+      font-size: 13px;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background-color: rgba(127, 127, 127, 0.12);
+    }
+  }
+
   button {
     padding: 3px 8px;
     border: none;
-    border-radius: 4px;
-    background-color: #ddd;
+    border-radius: 6px;
+    background-color: rgba(127, 127, 127, 0.15);
     cursor: pointer;
     transition: background-color 0.2s;
-    
+
     &:hover {
-      background-color: #ccc;
+      background-color: rgba(127, 127, 127, 0.25);
     }
-    
+
     &.active {
-      background-color: #0078d7;
+      background-color: var(--color-text-secondary, #776d6d);
       color: white;
     }
   }

--- a/test/dom/readableSegmentLabel.spec.ts
+++ b/test/dom/readableSegmentLabel.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { readableSegmentLabel } from "../../src/dom/colorUtils";
+
+/**
+ * Guards telemetry segment-label legibility: the muted palette has light members
+ * (sage, gold) where the old hardcoded white labels read poorly. The helper must
+ * pick white vs near-black by WCAG contrast.
+ */
+describe("readableSegmentLabel", () => {
+  it("uses white (with halo) on dark backgrounds", () => {
+    expect(readableSegmentLabel("#000000").color).toBe("#fff");
+    expect(readableSegmentLabel("#000000").textShadow).not.toBe("none");
+  });
+
+  it("uses dark text (no halo) on light backgrounds", () => {
+    const r = readableSegmentLabel("#ffffff");
+    expect(r.color).toBe("#222");
+    expect(r.textShadow).toBe("none");
+  });
+
+  it("uses dark text on the lighter palette members (sage, gold)", () => {
+    expect(readableSegmentLabel("#83996a").color).toBe("#222"); // sage
+    expect(readableSegmentLabel("#c2a14d").color).toBe("#222"); // gold
+  });
+
+  it("falls back to white for malformed input", () => {
+    expect(readableSegmentLabel("not-a-color").color).toBe("#fff");
+  });
+});


### PR DESCRIPTION
## Summary

The voice-turn telemetry panel used harsh Material primaries (red/blue/green/purple) on a cool grey card — jarring on pi.ai's warm cream. Refreshed it into a calmer, cohesive, host-sympathetic debugging view. (Seamlessness applies *loosely* here — it's an observability panel, not chat chrome — but it shouldn't clash.)

**Before:** `#DB4437` red / `#2979FF` blue / `#0F9D58` green … on a `#f5f5f5` grey card.
**After:** muted earthy palette on a soft translucent card.

### Changes
- **Cohesive muted palette** — terracotta / sage / teal / slate / mauve / gold / warm-neutral — replacing the Material primaries; reads on both pi's cream and Claude/ChatGPT's darker surfaces.
- **Theme-neutral translucent card** — soft raised surface (subtle bg + border + 12px radius + light shadow), Pi-native text colour via `--color-text-secondary` with a neutral fallback.
- **Cleaner header** — understated "PERFORMANCE" title + the total voice-turn time as a subtle pill (was a plain bold "Performance Metrics" h4).
- **Warmed inline track/tick greys** (`#f5f5f5`/`#e0e0e0`/`#ccc`/`#888` → translucent neutrals) so they don't read cold on cream.

Gantt geometry/positioning unchanged.

### Verification
Visual, against the **real built CSS** (Playwright screenshot of a representative panel):

`PERFORMANCE … 2.25s` · terracotta Transcription · sage Grace · teal LLM Wait · slate Pi writes — on a soft rounded card.

`npm test` green (884) · e2e suite green (9/9). Will L4-confirm on the live panel after merge.

## Related
Part of the telemetry observability work; depends on `saypi-api#257` (Server-Timing / Timing-Allow-Origin) for the upload-vs-server breakdown — this PR is the visual foundation that breakdown will slot into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)