### PR TITLE
fix(pi): re-anchor sidebar selector on the redesigned <nav> (Closes #350)

### DIFF
--- a/src/chatbots/Pi.ts
+++ b/src/chatbots/Pi.ts
@@ -83,10 +83,17 @@ class PiAIChatbot extends AbstractChatbot {
   }
 
   getSidebarSelector(): string {
-    // Matches Pi.ai's redesigned sidebar (Oct 2025) - works across all viewport sizes
-    // Key classes: z-[999] (stacking), h-screen (full height), border-r (right border)
-    // Works for both collapsed (w-0 md:w-16) and expanded (w-[280px]) states
-    return "div.z-\\[999\\].flex.h-screen.flex-col.border-r.border-neutral-300.bg-neutral-50";
+    // Pi.ai redesigned the sidebar (verified live 2026-06-20): it is now a
+    // <nav data-testid="side-navbar" aria-label="Side menu"> (was a <div>) whose
+    // colour tokens changed too — `h-screen`→`h-[100dvh]`, `border-neutral-300`→
+    // `border-divider-stroke`, `bg-neutral-50`→`bg-background-alt` — so the old
+    // class-literal selector matched 0 and the settings button was never added (#350).
+    //
+    // Anchor primarily on the stable `data-testid="side-navbar"`. Fall back to a
+    // tag-agnostic STRUCTURAL match (`z-[999]` + a bordered flex column) that survives
+    // both the colour-token churn and the tag change, in case the test id is dropped.
+    // (getSidebarConfig's inner header/menu anchors are unchanged and still resolve.)
+    return 'nav[data-testid="side-navbar"], [class~="z-[999]"][class~="flex-col"][class~="overflow-hidden"][class~="border-r"]';
   }
 
   getChatPath(): string {

--- a/test/chatbots/Pi-SidebarSelector.spec.ts
+++ b/test/chatbots/Pi-SidebarSelector.spec.ts
@@ -1,184 +1,108 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { JSDOM } from "jsdom";
 import { PiAIChatbot } from "../../src/chatbots/Pi";
 
-describe("Pi Sidebar Selector (Issue #243)", () => {
+/**
+ * Pi.ai sidebar selector — originally #243 (Oct 2025 redesign), updated for the
+ * 2026-06-20 redesign (#350): the sidebar is now a
+ *   <nav data-testid="side-navbar" aria-label="Side menu"
+ *        class="absolute left-0 top-0 z-[999] flex h-[100dvh] flex-col overflow-hidden
+ *               border-r border-divider-stroke bg-background-alt md:relative md:flex w-[280px]">
+ * (was a <div> with h-screen / border-neutral-300 / bg-neutral-50). Class strings
+ * below are taken verbatim from the live logged-out DOM.
+ */
+
+// Expanded (md, 280px) — verbatim live class string + the real inner header/menu.
+const expandedNavHTML = `
+  <div>
+    <nav data-testid="side-navbar" aria-label="Side menu"
+         class="absolute left-0 top-0 z-[999] flex h-[100dvh] flex-col overflow-hidden border-r border-divider-stroke bg-background-alt md:relative md:flex  w-[280px]">
+      <div class="pt-[0.875rem]  px-3 pb-3 pt-2 md:pt-[0.875rem]">
+        <div class="mb-4 flex h-[40px] items-center justify-between"><!-- logo + toggle --></div>
+        <div class="flex flex-col items-start">
+          <div role="button" aria-label="New chat">Nav Button 1</div>
+          <div role="button" aria-label="Discover">Nav Button 2</div>
+          <div role="button" aria-label="Threads">Nav Button 3</div>
+        </div>
+      </div>
+    </nav>
+  </div>`;
+
+// Collapsed (w-0 md:w-16) — same nav, narrower.
+const collapsedNavHTML = `
+  <div>
+    <nav data-testid="side-navbar" aria-label="Side menu"
+         class="absolute left-0 top-0 z-[999] flex h-[100dvh] flex-col overflow-hidden border-r border-divider-stroke bg-background-alt md:relative md:flex w-0 md:w-16">
+      <div class="pt-[0.875rem] pb-3"><div class="mb-4 flex h-[40px] items-center justify-between"></div></div>
+    </nav>
+  </div>`;
+
+describe("Pi Sidebar Selector (#350 — div→nav redesign)", () => {
   const chatbot = new PiAIChatbot();
 
-  describe("Old selector (should fail - documenting the bug)", () => {
-    const oldSelector = "div.hidden.w-22.flex-col.items-center.gap-1.border-r";
+  describe("Old class-literal selector no longer matches (documents the bug)", () => {
+    const oldSelector =
+      "div.z-\\[999\\].flex.h-screen.flex-col.border-r.border-neutral-300.bg-neutral-50";
 
-    it("should NOT match collapsed sidebar with old selector", () => {
-      const collapsedSidebarHTML = `
-        <div>
-          <div class="absolute left-0 top-0 z-[999] flex h-screen flex-col overflow-hidden border-r border-neutral-300 bg-neutral-50 md:relative md:flex w-0 md:w-16">
-            <div class="pt-[0.875rem] pb-3">
-              <div class="mb-4 flex h-[40px] items-center justify-between">
-                <!-- Logo and toggle -->
-              </div>
-            </div>
-          </div>
-        </div>
-      `;
-
-      const dom = new JSDOM(collapsedSidebarHTML);
-      const sidebar = dom.window.document.querySelector(oldSelector);
-      expect(sidebar).toBeNull(); // Old selector doesn't match anymore
-    });
-
-    it("should NOT match expanded sidebar with old selector", () => {
-      const expandedSidebarHTML = `
-        <div>
-          <div class="absolute left-0 top-0 z-[999] flex h-screen flex-col overflow-hidden border-r border-neutral-300 bg-neutral-50 md:relative md:flex w-[280px]">
-            <div class="pt-[0.875rem] px-3 pb-3 pt-2 md:pt-[0.875rem]">
-              <div class="mb-4 flex h-[40px] items-center justify-between">
-                <!-- Logo and toggle -->
-              </div>
-            </div>
-          </div>
-        </div>
-      `;
-
-      const dom = new JSDOM(expandedSidebarHTML);
-      const sidebar = dom.window.document.querySelector(oldSelector);
-      expect(sidebar).toBeNull(); // Old selector doesn't match anymore
+    it("does NOT match the redesigned <nav> sidebar", () => {
+      const dom = new JSDOM(expandedNavHTML);
+      expect(dom.window.document.querySelector(oldSelector)).toBeNull();
     });
   });
 
-  describe("New selector (should pass after fix)", () => {
-    it("should match collapsed sidebar with new selector", () => {
-      const collapsedSidebarHTML = `
-        <div>
-          <div class="absolute left-0 top-0 z-[999] flex h-screen flex-col overflow-hidden border-r border-neutral-300 bg-neutral-50 md:relative md:flex w-0 md:w-16">
-            <div class="pt-[0.875rem] pb-3">
-              <div class="mb-4 flex h-[40px] items-center justify-between">
-                <!-- Logo and toggle -->
-              </div>
-            </div>
-          </div>
-        </div>
-      `;
-
-      const dom = new JSDOM(collapsedSidebarHTML);
-      const newSelector = chatbot.getSidebarSelector();
-      const sidebar = dom.window.document.querySelector(newSelector);
-      expect(sidebar).not.toBeNull(); // New selector should match
-      expect(sidebar?.classList.contains("z-[999]")).toBe(true);
-      expect(sidebar?.classList.contains("h-screen")).toBe(true);
+  describe("New selector matches the redesigned sidebar", () => {
+    it("matches the expanded <nav> via data-testid", () => {
+      const dom = new JSDOM(expandedNavHTML);
+      const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector());
+      expect(sidebar).not.toBeNull();
+      expect(sidebar?.tagName.toLowerCase()).toBe("nav");
+      expect(sidebar?.getAttribute("data-testid")).toBe("side-navbar");
     });
 
-    it("should match expanded sidebar with new selector", () => {
-      const expandedSidebarHTML = `
-        <div>
-          <div class="absolute left-0 top-0 z-[999] flex h-screen flex-col overflow-hidden border-r border-neutral-300 bg-neutral-50 md:relative md:flex w-[280px]">
-            <div class="pt-[0.875rem] px-3 pb-3 pt-2 md:pt-[0.875rem]">
-              <div class="mb-4 flex h-[40px] items-center justify-between">
-                <!-- Logo and toggle -->
-              </div>
-            </div>
-          </div>
-        </div>
-      `;
-
-      const dom = new JSDOM(expandedSidebarHTML);
-      const newSelector = chatbot.getSidebarSelector();
-      const sidebar = dom.window.document.querySelector(newSelector);
-      expect(sidebar).not.toBeNull(); // New selector should match
-      expect(sidebar?.classList.contains("z-[999]")).toBe(true);
-      expect(sidebar?.classList.contains("h-screen")).toBe(true);
+    it("matches the collapsed <nav>", () => {
+      const dom = new JSDOM(collapsedNavHTML);
+      expect(dom.window.document.querySelector(chatbot.getSidebarSelector())).not.toBeNull();
     });
 
-    it("should work across viewport sizes (mobile and desktop)", () => {
-      // Both collapsed and expanded sidebars share core classes
-      // Width classes vary but aren't needed for matching
-      const mobileHTML = `
-        <div>
-          <div class="absolute left-0 top-0 z-[999] flex h-screen flex-col overflow-hidden border-r border-neutral-300 bg-neutral-50 w-0">
-            <!-- Mobile collapsed -->
-          </div>
-        </div>
-      `;
-
-      const desktopHTML = `
-        <div>
-          <div class="z-[999] flex h-screen flex-col overflow-hidden border-r border-neutral-300 bg-neutral-50 w-[280px]">
-            <!-- Desktop expanded -->
-          </div>
-        </div>
-      `;
-
-      const newSelector = chatbot.getSidebarSelector();
-
-      const mobileDom = new JSDOM(mobileHTML);
-      const mobileSidebar = mobileDom.window.document.querySelector(newSelector);
-      expect(mobileSidebar).not.toBeNull();
-
-      const desktopDom = new JSDOM(desktopHTML);
-      const desktopSidebar = desktopDom.window.document.querySelector(newSelector);
-      expect(desktopSidebar).not.toBeNull();
+    it("structural fallback matches even without the test id (colour-token agnostic)", () => {
+      // Drop data-testid; keep the structural classes (incl. the NEW colour tokens).
+      const noTestId = expandedNavHTML.replace('data-testid="side-navbar"', "");
+      const dom = new JSDOM(noTestId);
+      const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector());
+      expect(sidebar).not.toBeNull();
+      expect(sidebar?.classList.contains("border-divider-stroke")).toBe(true);
+      expect(sidebar?.classList.contains("bg-background-alt")).toBe(true);
     });
   });
 
-  describe("Sidebar configuration", () => {
-    it("should return menu-style config with correct button container", () => {
-      const expandedSidebarHTML = `
-        <div>
-          <div class="absolute left-0 top-0 z-[999] flex h-screen flex-col overflow-hidden border-r border-neutral-300 bg-neutral-50 md:relative md:flex w-[280px]">
-            <div class="pt-[0.875rem] px-3 pb-3 pt-2 md:pt-[0.875rem]">
-              <div class="mb-4 flex h-[40px] items-center justify-between">
-                <!-- Logo and toggle -->
-              </div>
-              <div class="flex flex-col items-start">
-                <div role="button" aria-label="New chat">Nav Button 1</div>
-                <div role="button" aria-label="Discover">Nav Button 2</div>
-                <div role="button" aria-label="Home chat">Nav Button 3</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      `;
-
-      const dom = new JSDOM(expandedSidebarHTML, { url: 'https://pi.ai' });
-      const newSelector = chatbot.getSidebarSelector();
-      const sidebar = dom.window.document.querySelector(newSelector) as HTMLElement;
+  describe("Sidebar configuration (inner header/menu anchors unchanged)", () => {
+    it("returns menu-style config; getSidebarConfig still resolves header + menu", () => {
+      const dom = new JSDOM(expandedNavHTML, { url: "https://pi.ai" });
+      const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector()) as HTMLElement;
       expect(sidebar).not.toBeNull();
 
-      // Get sidebar config
       const config = chatbot.getSidebarConfig(sidebar);
-
-      // Verify config is returned
       expect(config).not.toBeNull();
-      expect(config?.buttonStyle).toBe('menu');
-      expect(config?.insertPosition).toBe(2);  // Insert after Discover button
+      expect(config?.buttonStyle).toBe("menu");
+      expect(config?.insertPosition).toBe(2); // after Discover
+      // The button container is the inner menu column (div.flex.flex-col.items-start).
+      expect(config?.buttonContainer.classList.contains("items-start")).toBe(true);
+      expect(config?.buttonContainer.children.length).toBe(3);
 
-      // Verify button container is the menu element
-      expect(config?.buttonContainer.classList.contains('flex')).toBe(true);
-      expect(config?.buttonContainer.classList.contains('flex-col')).toBe(true);
-      expect(config?.buttonContainer.classList.contains('items-start')).toBe(true);
-
-      // Verify the sidebar itself got the ID and class
-      expect(sidebar.id).toBe('saypi-sidebar');
-      expect(sidebar.classList.contains('saypi-side-panel')).toBe(true);
-      expect(sidebar.classList.contains('saypi-control-panel')).toBe(true);
+      // decorateSidebar-equivalent identification still applies.
+      expect(sidebar.id).toBe("saypi-sidebar");
+      expect(sidebar.classList.contains("saypi-side-panel")).toBe(true);
     });
 
-    it("should return null config when menu container not found", () => {
-      const malformedSidebarHTML = `
+    it("returns null config when the inner menu structure is absent", () => {
+      const malformed = `
         <div>
-          <div class="z-[999] flex h-screen flex-col border-r border-neutral-300 bg-neutral-50">
-            <!-- Missing the header and menu structure -->
-          </div>
-        </div>
-      `;
-
-      const dom = new JSDOM(malformedSidebarHTML);
-      const newSelector = chatbot.getSidebarSelector();
-      const sidebar = dom.window.document.querySelector(newSelector) as HTMLElement;
+          <nav data-testid="side-navbar" class="z-[999] flex h-[100dvh] flex-col overflow-hidden border-r border-divider-stroke bg-background-alt"></nav>
+        </div>`;
+      const dom = new JSDOM(malformed);
+      const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector()) as HTMLElement;
       expect(sidebar).not.toBeNull();
-
-      // Should return null config when menu container not found
-      const config = chatbot.getSidebarConfig(sidebar);
-      expect(config).toBeNull();
+      expect(chatbot.getSidebarConfig(sidebar)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## What

Pi.ai redesigned the side navigation (verified live 2026-06-20): the sidebar is now a `<nav data-testid="side-navbar" aria-label="Side menu">` (was a `<div>`) with new colour tokens (`h-screen`→`h-[100dvh]`, `border-neutral-300`→`border-divider-stroke`, `bg-neutral-50`→`bg-background-alt`). Only `z-[999]` survived, so `getSidebarSelector()` matched **0** elements and the SayPi settings/menu button was never added. **Closes #350.**

## Fix

Anchor primarily on the stable `data-testid="side-navbar"`, with a tag-agnostic structural fallback (`[class~="z-[999]"][class~="flex-col"][class~="overflow-hidden"][class~="border-r"]`) that survives both the colour-token churn and the div→nav change.

`getSidebarConfig()`'s inner anchors are **unchanged** — verified live that the header (`div[class*="pt-"][class*="pb-"]`) and menu (`div.flex.flex-col.items-start`, 3 children) still resolve — so fixing the selector fully restores the button.

## Scope note (secondary drift)

The issue also flagged `getChatHistorySelector()` / `getVoiceMenuSelector()` (`div.t-body-chat` / `div.t-action-m`) as *possibly* drifted. **Left unchanged**: my live re-check was an anonymous, empty `/talk` (no chat history yet → those elements are legitimately absent), which is not evidence of drift; both were L4-verified working 2026-06-17/19, they are load-bearing (the #309 decoration saga), and the issue supplies no replacement tokens. Changing them blind would risk a regression — a logged-in, with-history live check is the right gate before touching them.

## Verification

- Live capture/prototype over CDP against real pi.ai confirmed the new selector matches the `<nav>` and `getSidebarConfig` still resolves header+menu.
- Fail-first L2 contract test (`Pi-SidebarSelector.spec.ts`) updated to the live `<nav>` shape (old class-literal selector → 0 matches; new selector matches via test id AND structural fallback). RED before the fix, GREEN after.
- Full required gate green locally: `tsc` + Jest + Vitest (122 files, 983 passed/1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)