### PR TITLE
refactor(ui): brand design-token layer (--saypi-*)

### DIFF
--- a/src/saypi.index.js
+++ b/src/saypi.index.js
@@ -8,6 +8,7 @@ import { stampBuildOnDocument } from "./build-stamp.ts";
 import { installDevReloadBridge, installDevFeedSpeechBridge } from "./dev/devReload.ts";
 
 // Import styles that are needed across all modes
+import "./styles/tokens.scss"; // SayPi design tokens (--saypi-*) on :root
 import "./styles/common.scss";
 import "./styles/desktop.scss";
 import "./styles/mobile.scss";

--- a/src/styles/chatgpt.scss
+++ b/src/styles/chatgpt.scss
@@ -87,7 +87,7 @@ body.chatgpt {
   /* ChatGPT theme-aware call button colors using accent theme */
   #saypi-callButton.chatgpt-call-button {
     /* Set custom properties for SVG colors based on ChatGPT's accent theme */
-    --call-button-bg: var(--theme-secondary-btn-bg, var(--theme-user-msg-bg, #418a2f));
+    --call-button-bg: var(--theme-secondary-btn-bg, var(--theme-user-msg-bg, var(--saypi-green)));
     --call-button-bg-starting: #4e84be; /* Keep blue for starting state */
     --call-button-bg-hangup: var(--theme-secondary-btn-bg, var(--theme-user-msg-bg, #776d6d)); /* Use accent color when available, fall back to gray */
     --call-button-icon: #ffffff; /* Always white icon for good contrast */
@@ -127,7 +127,7 @@ body.chatgpt {
     /* Ensure good contrast on light backgrounds */
     --call-button-icon: #ffffff;
     /* For very light accent colors, darken the background slightly */
-    --call-button-bg: color-mix(in srgb, var(--theme-secondary-btn-bg, var(--theme-user-msg-bg, #418a2f)) 85%, #000000 15%);
+    --call-button-bg: color-mix(in srgb, var(--theme-secondary-btn-bg, var(--theme-user-msg-bg, var(--saypi-green))) 85%, #000000 15%);
     --call-button-bg-hangup: color-mix(in srgb, var(--theme-secondary-btn-bg, var(--theme-user-msg-bg, #776d6d)) 85%, #000000 15%);
   }
 

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -2,7 +2,7 @@
 @use "sass:meta";
 
 #saypi-callButton.disabled svg path.background {
-  fill: rgb(245 238 223); /* bg-cream-550 */
+  fill: var(--saypi-cream); /* bg-cream-550 */
 }
 
 #saypi-enter-button {
@@ -17,13 +17,13 @@
   z-index: 60;
   svg {
     path.outer {
-      fill: rgb(237 225 209); /* bg-cream-550 */
+      fill: var(--saypi-cream-dark); /* bg-cream-550 */
     }
     path.inner {
-      color: rgb(13 60 38); /* text-primary-700 */
+      color: var(--saypi-ink); /* text-primary-700 */
     }
     circle.outer-circle-bg {
-      fill: rgb(237 225 209); /* bg-cream-550 */
+      fill: var(--saypi-cream-dark); /* bg-cream-550 */
     }
   }
 }
@@ -61,7 +61,7 @@ html:not(.immersive-view) .theme-toggle-button {
   white-space: nowrap;
   opacity: 0;
   transition: opacity 0.12s ease-in-out;
-  background-color: #24381b;
+  background-color: var(--saypi-green-dark, #24381b); /* fallback: body-portal sits outside host-themed scope */
   color: #fff;
   padding: 5px 10px;
   border-radius: 6px;

--- a/src/styles/desktop.scss
+++ b/src/styles/desktop.scss
@@ -65,7 +65,7 @@ html.desktop-view {
     svg {
       width: 30px;
       .cls-1 {
-        stroke: #24381b;
+        stroke: var(--saypi-green-dark);
       }
     }
   }

--- a/src/styles/lock.scss
+++ b/src/styles/lock.scss
@@ -7,7 +7,7 @@ html.immersive-view.mobile-device {
     border: 0;
     z-index: 60;
     svg path.inner {
-      color: rgb(13 60 38); /* text-primary-700 */
+      color: var(--saypi-ink); /* text-primary-700 */
     }
   }
 

--- a/src/styles/messages.scss
+++ b/src/styles/messages.scss
@@ -535,7 +535,7 @@ body.saypi-recent-telemetry .present-messages .assistant-message:last-of-type .s
     padding: 0.8rem;
 }
 .assistant-message.speech-enabled {
-    border-color:#24381b;
+    border-color: var(--saypi-green-dark);
 }
 .assistant-message .popup-menu {
     background-color: #f0f9f4;

--- a/src/styles/rectangles.css
+++ b/src/styles/rectangles.css
@@ -412,7 +412,7 @@
   }
   50% {
     opacity: 0.5;
-    fill: rgb(245 238 223); /* bg-cream-550 */
+    fill: var(--saypi-cream); /* bg-cream-550 */
   }
 }
 

--- a/src/styles/tokens.scss
+++ b/src/styles/tokens.scss
@@ -1,0 +1,22 @@
+/**
+ * SayPi design tokens — the single source of truth for brand colors.
+ *
+ * Declared on :root so they cascade to every injected widget in the host's
+ * light DOM. Each value is byte-identical to the literal it consolidated, so
+ * referencing it via var() is a no-visual-change refactor. This file is also
+ * the artifact a future Claude Design sync consumes.
+ *
+ * NOTE: this is NOT for host-borrowed Tailwind classes (e.g. bg-cream-550) —
+ * those stay as host classes so injected widgets keep inheriting host styling.
+ * These tokens are for SayPi's own CSS rules only.
+ */
+:root {
+  /* SayPi brand greens */
+  --saypi-green: #418a2f;
+  --saypi-green-dark: #24381b;
+
+  /* Pi-surface palette SayPi mirrors in its own CSS (cream composer + ink text) */
+  --saypi-cream: rgb(245 238 223);
+  --saypi-cream-dark: rgb(237 225 209);
+  --saypi-ink: rgb(13 60 38);
+}

--- a/test/styles/tokens.spec.ts
+++ b/test/styles/tokens.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Contract guard for the SayPi design-token layer.
+ *
+ * Downstream styling (and a future Claude Design sync) depends on these
+ * `--saypi-*` custom properties existing with these exact values — they are the
+ * single source of truth for the literals previously duplicated across the
+ * content-script SCSS. If a token is renamed or its value drifts, the SCSS that
+ * references it via var() silently changes appearance; this test catches that.
+ */
+const tokensCss = readFileSync(
+  fileURLToPath(new URL("../../src/styles/tokens.scss", import.meta.url)),
+  "utf-8",
+);
+
+// The exact literals these tokens replaced (whitespace-normalized on both sides).
+const EXPECTED: Record<string, string> = {
+  "--saypi-green": "#418a2f",
+  "--saypi-green-dark": "#24381b",
+  "--saypi-cream": "rgb(245 238 223)",
+  "--saypi-cream-dark": "rgb(237 225 209)",
+  "--saypi-ink": "rgb(13 60 38)",
+};
+
+function declaredValue(name: string): string | undefined {
+  const m = tokensCss.match(new RegExp(`${name}\\s*:\\s*([^;]+);`));
+  return m?.[1].replace(/\s+/g, " ").trim();
+}
+
+describe("SayPi design tokens", () => {
+  it("defines every brand token with its canonical value", () => {
+    for (const [name, value] of Object.entries(EXPECTED)) {
+      expect(declaredValue(name), `${name} should be defined`).toBe(value);
+    }
+  });
+
+  it("declares the tokens on :root so they cascade to injected widgets", () => {
+    expect(tokensCss).toMatch(/:root\s*\{/);
+  });
+});


### PR DESCRIPTION
## Why
Second step of the UI component-layer refactor (design/plan in `doc/specs/2026-06-20-preact-ui-component-layer-*`). The extension had **no design-token layer** — brand colors were raw hex/rgb literals duplicated across ~20 flat SCSS files. This introduces a single source of truth, which is also the artifact a future Claude Design sync consumes. **No visual change.**

## What
- **`src/styles/tokens.scss`** — `--saypi-*` custom properties on `:root`: `--saypi-green` (`#418a2f`), `--saypi-green-dark` (`#24381b`), `--saypi-cream` (`rgb(245 238 223)`), `--saypi-cream-dark` (`rgb(237 225 209)`), `--saypi-ink` (`rgb(13 60 38)`). Imported first in `src/saypi.index.js`.
- Replaced **10 duplicated literal sites** across `common/desktop/messages/lock/chatgpt.scss` + `rectangles.css` with **byte-identical** `var()` references.
- Body-portal tooltip uses `var(--saypi-green-dark, #24381b)` **with a literal fallback** (the `TooltipContrast` guard caught a bare `var()` regression — the tooltip sits outside host-themed scope).

## Scope / deliberately skipped (left as literals)
- Per-ring animation ramp in `dark-mode.scss` — an **intentional gradient**, not duplication.
- `rgba(...)` alpha variants (`mobile.scss`, `lock.scss`) — different values; would need relative-color syntax.
- Popup `tabs.css` (`#418a2f`) — separate settings surface; PR4 overhauls it.
- Commented-out literals.

## Verification
- `npm test` green: type-check + Jest + Vitest **126 files / 998 passed, 1 skipped**, incl. a new `tokens.spec.ts` contract test pinning each token to its canonical value, and the existing `TooltipContrast` guard now passing.
- `npx wxt build` succeeds (SCSS compiles).
- No-visual-change: each `var()` resolves to the identical literal it replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)