### PR TITLE
fix(vad): notify the displaced tab when another tab takes over the mic (#320)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1054,6 +1054,14 @@
     "message": "VAD processing stopped.",
     "description": "VAD detail indicating VAD processing has stopped."
   },
+  "vadStatusPreempted": {
+    "message": "Paused",
+    "description": "VAD status shown on a tab whose voice input was taken over by another tab."
+  },
+  "vadDetailVoiceMovedToOtherTab": {
+    "message": "Voice input moved to another tab",
+    "description": "VAD detail explaining the call ended because the microphone was claimed by a newer tab."
+  },
   "vadDetailStopError": {
     "message": "Stop Error: $error$",
     "description": "VAD detail for a stop error, with specific error message.",

--- a/src/offscreen/vad_handler.ts
+++ b/src/offscreen/vad_handler.ts
@@ -284,7 +284,60 @@ async function initializeVAD(initOptions: { preset?: VADPreset } = {}) {
   }
 }
 
-async function startVAD(tabId: number) {
+/**
+ * Decide whether starting VAD for `newTabId` should preempt a different tab that
+ * currently owns the single shared VAD instance. Returns the tab to notify, or
+ * null. Pure (no side effects) so the routing-overwrite contract is unit-testable. (#320)
+ */
+export function computePreemption(
+  previousTabId: number | null,
+  newTabId: number,
+  instanceActive: boolean
+): { targetTabId: number } | null {
+  if (previousTabId !== null && previousTabId !== newTabId && instanceActive) {
+    return { targetTabId: previousTabId };
+  }
+  return null;
+}
+
+/**
+ * A stop/destroy of the single shared VAD should be honored only when it comes
+ * from the tab that currently owns it. A request from a preempted (non-owner) tab
+ * must NOT tear down the instance the new owner is using. When there is no current
+ * owner (or no source tab id) there is no ambiguity, so honor it (legacy behavior). (#320)
+ */
+export function isTeardownFromOwner(
+  sourceTabId: number | undefined,
+  currentOwner: number | null
+): boolean {
+  if (sourceTabId === undefined || currentOwner === null) {
+    return true;
+  }
+  return sourceTabId === currentOwner;
+}
+
+export async function startVAD(tabId: number) {
+  // Last-tab-wins: if a DIFFERENT tab currently owns the shared VAD, it is being
+  // displaced. Notify it (VAD_PREEMPTED) so it can cleanly exit its call instead
+  // of silently losing voice input. (#320)
+  //
+  // Usage-counting note: this takeover still increments below, while the displaced
+  // tab's owner-guarded stop/destroy no-op (no matching decrement) — a deliberate
+  // asymmetry. It is safe: the count can only stay too HIGH (which never triggers
+  // auto-shutdown early), and the new owner's destroyVAD resetUsageCounter('vad')
+  // zeroes it, so the imbalance can't accumulate across calls.
+  const preemption = computePreemption(currentVadTabId, tabId, vadInstance !== null);
+  if (preemption) {
+    logger.log(
+      `[SayPi VAD Handler] Tab ${tabId} is taking over voice input from tab ${preemption.targetTabId}; notifying the displaced tab.`
+    );
+    chrome.runtime.sendMessage({
+      type: "VAD_PREEMPTED",
+      targetTabId: preemption.targetTabId,
+      origin: "offscreen-document",
+    });
+  }
+
   currentVadTabId = tabId;
   incrementUsage('vad');
   
@@ -310,7 +363,14 @@ async function startVAD(tabId: number) {
   }
 }
 
-async function stopVAD() {
+export async function stopVAD(sourceTabId?: number) {
+  // A preempted (non-owner) tab must not stop the shared VAD the new owner uses. (#320)
+  if (!isTeardownFromOwner(sourceTabId, currentVadTabId)) {
+    logger.debug(
+      `[SayPi VAD Handler] Ignoring VAD_STOP_REQUEST from non-owner tab ${sourceTabId} (current owner: ${currentVadTabId}).`
+    );
+    return { success: true, ignored: true };
+  }
   if (vadInstance) {
     try {
       logger.log("[SayPi VAD Handler] Stopping VAD...");
@@ -325,7 +385,14 @@ async function stopVAD() {
   return { success: false, error: "VAD not initialized or already stopped." };
 }
 
-function destroyVAD() {
+export function destroyVAD(sourceTabId?: number) {
+  // A preempted (non-owner) tab must not destroy the shared VAD the new owner uses. (#320)
+  if (!isTeardownFromOwner(sourceTabId, currentVadTabId)) {
+    logger.debug(
+      `[SayPi VAD Handler] Ignoring VAD_DESTROY_REQUEST from non-owner tab ${sourceTabId} (current owner: ${currentVadTabId}).`
+    );
+    return { success: true, ignored: true };
+  }
   logger.log("[SayPi VAD Handler] Destroying VAD...");
   if (vadInstance) {
     vadInstance.destroy();
@@ -355,12 +422,12 @@ function registerVadHandlersOnce() {
     return startVAD(sourceTabId);
   });
 
-  registerMessageHandler("VAD_STOP_REQUEST", () => {
-    return stopVAD();
+  registerMessageHandler("VAD_STOP_REQUEST", (message, sourceTabId) => {
+    return stopVAD(sourceTabId);
   });
 
-  registerMessageHandler("VAD_DESTROY_REQUEST", () => {
-    return destroyVAD();
+  registerMessageHandler("VAD_DESTROY_REQUEST", (message, sourceTabId) => {
+    return destroyVAD(sourceTabId);
   });
 
   // DEV-only: arm/disarm the synthetic audio source. Drops any mic-bound VAD

--- a/src/state-machines/AudioInputMachine.ts
+++ b/src/state-machines/AudioInputMachine.ts
@@ -100,6 +100,14 @@ function setupVADEventListeners() {
   vadClient.on('onFrameProcessed', (probabilities: { isSpeech: number; notSpeech: number }) => {
     EventBus.emit("saypi:vadFrameProcessed", probabilities);
   });
+
+  vadClient.on('onPreempted', () => {
+    // Another tab took over the single shared microphone (#320). End this tab's
+    // call cleanly via the normal hang-up path rather than letting it sit there
+    // with dead voice input. (Offscreen VAD only; the onscreen client never fires this.)
+    logger.info("[AudioInputMachine] Voice input was taken over by another tab; ending this tab's call.");
+    EventBus.emit("saypi:hangup");
+  });
 }
 
 // Initialize the appropriate VAD client based on browser support

--- a/src/vad/OffscreenVADClient.ts
+++ b/src/vad/OffscreenVADClient.ts
@@ -104,6 +104,15 @@ export class OffscreenVADClient implements VADClientInterface {
           this.statusIndicator.updateStatus(getMessage('vadStatusError'), message.error || getMessage('vadDetailUnknownVADError'));
           this.callbacks.onError?.(message.error || getMessage('vadDetailUnknownVADError'));
           break;
+        case "VAD_PREEMPTED":
+          // Another tab claimed the single shared offscreen mic (#320). This is an
+          // orderly handoff, NOT an error: show a calm "voice moved" status and let
+          // the call tear down cleanly via onPreempted. Clear isActive so a later
+          // idle port recycle isn't misreported as a mid-call failure.
+          this.isActive = false;
+          this.statusIndicator.updateStatus(getMessage('vadStatusPreempted'), getMessage('vadDetailVoiceMovedToOtherTab'));
+          this.callbacks.onPreempted?.();
+          break;
         case "OFFSCREEN_VAD_INITIALIZE_REQUEST_RESPONSE":
           if (message.payload.success) {
             const mode = message.payload.mode;

--- a/src/vad/VADClientInterface.ts
+++ b/src/vad/VADClientInterface.ts
@@ -13,6 +13,9 @@ export interface VADClientCallbacks {
   }) => void;
   onVADMisfire?: () => void;
   onError?: (error: string) => void;
+  // Fired when another tab claims the single shared offscreen mic, displacing
+  // this tab's VAD session. Offscreen VAD only — onscreen VAD is per-tab. (#320)
+  onPreempted?: () => void;
   onFrameProcessed?: (probabilities: { isSpeech: number; notSpeech: number }) => void;
   onInitialized?: (success: boolean, error?: string, mode?: string) => void;
   onStarted?: (success: boolean, error?: string) => void;

--- a/test/offscreen/vad_handler-preemption.spec.ts
+++ b/test/offscreen/vad_handler-preemption.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #320 — Option A (last-tab-wins + clean handoff). The single offscreen document
+ * holds ONE shared VAD instance and a single `currentVadTabId`. When a second tab
+ * starts a call while a first tab's call is active, the second tab wins the (one)
+ * mic and the first tab must be NOTIFIED (VAD_PREEMPTED) so it can cleanly exit —
+ * not go silently dead. Critically, the displaced tab's own teardown must NOT tear
+ * down the shared VAD instance the new owner is now using (owner-guarded stop/destroy).
+ *
+ * These tests pin the two pure decisions at L1 (the routing-overwrite contract and
+ * the owner-guard safety contract) and verify they are actually wired into
+ * startVAD / destroyVAD end-to-end.
+ */
+
+const { fakeVad, sendMessage } = vi.hoisted(() => {
+  const sendMessage = vi.fn();
+  (globalThis as any).chrome = {
+    runtime: {
+      getURL: (p: string) => `chrome-extension://test/${p}`,
+      sendMessage,
+    },
+  };
+  return {
+    fakeVad: { start: vi.fn(), pause: vi.fn(), destroy: vi.fn() },
+    sendMessage,
+  };
+});
+
+vi.mock("@ricky0123/vad-web", () => ({
+  MicVAD: { new: vi.fn(async () => fakeVad) },
+}));
+vi.mock("onnxruntime-web", () => ({ env: { logLevel: "error", wasm: {} } }));
+vi.mock("../../src/LoggingModule.js", () => ({
+  logger: { log: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), reportError: vi.fn() },
+}));
+vi.mock("../../src/offscreen/media_coordinator", () => ({
+  incrementUsage: vi.fn(),
+  decrementUsage: vi.fn(),
+  resetUsageCounter: vi.fn(),
+  registerMessageHandler: vi.fn(),
+}));
+
+import {
+  computePreemption,
+  isTeardownFromOwner,
+  startVAD,
+  stopVAD,
+  destroyVAD,
+} from "../../src/offscreen/vad_handler";
+
+describe("#320 computePreemption (routing-overwrite contract)", () => {
+  it("flags the PREVIOUS tab for preemption when a different tab takes over an active session", () => {
+    expect(computePreemption(1, 2, true)).toEqual({ targetTabId: 1 });
+  });
+
+  it("does NOT preempt when the same tab re-starts (mid-call stop/start)", () => {
+    expect(computePreemption(1, 1, true)).toBeNull();
+  });
+
+  it("does NOT preempt when there was no previous owner", () => {
+    expect(computePreemption(null, 2, true)).toBeNull();
+  });
+
+  it("does NOT preempt when no VAD instance is active (nothing to take over)", () => {
+    expect(computePreemption(1, 2, false)).toBeNull();
+  });
+});
+
+describe("#320 isTeardownFromOwner (owner-guard safety contract)", () => {
+  it("honors a teardown from the current owner", () => {
+    expect(isTeardownFromOwner(2, 2)).toBe(true);
+  });
+
+  it("REJECTS a teardown from a non-owner (a preempted tab must not kill the new owner's mic)", () => {
+    expect(isTeardownFromOwner(1, 2)).toBe(false);
+  });
+
+  it("honors a teardown when there is no current owner (no ambiguity — preserves legacy behavior)", () => {
+    expect(isTeardownFromOwner(1, null)).toBe(true);
+  });
+
+  it("honors a teardown with no source tab id (legacy callers)", () => {
+    expect(isTeardownFromOwner(undefined, 2)).toBe(true);
+  });
+});
+
+describe("#320 vad_handler wiring: preemption + owner-guarded teardown", () => {
+  beforeEach(() => {
+    sendMessage.mockClear();
+    fakeVad.start.mockClear();
+    fakeVad.pause.mockClear();
+    fakeVad.destroy.mockClear();
+  });
+
+  it("notifies the displaced tab on takeover, and a non-owner's stop/destroy does NOT tear down the shared VAD", async () => {
+    // Tab 1 starts a call.
+    await startVAD(1);
+
+    // Tab 2 starts a call → it wins the shared mic; tab 1 must be notified.
+    await startVAD(2);
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: "VAD_PREEMPTED",
+      targetTabId: 1,
+      origin: "offscreen-document",
+    });
+
+    // Tab 1 (now displaced) tears down its call. Neither its stop nor its destroy
+    // may touch the shared VAD instance that tab 2 (the new owner) is using — that
+    // would silently break tab 2's call (the whole point of the owner-guard).
+    await stopVAD(1);
+    expect(fakeVad.pause).not.toHaveBeenCalled();
+    destroyVAD(1);
+    expect(fakeVad.destroy).not.toHaveBeenCalled();
+
+    // The current owner (tab 2) can still tear down cleanly.
+    destroyVAD(2);
+    expect(fakeVad.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/state-machines/AudioInputMachine-preemptionWiring.spec.ts
+++ b/test/state-machines/AudioInputMachine-preemptionWiring.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * #320 wiring guard. The displaced tab only exits its call cleanly because
+ * AudioInputMachine registers an `onPreempted` VAD callback that emits the
+ * `saypi:hangup` event (the verified clean call-teardown). That 3-line
+ * registration is the load-bearing final link of the feature, and the
+ * OffscreenVADClient unit test only proves the callback FIRES — not that it is
+ * wired to hang-up. Importing AudioInputMachine to test it at runtime would pull
+ * in the whole content-script bootstrap (setupInterceptors, a real VAD client,
+ * many EventBus subscriptions) — too heavy/flaky for the required gate. So, in
+ * keeping with the repo's source-scanning i18n guards, assert the wiring against
+ * the real source: it catches a dropped handler or a renamed event.
+ */
+const src = readFileSync(
+  resolve(__dirname, "..", "..", "src/state-machines/AudioInputMachine.ts"),
+  "utf8"
+);
+
+describe("#320 AudioInputMachine onPreempted -> saypi:hangup wiring", () => {
+  it("registers an onPreempted VAD callback whose body emits saypi:hangup", () => {
+    // Capture the onPreempted handler block: vadClient.on('onPreempted', () => { ... })
+    const handler = src.match(
+      /onPreempted['"]\s*,\s*\(\s*\)\s*=>\s*\{([\s\S]*?)\}\s*\)/
+    );
+    expect(handler).toBeTruthy();
+    expect(handler![1]).toMatch(/EventBus\.emit\(\s*["']saypi:hangup["']\s*\)/);
+  });
+});

--- a/test/vad/OffscreenVADClient-preemption.spec.ts
+++ b/test/vad/OffscreenVADClient-preemption.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// #320 — when another tab claims the single shared offscreen mic, this tab
+// receives a VAD_PREEMPTED message. It must surface an orderly "voice moved to
+// another tab" status (NOT a red error), fire onPreempted so the call tears down
+// cleanly, and clear isActive so a subsequent idle port recycle stays quiet.
+
+const { indicatorInstances } = vi.hoisted(() => ({ indicatorInstances: [] as any[] }));
+
+vi.mock("../../src/LoggingModule", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../../src/i18n", () => ({
+  // Echo the message key back so assertions can match on it.
+  default: (key: string) => key,
+}));
+vi.mock("../../src/offscreen/media_coordinator", () => ({
+  sanitizeMessageForLogs: (m: any) => m,
+}));
+vi.mock("../../src/ui/VADStatusIndicator", () => ({
+  VADStatusIndicator: class {
+    updateStatus = vi.fn();
+    hide = vi.fn();
+    show = vi.fn();
+    destroy = vi.fn();
+    constructor() {
+      indicatorInstances.push(this);
+    }
+  },
+}));
+
+import { OffscreenVADClient } from "../../src/vad/OffscreenVADClient";
+
+const PREEMPT_STATUS = ["vadStatusPreempted", "vadDetailVoiceMovedToOtherTab"];
+const DISCONNECT_ERROR = ["vadStatusError", "vadDetailVADServiceDisconnected"];
+
+describe("OffscreenVADClient VAD_PREEMPTED (#320)", () => {
+  let ports: any[];
+
+  beforeEach(() => {
+    ports = [];
+    indicatorInstances.length = 0;
+    (global as any).chrome = {
+      runtime: {
+        connect: vi.fn(() => {
+          const port = {
+            onMessage: { addListener: vi.fn() },
+            onDisconnect: { addListener: vi.fn() },
+            postMessage: vi.fn(),
+            disconnect: vi.fn(),
+          };
+          ports.push(port);
+          return port;
+        }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete (global as any).chrome;
+  });
+
+  const deliver = (message: any, portIndex = 0) => {
+    const listener = ports[portIndex].onMessage.addListener.mock.calls[0][0];
+    listener(message);
+  };
+  const triggerDisconnect = (portIndex = 0) => {
+    const listener = ports[portIndex].onDisconnect.addListener.mock.calls[0][0];
+    listener();
+  };
+
+  it("surfaces an orderly 'voice moved' status (not an error) and fires onPreempted", () => {
+    const client = new OffscreenVADClient();
+    const indicator = indicatorInstances[0];
+    const onPreempted = vi.fn();
+    client.on("onPreempted", onPreempted);
+    client.start(); // user is mid-call
+
+    deliver({ origin: "offscreen-document", type: "VAD_PREEMPTED" });
+
+    expect(indicator.updateStatus).toHaveBeenCalledWith(...PREEMPT_STATUS);
+    expect(onPreempted).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the active session so a later idle port recycle stays quiet (no false 'try reloading')", () => {
+    const client = new OffscreenVADClient();
+    const indicator = indicatorInstances[0];
+    client.start(); // session active
+
+    deliver({ origin: "offscreen-document", type: "VAD_PREEMPTED" });
+    indicator.updateStatus.mockClear();
+
+    // The shared offscreen/SW may be recycled afterward; that must not be
+    // misreported as a mid-call failure, because this session already ended.
+    triggerDisconnect();
+    expect(indicator.updateStatus).not.toHaveBeenCalledWith(...DISCONNECT_ERROR);
+  });
+});


### PR DESCRIPTION
## What

Implements the founder-approved **Option A (last-tab-wins + clean handoff)** for #320. When a second browser tab starts a voice call while a first tab's call is active, the second tab wins the single shared microphone, and the first (displaced) tab is now **notified and cleanly exits its call** instead of going silently dead.

Closes #320.

## The bug

One offscreen document holds **one** shared VAD instance/stream and a single module-global `currentVadTabId` (`vad_handler.ts`). `startVAD` overwrote `currentVadTabId` unconditionally, so once a second tab started, every VAD event (`VAD_SPEECH_START/END/MISFIRE/FRAME`) routed to it and the first tab's voice input died with no feedback.

## The fix

- **Offscreen detects the takeover** — `startVAD` uses the pure helper `computePreemption(prev, new, instanceActive)` and, on a genuine cross-tab takeover, sends `VAD_PREEMPTED` to the **displaced** tab before reassigning ownership. Routing needed no change: `VAD_*` messages keyed by `targetTabId` are already forwarded generically to the right per-tab port.
- **Owner-guarded teardown (the subtle part)** — `stopVAD`/`destroyVAD` now take the requesting `sourceTabId` and **ignore a stop/destroy from a non-owner** (pure helper `isTeardownFromOwner`). Without this guard, the displaced tab's *own* clean teardown (`saypi:hangup` → `vadClient.destroy()` → `VAD_DESTROY_REQUEST`) would hit the global `destroyVAD` and tear down the shared VAD the **new owner** is using — silently breaking last-tab-wins. `offscreen_manager` already stamps `sourceTabId` onto every forwarded port message, so the guard has the data it needs.
- **Content client** — a new `VAD_PREEMPTED` case in `OffscreenVADClient` shows a calm *"Voice input moved to another tab"* status (deliberately **not** a red error — it's an orderly handoff), clears `isActive`, and fires the new `onPreempted` callback.
- **Wiring** — `AudioInputMachine` registers `onPreempted` to emit the existing, verified clean call-teardown event `saypi:hangup`, so the displaced tab ends its call exactly as if the user hit hang-up (`EventModule` → `ConversationMachine` → `stopRecording`/`callHasEnded`).
- **i18n** — en `vadStatusPreempted` + `vadDetailVoiceMovedToOtherTab` (en-only; non-en falls back to en, per the established pattern).

**Onscreen VAD is per-tab**, so it's untouched (it never fires `onPreempted`). **Single-tab behaviour is unchanged**: `computePreemption` returns null (no different previous owner) and `isTeardownFromOwner` returns true (owner).

## Tests (fail-first, L1)

- `test/offscreen/vad_handler-preemption.spec.ts` — pins the **routing-overwrite contract** (`computePreemption`: only a different active owner is preempted) and the **owner-guard safety contract** (`isTeardownFromOwner`), plus an integration test that drives `startVAD(1) → startVAD(2)` and asserts (a) tab 1 receives `VAD_PREEMPTED` and (b) a non-owner's `destroyVAD(1)` does **not** destroy the shared instance, while the owner's `destroyVAD(2)` does.
- `test/vad/OffscreenVADClient-preemption.spec.ts` — the client case: `VAD_PREEMPTED` → "voice moved" status + `onPreempted` fired + `isActive` cleared (a subsequent idle recycle stays quiet).
- The existing `OffscreenVADClient-disconnect.spec.ts` still passes (no regression to the #307 idle-recycle behaviour).

Both confirmed RED before the fix (11 failing), GREEN after. Full suite: Jest 2/2, Vitest 117 files / 942 passed / 1 skipped.

## Layer

L1 unit (the routing/owner decisions are pure and exhaustively testable — the issue itself pointed at L1 for the routing-overwrite contract). The full cross-tab handoff is verifiable later at L4; true two-context concurrency (Option B) remains out of scope by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)