### PR TITLE
fix(claude): suppress native composer placeholder so it doesn't double up (Closes #351)

### DIFF
--- a/src/chatbots/Claude.ts
+++ b/src/chatbots/Claude.ts
@@ -297,7 +297,10 @@ class ClaudeChatbot extends AbstractChatbot {
 
 // Claude response parsing moved to ./claude/ClaudeResponse.ts
 
-function findAndDecorateCustomPlaceholderElement(
+// Exported for contract testing (#351): tests assert the clone is inserted as the
+// next sibling of #saypi-prompt — the adjacency claude.scss keys its native-placeholder
+// suppression off.
+export function findAndDecorateCustomPlaceholderElement(
   prompt: HTMLElement
 ): Observation {
   const existing = prompt.parentElement?.querySelector("#claude-placeholder");

--- a/src/styles/claude.scss
+++ b/src/styles/claude.scss
@@ -10,19 +10,27 @@ html body.claude {
     height: 32px;
   }
 
-  /* hide Claude's original placeholder when custom placeholder is present and non-empty */
-  #saypi-prompt-container:has(+ .custom-placeholder) #saypi-prompt {
-    // this selector may not be working?
-    p[data-placeholder].is-empty {
-      visibility: hidden; // display: none doesn't work, causes it to reappear
-    }
-  }
+  /* Suppress Claude's native placeholder while SayPi's custom placeholder is present,
+     so the two don't render on top of each other (#351).
 
-  #saypi-prompt p.is-empty.is-editor-empty::before {
-    // hide Claude's original placeholder, but somehow keep the caret visible
-    // display: none doesn't work, and causes the placeholder to reappear
-    // visibility: hidden doesn't work, and causes the caret to disappear
-    --tw-text-opacity: 0 !important; // hide the text while keeping the caret visible
+     SayPi inserts its clone (`#claude-placeholder.custom-placeholder`) as the *next
+     sibling of `#saypi-prompt`* (see findAndDecorateCustomPlaceholderElement —
+     `prompt.insertAdjacentElement("afterend", …)`). The old rule keyed off
+     `#saypi-prompt-container:has(+ .custom-placeholder)`, which never matched on two
+     counts: (1) `#saypi-prompt-container` is an *id* selector, but the container only
+     ever gets the `.saypi-prompt-container` *class*; (2) the clone is a sibling of
+     `#saypi-prompt`, not of the container. So the suppression never applied and both
+     placeholders showed.
+
+     Claude renders its placeholder via `::before { content: attr(data-placeholder) }`
+     (Tailwind `before:content-[attr(data-placeholder)]`) coloured with an *!important*
+     utility (`before:!text-text-500`). The old `--tw-text-opacity: 0` fallback couldn't
+     win against that colour, so override `content` itself (also `!important`) to drop the
+     duplicate text — Claude's `content` is not `!important`, so this wins — while leaving
+     the contenteditable `<p>` (and the caret) intact. Scoped to when our clone exists, so
+     a normal Claude composer (no SayPi clone) is untouched. */
+  #saypi-prompt:has(+ .custom-placeholder) p[data-placeholder]::before {
+    content: "" !important;
   }
 
   /* shift the custom placeholder up to Claude's standard placeholder position */

--- a/test/chatbots/ClaudePlaceholderSuppression.spec.ts
+++ b/test/chatbots/ClaudePlaceholderSuppression.spec.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Claude.ts pulls in MessageElements + VoiceMenu transitively; stub them (mirrors
+// ClaudeSidebarConfig.spec.ts) so we can import the placeholder decoration helper.
+vi.mock("../../src/dom/MessageElements", () => {
+  class AssistantResponse {}
+  class MessageControls {}
+  class UserMessage {}
+  return { AssistantResponse, MessageControls, UserMessage };
+});
+vi.mock("../../src/tts/VoiceMenu", () => {
+  class VoiceSelector {
+    constructor() {}
+    getId() { return "voice-selector"; }
+    getButtonClasses() { return []; }
+  }
+  return { VoiceSelector, addSvgToButton: () => {} };
+});
+
+let findAndDecorateCustomPlaceholderElement: typeof import("../../src/chatbots/Claude").findAndDecorateCustomPlaceholderElement;
+
+beforeAll(async () => {
+  const module = await import("../../src/chatbots/Claude");
+  findAndDecorateCustomPlaceholderElement = module.findAndDecorateCustomPlaceholderElement;
+});
+
+/**
+ * Build the real Claude composer shape (verified live on claude.ai 2026-06-20):
+ *   div.saypi-prompt-container               (a CLASS, never an id)
+ *     └── #saypi-prompt (.tiptap .ProseMirror, contenteditable)
+ *           └── p[data-placeholder] .is-empty .is-editor-empty
+ *                 before:content-[attr(data-placeholder)] before:!text-text-500
+ * SayPi clones that <p> into #claude-placeholder.custom-placeholder, inserted
+ * `afterend` of #saypi-prompt (so the clone is #saypi-prompt's next sibling).
+ */
+function buildComposer(): HTMLElement {
+  document.body.innerHTML = `
+    <div class="saypi-prompt-container">
+      <div id="saypi-prompt" contenteditable="true" class="tiptap ProseMirror">
+        <p data-placeholder="How can I help you today?"
+           class="is-empty is-editor-empty before:content-[attr(data-placeholder)] before:!text-text-500 before:whitespace-nowrap"><br></p>
+      </div>
+    </div>`;
+  return document.getElementById("saypi-prompt") as HTMLElement;
+}
+
+describe("Claude composer placeholder suppression (#351)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("inserts the custom-placeholder clone as the next sibling of #saypi-prompt", () => {
+    const prompt = buildComposer();
+    const obs = findAndDecorateCustomPlaceholderElement(prompt);
+
+    expect(obs.found).toBe(true);
+    const clone = document.getElementById("claude-placeholder")!;
+    expect(clone).not.toBeNull();
+    expect(clone.classList.contains("custom-placeholder")).toBe(true);
+    // The adjacency the suppression CSS keys off: clone is the prompt's NEXT SIBLING,
+    // sharing the prompt's parent (NOT a sibling of the container).
+    expect(prompt.nextElementSibling).toBe(clone);
+    expect(clone.parentElement).toBe(prompt.parentElement);
+  });
+
+  it("the corrected suppression selector targets the native placeholder; the old one cannot", () => {
+    const prompt = buildComposer();
+    findAndDecorateCustomPlaceholderElement(prompt);
+    const native = prompt.querySelector("p[data-placeholder]")!;
+
+    // FIXED selector (claude.scss): #saypi-prompt:has(+ .custom-placeholder) p[data-placeholder]
+    expect(
+      document.querySelector("#saypi-prompt:has(+ .custom-placeholder) p[data-placeholder]")
+    ).toBe(native);
+
+    // OLD selector failed two ways:
+    // (1) #saypi-prompt-container is an *id* selector — only a CLASS is ever set.
+    expect(
+      document.querySelector(
+        "#saypi-prompt-container:has(+ .custom-placeholder) #saypi-prompt p[data-placeholder]"
+      )
+    ).toBeNull();
+    // (2) the clone is a sibling of #saypi-prompt, not of the container — so even by
+    //     class the `+ .custom-placeholder` adjacency on the container never holds.
+    expect(document.querySelector(".saypi-prompt-container:has(+ .custom-placeholder)")).toBeNull();
+  });
+
+  it("claude.scss suppresses the native placeholder via the correct adjacency + content override", () => {
+    const raw = readFileSync(resolve(__dirname, "../../src/styles/claude.scss"), "utf8");
+    // Strip comments so we assert against actual rules, not prose (the explanatory
+    // comment legitimately names the old broken selector).
+    const scss = raw.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+    // The corrected rule: key off #saypi-prompt + .custom-placeholder and override the
+    // ::before content (Claude's content is not !important, so ours wins).
+    expect(scss).toMatch(/#saypi-prompt:has\(\+\s*\.custom-placeholder\)/);
+    expect(scss).toMatch(/p\[data-placeholder\]::before\s*\{[^}]*content:\s*["']{2}\s*!important/);
+
+    // The broken selector must be gone (it never matched: id-vs-class + wrong sibling).
+    expect(scss).not.toMatch(/#saypi-prompt-container:has\(/);
+  });
+});


### PR DESCRIPTION
## What

On claude.ai the composer showed **doubled/garbled placeholder text** whenever SayPi's custom placeholder differed from Claude's native one (e.g. during/after a call): SayPi's clone (`#claude-placeholder.custom-placeholder`) rendered on top of Claude's native `p[data-placeholder]`, interleaving glyph-by-glyph. **Closes #351.**

## Root cause (confirmed live 2026-06-20)

The CSS meant to hide the native placeholder never matched — doubly broken:
1. `#saypi-prompt-container:has(...)` is an **id** selector, but the container only ever gets the `.saypi-prompt-container` **class** (`promptContainerIdExists: false` live).
2. SayPi inserts the clone as the **next sibling of `#saypi-prompt`** (not of the container), so the `+ .custom-placeholder` adjacency on the container never held.

The opacity fallback (`--tw-text-opacity: 0`) was also defeated, because Claude colours the placeholder with an `!important` utility (`before:!text-text-500`).

## Fix

Suppress via the correct adjacency and override `content` itself — Claude renders the text with `::before { content: attr(data-placeholder) }`, which is **not** `!important`, so ours wins — leaving the contenteditable `<p>` and caret intact:

```scss
#saypi-prompt:has(+ .custom-placeholder) p[data-placeholder]::before {
  content: "" !important;
}
```

## Verification

- Live (CDP, real claude.ai): the selector matches the native element in the real engine when the clone is present (`rule-matches-native`); clone confirmed as `#saypi-prompt`'s next sibling.
- Fail-first L2 test (`ClaudePlaceholderSuppression.spec.ts`): runs the real decoration helper (now exported), asserts the clone adjacency, that the corrected `:has()` selector targets the native placeholder while the old one returns null, and that `claude.scss` carries the corrected rule (not the dead one). RED against the pre-fix scss, GREEN after.
- Full required gate green locally: `tsc` + Jest + Vitest (123 files, 987 passed/1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)