### PR TITLE
feat(ui): Preact UI component-layer foundation

### DIFF
--- a/doc/preact-component-conventions.md
+++ b/doc/preact-component-conventions.md
@@ -1,0 +1,23 @@
+# Preact UI Component Conventions
+
+SayPi UI is migrating from imperative DOM mutation to Preact components
+(design: `doc/specs/2026-06-20-preact-ui-component-layer-design.md`).
+
+- **Author components as `.tsx`.** JSX uses esbuild's automatic runtime
+  (`jsxImportSource: "preact"` in `tsconfig.json`, `wxt.config.ts`, and
+  `vitest.config.js`); no `import { h }` needed.
+- **Render via the registry, never `preact.render` directly:**
+  `mountInto(container, <Component .../>)` and `unmountFrom(container)`
+  (`src/ui/preact/mount.ts`). For host-driven removals, the bootstrap
+  removed-nodes path calls `unmountAllUnder(removedNode)` so component effect
+  cleanup runs instead of orphaning listeners.
+- **Light DOM only — no Shadow DOM.** Injected widgets must inherit host CSS to
+  blend into pi.ai / claude.ai / chatgpt. Owned chrome (settings, notices)
+  styles from `src/styles/tokens.scss`.
+- **Host-injected widgets borrow the host's *compiled* utility classes only**
+  (e.g. `h-10`, never arbitrary `h-[2.5rem]` — hosts compile only their own
+  utilities, so arbitrary values resolve to nothing).
+- **Test under Vitest** (`*.spec.tsx`) with `@testing-library/preact`. Never
+  Jest for JSX: Jest matches `*.test.js` only and has no JSX transform.
+- **Never import Preact into the offscreen document** (`entrypoints/offscreen/`),
+  which renders no user-visible UI.

--- a/doc/preact-component-conventions.md
+++ b/doc/preact-component-conventions.md
@@ -17,7 +17,9 @@ SayPi UI is migrating from imperative DOM mutation to Preact components
 - **Host-injected widgets borrow the host's *compiled* utility classes only**
   (e.g. `h-10`, never arbitrary `h-[2.5rem]` — hosts compile only their own
   utilities, so arbitrary values resolve to nothing).
-- **Test under Vitest** (`*.spec.tsx`) with `@testing-library/preact`. Never
-  Jest for JSX: Jest matches `*.test.js` only and has no JSX transform.
+- **Test under Vitest** (`*.spec.tsx`); component tests use
+  `@testing-library/preact` (added with the first component in PR3 — the mount
+  registry itself uses raw Preact). Never Jest for JSX: Jest matches `*.test.js`
+  only and has no JSX transform.
 - **Never import Preact into the offscreen document** (`entrypoints/offscreen/`),
   which renders no user-visible UI.

