### PR TITLE
fix(tts): guard against duplicate voice menu insertion (#321)

### DIFF
--- a/src/tts/VoiceMenuUIManager.ts
+++ b/src/tts/VoiceMenuUIManager.ts
@@ -45,6 +45,24 @@ export class VoiceMenuUIManager {
       return Observation.foundAndDecorated(obs);
     }
 
+    // Idempotency guard (#321): a menu we created on a previous call carries its
+    // assigned id (e.g. "saypi-voice-menu") but NOT the host's
+    // getVoiceMenuSelector() class, so the query above can never re-find it.
+    // bootstrap re-invokes findAndDecorateVoiceMenu on every ready audio-controls
+    // mutation, so without this guard the create branch below would insert a
+    // SECOND menu each time. Re-find our own element by its id and report it as
+    // already decorated rather than creating a duplicate. Keyed on the live
+    // instance's getId() so it stays correct across chatbots (Pi, Claude, …).
+    if (this.voiceMenuInstance) {
+      const existing = document.getElementById(this.voiceMenuInstance.getId());
+      if (existing && audioControlsContainer.contains(existing)) {
+        return Observation.foundAlreadyDecorated(
+          this.voiceMenuInstance.getId(),
+          existing
+        );
+      }
+    }
+
     // --- Element not found, create it ---
     console.debug("Voice menu element not found via selector, creating...");
     voiceMenuElement = document.createElement("div");

--- a/test/tts/VoiceMenuUIManager.spec.ts
+++ b/test/tts/VoiceMenuUIManager.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// VoiceMenuUIManager -> VoiceMenu -> Pi forms an import cycle; ConfigModule reads
+// injected env at import time; JwtManager is touched when a selector constructs.
+// Mirror test/tts/VoiceMenu.spec.ts so the module graph imports cleanly.
+vi.mock("../../src/ConfigModule", () => ({
+  config: {
+    appServerUrl: "https://app.example.com",
+    apiServerUrl: "https://api.saypi.ai",
+    GA_MEASUREMENT_ID: "x",
+    GA_API_SECRET: "x",
+    GA_ENDPOINT: "x",
+  },
+}));
+vi.mock("../../src/chatbots/Pi", () => ({ PiAIChatbot: class {} }));
+vi.mock("../../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({
+    isAuthenticated: () => false,
+    getClaims: () => null,
+  }),
+}));
+
+import { VoiceMenuUIManager } from "../../src/tts/VoiceMenuUIManager";
+
+const VOICE_MENU_ID = "saypi-voice-menu";
+
+/**
+ * A stand-in for PiVoiceMenu: it assigns the menu ID to its element (as
+ * PiVoiceMenu's constructor does via addIdVoiceMenu) but NOT the host's
+ * getVoiceMenuSelector() class. That is the exact shape behind #321 — the
+ * selector re-query can never re-find the element SayPi created, so a repeat
+ * call falls through to the create branch and inserts a second menu.
+ */
+class FakeVoiceSelector {
+  constructor(public element: HTMLElement) {
+    this.element.id = VOICE_MENU_ID;
+  }
+  getId(): string {
+    return VOICE_MENU_ID;
+  }
+  getPositionFromEnd(): number {
+    return 0;
+  }
+}
+
+class FakeChatbot {
+  // A host selector that a bare <div id="saypi-voice-menu"> never matches.
+  getVoiceMenuSelector(): string {
+    return "div.t-action-m";
+  }
+  getVoiceMenu(_prefs: any, element: HTMLElement): any {
+    return new FakeVoiceSelector(element);
+  }
+}
+
+describe("VoiceMenuUIManager.findAndDecorateVoiceMenu idempotency (#321)", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    // document.getElementById only searches the live document tree.
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("inserts exactly one menu even when called repeatedly on the same container", () => {
+    const mgr = new VoiceMenuUIManager(new FakeChatbot() as any, {} as any);
+
+    mgr.findAndDecorateVoiceMenu(container);
+    mgr.findAndDecorateVoiceMenu(container);
+    mgr.findAndDecorateVoiceMenu(container);
+
+    expect(container.querySelectorAll(`#${VOICE_MENU_ID}`).length).toBe(1);
+  });
+
+  it("reuses the same element on the repeat call (no duplicate, reported as found+decorated)", () => {
+    const mgr = new VoiceMenuUIManager(new FakeChatbot() as any, {} as any);
+
+    const first = mgr.findAndDecorateVoiceMenu(container);
+    const second = mgr.findAndDecorateVoiceMenu(container);
+
+    expect(first.target).not.toBeNull();
+    expect(second.target).toBe(first.target);
+    expect(second.found).toBe(true);
+    expect(second.decorated).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds an ID-based idempotency guard to `VoiceMenuUIManager.findAndDecorateVoiceMenu` so a repeated call on the same container can never insert a second voice menu.

Closes #321.

## Why

`findAndDecorateVoiceMenu` guarded against re-creating the menu **only** by querying the host's `getVoiceMenuSelector()` (for Pi, `div.t-action-m`). When that query missed, it created a bare `<div>` and the `VoiceSelector` constructor assigned it `id="saypi-voice-menu"` — but the created element never carries the host selector class. So on a *subsequent* call for the same container, the selector query missed again and the create branch ran a second time → **a second voice menu inserted**.

`bootstrap.ts` re-invokes `this.voiceMenuUiMgr.findAndDecorateVoiceMenu(...)` on every mutation where the audio-controls container reports `isReady()` (it's true even for an already-decorated container), so the call recurs against the same container with no idempotency in the create branch.

## How

Before the create branch, if we already hold a `voiceMenuInstance` whose element is still present **within this container**, return it as already-decorated rather than creating a duplicate. The guard is keyed on the live instance's `getId()`, so it's correct across chatbots (Pi → `saypi-voice-menu`, Claude → `claude-voice-selector`) rather than hardcoding Pi's id. It sits *after* the host-selector branch, so a genuine host element still takes precedence; and it falls through to create if the prior element was removed from the DOM or the container changed (route change), so re-creation after host churn still works.

## Test (fail-first)

`test/tts/VoiceMenuUIManager.spec.ts` calls `findAndDecorateVoiceMenu` three times on one container and asserts exactly one `#saypi-voice-menu`. **RED before the guard** (3 menus created); GREEN after. A second case asserts the repeat call returns the *same* element (found + decorated), not a freshly-built one.

Full Vitest suite green locally (114 files, 898 passed / 1 skipped).

## Layer

L2 (JSDOM contract) — a controlled DOM reproduces the duplicate exactly, so this is provable in the required gate. The issue noted an optional L4 live confirmation that a second `#saypi-voice-menu` actually appears in practice; that's about *frequency* of the trigger — the missing idempotency guard is a real defect either way, and the guard is behavior-neutral when no duplicate would occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)