### PR TITLE
feat(telemetry): break out transcription latency from Server-Timing (#258)

### DIFF
--- a/src/TelemetryModule.ts
+++ b/src/TelemetryModule.ts
@@ -1,5 +1,6 @@
 import EventBus from "./events/EventBus";
 import { logger } from "./LoggingModule";
+import { ServerTimingMetric } from "./telemetry/serverTiming";
 
 /**
  * Telemetry data for a single speech/chat message
@@ -25,7 +26,13 @@ export interface TelemetryData {
   
   // Time from start of chat completion to start of audio playback
   timeToTalk?: number;
-  
+
+  // Server-side latency breakdown for the transcription request, parsed from the
+  // `/transcribe` response's `Server-Timing` header (queue / recv / stt / filters
+  // / transformers / decorators / total). Present only when the API annotated the
+  // response; used to break out *where* transcription time went (usually STT).
+  serverTiming?: ServerTimingMetric[];
+
   // Absolute timestamps for key events (in milliseconds since epoch)
   timestamps?: {
     speechStart?: number;
@@ -161,6 +168,18 @@ export class TelemetryModule {
         logger.debug(`Transcription received and lastTranscriptionTime updated: ${this.lastTranscriptionTime}`);
         this.emitUpdate();
       }
+    });
+
+    // Server-side latency breakdown for the transcription request, parsed by
+    // TranscriptionModule from the `/transcribe` response's `Server-Timing`
+    // header. Stored on the current turn so the telemetry viz can show where the
+    // transcription time actually went (queue / recv / stt / filters / ...).
+    EventBus.on("saypi:transcription:serverTiming", (event: any) => {
+      const metrics: ServerTimingMetric[] | undefined = event?.metrics;
+      if (!metrics || !metrics.length) return;
+      this.currentTelemetry.serverTiming = metrics;
+      logger.debug("Recorded transcription Server-Timing breakdown", metrics);
+      this.emitUpdate();
     });
 
     // Listen for chat completion events

--- a/src/TranscriptionModule.ts
+++ b/src/TranscriptionModule.ts
@@ -7,6 +7,30 @@ import EventBus from "./events/EventBus";
 import { ChatbotService } from "./chatbots/ChatbotService";
 import { buildUsageMetadata } from "./usage/UsageMetadata";
 import { constructTranscriptionFormData } from "./TranscriptionForm";
+import { parseServerTiming } from "./telemetry/serverTiming";
+
+/**
+ * Parse the `/transcribe` response's `Server-Timing` header (saypi-api#258) and
+ * publish the per-phase server latency breakdown (queue / recv / stt / filters /
+ * transformers / decorators / total) for the telemetry viz. Best-effort: an
+ * absent header yields nothing and the viz simply falls back to the single
+ * transcription bar. The header can be absent for several harmless reasons: an
+ * older API deploy that doesn't set it; or the `callApi` direct-fetch fallback
+ * (when background routing fails) reading it from a content-script context, where
+ * the browser hides `Server-Timing` unless the response carries `Timing-Allow-
+ * Origin` — the privileged background service-worker fetch (the normal path) has
+ * no such restriction and forwards the header verbatim.
+ */
+function emitTranscriptionServerTiming(response: Response): void {
+  try {
+    const metrics = parseServerTiming(response.headers.get("Server-Timing"));
+    if (metrics.length) {
+      EventBus.emit("saypi:transcription:serverTiming", { metrics });
+    }
+  } catch (e) {
+    logger.debug("Failed to parse transcription Server-Timing header", e);
+  }
+}
 
 // Define the shape of the response JSON object
 interface TranscriptionResponse {
@@ -610,6 +634,8 @@ async function uploadAudio(
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
+
+    emitTranscriptionServerTiming(response);
 
     const responseJson: TranscriptionResponse = await response.json();
     const seq = responseJson.sequenceNumber;

--- a/src/dom/MessageElements.ts
+++ b/src/dom/MessageElements.ts
@@ -17,6 +17,7 @@ import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { SpeechHistoryModule } from "../tts/SpeechHistoryModule";
 import { regenerateSpeech } from "./regenerateSpeech";
 import { readableSegmentLabel } from "./colorUtils";
+import { ServerTimingMetric } from "../telemetry/serverTiming";
 import { MessageState } from "../tts/MessageHistoryModule";
 import telemetryModule, { TelemetryData } from "../TelemetryModule";
 import { IconModule } from "../icons/IconModule";
@@ -1128,9 +1129,114 @@ abstract class MessageControls {
     // Create the timeline chart (Gantt chart)
     this.createTimelineChart(chartContainer, metrics);
 
+    // If the API annotated the transcription with a server-side latency breakdown
+    // (Server-Timing header, saypi-api#258), render it as a dedicated panel below
+    // the timeline so the dominant cost (almost always speech-to-text) is visible.
+    const serverTiming = telemetryModule.getCurrentTelemetry().serverTiming;
+    if (serverTiming && serverTiming.length) {
+      this.createServerTimingBreakdown(container, serverTiming);
+    }
+
     // Insert the telemetry visualization into the DOM
     this.message.element.appendChild(container);
     this.telemetryContainer = container;
+  }
+
+  /**
+   * Render the transcription's server-side latency breakdown (from the
+   * `Server-Timing` header) as a compact stacked bar + legend. Additive and
+   * no-op-safe: it sits below the main timeline and only appears when the API
+   * supplied the header, so it never disturbs the timestamp-based Gantt above.
+   */
+  private createServerTimingBreakdown(
+    container: HTMLElement,
+    metrics: ServerTimingMetric[]
+  ): void {
+    // Muted palette consistent with the main timeline; STT (the usual culprit)
+    // gets the terracotta the single Transcription bar uses.
+    const PHASE_META: Record<string, { label: string; color: string }> = {
+      queue: { label: "Queue", color: "#857a6e" },
+      recv: { label: "Audio upload", color: "#c2a14d" },
+      stt: { label: "Speech-to-text", color: "#bd6b52" },
+      filters: { label: "Filters", color: "#83996a" },
+      transformers: { label: "Transformers", color: "#6a82a3" },
+      decorators: { label: "Decorators", color: "#9a7aa0" },
+    };
+    const fallback = (name: string) => ({ label: name, color: "#857a6e" });
+
+    const totalMetric = metrics.find((m) => m.name === "total");
+    const phases = metrics.filter(
+      (m) => m.name !== "total" && (m.duration ?? 0) > 0
+    );
+    if (!phases.length) return;
+
+    const sumPhases = phases.reduce((sum, m) => sum + (m.duration || 0), 0);
+    const scale = Math.max(totalMetric?.duration ?? 0, sumPhases);
+    if (scale <= 0) return;
+
+    const panel = document.createElement("div");
+    panel.className = "saypi-server-timing";
+
+    const header = document.createElement("div");
+    header.className = "saypi-server-timing-header";
+    const title = document.createElement("span");
+    title.className = "saypi-server-timing-title";
+    title.textContent = "Transcription breakdown";
+    header.appendChild(title);
+    if (totalMetric?.duration) {
+      const total = document.createElement("span");
+      total.className = "saypi-server-timing-total";
+      total.textContent = `${(totalMetric.duration / 1000).toFixed(2)}s server`;
+      total.title = "Total time spent server-side transcribing this turn";
+      header.appendChild(total);
+    }
+    panel.appendChild(header);
+
+    const bar = document.createElement("div");
+    bar.className = "saypi-server-timing-bar";
+    phases.forEach((m) => {
+      const meta = PHASE_META[m.name] || fallback(m.name);
+      const seg = document.createElement("div");
+      seg.className = "saypi-server-timing-seg";
+      seg.style.width = `${((m.duration || 0) / scale) * 100}%`;
+      seg.style.backgroundColor = meta.color;
+      seg.title = `${meta.label}: ${m.duration || 0}ms`;
+      bar.appendChild(seg);
+    });
+    panel.appendChild(bar);
+
+    const legend = document.createElement("ul");
+    legend.className = "saypi-server-timing-legend";
+    phases.forEach((m) => {
+      const meta = PHASE_META[m.name] || fallback(m.name);
+      const item = document.createElement("li");
+      item.className = "saypi-server-timing-item";
+
+      const swatch = document.createElement("span");
+      swatch.className = "saypi-server-timing-swatch";
+      swatch.style.backgroundColor = meta.color;
+
+      const label = document.createElement("span");
+      label.className = "saypi-server-timing-label";
+      // Surface the STT provider (the header's `desc`) so slow turns are
+      // attributable, e.g. "Speech-to-text · fal-wizper".
+      label.textContent =
+        m.name === "stt" && m.description
+          ? `${meta.label} · ${m.description}`
+          : meta.label;
+
+      const value = document.createElement("span");
+      value.className = "saypi-server-timing-value";
+      const ms = m.duration || 0;
+      value.textContent =
+        ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${ms}ms`;
+
+      item.append(swatch, label, value);
+      legend.appendChild(item);
+    });
+    panel.appendChild(legend);
+
+    container.appendChild(panel);
   }
 
   /**

--- a/src/styles/messages.scss
+++ b/src/styles/messages.scss
@@ -299,9 +299,91 @@ body.saypi-recent-telemetry .present-messages .assistant-message:last-of-type .s
       color: #666;
       margin-top: 10px;
       text-align: center;
-      
+
       i {
         font-style: italic;
+      }
+    }
+  }
+
+  // Server-side transcription latency breakdown (Server-Timing header,
+  // saypi-api#258). A compact stacked bar + legend below the timeline; present
+  // only when the API supplies the header. STT usually dominates, so this
+  // attributes slow turns to the right phase (and STT provider).
+  .saypi-server-timing {
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(127, 127, 127, 0.18);
+
+    .saypi-server-timing-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 8px;
+
+      .saypi-server-timing-title {
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .saypi-server-timing-total {
+        font-size: 12px;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        opacity: 0.7;
+      }
+    }
+
+    .saypi-server-timing-bar {
+      display: flex;
+      width: 100%;
+      height: 10px;
+      border-radius: 999px;
+      overflow: hidden;
+      background-color: rgba(127, 127, 127, 0.12);
+
+      .saypi-server-timing-seg {
+        height: 100%;
+        min-width: 1px;
+        transition: filter 0.2s ease;
+
+        &:hover {
+          filter: brightness(1.1);
+        }
+      }
+    }
+
+    .saypi-server-timing-legend {
+      list-style: none;
+      margin: 10px 0 0;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 16px;
+
+      .saypi-server-timing-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+
+        .saypi-server-timing-swatch {
+          width: 10px;
+          height: 10px;
+          border-radius: 2px;
+          flex: none;
+        }
+        .saypi-server-timing-label {
+          opacity: 0.85;
+        }
+        .saypi-server-timing-value {
+          font-variant-numeric: tabular-nums;
+          font-weight: 600;
+          opacity: 0.95;
+        }
       }
     }
   }

--- a/src/telemetry/serverTiming.ts
+++ b/src/telemetry/serverTiming.ts
@@ -1,0 +1,98 @@
+/**
+ * Parser for the HTTP `Server-Timing` response header.
+ *
+ * saypi-api annotates `/transcribe` responses with a per-phase latency breakdown
+ * (see Pedal-Intelligence/saypi-api#258), so the client can show *where* a slow
+ * transcription went — the dominant cost is almost always speech-to-text. The
+ * header looks like:
+ *
+ *   Server-Timing: queue;dur=2;desc="queue wait", recv;dur=1;desc="audio received",
+ *                  stt;dur=9800;desc="fal-wizper", filters;dur=12, transformers;dur=200,
+ *                  decorators;dur=50, total;dur=10100;desc="server total"
+ *
+ * Phases with no measurement are omitted by the server (not sent as `0`), so an
+ * absent metric means "not measured", not "instant".
+ *
+ * Grammar (RFC-ish, per the spec): comma-separated metrics; each metric is a
+ * token name followed by optional `;param=value` pairs. We only care about `dur`
+ * (a number, ms) and `desc` (token or quoted-string). We split on top-level
+ * commas/semicolons — i.e. those not inside a quoted `desc` value — so a desc
+ * like `"server total"` (or one containing a comma) survives intact.
+ */
+export interface ServerTimingMetric {
+  /** The metric name token, e.g. "stt", "queue", "total". */
+  name: string;
+  /** Duration in milliseconds, if the server reported one. */
+  duration?: number;
+  /** Human description, e.g. the STT provider ("fal-wizper") or "server total". */
+  description?: string;
+}
+
+/**
+ * Split a string on a delimiter char, ignoring delimiters inside double quotes.
+ */
+function splitTopLevel(input: string, delimiter: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+      current += ch;
+      continue;
+    }
+    if (ch === delimiter && !inQuotes) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  parts.push(current);
+  return parts;
+}
+
+/** Strip surrounding double quotes from a `desc` value, if present. */
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function parseServerTiming(
+  header: string | null | undefined
+): ServerTimingMetric[] {
+  if (!header || !header.trim()) return [];
+
+  const metrics: ServerTimingMetric[] = [];
+  for (const rawEntry of splitTopLevel(header, ",")) {
+    const entry = rawEntry.trim();
+    if (!entry) continue;
+
+    const segments = splitTopLevel(entry, ";");
+    const name = segments[0]?.trim();
+    if (!name) continue;
+
+    const metric: ServerTimingMetric = { name };
+    for (let i = 1; i < segments.length; i++) {
+      const param = segments[i].trim();
+      if (!param) continue;
+      const eq = param.indexOf("=");
+      if (eq === -1) continue;
+      const key = param.slice(0, eq).trim().toLowerCase();
+      const value = param.slice(eq + 1).trim();
+      if (key === "dur") {
+        const num = Number(value);
+        if (!Number.isNaN(num)) metric.duration = num;
+      } else if (key === "desc") {
+        const desc = unquote(value);
+        if (desc) metric.description = desc;
+      }
+    }
+    metrics.push(metric);
+  }
+  return metrics;
+}

--- a/test/telemetry/serverTiming-telemetry.spec.ts
+++ b/test/telemetry/serverTiming-telemetry.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import telemetryModule from "../../src/TelemetryModule";
+import EventBus from "../../src/events/EventBus";
+import type { ServerTimingMetric } from "../../src/telemetry/serverTiming";
+
+/**
+ * The transcription Server-Timing breakdown is published by TranscriptionModule as
+ * a `saypi:transcription:serverTiming` event; TelemetryModule stores it on the
+ * current turn so the viz can render the per-phase panel. It must clear on reset
+ * (turn start / navigation) like every other per-turn metric.
+ */
+describe("TelemetryModule transcription Server-Timing", () => {
+  beforeEach(() => {
+    telemetryModule.resetTelemetry();
+  });
+
+  const metrics: ServerTimingMetric[] = [
+    { name: "stt", duration: 9800, description: "fal-wizper" },
+    { name: "filters", duration: 12 },
+    { name: "total", duration: 10100, description: "server total" },
+  ];
+
+  it("stores metrics from the serverTiming event on the current turn", () => {
+    expect(telemetryModule.getCurrentTelemetry().serverTiming).toBeUndefined();
+    EventBus.emit("saypi:transcription:serverTiming", { metrics });
+    expect(telemetryModule.getCurrentTelemetry().serverTiming).toEqual(metrics);
+  });
+
+  it("ignores empty / malformed payloads", () => {
+    EventBus.emit("saypi:transcription:serverTiming", { metrics: [] });
+    expect(telemetryModule.getCurrentTelemetry().serverTiming).toBeUndefined();
+    EventBus.emit("saypi:transcription:serverTiming", {});
+    expect(telemetryModule.getCurrentTelemetry().serverTiming).toBeUndefined();
+  });
+
+  it("clears the breakdown on reset", () => {
+    EventBus.emit("saypi:transcription:serverTiming", { metrics });
+    expect(telemetryModule.getCurrentTelemetry().serverTiming).toEqual(metrics);
+    telemetryModule.resetTelemetry();
+    expect(telemetryModule.getCurrentTelemetry().serverTiming).toBeUndefined();
+  });
+});

--- a/test/telemetry/serverTiming.spec.ts
+++ b/test/telemetry/serverTiming.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { parseServerTiming } from "../../src/telemetry/serverTiming";
+
+describe("parseServerTiming", () => {
+  it("returns [] for empty/missing headers", () => {
+    expect(parseServerTiming(null)).toEqual([]);
+    expect(parseServerTiming(undefined)).toEqual([]);
+    expect(parseServerTiming("")).toEqual([]);
+    expect(parseServerTiming("   ")).toEqual([]);
+  });
+
+  it("parses the saypi-api #258 /transcribe contract example", () => {
+    const header =
+      'queue;dur=2;desc="queue wait", recv;dur=1;desc="audio received", ' +
+      'stt;dur=9800;desc="fal-wizper", filters;dur=12, transformers;dur=200, ' +
+      'decorators;dur=50, total;dur=10100;desc="server total"';
+
+    const metrics = parseServerTiming(header);
+
+    expect(metrics).toEqual([
+      { name: "queue", duration: 2, description: "queue wait" },
+      { name: "recv", duration: 1, description: "audio received" },
+      { name: "stt", duration: 9800, description: "fal-wizper" },
+      { name: "filters", duration: 12 },
+      { name: "transformers", duration: 200 },
+      { name: "decorators", duration: 50 },
+      { name: "total", duration: 10100, description: "server total" },
+    ]);
+  });
+
+  it("keeps a desc value that contains a comma intact", () => {
+    const metrics = parseServerTiming('stt;dur=500;desc="whisper, large-v3"');
+    expect(metrics).toEqual([
+      { name: "stt", duration: 500, description: "whisper, large-v3" },
+    ]);
+  });
+
+  it("tolerates an unquoted desc token and missing dur", () => {
+    const metrics = parseServerTiming("cache;desc=hit, stt;dur=42");
+    expect(metrics).toEqual([
+      { name: "cache", description: "hit" },
+      { name: "stt", duration: 42 },
+    ]);
+  });
+
+  it("ignores malformed params and fractional durations are preserved", () => {
+    const metrics = parseServerTiming("a;dur=1.5;junk, b; ; dur=3");
+    expect(metrics).toEqual([
+      { name: "a", duration: 1.5 },
+      { name: "b", duration: 3 },
+    ]);
+  });
+
+  it("skips a non-numeric dur rather than emitting NaN", () => {
+    const metrics = parseServerTiming("x;dur=abc");
+    expect(metrics).toEqual([{ name: "x" }]);
+  });
+});


### PR DESCRIPTION
## Why

The Performance Metrics panel showed a single opaque **Transcription** bar. When a turn is slow (we measured ~10s live), there was no way to see *where* the time went — client filters? upload? the STT model itself?

saypi-api now annotates `/transcribe` responses with a standard `Server-Timing` header (closes the client half of the work tracked in **Pedal-Intelligence/saypi-api#258**), breaking the server cost into phases:

```
Server-Timing: queue;dur=2;desc="queue wait", recv;dur=1;desc="audio received",
               stt;dur=9800;desc="fal-wizper", filters;dur=12, transformers;dur=200,
               decorators;dur=50, total;dur=10100;desc="server total"
```

This PR parses that header and renders the breakdown, so a slow turn is immediately attributable — almost always the STT provider, now labelled by name.

## What

| File | Change |
|---|---|
| `src/telemetry/serverTiming.ts` (new) | Pure `parseServerTiming()` — handles quoted/unquoted `desc`, comma-in-`desc`, missing/NaN `dur`. |
| `src/TranscriptionModule.ts` | After the **live** `/transcribe` response (not the refinement call, so the breakdown matches the displayed Transcription bar), reads `response.headers.get("Server-Timing")` and emits `saypi:transcription:serverTiming`. |
| `src/TelemetryModule.ts` | Stores the breakdown on the current turn (`TelemetryData.serverTiming`); cleared on reset like every other per-turn metric. |
| `src/dom/MessageElements.ts` | `createServerTimingBreakdown()` renders a compact stacked bar + legend **below** the existing timeline. Deliberately does **not** touch the timestamp-coupled Gantt above it. |
| `src/styles/messages.scss` | `.saypi-server-timing` styles, consistent with the refreshed telemetry card (muted palette; STT keeps the terracotta the Transcription bar uses). |

## Header delivery

`callApi` routes `/transcribe` through the **background service worker** (to bypass host CSP), and the SW forwards *all* response headers (`background.ts:857`). A privileged SW fetch to a host-permitted origin can read `Server-Timing` without `Timing-Allow-Origin`, so the header arrives verbatim on the normal path.

## No-op safety

Nothing renders and no behaviour changes when the header is absent (older API deploy, or the rare direct-fetch fallback). Guarded at three layers: parser returns `[]` → emit guard checks `metrics.length` → render guard checks `serverTiming?.length`. All server-derived text uses `textContent`.

## Testing

- **L1** parser (6 cases incl. the #258 contract example) + telemetry store/reset (3). Full suite green (**898 passed, 1 skipped**); `tsc` clean; SCSS compiles.
- **L4 pending**: the live render needs #258 *deployed* and a real (mic-gated) voice turn. Reviewed via `feature-dev:code-reviewer` (no blocking issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)