### PR TITLE
chore(i18n): remove dead previewStatus* keys (#329)

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "نشط بيتا"
-  },
-  "previewStatusCompleted": {
-    "message": "اكتمل التجريب"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "تم إيقاف التجربة حتى $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "غير قادر على الاتصال..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "حساب تعريفي"

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Бета активен"
-  },
-  "previewStatusCompleted": {
-    "message": "Бета завършена"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Бета версията е на пауза до $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Не може да се свърже..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Профил"

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "বেটা সক্রিয়"
-  },
-  "previewStatusCompleted": {
-    "message": "বেটা সম্পন্ন হয়েছে"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "বেটা বন্ধ রাখা হয়েছে $resetDate$ পর্যন্ত",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "সংযোগ করতে অক্ষম..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "প্রোফাইল"

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta aktivní"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Dokončeno"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta pozastavena do $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Nelze se připojit..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Aktiv"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Fuldført"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta sat på pause indtil $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Kan ikke oprette forbindelse..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Aktiv"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Abgeschlossen"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta pausiert bis $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Verbindung nicht möglich..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Ενεργό Βήτα"
-  },
-  "previewStatusCompleted": {
-    "message": "Ολοκληρώθηκε η Βήτα"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Η Βήτα έχει παύσει μέχρι την $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Αδυναμία σύνδεσης..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Προφίλ"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -516,25 +516,6 @@
     "message": "Multilingual voices are currently not supported in Safari.",
     "description": "Message shown when TTS is disabled in Safari"
   },
-  "previewStatusActive": {
-    "message": "Beta Active"
-  },
-  "previewStatusPaused": {
-    "message": "Beta Paused until $resetDate$",
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Completed"
-  },
-  "previewStatusUnknown": {
-    "message": "Unable to connect..."
-  },
   "previewProgress": {
     "message": "$count$ characters used out of $limit$",
     "description": "The message to display when the user is previewing a feature that has a character limit.",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta activa"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta completada"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta pausada hasta $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "No se puede conectar..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Perfil"

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beeta-aktiivinen"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Valmis"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta keskeytetty, kunnes $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Yhteys ei onnistu..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profiili"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Actif"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Terminée"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta en pause jusqu'à $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Impossible de se connecter..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "बीटा सक्रिय"
-  },
-  "previewStatusCompleted": {
-    "message": "बीटा पूरा हुआ"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "बीटा $resetDate$ तक रोके गए हैं",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "संपर्क करने में असमर्थ..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "प्रोफ़ाइल"

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Aktivni Beta"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta završena"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta pauzirana do $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Nije moguće povezati se..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Aktív Béta"
-  },
-  "previewStatusCompleted": {
-    "message": "Béta Befejezve"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Béta szünetel, amíg $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Nem sikerül csatlakozni..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Aktif"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Selesai"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta Dijeda hingga $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Tidak dapat terhubung..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta attiva"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta completata"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta in pausa fino al $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Impossibile connettersi..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profilo"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "ベータアクティブ"
-  },
-  "previewStatusCompleted": {
-    "message": "ベータ完了"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "ベータ版は$resetDate$まで一時停止中",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "接続できません..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "プロフィール"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "베타 활성"
-  },
-  "previewStatusCompleted": {
-    "message": "베타 완료"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "베타 일시 중지, $resetDate$까지",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "연결할 수 없습니다..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "윤곽"

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Aktif Beta"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Selesai"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta Ditangguhkan sehingga $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Tidak dapat menyambung..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Actief"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Voltooid"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta Gepauzeerd tot $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Kan geen verbinding maken..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profiel"

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta aktywna"
-  },
-  "previewStatusCompleted": {
-    "message": "Wersja beta ukończona"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Wersja beta wstrzymana do $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Nie można połączyć..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Ativo"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Concluído"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta Pausado até $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Incapaz de conectar..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Perfil"

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Activ"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Finalizată"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta în pauză până la $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Imposibil de conectat..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Активная Бета"
-  },
-  "previewStatusCompleted": {
-    "message": "Бета Завершена"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Бета приостановлена до $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Не удается подключиться..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Профиль"

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Aktívne"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Dokončená"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta Pozastavené do $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Nemožno sa pripojiť..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Aktiv"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Slutförd"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta Pausad tills $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Kan inte ansluta..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "பீட்டா செயலிழப்பு"
-  },
-  "previewStatusCompleted": {
-    "message": "பீட்டா முடிந்தது"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "பீட்டா $resetDate$ வரை நிறுத்தியுள்ளது",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "இணைக்க முடியவில்லை..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "சுயவிவரம்"

--- a/_locales/tl/messages.json
+++ b/_locales/tl/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Aktibong Beta"
-  },
-  "previewStatusCompleted": {
-    "message": "Nakumpleto na ang Beta"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta Itinigil hanggang $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Hindi makakonekta..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profile"

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta Aktif"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Tamamlandı"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta, $resetDate$ tarihine kadar duraklatıldı.",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Bağlanılamıyor..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Бета Активна"
-  },
-  "previewStatusCompleted": {
-    "message": "Бета Завершено"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Бета призупинена до $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Не вдається підключитися..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Профіл"

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Hoạt động Beta"
-  },
-  "previewStatusCompleted": {
-    "message": "Beta Hoàn Thành"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta Tạm dừng cho đến $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "Không thể kết nối..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Hồ sơ"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -722,25 +722,6 @@
       }
     }
   },