--- a/doc/specs/2026-06-20-preact-ui-component-layer-design.md
+++ b/doc/specs/2026-06-20-preact-ui-component-layer-design.md
@@ -1,0 +1,199 @@
+# Preact UI Component Layer — Design
+
+**Date:** 2026-06-20
+**Status:** Approved (design); implementation staged across PRs
+**Author:** Autonomous engineering session (Claude)
+
+## Why
+
+The extension's UI is built entirely by imperative DOM mutation — **0 `.tsx/.jsx`
+files, no UI framework dependency, ~211 `document.createElement` sites in `src/`,
+45 `innerHTML` injections, 35 raw-SVG `?raw` imports**, spread across singleton
+classes that own and mutate their own DOM subtree. This is the codebase's single
+largest maintainability and testability tax. Concretely:
+
+- The "notice/banner" widget skeleton is **logically byte-identical** across three
+  modules — `src/ui/AgentModeNoticeModule.ts`, `src/compat/CompatibilityNotificationUI.ts`,
+  and `src/auth/AuthPromptUI.ts` — including the `findInjectionPoint` host-selector
+  fallback chain, which has **already silently diverged in comments** between copies.
+- Widget tests are forced into brittle hacks: `test/buttons/CallButton-arc-rebuild.spec.ts`
+  does `Object.create(CallButton.prototype)` + hand-assigns nine private fields;
+  `test/tts/VoiceMenu.spec.ts` runs `vi.mock("Pi")` purely to break an import cycle.
+- Bug #203 is the textbook hand-rolled-rerender failure: a re-render tore down and
+  rebuilt the call-button SVG, destroying the live `#progress-ring` countdown; the
+  fix was a hand-written "skip rebuild if same state" guard.
+- There is **no design-token layer** (raw hex/rgb literals duplicated across ~20
+  flat SCSS files) and **no visual-regression testing anywhere**.
+- The settings page imports a **2.9 MB vendored Tailwind v2 dump**
+  (`src/popup/tailwind.min.css`, the single largest non-binary asset against
+  Firefox AMO's 5 MB limit) for a surface that already ships its own per-tab CSS.
+
+This refactor is justified **on maintainability and testability grounds alone**,
+independent of any design tool. As a deliberate downstream bonus, it also leaves
+the door open to a future Claude Design sync of the SayPi-owned chrome (see
+`doc/specs/` sibling note / project memory `claude-design-fit-evaluation`): Preact
+components are compilable, syncable artifacts, whereas an in-house primitive is not.
+
+## Decision: Preact (light-DOM, single primitive)
+
+We adopt **Preact**, rendering into **light DOM** (no Shadow DOM), as the single UI
+component primitive. Rationale, verified against the actual repo:
+
+- **Maintainability (clear win):** declarative components + a diffing reconciler
+  collapse the triplicated `<Notice>`, retire the by-hand tree construction, and
+  prevent the #203 class of bug by construction (the VDOM keeps live nodes across
+  re-renders).
+- **Testability (moderate win):** prop-driven, independently mountable components
+  remove the reason for the `Object.create(prototype)` and cycle-break-mock hacks.
+  (Caveat: the deeper root cause — module-level singletons + EventBus coupling —
+  is fixed by *injecting props instead of `getInstance()`*, a discipline neither
+  tool enforces. The win requires that discipline.)
+- **Portability across hosts (conditional lean):** light DOM is mandatory — the
+  injected widgets must inherit host CSS to blend in (Shadow DOM would sever that).
+  Preact's real edge is that it **forces the adapter inversion**: presentation moves
+  into `{anchor, port}`-prop components, letting `src/chatbots/Chatbot.ts` shrink
+  from a god-interface that smuggles presentation (`getExtraCallButtonClasses()`,
+  `SidebarConfig.createButton`) toward selectors + actions + data. The dominant
+  per-host theming mechanism (the `body.claude/pi/chatgpt` cascade) is
+  framework-agnostic and unchanged.
+
+**Integration is low-friction (verified):** Preact needs **no `unsafe-eval`** (the
+extension CSP at `wxt.config.ts` is already eval-free; JSX→`h()` is a build-time
+transform); host CSP restrictions are `media-src`, not `script-src`, and content
+scripts run in MV3's isolated world; the repo already renders 100% into light DOM.
+Wiring is three steps (`preact` + `@preact/preset-vite`, `plugins:[preact()]` in the
+existing `vite()` block, `jsx`/`jsxImportSource` in `tsconfig.json`), JSX is
+**opt-in per `.tsx` file** so the 173 existing `.ts/.js` files are untouched, and the
+bundle math is **net-negative** (delete 2.9 MB Tailwind, add ~10–12 KB Preact).
+
+Rejected alternatives: **in-house base class** (serves only the present, becomes
+integration debt if Claude Design is ever pursued, and gives no declarative
+state→DOM binding so #203-class bugs persist); **Lit/web components** (Shadow DOM
+isolates from host CSS — the opposite of what injected widgets need).
+
+## Architecture
+
+### Foundation
+
+- Add `preact` (runtime dep) + `@preact/preset-vite` (dev dep) + `@testing-library/preact` (dev dep).
+- `wxt.config.ts`: add `plugins: [preact()]` to the existing `vite()` return. **No
+  manifest / permissions / content-script-injection-scope change** — verified by
+  diffing the generated `manifest.json` before/after (must be byte-identical).
+- `tsconfig.json`: add `"jsx": "react-jsx"`, `"jsxImportSource": "preact"`.
+- New components live in `.tsx`, tested under **Vitest** (Vite-native, picks up the
+  plugin) with `@testing-library/preact`. **Never Jest** for JSX (avoids adding a
+  second JSX transform). **Never import Preact into the offscreen document.**
+
+### Mount lifecycle (the load-bearing decision)
+
+Preact's cleanup guarantee is conditional: it only prevents the listener leaks this
+repo demonstrably has (`VADStatusIndicator.ts`'s `// TODO: Remove keydown listener`,
+`CallButton`'s 9+ unsubscribed EventBus listeners) **if** the unmount path calls
+`unmountComponentAtNode`. So the foundation ships a thin `mountInto(container, vnode)` /
+`unmountFrom(container)` helper **wired into the existing `Observation`/`bootstrap`
+find-decorate-and-removedNodes lifecycle** (`src/chatbots/bootstrap.ts`). Cleanup
+becomes wired-once-centrally rather than per-author discipline.
+
+### Token layer
+
+A new `src/styles/tokens.scss` of CSS custom properties consolidating the scattered
+brand literals — SayPi green (`#418a2f`, `#24381b`), cream tones, the `rectangles.css`
+animation color ramp — as `var(--saypi-*)`. Rules:
+
+- **Owned chrome** (settings, overlays/notices) styles itself from these tokens. This
+  is the single artifact a future Claude Design sync consumes.
+- **Host-injected widgets** keep borrowing the host's *compiled* utility classes
+  (per memory `host-injected-arbitrary-tailwind`: no arbitrary `h-[2.5rem]` values —
+  only real host utilities like `h-10`, because the host only compiles its own).
+  Tokens live in our stylesheets, never as Tailwind arbitrary values.
+
+### Boundaries
+
+Presentation (host-agnostic, prop-driven Preact components) is separated from
+host-coupling (adapters + bootstrap, which keep the brittle selectors). Selector
+drift stays in the adapters; nothing here makes the live host DOM an API contract.
+
+## Migration units (each independently shippable)
+
+**Unit A — `<Notice>` (highest ROI, lowest risk).** One `<Notice variant icon onDismiss>`
+component + one shared `injectNotice(host, vnode)` helper absorbing the triplicated
+`findInjectionPoint`. Migrate agent-mode and compat notices directly; **`AuthPromptUI`
+is the exception** — its modal + overlay + focus-trap + benefits list become
+`<AuthPrompt>` *composing* `<Notice>`, not collapsing into it.
+
+**Unit B — Settings page → Preact (deletes the 2.9 MB Tailwind dump).** Migrate the
+four tabs from `html?raw` + `innerHTML` + manual `querySelector` binding to Preact
+components, reusing the existing `TabController`/`TabNavigator` shape (already
+prop/callback-driven, well-tested at `TabNavigator.spec.ts`). Audit which Tailwind
+utilities the settings HTML actually uses (expected: few — each tab ships its own
+CSS), replace with the token layer + bespoke CSS, then **delete the
+`import "../../src/popup/tailwind.min.css"` at `entrypoints/settings/index.ts`**.
+
+**Unit C — Mountable injected widgets (the seam; riskiest, done last).** Refactor
+`CallButton` and the voice menus so **presentation** is a Preact component taking
+props (`state`, `segments`, `hostClasses`, callbacks), while **host-node mutation**
+(assigning `#saypi-prompt`, decorating host containers) stays imperative in bootstrap.
+Bridge XState→props (subscribe to actor, map state→props, re-render) — which lets us
+**delete** the #203 "skip rebuild if same state" guard, because the VDOM diff
+preserves the live `#progress-ring` node by construction.
+
+**Out of scope:** in-place host decoration (mutating the host's *own* DOM nodes)
+stays imperative — Preact must never own those subtrees. Restyling the injected
+widgets (Unit C is "make mountable + extract presentation," not "restyle"). Selector
+drift remains an adapter concern.
+
+## Testing strategy
+
+- **Layer 0 (`tsc`):** stays green; JSX type config part of PR1.
+- **Layers 1–2 (Vitest):** every new component gets a `@testing-library/preact` unit
+  test. `render(<CallButton state=… />)` + assert output DOM replaces the
+  `Object.create` + private-field hack and the cycle-break mock. `<Notice>` gets one
+  test covering all three variants.
+- **Layer 3 (Playwright):** existing decoration E2E + mock host pages stay; stop
+  hand-building synthetic widget copies (`pi-action-buttons.e2e.ts`) — mount the
+  **real** component (single source of truth). `e2e` is a required CI check.
+- **Adapter selector contract tests untouched** (they sit below presentation).
+
+### Visual regression (new — the net has none today)
+
+Add Playwright `toHaveScreenshot()` baselines via a tiny **harness page** that mounts
+each Preact component in isolation (cheap, now that components are mountable) — owned
+chrome (settings tabs, the three `<Notice>` variants) + injected widgets against
+`mock-pi-page.html`/`mock-claude-page.html`. Baselines committed; CI compares. The
+harness doubles as the basis for a future Claude Design preview.
+
+## PR staging (small, independently green, revertible — matches merge-on-green workflow)
+
+1. **PR1 — Preact foundation:** deps + `wxt.config.ts`/`tsconfig` wiring +
+   `mountInto`/`unmountFrom` helper wired into the bootstrap lifecycle + conventions
+   note + this spec + the implementation plan. No behavior change. Includes the
+   generated-manifest byte-identity check.
+2. **PR2 — Token layer:** `tokens.scss` + migrate a first batch of duplicated brand
+   literals to `var(--saypi-*)`. No behavior change.
+3. **PR3 — `<Notice>`:** component + migrate all three notice modules (incl.
+   `<AuthPrompt>` composition). Highest ROI.
+4. **PR4 — Settings → Preact + delete the 2.9 MB Tailwind dump.** Biggest bundle win.
+5. **PR5 — Mountable `CallButton`/voice menus + XState→props bridge.** Riskiest; after
+   the pattern is proven.
+6. **PR6 — Visual-regression harness + baselines.**
+
+PR1 and PR2 are pure enablers. PR3 is the first user-visible win and may swap order
+with PR4. Each PR: CI green (`tsc` + Jest + Vitest + `e2e`) **plus an independent
+subagent reviewer verdict** posted as a PR comment, then merge (squash + delete
+branch).
+
+## Risks
+
+- **Bootstrap unmount wiring (PR1)** is the correctness keystone — get it wrong and
+  Preact leaks exactly like vanilla does today. That's why the lifecycle helper is in
+  the *first* PR.
+- **`wxt.config.ts` edit** — must verify the generated manifest is byte-identical so
+  the change stays out of the manifest/permissions/injection-scope high-blast-radius
+  category (which would need founder sign-off).
+- **Mixed-paradigm window** during migration — bounded by migrating whole surfaces at
+  a time and by PR sequencing.
+- **`AuthPromptUI` complexity** (modal/focus-trap) — the one notice that needs
+  composition, not collapse.
+- **Dual test runners** — keep new `.tsx` on Vitest; don't drag Jest into JSX.
+- **Per-host borrowed Tailwind classes** are a presentation-side drift surface neither
+  paradigm fixes; consolidating them into typed props gives one place to fix drift.

--- a/doc/specs/2026-06-20-preact-ui-component-layer-plan.md
+++ b/doc/specs/2026-06-20-preact-ui-component-layer-plan.md
@@ -1,0 +1,431 @@
+# Preact UI Component Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce Preact (light-DOM) as the extension's UI component primitive and migrate the SayPi-owned UI onto it, in independently-shippable PRs, for maintainability + testability (and a future-cheap Claude Design sync).
+
+**Architecture:** A thin light-DOM mount/unmount registry wraps Preact's `render`; new UI is authored as `.tsx` components tested under Vitest; host-injected widgets keep inheriting host CSS (no Shadow DOM) while presentation moves into prop-driven components and host-coupling stays in the adapters. Design: `doc/specs/2026-06-20-preact-ui-component-layer-design.md`.
+
+**Tech Stack:** Preact 10 (esbuild automatic JSX, no Babel preset), WXT/Vite, Vitest + JSDOM, Playwright (E2E + visual regression).
+
+---
+
+## Working conventions (every PR)
+
+- **Worktree isolation:** each PR in its own `.worktrees/<task>` worktree off latest `origin/main`. PR1 uses the existing `.worktrees/preact-foundation` on branch `refactor/preact-foundation`.
+- **Branch guard every commit/push:** prefix with `[ "$(git rev-parse --abbrev-ref HEAD)" = "<branch>" ] || exit 1`.
+- **Merge gate:** CI green (`npm test` = `tsc` + Jest + Vitest, plus required `e2e`) **plus an independent subagent reviewer verdict posted as a PR comment**. Then squash-merge + delete branch.
+- **Commit trailer:** `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **PR body trailer:** `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- **Never** edit `.output/`, `.wxt/`, `dist/`, generated `public/`. **Never** load `.env.production`.
+
+---
+
+## PR1 — Preact foundation (no runtime behavior change)
+
+Branch: `refactor/preact-foundation`. Establishes the JSX toolchain + the mount/unmount registry (the cleanup keystone), proven in isolation. Ships the design + this plan.
+
+### Task 0: Commit the design + plan docs
+
+**Files:**
+- Create: `doc/specs/2026-06-20-preact-ui-component-layer-design.md` (already written)
+- Create: `doc/specs/2026-06-20-preact-ui-component-layer-plan.md` (this file)
+
+- [ ] **Step 1: Commit the docs**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "refactor/preact-foundation" ] || exit 1
+git add doc/specs/2026-06-20-preact-ui-component-layer-design.md doc/specs/2026-06-20-preact-ui-component-layer-plan.md
+git commit -m "docs(ui): design + plan for Preact UI component layer
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 1: Add Preact + JSX toolchain config
+
+**Files:**
+- Modify: `package.json` (add `preact` to dependencies)
+- Modify: `tsconfig.json` (add `jsx`, `jsxImportSource`)
+- Modify: `wxt.config.ts:491` (add `esbuild` to the `vite()` return)
+- Modify: `vitest.config.js` (add `esbuild` jsx + include `.spec.tsx`)
+
+- [ ] **Step 1: Install Preact**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "refactor/preact-foundation" ] || exit 1
+npm install preact@^10
+```
+
+Expected: `preact` appears in `dependencies` (it is imported by runtime code).
+
+- [ ] **Step 2: Enable JSX in `tsconfig.json`**
+
+Change `compilerOptions` to:
+
+```jsonc
+"compilerOptions": {
+  "allowJs": true,
+  "jsx": "react-jsx",
+  "jsxImportSource": "preact",
+  "types": ["node", "chrome", "firefox-webext-browser", "vitest/globals"]
+},
+```
+
+(`jsx`/`jsxImportSource` only affect files containing JSX — i.e. new `.tsx`. The 173 existing `.ts/.js` files are unaffected.)
+
+- [ ] **Step 3: Enable build-side JSX in `wxt.config.ts`**
+
+The `vite()` function (line ~491) currently returns `{ define, resolve, build }`. Add an `esbuild` key:
+
+```ts
+vite: () => ({
+  define: {
+    // ...existing...
+  },
+  resolve: {
+    // ...existing...
+  },
+  build: {
+    // ...existing...
+  },
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "preact",
+  },
+}),
+```
+
+Do **not** touch the `manifest` block (~443-490) or the `vite:build:extendConfig` / `build:manifestGenerated` hooks.
+
+- [ ] **Step 4: Enable test-side JSX in `vitest.config.js`**
+
+Add top-level `esbuild` and extend `test.include`:
+
+```js
+export default defineConfig({
+  resolve: {
+    alias: {
+      "~": fileURLToPath(new URL("./src", import.meta.url)),
+      "~/": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "preact",
+  },
+  test: {
+    include: ["**/*.spec.ts", "**/*.spec.tsx"],
+    exclude: [...configDefaults.exclude, "e2e/**"],
+    globals: true,
+    setupFiles: ["test/vitest.setup.js"],
+  },
+  testTimeout: 10000,
+});
+```
+
+- [ ] **Step 5: Verify type-check + existing tests unchanged**
+
+Run: `npm run typecheck`
+Expected: PASS (no `.tsx` yet, so jsx config is a no-op).
+
+Run: `npm run test:vitest`
+Expected: PASS (existing specs unaffected; `.spec.tsx` glob matches nothing yet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "refactor/preact-foundation" ] || exit 1
+git add package.json package-lock.json tsconfig.json wxt.config.ts vitest.config.js
+git commit -m "build(ui): add Preact + esbuild automatic-JSX toolchain (opt-in .tsx)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 2: Light-DOM mount/unmount registry (TDD)
+
+**Files:**
+- Create: `src/ui/preact/mount.ts`
+- Test: `test/ui/preact/mount.spec.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/ui/preact/mount.spec.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { useLayoutEffect } from "preact/hooks";
+import {
+  mountInto,
+  unmountFrom,
+  unmountAllUnder,
+  mountedCount,
+} from "../../../src/ui/preact/mount";
+
+// Records cleanup synchronously via useLayoutEffect so unmount assertions are
+// deterministic without awaiting Preact's deferred (passive) effects.
+let cleanupCalls = 0;
+function Probe({ label }: { label: string }) {
+  useLayoutEffect(() => () => {
+    cleanupCalls += 1;
+  }, []);
+  return <span class="probe">{label}</span>;
+}
+
+describe("preact light-DOM mount registry", () => {
+  beforeEach(() => {
+    cleanupCalls = 0;
+    document.body.innerHTML = "";
+  });
+
+  it("renders component output into the container", () => {
+    const container = document.createElement("div");
+    mountInto(container, <Probe label="hello" />);
+    expect(container.querySelector(".probe")?.textContent).toBe("hello");
+    expect(mountedCount()).toBe(1);
+    unmountFrom(container);
+  });
+
+  it("unmounts: clears DOM and runs effect cleanup", () => {
+    const container = document.createElement("div");
+    mountInto(container, <Probe label="x" />);
+    expect(cleanupCalls).toBe(0);
+    unmountFrom(container);
+    expect(container.querySelector(".probe")).toBeNull();
+    expect(cleanupCalls).toBe(1);
+    expect(mountedCount()).toBe(0);
+  });
+
+  it("unmountFrom is idempotent", () => {
+    const container = document.createElement("div");
+    mountInto(container, <Probe label="x" />);
+    unmountFrom(container);
+    unmountFrom(container);
+    expect(cleanupCalls).toBe(1);
+    expect(mountedCount()).toBe(0);
+  });
+
+  it("unmountAllUnder tears down trees nested under a removed host node", () => {
+    const host = document.createElement("div");
+    const widgetContainer = document.createElement("div");
+    host.appendChild(widgetContainer);
+    document.body.appendChild(host);
+
+    mountInto(widgetContainer, <Probe label="nested" />);
+    expect(mountedCount()).toBe(1);
+
+    unmountAllUnder(host);
+    expect(cleanupCalls).toBe(1);
+    expect(mountedCount()).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:vitest -- mount.spec`
+Expected: FAIL — cannot resolve `../../../src/ui/preact/mount`.
+
+- [ ] **Step 3: Implement the registry**
+
+Create `src/ui/preact/mount.ts`:
+
+```ts
+import { render, type ComponentChild } from "preact";
+
+/**
+ * Light-DOM Preact mount registry.
+ *
+ * Tracks every container we render a Preact tree into so that unmount is
+ * idempotent and the bootstrap find/decorate lifecycle can tear down any tree
+ * under a host node the SPA removed (unmountAllUnder), running each component's
+ * effect cleanup instead of orphaning its listeners. Preact 10 unmounts and
+ * runs hook cleanup when you render `null` into a container, so we do not need
+ * preact/compat's unmountComponentAtNode.
+ */
+const mountedContainers = new Set<Element>();
+
+/** Render `vnode` into `container`; remember the container for cleanup. */
+export function mountInto(container: Element, vnode: ComponentChild): void {
+  render(vnode, container);
+  mountedContainers.add(container);
+}
+
+/** Unmount any Preact tree previously mounted into `container`. Idempotent. */
+export function unmountFrom(container: Element): void {
+  if (!mountedContainers.has(container)) return;
+  render(null, container);
+  mountedContainers.delete(container);
+}
+
+/**
+ * Unmount every tracked container that is `node` or a descendant of it. Call
+ * from the bootstrap removed-nodes path so host-driven DOM removals trigger
+ * Preact cleanup.
+ */
+export function unmountAllUnder(node: Node): void {
+  for (const container of [...mountedContainers]) {
+    if (node === container || node.contains(container)) {
+      unmountFrom(container);
+    }
+  }
+}
+
+/** Number of currently mounted containers (diagnostics + tests). */
+export function mountedCount(): number {
+  return mountedContainers.size;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test:vitest -- mount.spec`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Run the full required gate**
+
+Run: `npm test`
+Expected: PASS (`tsc` + Jest + Vitest all green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "refactor/preact-foundation" ] || exit 1
+git add src/ui/preact/mount.ts test/ui/preact/mount.spec.tsx
+git commit -m "feat(ui): light-DOM Preact mount/unmount registry with cleanup
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 3: Developer conventions note
+
+**Files:**
+- Create: `doc/preact-component-conventions.md`
+
+- [ ] **Step 1: Write the conventions note**
+
+Create `doc/preact-component-conventions.md`:
+
+```markdown
+# Preact UI Component Conventions
+
+SayPi UI is migrating from imperative DOM mutation to Preact components.
+
+- **Author components as `.tsx`.** JSX uses the automatic runtime
+  (`jsxImportSource: "preact"`); no `import { h }` needed.
+- **Render via the registry**, never `preact.render` directly:
+  `mountInto(container, <Component .../>)` and `unmountFrom(container)`
+  (`src/ui/preact/mount.ts`). For host-driven removals, the bootstrap
+  removed-nodes path calls `unmountAllUnder(removedNode)`.
+- **Light DOM only — no Shadow DOM.** Injected widgets must inherit host CSS.
+  Owned chrome (settings, notices) styles from `src/styles/tokens.scss`.
+- **Host-injected widgets borrow the host's *compiled* utility classes only**
+  (e.g. `h-10`, never arbitrary `h-[2.5rem]` — hosts compile only their own).
+- **Test under Vitest** (`.spec.tsx`) with `@testing-library/preact`. Never
+  Jest for JSX (Jest matches `*.test.js` only and has no JSX transform).
+- **Never import Preact into the offscreen document** (`entrypoints/offscreen/`).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "refactor/preact-foundation" ] || exit 1
+git add doc/preact-component-conventions.md
+git commit -m "docs(ui): Preact component authoring conventions
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 4: Build verification + manifest byte-identity, then open PR
+
+- [ ] **Step 1: Confirm the generated manifest is unchanged**
+
+Build on this branch and on a clean `origin/main`, then diff the manifests:
+
+```bash
+# this branch
+npx wxt build 2>/dev/null; cp .output/chrome-mv3/manifest.json /tmp/manifest.branch.json
+# baseline from the main checkout (a sibling worktree at repo root)
+( cd ../.. && npx wxt build 2>/dev/null && cp .output/chrome-mv3/manifest.json /tmp/manifest.main.json )
+diff /tmp/manifest.main.json /tmp/manifest.branch.json && echo "MANIFEST IDENTICAL"
+```
+
+Expected: `MANIFEST IDENTICAL` (no differences). This proves the `wxt.config.ts` edit is confined to the Vite/esbuild transform and does **not** change the manifest / permissions / content-script injection scope — so it is **not** a high-blast-radius change requiring founder sign-off.
+Fallback if the prod build needs unavailable env: document that the only `wxt.config.ts` edit is the `esbuild` key inside `vite()`, outside the `manifest` block and outside every manifest-affecting hook, and have the reviewer subagent confirm from the diff.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+[ "$(git rev-parse --abbrev-ref HEAD)" = "refactor/preact-foundation" ] || exit 1
+git push -u origin refactor/preact-foundation
+gh pr create --title "feat(ui): Preact UI component-layer foundation" --body "$(cat <<'EOF'
+## Why
+First step of the UI component-layer refactor (design: `doc/specs/2026-06-20-preact-ui-component-layer-design.md`). The extension builds all UI by imperative DOM mutation (~211 createElement sites, a triplicated Notice, brittle private-field widget tests, bug #203). This PR lays the Preact foundation; no runtime behavior changes.
+
+## What
+- Add `preact` + esbuild automatic-JSX toolchain (opt-in `.tsx`; 173 existing `.ts/.js` files untouched; Jest stays clear of JSX).
+- `src/ui/preact/mount.ts`: light-DOM `mountInto`/`unmountFrom`/`unmountAllUnder` registry — the cleanup keystone, so host-driven DOM removals run Preact effect cleanup instead of orphaning listeners.
+- Conventions note + design/plan docs.
+
+## Verification
+- `npm test` green (tsc + Jest + Vitest); 4 new mount-registry tests.
+- Generated `manifest.json` byte-identical vs `main` (see Task 4) — confirms this is **not** a manifest/permissions/injection-scope change.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Independent subagent review + merge on green** (see "Per-PR review & merge" below).
+
+---
+
+## Roadmap: PR2–PR6
+
+These build on the merged foundation. **Each gets its own detailed bite-sized plan written just-in-time** when it starts (against the then-current `main`), because their concrete steps depend on the merged primitives and would otherwise be speculative. Summaries + acceptance criteria:
+
+### PR2 — Token layer (no behavior change)
+- Create `src/styles/tokens.scss` (CSS custom properties): SayPi green (`#418a2f`, `#24381b`), cream tones, the `rectangles.css` animation color ramp, as `var(--saypi-*)`.
+- Import it once in the content-script style entry (`src/saypi.index.js`) and the settings entry.
+- Migrate a first batch of duplicated literals to `var(--saypi-*)`.
+- **Acceptance:** tokens defined + imported; a batch of literals replaced; `npm test` green; no visual change (verify against existing E2E).
+
+### PR3 — `<Notice>` component (highest ROI)
+- Add `@testing-library/preact` (dev dep — first real component test).
+- `src/ui/Notice.tsx`: `<Notice variant icon onDismiss children>` + one shared `injectNotice(host, vnode)` absorbing the triplicated `findInjectionPoint` (currently duplicated in `AgentModeNoticeModule.ts:223`, `CompatibilityNotificationUI.ts:233`).
+- Migrate `AgentModeNoticeModule` + `CompatibilityNotificationUI` to render `<Notice>`; refactor `AuthPromptUI` into `<AuthPrompt>` *composing* `<Notice>` (keeps its modal/overlay/focus-trap).
+- **First build of a `.tsx`** — verify the wxt/esbuild JSX transform works in the real build (the foundation only proved tsc + Vitest JSX).
+- **Acceptance:** one `<Notice>` replaces three skeletons; component unit test covers all variants; `findInjectionPoint` exists once; `npm test` + `e2e` green.
+
+### PR4 — Settings → Preact + delete the 2.9 MB Tailwind dump
+- Migrate the four settings tabs from `html?raw` + `innerHTML` to Preact components, reusing `TabController`/`TabNavigator`.
+- Audit which Tailwind utilities the settings HTML uses; replace with `tokens.scss` + bespoke CSS; **delete `import "../../src/popup/tailwind.min.css"` (`entrypoints/settings/index.ts:15`)** and the 2.9 MB file.
+- **Acceptance:** settings renders identically; Tailwind dump deleted; bundle measurably smaller; settings component tests pass; `npm test` green.
+
+### PR5 — Mountable `CallButton` / voice menus + XState→props bridge (riskiest)
+- Extract `CallButton` + voice-menu **presentation** into Preact components taking props (`state`, `segments`, `hostClasses`, callbacks); keep host-node mutation imperative in bootstrap.
+- Wire `unmountAllUnder` into the bootstrap removed-nodes path (`src/chatbots/bootstrap.ts:60-94`) — first real consumer of the cleanup keystone.
+- Bridge XState→props; **delete** the bug-#203 "skip rebuild if same state" guard (VDOM diff preserves the live `#progress-ring`).
+- Replace the private-field test hacks (`CallButton-arc-rebuild.spec.ts`, `VoiceMenu.spec.ts`) with prop-driven component tests.
+- **Acceptance:** widgets render/behave identically on all hosts (Layer 3 E2E + Layer 4 spot-check); no listener leaks; #203 regression test passes without the manual guard; `npm test` + `e2e` green.
+
+### PR6 — Visual-regression harness + baselines
+- A harness page mounting each Preact component in isolation; Playwright `toHaveScreenshot()` baselines for owned chrome (settings tabs, `<Notice>` variants) + injected widgets against `mock-pi-page.html`/`mock-claude-page.html`.
+- **Acceptance:** baselines committed; CI compares; harness reusable as a future Claude Design preview.
+
+---
+
+## Per-PR review & merge (applies to every PR)
+
+1. After CI is green, dispatch an **independent subagent reviewer** (multi-lens if the PR touches a high-blast-radius surface — none of PR1–PR6 touch auth/manifest-semantics/server-contract, but PR4/PR5 touch content-script behavior, so review decoration carefully).
+2. Post the reviewer verdict as a PR comment (GitHub disallows self-approval).
+3. Address blocking findings; re-run gate.
+4. Merge (squash + delete branch) once CI green + mergeable + reviewer approves. Confirm `gh pr view --json state` is `MERGED`.
+
+---
+
+## Self-review (writing-plans)
+
+- **Spec coverage:** foundation (PR1), tokens (PR2), `<Notice>` consolidation (PR3), settings + Tailwind deletion (PR4), mountable widgets + XState bridge + #203 (PR5), visual regression (PR6) — every spec section maps to a PR. Mount-lifecycle keystone is in PR1; its first call-site is PR5 (documented).
+- **Placeholder scan:** PR1 tasks contain complete code + exact commands. PR2–6 are deliberately roadmap-level (each gets its own detailed plan), not placeholder steps inside a task.
+- **Type consistency:** `mountInto`/`unmountFrom`/`unmountAllUnder`/`mountedCount` names are used consistently across the test, implementation, conventions note, and PR5 wiring reference.
+- **Known verification boundary:** PR1 proves JSX for `tsc` + Vitest; the WXT *build*-side JSX transform is first exercised by a runtime `.tsx` in PR3 (called out in PR3 acceptance).

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "lodash": "^4.17.21",
         "lucide": "^0.536.0",
         "onnxruntime-web": "1.14.0",
+        "preact": "^10.29.2",
         "rxjs": "^7.8.1",
         "serve-handler": "^6.1.5",
         "wasm-feature-detect": "^1.8.0",
@@ -16692,6 +16693,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "lodash": "^4.17.21",
     "lucide": "^0.536.0",
     "onnxruntime-web": "1.14.0",
+    "preact": "^10.29.2",
     "rxjs": "^7.8.1",
     "serve-handler": "^6.1.5",
     "wasm-feature-detect": "^1.8.0",

--- a/src/ui/preact/mount.ts
+++ b/src/ui/preact/mount.ts
@@ -1,0 +1,47 @@
+import { render, type ComponentChild } from "preact";
+
+/**
+ * Light-DOM Preact mount registry.
+ *
+ * Tracks every container we render a Preact tree into so that unmount is
+ * idempotent and the bootstrap find/decorate lifecycle can tear down any tree
+ * under a host node the SPA removed (unmountAllUnder), running each component's
+ * effect cleanup instead of orphaning its listeners. Preact 10 unmounts and
+ * runs hook cleanup when you render `null` into a container, so we do not need
+ * preact/compat's unmountComponentAtNode.
+ *
+ * No Shadow DOM: injected widgets render into the host's light DOM so they
+ * inherit host CSS (see doc/preact-component-conventions.md).
+ */
+const mountedContainers = new Set<Element>();
+
+/** Render `vnode` into `container`; remember the container for cleanup. */
+export function mountInto(container: Element, vnode: ComponentChild): void {
+  render(vnode, container);
+  mountedContainers.add(container);
+}
+
+/** Unmount any Preact tree previously mounted into `container`. Idempotent. */
+export function unmountFrom(container: Element): void {
+  if (!mountedContainers.has(container)) return;
+  render(null, container);
+  mountedContainers.delete(container);
+}
+
+/**
+ * Unmount every tracked container that is `node` or a descendant of it. Call
+ * from the bootstrap removed-nodes path so host-driven DOM removals trigger
+ * Preact cleanup.
+ */
+export function unmountAllUnder(node: Node): void {
+  for (const container of [...mountedContainers]) {
+    if (node === container || node.contains(container)) {
+      unmountFrom(container);
+    }
+  }
+}
+
+/** Number of currently mounted containers (diagnostics + tests). */
+export function mountedCount(): number {
+  return mountedContainers.size;
+}

--- a/test/test-runner-coverage.spec.ts
+++ b/test/test-runner-coverage.spec.ts
@@ -29,7 +29,7 @@ const TEST_FILE = /\.(test|spec)\.(ts|tsx|js|jsx|mts|cts|mjs|cjs)$/;
 // These MUST mirror the runner configs:
 const RUNNERS = [
   { name: "Jest (**/*.test.js)", match: /\.test\.js$/ }, // package.json -> jest.testMatch
-  { name: "Vitest (**/*.spec.ts)", match: /\.spec\.ts$/ }, // vitest.config.js -> test.include
+  { name: "Vitest (**/*.spec.{ts,tsx})", match: /\.spec\.tsx?$/ }, // vitest.config.js -> test.include
 ];
 
 function trackedTestFiles(): string[] {

--- a/test/ui/preact/mount.spec.tsx
+++ b/test/ui/preact/mount.spec.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useLayoutEffect } from "preact/hooks";
+import {
+  mountInto,
+  unmountFrom,
+  unmountAllUnder,
+  mountedCount,
+} from "../../../src/ui/preact/mount";
+
+// Records cleanup synchronously via useLayoutEffect so unmount assertions are
+// deterministic without awaiting Preact's deferred (passive) effects.
+let cleanupCalls = 0;
+function Probe({ label }: { label: string }) {
+  useLayoutEffect(
+    () => () => {
+      cleanupCalls += 1;
+    },
+    [],
+  );
+  return <span class="probe">{label}</span>;
+}
+
+describe("preact light-DOM mount registry", () => {
+  beforeEach(() => {
+    cleanupCalls = 0;
+    document.body.innerHTML = "";
+  });
+
+  it("renders component output into the container", () => {
+    const container = document.createElement("div");
+    mountInto(container, <Probe label="hello" />);
+    expect(container.querySelector(".probe")?.textContent).toBe("hello");
+    expect(mountedCount()).toBe(1);
+    unmountFrom(container);
+  });
+
+  it("unmounts: clears DOM and runs effect cleanup", () => {
+    const container = document.createElement("div");
+    mountInto(container, <Probe label="x" />);
+    expect(cleanupCalls).toBe(0);
+    unmountFrom(container);
+    expect(container.querySelector(".probe")).toBeNull();
+    expect(cleanupCalls).toBe(1);
+    expect(mountedCount()).toBe(0);
+  });
+
+  it("unmountFrom is idempotent", () => {
+    const container = document.createElement("div");
+    mountInto(container, <Probe label="x" />);
+    unmountFrom(container);
+    unmountFrom(container);
+    expect(cleanupCalls).toBe(1);
+    expect(mountedCount()).toBe(0);
+  });
+
+  it("unmountAllUnder tears down trees nested under a removed host node", () => {
+    const host = document.createElement("div");
+    const widgetContainer = document.createElement("div");
+    host.appendChild(widgetContainer);
+    document.body.appendChild(host);
+
+    mountInto(widgetContainer, <Probe label="nested" />);
+    expect(mountedCount()).toBe(1);
+
+    unmountAllUnder(host);
+    expect(cleanupCalls).toBe(1);
+    expect(mountedCount()).toBe(0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "types": ["node", "chrome", "firefox-webext-browser", "vitest/globals"]
   },
   "include": [

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,8 +8,12 @@ export default defineConfig({
       "~/": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "preact",
+  },
   test: {
-    include: ["**/*.spec.ts"],
+    include: ["**/*.spec.ts", "**/*.spec.tsx"],
     exclude: [...configDefaults.exclude, "e2e/**"],
     globals: true,
     setupFiles: ["test/vitest.setup.js"],

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -511,6 +511,12 @@ const configFactory = (
           },
         },
       },
+      // Preact JSX via esbuild's automatic runtime. Affects only files that
+      // contain JSX (i.e. .tsx); the existing .ts/.js sources are untouched.
+      esbuild: {
+        jsx: "automatic",
+        jsxImportSource: "preact",
+      },
     }),
   };
 };


### PR DESCRIPTION
## Why
First step of the UI component-layer refactor (design: `doc/specs/2026-06-20-preact-ui-component-layer-design.md`, plan: `…-plan.md`). The extension builds all UI by imperative DOM mutation — ~211 `createElement` sites, a **triplicated** `<Notice>` skeleton (byte-identical `findInjectionPoint`, already silently diverged in comments), brittle private-field widget tests (`Object.create(prototype)`), and bug #203 (a re-render wiped the live `#progress-ring` countdown). This PR lays the Preact foundation. **No runtime behavior changes.**

## What
- **Preact + esbuild automatic-JSX toolchain** (`preact@^10`; `jsx`/`jsxImportSource` in `tsconfig.json`, `wxt.config.ts` `vite()`, `vitest.config.js`). JSX is **opt-in per `.tsx`** — the 173 existing `.ts/.js` files are untouched, and Jest (matches `*.test.js` only) stays clear of JSX. No Babel preset.
- **`src/ui/preact/mount.ts`** — light-DOM `mountInto` / `unmountFrom` / `unmountAllUnder` registry. This is the cleanup **keystone**: `unmountAllUnder(removedNode)` lets the bootstrap removed-nodes path run component effect cleanup instead of orphaning listeners (the leak class this repo has today, e.g. `VADStatusIndicator`'s `// TODO: Remove keydown listener`). Light DOM (no Shadow DOM) so injected widgets keep inheriting host CSS.
- Conventions note + design/plan docs.

## Verification
- `npm test` green: type-check + Jest + all 125 Vitest files (996 passed, 1 skipped), incl. 4 new mount-registry tests (render, unmount-runs-cleanup, idempotent, `unmountAllUnder` nested teardown).
- **Generated `manifest.json` byte-identical** with vs without the `wxt.config.ts` change (A/B build + `diff`) — confirms this edit is confined to the Vite/esbuild transform and is **not** a manifest / permissions / content-script-injection-scope change.

## Scope / notes
- The `wxt.config.ts` `vite()` `esbuild` JSX path is first exercised by a real build in PR3 (first runtime `.tsx`); this PR proves the `tsc` + Vitest JSX paths.
- Reviewer: please confirm the `wxt.config.ts` diff is the `esbuild` key only (outside the `manifest` block / hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)