### PR TITLE
docs(agents): codify concurrent-agent worktree isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Since 2026-06-13, saypi-userscript is maintained as an **autonomously engineered
 - Explore the codebase; bring `AGENTS.md`/`CLAUDE.md` to verified reality; remove dead cruft coherently.
 - Build the testability layers and their CI wiring — *additive* test/CI changes are explicitly yours to make.
 - Triage the backlog with adversarially-verified evidence; file issues per the Issue Authoring Standard.
-- Fix issues via fail-first TDD (see Testing Guidelines) in **isolated git worktrees**; open small, blast-radius-scoped PRs with full provenance (narrative why/what/verification, `Fixes #N`, Claude Code attribution).
+- Fix issues via fail-first TDD (see Testing Guidelines) in **isolated git worktrees** under `.worktrees/` (see Hard guardrails — sibling agents run concurrently); open small, blast-radius-scoped PRs with full provenance (narrative why/what/verification, `Fixes #N`, Claude Code attribution).
 - Review every PR with independent subagent reviewers before merge (multi-lens for the high-blast-radius domains below). GitHub disallows self-approval, so post verdicts as PR comments.
 - Merge when gates pass; keep persistent operational memory across sessions.
 
@@ -23,6 +23,7 @@ Since 2026-06-13, saypi-userscript is maintained as an **autonomously engineered
 
 **Hard guardrails (defense-in-depth):**
 - All changes via PR. Never push to `main`, force-push shared branches, or touch branches/issues/PRs that aren't yours.
+- **Concurrent agents — isolate in `.worktrees/`.** Sibling Claude sessions work this repo at the same time (you may see live peers as sibling directories under the gitignored `.worktrees/`). Run every fix in its **own per-task git worktree under `.worktrees/`** — e.g. `git worktree add .worktrees/<task> -b <branch>` — never the shared `main` checkout and never an out-of-repo location (it must stay gitignored and discoverable to peers). Treat another agent's worktree, branch, and uncommitted files as off-limits: never edit, commit to, rebase, or `git worktree remove` them.
 - Begin every commit/push command with `[ "$(git rev-parse --abbrev-ref HEAD)" = "<expected-branch>" ] || exit 1` in the same shell invocation. After `gh pr merge`, confirm `gh pr view --json state` is `MERGED`.
 - Never hand-edit generated artifacts: `.output/`, `dist/`, `public/` build output, `.wxt/`. Fix the generator or env input instead.
 - **Credentials (permanent boundary):** never read, copy, load, or echo `.env.production` or any secret; never run `npm run env:pull` against production. Copy only non-production env files into worktrees; never commit them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,3 +192,4 @@ npm run test:vitest:watch  # Run Vitest in watch mode
 - Offscreen documents required for audio processing due to host page CSP restrictions
 - Authentication system handles both direct JWT tokens and cookie-based fallback
 - Progressive search patterns handle dynamic content loading in modern SPAs
+- **Concurrent agents:** this repo is maintained autonomously by multiple Claude sessions at once. Isolate every change in its own git worktree under the gitignored `.worktrees/` directory (not the shared `main` checkout, not an out-of-repo location), and never touch another agent's worktree or branch. The canonical rule lives in `AGENTS.md` (Hard guardrails).


### PR DESCRIPTION
## Why

The autonomous-engineering mandate tells agents to fix issues **"in isolated git worktrees"** (`AGENTS.md`, standing authorization + `doc/autonomous-bootstrap.md`). But two load-bearing details were never written into the always-read guidelines:

1. **Why** the isolation matters — *sibling Claude sessions work this repo concurrently* (right now there's a live peer at `.worktrees/layer35-cloudflare/`). The bare word "isolated" reads as "isolation from your own uncommitted work on `main`" — the generic `superpowers:using-git-worktrees` framing — not "isolation from another agent."
2. **Where** worktrees go — the agreed location is the in-repo, gitignored `.worktrees/`.

Those two facts lived only in operator **memory** and a passive `.gitignore:90-91` comment (`# Git worktrees for isolated agent workspaces`). A fresh agent that doesn't share that memory store would know to use *a* worktree, but not the concurrency rationale, and would likely default (via the superpowers skill's "smart directory selection") to the now-**deprecated** out-of-repo location `~/.config/superpowers/worktrees/`.

## What

Promote the rule from memory into the docs every session reads:

- **`AGENTS.md` › Hard guardrails** — new canonical bullet: per-task worktree under `.worktrees/`, never the shared `main` checkout, never an out-of-repo location, and never touch a peer's worktree/branch. Plus a cross-reference added to the standing-authorization "Fix issues…" bullet.
- **`CLAUDE.md` › Development Notes** — concise pointer to the canonical rule.

The operator-memory note is trimmed to a back-reference (canonical text now lives in the repo).

## Verification

Docs-only — no source, test, or build surface touched. `git diff` is 3 insertions / 1 deletion across `AGENTS.md` + `CLAUDE.md`. Required `test (22.x)` and `e2e` checks run for confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