-  "previewStatusActive": {
-    "message": "Beta活跃"
-  },
-  "previewStatusCompleted": {
-    "message": "测试版已完成"
-  },
-  "previewStatusPaused": {
-    "description": "The message to display when the user is previewing a feature that has been paused.",
-    "message": "Beta 暂停，直到 $resetDate$",
-    "placeholders": {
-      "resetDate": {
-        "content": "$1",
-        "example": "2021-12-31"
-      }
-    }
-  },
-  "previewStatusUnknown": {
-    "message": "无法连接..."
-  },
   "profile": {
     "description": "Label for the user profile section.",
     "message": "轮廓"

--- a/test/i18n-no-dead-preview-status-keys.spec.ts
+++ b/test/i18n-no-dead-preview-status-keys.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Regression guard for #329: the previewStatus* messages were the last residue
+ * of the retired TTS "beta paused" surface (its runtime half was removed in
+ * #325 / PR #328). They have zero code consumers anywhere in src/, entrypoints/,
+ * public/, or tests, yet they were carried in every locale file.
+ *
+ * This scans the REAL locale files (not mocks), so it both proves the removal
+ * and prevents the dead keys from creeping back into any translation.
+ */
+const root = resolve(__dirname, "..");
+const localesDir = resolve(root, "_locales");
+
+const DEAD_KEYS = [
+  "previewStatusActive",
+  "previewStatusPaused",
+  "previewStatusCompleted",
+  "previewStatusUnknown",
+];
+
+const localeFiles = readdirSync(localesDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name)
+  .filter((locale) => existsSync(resolve(localesDir, locale, "messages.json")));
+
+describe("#329 retired previewStatus* i18n keys are gone from every locale", () => {
+  it("scans the full locale set (sanity: the scan actually found locale files)", () => {
+    expect(localeFiles.length).toBeGreaterThanOrEqual(30);
+  });
+
+  for (const locale of localeFiles) {
+    it(`_locales/${locale}/messages.json carries none of the retired previewStatus* keys`, () => {
+      const messages = JSON.parse(
+        readFileSync(resolve(localesDir, locale, "messages.json"), "utf8")
+      );
+      const present = DEAD_KEYS.filter((key) => key in messages);
+      expect(present).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## What

Removes the four dead `previewStatus*` i18n keys from all 32 `_locales/*/messages.json` files:

- `previewStatusActive` — "Beta Active"
- `previewStatusPaused` — "Beta Paused until $resetDate$"
- `previewStatusCompleted` — "Beta Completed"
- `previewStatusUnknown`

Closes #329.

## Why

These are the last residue of the retired TTS "beta paused" feature surface. Their runtime half (`isTTSBetaPaused` / the per-page-load `GET /status/tts` poll) was removed in #325 (PR #328), and the server stopped reporting a beta-preview status when TTS GA'd. The keys have **zero code consumers** anywhere in `src/`, `entrypoints/`, `public/`, or tests:

```
$ grep -rn "previewStatus" --include="*.ts" --include="*.js" --include="*.html" src entrypoints public
# (no matches)
```

They were left out of #325 because they touch all 32 locale files and don't affect behavior — folding them into a tight, poll-focused diff would have ballooned it.

## How

Behavior-neutral removal — no consumers, no new translations needed. The deletion is surgical (brace-matched per key, validated by re-parsing each file and deep-comparing to the original-minus-keys), so each locale file keeps its exact existing formatting and key order. The diff is **608 deletions and nothing else** — sibling keys like `previewProgress` (which legitimately uses "characters") are untouched.

## Test

Adds `test/i18n-no-dead-preview-status-keys.spec.ts` — a guard that scans the real locale files and fails if any of the four keys reappear in any locale. **RED before this change** (32 locales carried them); GREEN after. This is the same real-source-scan pattern as `test/i18n-tts-credits.spec.ts`; the spec necessarily *names* the keys to assert their absence, which is why a repo-wide `grep previewStatus` now matches only this guard file (not a consumer).

`npm test` green (Jest 2/2; Vitest 114 files, 929 passed / 1 skipped).

## Acceptance criteria (from #329)

- [x] The four `previewStatus*` keys are gone from every locale file
- [x] `npm test` stays green
- [x] Repo-wide `grep "previewStatus"` returns nothing outside git history (except the new guard test that asserts their absence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)