### PR TITLE
fix(synthetic-audio): one-shot default so a synthetic turn transcribes (Closes #349)

### DIFF
--- a/e2e/specs/synthetic-audio-stt.e2e.ts
+++ b/e2e/specs/synthetic-audio-stt.e2e.ts
@@ -34,9 +34,12 @@ test("in-extension synthetic audio -> VAD -> mock STT -> transcript in prompt", 
 
   // Arm the synthetic source via the page bridge (the exact path the Layer-4 MCP
   // loop uses): main-world CustomEvent -> content script -> SW -> offscreen latch.
+  // One-shot (loop:false, the default) — a single utterance + trailing silence so
+  // the VAD sees end-of-speech and STT submits; loop:true never fires end-of-speech
+  // (#349). Omitting the detail entirely would also default to one-shot.
   await page.evaluate(() => {
     window.dispatchEvent(
-      new CustomEvent("saypi:dev-feed-speech", { detail: { loop: true } }),
+      new CustomEvent("saypi:dev-feed-speech", { detail: { loop: false } }),
     );
   });
 

--- a/scripts/layer35.mjs
+++ b/scripts/layer35.mjs
@@ -111,9 +111,10 @@ async function verify(opts) {
     log(`loaded build: ${build}`);
 
     if (!opts.noTurn) {
-      // Arm the in-extension synthetic source via the page bridge, then start a call.
+      // Arm the in-extension synthetic source (one-shot — loop:true yields no
+      // end-of-speech gap → no transcript, #349), then start a call.
       await page.evaluate(() =>
-        window.dispatchEvent(new CustomEvent("saypi:dev-feed-speech", { detail: { loop: true } })));
+        window.dispatchEvent(new CustomEvent("saypi:dev-feed-speech", { detail: { loop: false } })));
       await page.click("#saypi-callButton").catch(() => log("could not click call button"));
       log("armed synthetic speech + started a call; watching the prompt for a transcript…");
       const got = await page

--- a/scripts/layer4cdp.mjs
+++ b/scripts/layer4cdp.mjs
@@ -256,8 +256,9 @@ async function verify(opts) {
     const build = await page.evaluate(() => document.documentElement.dataset.saypiBuild ?? "(none)");
     log(`loaded build: ${build}`);
     if (!opts.noTurn) {
+      // One-shot (#349): loop:true never produces an end-of-speech gap → no transcript.
       await page.evaluate(() =>
-        window.dispatchEvent(new CustomEvent("saypi:dev-feed-speech", { detail: { loop: true } })));
+        window.dispatchEvent(new CustomEvent("saypi:dev-feed-speech", { detail: { loop: false } })));
       await page.click("#saypi-callButton").catch(() => log("could not click call button"));
       log("armed synthetic speech + started a call; watching the prompt…");
       const got = await page

--- a/src/dev/devReload.ts
+++ b/src/dev/devReload.ts
@@ -50,7 +50,9 @@ export function installDevReloadBridge(): void {
  */
 export function installDevFeedSpeechBridge(): void {
   window.addEventListener(DEV_FEED_SPEECH_EVENT, (e) => {
-    const loop = (e as CustomEvent)?.detail?.loop !== false;
+    // Default ONE-SHOT (#349): a single utterance → trailing silence → end-of-speech
+    // → STT submits. loop:true plays back-to-back with no gap → no transcript.
+    const loop = (e as CustomEvent)?.detail?.loop === true;
     chrome.runtime.sendMessage({ type: DEV_FEED_SPEECH_MESSAGE, loop });
   });
   logger.debug("[SayPi dev-feed-speech] bridge installed");

--- a/src/offscreen/synthetic-audio.ts
+++ b/src/offscreen/synthetic-audio.ts
@@ -7,7 +7,14 @@
 import { logger } from "../LoggingModule.js";
 
 export interface SyntheticStreamOptions {
-  /** Loop the clip for a continuous VAD session (default true). */
+  /**
+   * Loop the clip continuously (default FALSE = one-shot). One-shot is what you want
+   * for a voice TURN: the clip plays once, then silence, so the VAD sees an
+   * end-of-speech gap and `userStoppedSpeaking` fires → STT submits. With loop:true
+   * the clip replays back-to-back with no trailing silence, so end-of-speech never
+   * fires and nothing is transcribed (#349). Only set true for a continuous VAD
+   * session that doesn't need a transcript.
+   */
   loop?: boolean;
   /** Injectable for unit tests; defaults to the global AudioContext. */
   AudioContextClass?: typeof AudioContext;
@@ -32,7 +39,7 @@ export async function createSyntheticSpeechStream(
   const buffer = await ctx.decodeAudioData(encoded);
   const source = ctx.createBufferSource();
   source.buffer = buffer;
-  source.loop = opts.loop ?? true;
+  source.loop = opts.loop ?? false;
   const destination = ctx.createMediaStreamDestination();
   source.connect(destination);
   // A freshly created AudioContext can be 'suspended' when there's no user gesture

--- a/src/offscreen/vad_handler.ts
+++ b/src/offscreen/vad_handler.ts
@@ -60,7 +60,7 @@ let activePreset: VADPreset = "none";
 // DEV-only: when armed (via VAD_USE_SYNTHETIC_AUDIO), the next VAD init is fed a
 // bundled WAV instead of the live mic, so the agent can drive a voice turn with
 // no human speaking. See src/offscreen/synthetic-audio.ts.
-let syntheticAudioLatch: SyntheticAudioLatch = { enabled: false, clipUrl: "", loop: true };
+let syntheticAudioLatch: SyntheticAudioLatch = { enabled: false, clipUrl: "", loop: false };
 
 // Debounced sender for VAD frame events, max once per 100ms
 const debouncedSendFrameProcessed = debounce(
@@ -436,7 +436,7 @@ function registerVadHandlersOnce() {
     syntheticAudioLatch = {
       enabled: message.enabled !== false,
       clipUrl: message.clipUrl,
-      loop: message.loop !== false,
+      loop: message.loop === true, // default one-shot (#349); loop:true never yields a transcript
     };
     if (vadInstance) {
       destroyVAD();

--- a/src/svc/background.ts
+++ b/src/svc/background.ts
@@ -163,7 +163,7 @@ if (import.meta.env.DEV) {
       {
         type: "VAD_USE_SYNTHETIC_AUDIO",
         enabled: true,
-        loop: opts.loop !== false,
+        loop: opts.loop === true, // default one-shot (#349) so end-of-speech fires → STT submits
         clipUrl: getExtensionURL("audio/synthetic-speech.wav"),
         origin: "background",
       },

--- a/src/vad/OffscreenVADClient.ts
+++ b/src/vad/OffscreenVADClient.ts
@@ -162,6 +162,11 @@ export class OffscreenVADClient implements VADClientInterface {
           this.statusIndicator.updateStatus(getMessage('vadStatusDestroyed'), getMessage('vadDetailVADServiceShutdown'));
           logger.info("[SayPi OffscreenVADClient] VAD destroyed in offscreen:", message.payload);
           break;
+        case "OFFSCREEN_VAD_USE_SYNTHETIC_AUDIO_RESPONSE":
+        case "OFFSCREEN_VAD_USE_SYNTHETIC_AUDIO_ERROR":
+          // DEV-only synthetic-audio arm ack relayed here; nothing for the client to
+          // do — swallow quietly so it doesn't log as an unknown message type (#349).
+          break;
         default:
           logger.warn("[SayPi OffscreenVADClient] Received unknown message type:", message.type);
       }

--- a/test/dev/devReload.spec.ts
+++ b/test/dev/devReload.spec.ts
@@ -49,12 +49,16 @@ describe("dev self-reload bridge", () => {
     expect(chrome.runtime.reload).not.toHaveBeenCalled();
   });
 
-  it("feed-speech bridge relays the DOM event to a synthetic-audio message", () => {
+  it("feed-speech bridge defaults to one-shot (loop:false) — loop:true never transcribes (#349)", () => {
     installDevFeedSpeechBridge();
-    window.dispatchEvent(
-      new window.CustomEvent(DEV_FEED_SPEECH_EVENT, { detail: { loop: true } }),
+    // No detail → one-shot.
+    window.dispatchEvent(new window.CustomEvent(DEV_FEED_SPEECH_EVENT));
+    expect(chrome.runtime.sendMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: DEV_FEED_SPEECH_MESSAGE, loop: false }),
     );
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+    // Only an explicit loop:true opts into continuous looping.
+    window.dispatchEvent(new window.CustomEvent(DEV_FEED_SPEECH_EVENT, { detail: { loop: true } }));
+    expect(chrome.runtime.sendMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: DEV_FEED_SPEECH_MESSAGE, loop: true }),
     );
   });

--- a/test/offscreen/synthetic-audio.spec.ts
+++ b/test/offscreen/synthetic-audio.spec.ts
@@ -9,7 +9,7 @@ function fakeAudioContextClass(captured: any) {
   return class {
     destinationStream = { id: "synthetic-stream" };
     createBufferSource() {
-      return {
+      const source = {
         buffer: null as any,
         loop: false,
         connect: vi.fn(),
@@ -20,6 +20,8 @@ function fakeAudioContextClass(captured: any) {
           captured.startedBeforeResume = !captured.resumed;
         }),
       };
+      captured.source = source;
+      return source;
     }
     createMediaStreamDestination() {
       return { stream: this.destinationStream };
@@ -53,7 +55,18 @@ describe("createSyntheticSpeechStream", () => {
     // no user gesture — e.g. the real Layer-4 browser — which would yield silence).
     expect(captured.resumed).toBe(true);
     expect(captured.startedBeforeResume).toBe(false);
+    expect(captured.source.loop).toBe(true);
     expect((stream as any).id).toBe("synthetic-stream");
+  });
+
+  it("defaults to ONE-SHOT (loop:false) so end-of-speech fires → STT submits (#349)", async () => {
+    const captured: any = {};
+    await createSyntheticSpeechStream("blob:clip", {
+      // loop omitted → default
+      AudioContextClass: fakeAudioContextClass(captured) as any,
+      fetchImpl: vi.fn().mockResolvedValue({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) }) as any,
+    });
+    expect(captured.source.loop).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why

#349: `layer4cdp:verify` / `layer35:verify` advertise a voice turn + "whether a transcript reached the composer", but the assertion **never passed** — always `WARN: no transcript`. Root cause: the synthetic mic was armed with `loop:true`, replaying the ~4s clip back-to-back with no trailing silence, so the VAD never sees end-of-speech → `saypi:userStoppedSpeaking` never fires → nothing transcribed. (Founder verified the *identical* source with `loop:false` transcribes reliably on real Claude.)

## What

**Flip the default to one-shot (`loop:false`) across the whole chain** — synthetic-audio source, VAD latch + `VAD_USE_SYNTHETIC_AUDIO` handler, SW `feedSyntheticSpeech` hook, the `saypi:dev-feed-speech` page bridge, and both runners. A single utterance → trailing silence → end-of-speech → STT submits. `loop:true` stays opt-in (continuous VAD session, no transcript expected).

Secondary (#349): `OffscreenVADClient` now swallows the relayed `OFFSCREEN_VAD_USE_SYNTHETIC_AUDIO_RESPONSE`/`_ERROR` instead of logging "unknown message type".

## Test plan
- [x] Required gate green (Vitest+Jest 985/1 skipped; new unit assertions: factory + page bridge default to `loop:false`, opt-in `true`).
- [x] **`e2e/specs/synthetic-audio-stt.e2e.ts` switched to one-shot and still lands the transcript** — regression guard for the fix. Full e2e suite 10/10.
- [ ] Founder (optional): `npm run layer4cdp:verify https://claude.ai/new` now reports a real transcript, not `WARN: no transcript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)