### PR TITLE
fix(layer35): gate pi.ai as Cloudflare-blocked — honest Layer-4 pointer (Closes #348)

### DIFF
--- a/doc/layer35-real-host-loop.md
+++ b/doc/layer35-real-host-loop.md
@@ -44,11 +44,10 @@ launcher) and attaching over CDP — real Chrome loads the extension AND passes
 Cloudflare (headed). **Use Layer 4 (CDP) for real-host turns on any host, including
 pi.ai** (`doc/layer4-cdp-real-host-loop.md`).
 
-`isUnsupportedCloudflareHost` (in `scripts/layer35-lib.mjs`) currently only refuses
-claude.ai/chatgpt.com and still lets pi.ai through — that's a **known stale guard**
-(pi.ai is also Cloudflare-gated headless); prefer Layer 4 CDP rather than relying on
-this list. We deliberately do **not** use stealth/evasion plugins (an arms race, and
-ToS-sensitive).
+`isUnsupportedCloudflareHost` (in `scripts/layer35-lib.mjs`) now refuses **pi.ai**,
+claude.ai and chatgpt.com (#348) — so `layer35:verify`/`seed` give an honest "use
+Layer 4 (CDP)" pointer instead of a 25s decoration timeout. We deliberately do
+**not** use stealth/evasion plugins (an arms race, and ToS-sensitive).
 
 ## What it is and isn't
 

--- a/scripts/layer35-lib.mjs
+++ b/scripts/layer35-lib.mjs
@@ -71,11 +71,11 @@ export function buildSeedChromeArgs() {
 }
 
 // Hosts behind Cloudflare bot management that Layer 3.5 cannot drive: bundled
-// Chromium (the only channel that loads the unpacked extension) is fingerprinted
-// and blocked, and stable Chrome (which Cloudflare accepts) refuses
-// --load-extension. These belong to Layer 4 (real browser, extension installed
-// normally, already past Cloudflare). pi.ai is NOT here — it has no such gate.
-const CLOUDFLARE_GATED_HOSTS = ["claude.ai", "chatgpt.com", "chat.openai.com"];
+// Chromium is fingerprinted and served a "Just a moment…" challenge, so it never
+// reaches the chat UI. pi.ai joined this list 2026-06-20 (#348) — it is NOT an
+// exception (the old "pi.ai is ungated" assumption was only ever true headed). Use
+// Layer 4 (CDP, real Chrome) for these — it passes Cloudflare on every host.
+const CLOUDFLARE_GATED_HOSTS = ["pi.ai", "claude.ai", "chatgpt.com", "chat.openai.com"];
 
 export function isUnsupportedCloudflareHost(url) {
   try {

--- a/scripts/layer35.mjs
+++ b/scripts/layer35.mjs
@@ -83,12 +83,12 @@ async function verify(opts) {
     process.exit(1);
   }
   if (isUnsupportedCloudflareHost(opts.url)) {
-    log(`${new URL(opts.url).hostname} is behind Cloudflare — Layer 3.5 can't drive it.`);
-    log("Bundled Chromium (the only channel that loads the extension) is blocked by");
-    log("Cloudflare; stable Chrome (which Cloudflare accepts) refuses --load-extension.");
-    log("Use Layer 4 for Claude/ChatGPT (real browser, extension installed normally,");
-    log("already past Cloudflare + the saypi:dev-feed-speech/dev-reload hooks). See");
-    log("doc/layer35-real-host-loop.md.");
+    log(`${new URL(opts.url).hostname} is behind Cloudflare — Layer 3.5 (bundled Chromium) can't drive it.`);
+    log("Bundled Chromium is fingerprinted and served a 'Just a moment…' challenge,");
+    log("so it never reaches the chat UI. This applies to pi.ai too (#348).");
+    log("Use Layer 4 (CDP) instead — real Chrome passes Cloudflare on every host:");
+    log(`  node scripts/layer4cdp.mjs verify ${opts.url}`);
+    log("See doc/layer4-cdp-real-host-loop.md.");
     process.exit(2);
   }
   log(`verify ${opts.url} (profile ${profileDir}, ${opts.headed ? "headed" : "headless"})`);

--- a/test/scripts/layer35-lib.spec.ts
+++ b/test/scripts/layer35-lib.spec.ts
@@ -83,14 +83,15 @@ describe("buildSeedChromeArgs", () => {
 });
 
 describe("isUnsupportedCloudflareHost", () => {
-  it("flags claude.ai and chatgpt.com (and subdomains)", () => {
+  it("flags pi.ai, claude.ai and chatgpt.com (and subdomains)", () => {
+    expect(isUnsupportedCloudflareHost("https://pi.ai/talk")).toBe(true); // #348: now Cloudflare-gated
     expect(isUnsupportedCloudflareHost("https://claude.ai/new")).toBe(true);
     expect(isUnsupportedCloudflareHost("https://chatgpt.com/")).toBe(true);
     expect(isUnsupportedCloudflareHost("https://www.chatgpt.com/")).toBe(true);
     expect(isUnsupportedCloudflareHost("https://chat.openai.com/")).toBe(true);
   });
-  it("does NOT flag pi.ai (no Cloudflare gate — Layer 3.5's supported host)", () => {
-    expect(isUnsupportedCloudflareHost("https://pi.ai/talk")).toBe(false);
+  it("does not flag an unrelated host", () => {
+    expect(isUnsupportedCloudflareHost("https://example.com/")).toBe(false);
   });
   it("is false for a malformed url rather than throwing", () => {
     expect(isUnsupportedCloudflareHost("not a url")).toBe(false);


### PR DESCRIPTION
## Why

#348: pi.ai is now behind Cloudflare bot-management. `npm run layer35:verify` (bundled Chromium) gets a `403` "Just a moment…" page and times out waiting for `#saypi-callButton` — a confusing failure. The harness hard-coded pi.ai as *not* gated.

PR #347 already corrected the **docs**; this is the **code** fix #348 asked for.

## What

- `scripts/layer35-lib.mjs`: add **`pi.ai`** to `CLOUDFLARE_GATED_HOSTS` (it's not an exception — the old "ungated" claim was only ever true *headed*).
- `scripts/layer35.mjs`: the refusal message is now host-agnostic and prints the exact Layer-4 command (`node scripts/layer4cdp.mjs verify <url>`) instead of a Claude/ChatGPT-only note.
- `doc/layer35-real-host-loop.md`: removed the now-resolved "known stale guard" note.
- Unit test flipped: `isUnsupportedCloudflareHost("https://pi.ai/talk") === true`.

Net: `layer35:verify`/`seed` against pi.ai now give an immediate, honest "use Layer 4 (CDP)" pointer. Real Chrome (Layer 4 CDP) passes pi.ai's Cloudflare — verified in the reporting session.

## Test plan
- [x] Required gate green (Vitest 983/1 skipped incl. flipped pi.ai assertion).
- [x] `npm run layer35:verify` → refuses pi.ai with the Layer-4 pointer (exit 2), no timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)