### PR TITLE
fix(chatgpt): re-anchor sidebar menu button now that <aside> is gone (Closes #352)

### DIFF
--- a/src/chatbots/ChatGPT.ts
+++ b/src/chatbots/ChatGPT.ts
@@ -186,8 +186,29 @@ class ChatGPTChatbot extends AbstractChatbot {
   }
 
   getSidebarConfig(sidebar: HTMLElement): SidebarConfig | null {
-    const menuContainer = sidebar.querySelector('aside');
+    // ChatGPT removed the <aside> menu wrapper (verified live 2026-06-20), so the old
+    // `sidebar.querySelector('aside')` matched nothing and the settings button was never
+    // added (#352). Re-anchor on the stable "New chat" menu item instead.
+    //
+    // There are two copies of the New-chat item: the always-present collapsed rail
+    // (#stage-sidebar-tiny-bar, which is opacity-0/pointer-events-none) and the expanded
+    // sidebar. Pick the one NOT inside the tiny bar so our button is visible.
+    const newChats = Array.from(
+      sidebar.querySelectorAll('[data-testid="create-new-chat-button"]')
+    ) as HTMLElement[];
+    const newChat =
+      newChats.find((b) => !b.closest('#stage-sidebar-tiny-bar')) || newChats[0];
+    if (!newChat) {
+      console.warn('[ChatGPT] sidebar: Could not find New chat menu item');
+      return null;
+    }
 
+    // The primary nav menu is the list holding New chat + Search — a <ul> of
+    // <li.list-none> rows on the expanded sidebar (fall back to the item's wrapper
+    // parent if the markup changes). createChatGPTMenuButton returns an <li> so it
+    // slots in natively.
+    const menuContainer = (newChat.closest('ul') ||
+      newChat.parentElement?.parentElement) as HTMLElement | null;
     if (!menuContainer) {
       console.warn('[ChatGPT] sidebar: Could not find menu container');
       return null;
@@ -202,7 +223,9 @@ class ChatGPTChatbot extends AbstractChatbot {
   }
 
   /**
-   * Creates a menu button matching ChatGPT's native sidebar button structure
+   * Creates a menu button matching ChatGPT's native sidebar button structure,
+   * wrapped in an <li class="list-none"> so it slots natively into the sidebar's
+   * <ul> menu list (#352).
    */
   private createChatGPTMenuButton(options: { label: string; icon: string | SVGElement; onClick: () => void }): HTMLElement {
     const { label, icon, onClick } = options;
@@ -263,7 +286,14 @@ class ChatGPTChatbot extends AbstractChatbot {
     button.appendChild(iconContainer);
     button.appendChild(labelContainer);
 
-    return button;
+    // ChatGPT's expanded sidebar nests each menu item in <li class="list-none">
+    // inside the <ul> list; wrap our button to match (#352). The interactive
+    // element (classes/handlers/aria) remains the inner div.
+    const listItem = document.createElement('li');
+    listItem.className = 'list-none';
+    listItem.appendChild(button);
+
+    return listItem;
   }
 
   private findChatGPTSubmitButton(): HTMLElement | null {

--- a/src/chatbots/ChatGPT.ts
+++ b/src/chatbots/ChatGPT.ts
@@ -196,21 +196,22 @@ class ChatGPTChatbot extends AbstractChatbot {
     const newChats = Array.from(
       sidebar.querySelectorAll('[data-testid="create-new-chat-button"]')
     ) as HTMLElement[];
-    const newChat =
-      newChats.find((b) => !b.closest('#stage-sidebar-tiny-bar')) || newChats[0];
+    // Use the EXPANDED copy only — never the collapsed rail's (it's hidden). If the only
+    // New-chat is in the tiny bar (collapsed-only state), bail and let the observer retry
+    // when the expanded sidebar mounts, rather than inserting into a hidden element.
+    const newChat = newChats.find((b) => !b.closest('#stage-sidebar-tiny-bar'));
     if (!newChat) {
-      console.warn('[ChatGPT] sidebar: Could not find New chat menu item');
+      console.warn('[ChatGPT] sidebar: no visible New chat menu item (collapsed sidebar?)');
       return null;
     }
 
-    // The primary nav menu is the list holding New chat + Search — a <ul> of
-    // <li.list-none> rows on the expanded sidebar (fall back to the item's wrapper
-    // parent if the markup changes). createChatGPTMenuButton returns an <li> so it
-    // slots in natively.
-    const menuContainer = (newChat.closest('ul') ||
-      newChat.parentElement?.parentElement) as HTMLElement | null;
+    // The primary nav menu is the <ul> of <li.list-none> rows holding New chat + Search.
+    // Anchor strictly on it (createChatGPTMenuButton returns an <li> to slot in natively);
+    // if the markup ever moves New chat out of a <ul>, bail rather than guess a container
+    // + index that would mis-place the button.
+    const menuContainer = newChat.closest('ul') as HTMLElement | null;
     if (!menuContainer) {
-      console.warn('[ChatGPT] sidebar: Could not find menu container');
+      console.warn('[ChatGPT] sidebar: New chat item is not inside a menu list');
       return null;
     }
 

--- a/test/chatbots/ChatGPTSidebarConfig.spec.ts
+++ b/test/chatbots/ChatGPTSidebarConfig.spec.ts
@@ -118,6 +118,46 @@ describe("ChatGPT sidebar integration (#352 — <aside> removed)", () => {
     expect(clicked).toBe(1);
   });
 
+  it("returns null when the only New-chat item is in the hidden collapsed rail", () => {
+    // Collapsed-only state: a New-chat exists, but only inside #stage-sidebar-tiny-bar
+    // (opacity-0). We must NOT insert into the hidden rail — bail so the observer retries.
+    const html = `
+      <div id="stage-slideover-sidebar">
+        <div class="relative flex h-full flex-col">
+          <nav id="stage-sidebar-tiny-bar" aria-label="Sidebar" class="opacity-0 pointer-events-none">
+            <div class="mt-(--sidebar-section-first-margin-top)">
+              <div data-state="closed">
+                <a data-testid="create-new-chat-button" class="group __menu-item hoverable" href="/"><span class="sr-only">New chat</span></a>
+              </div>
+            </div>
+          </nav>
+        </div>
+      </div>`;
+    const dom = new JSDOM(html);
+    const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector()) as HTMLElement;
+    expect(sidebar).not.toBeNull();
+    expect(chatbot.getSidebarConfig(sidebar)).toBeNull();
+  });
+
+  it("returns null when the New-chat item is not inside a <ul> menu list", () => {
+    // Defensive: if ChatGPT moves New chat out of a <ul>, bail rather than guess a
+    // container/index that would mis-place the button.
+    const html = `
+      <div id="stage-slideover-sidebar">
+        <div class="relative flex h-full flex-col">
+          <nav aria-label="Chat history">
+            <div class="some-section">
+              <a data-testid="create-new-chat-button" class="group __menu-item hoverable" href="/">New chat</a>
+            </div>
+          </nav>
+        </div>
+      </div>`;
+    const dom = new JSDOM(html);
+    const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector()) as HTMLElement;
+    expect(sidebar).not.toBeNull();
+    expect(chatbot.getSidebarConfig(sidebar)).toBeNull();
+  });
+
   it("returns null configuration when no New-chat menu item is present", () => {
     const html = `
       <div id="stage-slideover-sidebar">

--- a/test/chatbots/ChatGPTSidebarConfig.spec.ts
+++ b/test/chatbots/ChatGPTSidebarConfig.spec.ts
@@ -24,89 +24,110 @@ beforeAll(async () => {
   ChatGPTChatbot = module.default;
 });
 
-describe("ChatGPT sidebar integration (GH-249/GH-252)", () => {
+/**
+ * The current chatgpt.com sidebar (verified live 2026-06-20, #352): there is NO
+ * <aside>. The expanded sidebar's primary menu is a <ul.list-none> of <li.list-none>
+ * rows holding "New chat" + "Search chats"; further nav items (Library …) are direct
+ * <a.__menu-item> children of nav[aria-label="Chat history"]. A separate, hidden
+ * collapsed rail (#stage-sidebar-tiny-bar, opacity-0) carries its OWN icon-only copy
+ * of New chat / Search — so detection must skip the tiny bar.
+ */
+function buildSidebar(): string {
+  return `
+    <div id="stage-slideover-sidebar">
+      <div class="relative flex h-full flex-col">
+        <nav id="stage-sidebar-tiny-bar" aria-label="Sidebar"
+             class="group/tiny-bar flex flex-col items-start absolute inset-0 pointer-events-none opacity-0">
+          <div class="mt-(--sidebar-section-first-margin-top)">
+            <div data-state="closed">
+              <a data-testid="create-new-chat-button" class="group __menu-item hoverable" href="/"><span class="sr-only">New chat</span></a>
+            </div>
+            <div data-state="closed">
+              <button class="group __menu-item hoverable w-full"><span class="sr-only">Search chats</span></button>
+            </div>
+          </div>
+        </nav>
+        <div class="flex h-full w-(--sidebar-width) flex-col">
+          <nav aria-label="Chat history" class="group/scrollport relative flex min-h-0 w-full flex-1 flex-col overflow-y-auto">
+            <div class="sticky top-0 z-30">
+              <ul class="m-0 list-none p-0">
+                <li class="list-none">
+                  <a data-testid="create-new-chat-button" class="group __menu-item hoverable gap-1.5" href="/" data-sidebar-item="true">New chat</a>
+                </li>
+                <li class="list-none">
+                  <button class="group __menu-item hoverable gap-1.5 w-full" type="button">Search chats</button>
+                </li>
+              </ul>
+            </div>
+            <a data-testid="sidebar-item-recall" class="group __menu-item hoverable gap-1.5">Library</a>
+          </nav>
+        </div>
+      </div>
+    </div>`;
+}
+
+describe("ChatGPT sidebar integration (#352 — <aside> removed)", () => {
   let chatbot: InstanceType<typeof ChatGPTChatbot>;
 
   beforeEach(() => {
     chatbot = new ChatGPTChatbot();
   });
 
-  it("should locate the sidebar root using the selector", () => {
-    const html = `
-      <div>
-        <div id="stage-slideover-sidebar">
-          <div aria-label="Header">
-            <aside>
-              <div data-state="open">
-                <a data-testid="create-new-chat-button" class="group __menu-item">New chat</a>
-              </div>
-              <div data-state="open">
-                <div class="group __menu-item">Search chats</div>
-              </div>
-              <div data-state="open">
-                <a class="group __menu-item">Library</a>
-              </div>
-            </aside>
-          </div>
-        </div>
-      </div>
-    `;
-
-    const dom = new JSDOM(html);
-    const selector = chatbot.getSidebarSelector();
-    const sidebar = dom.window.document.querySelector(selector);
+  it("locates the sidebar root using the selector", () => {
+    const dom = new JSDOM(buildSidebar());
+    const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector());
     expect(sidebar).not.toBeNull();
   });
 
-  it("should return menu configuration with insert position after Search", () => {
-    const html = `
-      <div id="stage-slideover-sidebar">
-        <div aria-label="Header">
-          <aside>
-            <div data-state="open">
-              <a data-testid="create-new-chat-button" class="group __menu-item">New chat</a>
-            </div>
-            <div data-state="open">
-              <div class="group __menu-item">Search chats</div>
-            </div>
-            <div data-state="open">
-              <a class="group __menu-item">Library</a>
-            </div>
-          </aside>
-        </div>
-      </div>
-    `;
-
-    const dom = new JSDOM(html);
-    const selector = chatbot.getSidebarSelector();
-    const sidebar = dom.window.document.querySelector(selector) as HTMLElement;
+  it("anchors the menu on the EXPANDED New-chat item (not the hidden tiny bar)", () => {
+    const dom = new JSDOM(buildSidebar());
+    const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector()) as HTMLElement;
     expect(sidebar).not.toBeNull();
+    // Sanity: there is no <aside> anymore, and there ARE two New-chat copies.
+    expect(sidebar.querySelector("aside")).toBeNull();
+    expect(sidebar.querySelectorAll('[data-testid="create-new-chat-button"]').length).toBe(2);
 
     const config = chatbot.getSidebarConfig(sidebar);
     expect(config).not.toBeNull();
     expect(config?.buttonStyle).toBe("menu");
     expect(config?.insertPosition).toBe(2);
-    expect(config?.buttonContainer.children.length).toBe(3);
+    expect(typeof config?.createButton).toBe("function");
+
+    // The container is the expanded <ul.list-none> (New chat + Search), NOT inside the tiny bar.
+    const container = config!.buttonContainer;
+    expect(container.tagName.toLowerCase()).toBe("ul");
+    expect(container.classList.contains("list-none")).toBe(true);
+    expect(container.closest("#stage-sidebar-tiny-bar")).toBeNull();
+    expect(container.children.length).toBe(2); // New chat li + Search li
   });
 
-  it("returns null configuration when aside menu container missing", () => {
+  it("createButton returns an <li> wrapping a native __menu-item button with a working handler", () => {
+    const dom = new JSDOM(buildSidebar());
+    const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector()) as HTMLElement;
+    const config = chatbot.getSidebarConfig(sidebar)!;
+
+    const icon = dom.window.document.createElementNS("http://www.w3.org/2000/svg", "svg") as unknown as SVGElement;
+    let clicked = 0;
+    const el = config.createButton!({ label: "Voice Settings", icon, onClick: () => { clicked++; } });
+
+    expect(el.tagName.toLowerCase()).toBe("li");
+    const inner = el.querySelector(".settings-button.__menu-item") as HTMLElement;
+    expect(inner).not.toBeNull();
+    expect(inner.getAttribute("aria-label")).toBe("Voice Settings");
+    inner.dispatchEvent(new dom.window.Event("click"));
+    expect(clicked).toBe(1);
+  });
+
+  it("returns null configuration when no New-chat menu item is present", () => {
     const html = `
       <div id="stage-slideover-sidebar">
-        <div aria-label="Header">
-          <!-- Missing aside wrapper -->
-          <div data-state="open">
-            <a data-testid="create-new-chat-button" class="group __menu-item">New chat</a>
-          </div>
+        <div class="relative flex h-full flex-col">
+          <nav aria-label="Chat history"><!-- empty: no menu yet --></nav>
         </div>
-      </div>
-    `;
-
+      </div>`;
     const dom = new JSDOM(html);
-    const selector = chatbot.getSidebarSelector();
-    const sidebar = dom.window.document.querySelector(selector) as HTMLElement;
+    const sidebar = dom.window.document.querySelector(chatbot.getSidebarSelector()) as HTMLElement;
     expect(sidebar).not.toBeNull();
-
-    const config = chatbot.getSidebarConfig(sidebar);
-    expect(config).toBeNull();
+    expect(chatbot.getSidebarConfig(sidebar)).toBeNull();
   });
 });


### PR DESCRIPTION
## What

ChatGPT restructured its sidebar (verified live 2026-06-20): there is no longer an `<aside>` inside `#stage-slideover-sidebar`. `getSidebarConfig()` required `sidebar.querySelector('aside')`, so it returned null and SayPi's menu/settings button was never inserted (the `[ChatGPT] sidebar: Could not find menu container` warning). **Closes #352.**

## Fix

Re-anchor on the stable `data-testid="create-new-chat-button"`. There are two copies of the New-chat item — the always-present collapsed rail (`#stage-sidebar-tiny-bar`, opacity-0/pointer-events-none) and the expanded sidebar — so pick the one **not** inside the tiny bar. The primary menu is the `<ul.list-none>` of `<li.list-none>` rows holding New chat + Search; insert SayPi's row after them (position 2, the original intent). `createChatGPTMenuButton` now wraps its `__menu-item` button in `<li class="list-none">` so it slots in natively.

## Verification

- Prototyped live over CDP against the real chatgpt.com DOM: the logic finds the expanded `<ul>` and the inserted button renders as a native menu row directly under New chat + Search, above Library/Scheduled/Apps (screenshot-confirmed).
- Fail-first L2 contract test (`ChatGPTSidebarConfig.spec.ts`) rebuilt for the aside-less structure (incl. the hidden tiny-bar decoy): asserts the config anchors on the EXPANDED New-chat `<ul>` (not the tiny bar), insertPosition 2, and that createButton returns an `<li>` wrapping a working `__menu-item` button. RED against the old aside-based config, GREEN after.
- Full required gate green locally: `tsc` + Jest + Vitest (122 files, 985 passed/1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)