### PR TITLE
refactor(ui): <Notice> Preact component + shared injection helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@eslint/config-array": "^0.19.2",
         "@eslint/object-schema": "^2.1.6",
         "@playwright/test": "^1.60.0",
+        "@testing-library/preact": "^3.2.4",
         "@types/chai": "^4.3.9",
         "@types/chrome": "^0.0.253",
         "@types/firefox-webext-browser": "^120.0.5",
@@ -4760,6 +4761,163 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
+      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/preact": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/preact/-/preact-3.2.4.tgz",
+      "integrity": "sha512-F+kJ243LP6VmEK1M809unzTE/ijg+bsMNuiRN0JEDIJBELKKDNhdgC/WrUSZ7klwJvtlO3wQZ9ix+jhObG07Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "^8.11.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "preact": ">=10 || ^10.0.0-alpha.0 || ^10.0.0-beta.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -4795,6 +4953,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6343,6 +6508,16 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -8542,6 +8717,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -8781,6 +8989,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -9115,6 +9330,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-module-lexer": {
@@ -11213,6 +11449,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -14820,6 +15073,16 @@
       "integrity": "sha512-BmwmMcTpPcyW2fsF8psFg+/5/xQkSvJ7eSt223hzUSmITfxhfEc7gg16ivWz97cAPMzVSmhkQ2Uj5kN2xOnUeQ==",
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -15834,6 +16097,23 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@eslint/config-array": "^0.19.2",
     "@eslint/object-schema": "^2.1.6",
     "@playwright/test": "^1.60.0",
+    "@testing-library/preact": "^3.2.4",
     "@types/chai": "^4.3.9",
     "@types/chrome": "^0.0.253",
     "@types/firefox-webext-browser": "^120.0.5",

--- a/src/ui/AgentModeNoticeModule.ts
+++ b/src/ui/AgentModeNoticeModule.ts
@@ -5,6 +5,9 @@ import getMessage from "../i18n";
 import { openSettings } from "../popup/popupopener";
 import { ChatbotService } from "../chatbots/ChatbotService";
 import { IconModule } from "../icons/IconModule";
+import { h, render } from "preact";
+import { Notice } from "./Notice";
+import { findNoticeInjectionPoint } from "./notice/findNoticeInjectionPoint";
 
 export class AgentModeNoticeModule {
   private static instance: AgentModeNoticeModule;
@@ -130,52 +133,40 @@ export class AgentModeNoticeModule {
   private async createAndShowNotice(chatbotId: string, chatbotName: string): Promise<void> {
     await this.hideNotice(); // Remove any existing notice
 
-    const notice = document.createElement("div");
-    notice.className = "saypi-agent-notice";
-    notice.setAttribute("data-chatbot", chatbotId);
-
-    // Notice content
-    const content = document.createElement("div");
-    content.className = "saypi-agent-notice-content";
-
-    // Icon
-    const iconContainer = document.createElement("div");
-    iconContainer.className = "saypi-agent-notice-icon";
-    
-    // Use bot icon from IconModule (Lucide bot icon)
+    // Build the icon as raw SVG (carrying its class + size) with an emoji
+    // fallback — same Lucide bot icon as before.
+    let iconSvg: string | null = null;
     try {
       const botIcon = IconModule.bot.cloneNode(true) as SVGElement;
       botIcon.setAttribute("class", "saypi-agent-notice-robot-icon");
       botIcon.setAttribute("width", "20");
       botIcon.setAttribute("height", "20");
-      iconContainer.appendChild(botIcon);
+      iconSvg = botIcon.outerHTML;
     } catch {
-      // Fallback to simple emoji or text
-      iconContainer.innerHTML = "🤖";
+      iconSvg = null;
     }
-    
-    content.appendChild(iconContainer);
-
-    // Text content
-    const textContainer = document.createElement("div");
-    textContainer.className = "saypi-agent-notice-text";
 
     // Escape HTML in chatbot name to prevent injection attacks
     const escapedChatbotName = this.escapeHtml(chatbotName);
     const rawMessage = getMessage("agentModeNoticeMessage", [escapedChatbotName]);
-    textContainer.innerHTML = this.formatNoticeMessage(rawMessage);
 
-    content.appendChild(textContainer);
-
-    // Close button
-    const closeButton = document.createElement("button");
-    closeButton.className = "saypi-agent-notice-close";
-    closeButton.setAttribute("aria-label", getMessage("dismissNotice") || "Dismiss");
-    closeButton.innerHTML = "×";
-    closeButton.addEventListener("click", () => this.dismissNotice(chatbotId));
-
-    content.appendChild(closeButton);
-    notice.appendChild(content);
+    // Render the shared <Notice> component into a detached host, then take its
+    // root element. Injection + show/hide animation + dismissal stay below,
+    // unchanged, operating on that element.
+    const host = document.createElement("div");
+    render(
+      h(Notice, {
+        variant: "agent",
+        dataAttr: { name: "data-chatbot", value: chatbotId },
+        iconSvg,
+        iconFallback: "🤖",
+        bodyHtml: this.formatNoticeMessage(rawMessage),
+        dismissLabel: getMessage("dismissNotice") || "Dismiss",
+        onDismiss: () => this.dismissNotice(chatbotId),
+      }),
+      host,
+    );
+    const notice = host.firstElementChild as HTMLElement;
 
     // Inject into appropriate location
     this.injectNotice(notice, chatbotId);
@@ -221,33 +212,10 @@ export class AgentModeNoticeModule {
   }
 
   private findInjectionPoint(chatbotId: string): HTMLElement | null {
-    // Primary approach: Use universal #saypi-chat-ancestor if available
-    const chatAncestor = document.querySelector("#saypi-chat-ancestor") as HTMLElement;
-    if (chatAncestor) {
-      return chatAncestor;
-    }
-
-    // Fallback to chatbot-specific selectors if chat ancestor isn't found
-    switch (chatbotId) {
-      case "chatgpt":
-        // Look for ChatGPT's unified composer form
-        return document.querySelector('form[data-type="unified-composer"]') as HTMLElement;
-        
-      case "claude":
-        // Look for Claude's prompt container fieldset
-        return document.querySelector("fieldset.w-full") as HTMLElement;
-        
-      case "pi":
-        // Look for Pi's prompt controls container
-        return document.querySelector("#saypi-prompt-controls-container")?.parentElement as HTMLElement ||
-               document.querySelector(".saypi-prompt-container") as HTMLElement;
-        
-      default:
-        // Generic fallback - look for any prompt container
-        return document.querySelector("#saypi-prompt-controls-container")?.parentElement as HTMLElement ||
-               document.querySelector(".saypi-prompt-container") as HTMLElement ||
-               document.querySelector('form[data-type="unified-composer"]') as HTMLElement;
-    }
+    // Delegates to the shared helper (formerly duplicated byte-for-byte in
+    // CompatibilityNotificationUI). Kept as a thin private method so existing
+    // tests that call it directly continue to work.
+    return findNoticeInjectionPoint(chatbotId);
   }
 
   private dismissNotice(chatbotId: string): void {

--- a/src/ui/Notice.tsx
+++ b/src/ui/Notice.tsx
@@ -1,0 +1,74 @@
+/**
+ * Below-composer notice — the single presentational component behind SayPi's
+ * dismissible banners (agent-mode notice, compatibility notice).
+ *
+ * Class names are templated from `variant` (`saypi-agent-notice*` /
+ * `saypi-compat-notice*`) so the existing per-variant SCSS applies unchanged —
+ * this is a structure-faithful replacement for the imperative DOM the modules
+ * used to build by hand. Rendered into the host's light DOM (no Shadow DOM) so
+ * it inherits host styling. Orchestration (show/hide animation, dismissal
+ * persistence, injection) stays in the owning module; this component is pure
+ * presentation plus the close-button callback.
+ */
+export interface NoticeProps {
+  /** Drives the class prefix and which stylesheet applies. */
+  variant: "agent" | "compat";
+  /** Optional root data attribute (e.g. `data-chatbot` / `data-issue-key`). */
+  dataAttr?: { name: string; value: string };
+  /** Raw SVG markup for the icon (already carrying its class + size), or null. */
+  iconSvg: string | null;
+  /** Emoji shown when `iconSvg` is null. */
+  iconFallback: string;
+  /** Rich HTML body (e.g. message with links); rendered as live markup. */
+  bodyHtml?: string;
+  /** Plain-text body; rendered escaped. Used when `bodyHtml` is absent. */
+  bodyText?: string;
+  /** Accessible label for the × close button. */
+  dismissLabel: string;
+  /** Called when the × close button is clicked. */
+  onDismiss: () => void;
+}
+
+export function Notice(props: NoticeProps) {
+  const p = `saypi-${props.variant}-notice`;
+
+  // Apply the data attribute imperatively to keep the root typed as a plain div
+  // (the attribute name is dynamic per variant).
+  const applyDataAttr = (el: HTMLDivElement | null) => {
+    if (el && props.dataAttr) {
+      el.setAttribute(props.dataAttr.name, props.dataAttr.value);
+    }
+  };
+
+  return (
+    <div class={p} ref={applyDataAttr}>
+      <div class={`${p}-content`}>
+        {props.iconSvg ? (
+          <div
+            class={`${p}-icon`}
+            dangerouslySetInnerHTML={{ __html: props.iconSvg }}
+          />
+        ) : (
+          <div class={`${p}-icon`}>{props.iconFallback}</div>
+        )}
+
+        {props.bodyHtml != null ? (
+          <div
+            class={`${p}-text`}
+            dangerouslySetInnerHTML={{ __html: props.bodyHtml }}
+          />
+        ) : (
+          <div class={`${p}-text`}>{props.bodyText}</div>
+        )}
+
+        <button
+          class={`${p}-close`}
+          aria-label={props.dismissLabel}
+          onClick={props.onDismiss}
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/notice/findNoticeInjectionPoint.ts
+++ b/src/ui/notice/findNoticeInjectionPoint.ts
@@ -1,0 +1,46 @@
+/**
+ * Find the element AFTER which a below-composer SayPi notice should be inserted.
+ *
+ * Shared by AgentModeNoticeModule and CompatibilityNotificationUI, which both
+ * previously carried a byte-identical copy of this logic. Prefers the universal
+ * `#saypi-chat-ancestor`, then falls back to per-host composer selectors.
+ * Returns null when nothing matches (callers handle their own fallback).
+ */
+export function findNoticeInjectionPoint(chatbotId: string): HTMLElement | null {
+  // Primary approach: the universal chat ancestor if available.
+  const chatAncestor = document.querySelector(
+    "#saypi-chat-ancestor",
+  ) as HTMLElement | null;
+  if (chatAncestor) {
+    return chatAncestor;
+  }
+
+  // Fall back to chatbot-specific selectors.
+  switch (chatbotId) {
+    case "chatgpt":
+      return document.querySelector(
+        'form[data-type="unified-composer"]',
+      ) as HTMLElement | null;
+
+    case "claude":
+      return document.querySelector("fieldset.w-full") as HTMLElement | null;
+
+    case "pi":
+      return (
+        (document.querySelector("#saypi-prompt-controls-container")
+          ?.parentElement as HTMLElement | null) ||
+        (document.querySelector(".saypi-prompt-container") as HTMLElement | null)
+      );
+
+    default:
+      // Generic fallback - look for any prompt container.
+      return (
+        (document.querySelector("#saypi-prompt-controls-container")
+          ?.parentElement as HTMLElement | null) ||
+        (document.querySelector(".saypi-prompt-container") as HTMLElement | null) ||
+        (document.querySelector(
+          'form[data-type="unified-composer"]',
+        ) as HTMLElement | null)
+      );
+  }
+}

--- a/test/ui/Notice.spec.tsx
+++ b/test/ui/Notice.spec.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/preact";
+import { Notice } from "../../src/ui/Notice";
+
+afterEach(() => cleanup());
+
+describe("Notice", () => {
+  it("renders the agent variant's templated class names", () => {
+    const { container } = render(
+      <Notice
+        variant="agent"
+        iconSvg={null}
+        iconFallback="🤖"
+        bodyText="hello"
+        dismissLabel="Dismiss"
+        onDismiss={() => {}}
+      />,
+    );
+    expect(container.querySelector(".saypi-agent-notice")).toBeTruthy();
+    expect(container.querySelector(".saypi-agent-notice-content")).toBeTruthy();
+    expect(container.querySelector(".saypi-agent-notice-icon")).toBeTruthy();
+    expect(container.querySelector(".saypi-agent-notice-text")).toBeTruthy();
+    expect(container.querySelector(".saypi-agent-notice-close")).toBeTruthy();
+  });
+
+  it("renders the compat variant's templated class names", () => {
+    const { container } = render(
+      <Notice
+        variant="compat"
+        iconSvg={null}
+        iconFallback="ℹ️"
+        bodyText="x"
+        dismissLabel="Dismiss"
+        onDismiss={() => {}}
+      />,
+    );
+    expect(container.querySelector(".saypi-compat-notice")).toBeTruthy();
+    expect(container.querySelector(".saypi-compat-notice-close")).toBeTruthy();
+  });
+
+  it("applies the root data attribute", () => {
+    const { container } = render(
+      <Notice
+        variant="agent"
+        dataAttr={{ name: "data-chatbot", value: "pi" }}
+        iconSvg={null}
+        iconFallback="🤖"
+        bodyText="x"
+        dismissLabel="d"
+        onDismiss={() => {}}
+      />,
+    );
+    expect(
+      container.querySelector(".saypi-agent-notice")?.getAttribute("data-chatbot"),
+    ).toBe("pi");
+  });
+
+  it("renders bodyHtml as live markup (links)", () => {
+    const { container } = render(
+      <Notice
+        variant="agent"
+        iconSvg={null}
+        iconFallback="🤖"
+        bodyHtml={'before <a class="saypi-settings-link" href="#">settings</a> after'}
+        dismissLabel="d"
+        onDismiss={() => {}}
+      />,
+    );
+    const link = container.querySelector(
+      ".saypi-agent-notice-text .saypi-settings-link",
+    );
+    expect(link).toBeTruthy();
+    expect(link?.tagName).toBe("A");
+  });
+
+  it("renders bodyText as escaped plain text (no markup parsed)", () => {
+    const { container } = render(
+      <Notice
+        variant="compat"
+        iconSvg={null}
+        iconFallback="ℹ️"
+        bodyText={"<b>not bold</b>"}
+        dismissLabel="d"
+        onDismiss={() => {}}
+      />,
+    );
+    const text = container.querySelector(".saypi-compat-notice-text");
+    expect(text?.querySelector("b")).toBeNull();
+    expect(text?.textContent).toContain("<b>not bold</b>");
+  });
+
+  it("renders the icon svg (with its class) when iconSvg is provided", () => {
+    const { container } = render(
+      <Notice
+        variant="agent"
+        iconSvg={'<svg class="saypi-agent-notice-robot-icon" width="20" height="20"></svg>'}
+        iconFallback="🤖"
+        bodyText="x"
+        dismissLabel="d"
+        onDismiss={() => {}}
+      />,
+    );
+    expect(
+      container.querySelector(
+        ".saypi-agent-notice-icon svg.saypi-agent-notice-robot-icon",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("renders the emoji fallback when iconSvg is null", () => {
+    const { container } = render(
+      <Notice
+        variant="agent"
+        iconSvg={null}
+        iconFallback="🤖"
+        bodyText="x"
+        dismissLabel="d"
+        onDismiss={() => {}}
+      />,
+    );
+    expect(
+      container.querySelector(".saypi-agent-notice-icon")?.textContent,
+    ).toContain("🤖");
+  });
+
+  it("calls onDismiss when the close button is clicked", () => {
+    const onDismiss = vi.fn();
+    const { container } = render(
+      <Notice
+        variant="agent"
+        iconSvg={null}
+        iconFallback="🤖"
+        bodyText="x"
+        dismissLabel="Dismiss"
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(
+      container.querySelector(".saypi-agent-notice-close") as HTMLElement,
+    );
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets aria-label on the close button", () => {
+    const { container } = render(
+      <Notice
+        variant="agent"
+        iconSvg={null}
+        iconFallback="🤖"
+        bodyText="x"
+        dismissLabel="Dismiss notice"
+        onDismiss={() => {}}
+      />,
+    );
+    expect(
+      container
+        .querySelector(".saypi-agent-notice-close")
+        ?.getAttribute("aria-label"),
+    ).toBe("Dismiss notice");
+  });
+});

--- a/test/ui/notice/findNoticeInjectionPoint.spec.ts
+++ b/test/ui/notice/findNoticeInjectionPoint.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { findNoticeInjectionPoint } from "../../../src/ui/notice/findNoticeInjectionPoint";
+
+/**
+ * Contract for the shared injection-point finder previously duplicated
+ * byte-for-byte in AgentModeNoticeModule and CompatibilityNotificationUI.
+ */
+describe("findNoticeInjectionPoint", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("prefers the universal #saypi-chat-ancestor when present", () => {
+    const anchor = document.createElement("div");
+    anchor.id = "saypi-chat-ancestor";
+    document.body.appendChild(anchor);
+    // Even with a host-specific element also present, the ancestor wins.
+    const form = document.createElement("form");
+    form.setAttribute("data-type", "unified-composer");
+    document.body.appendChild(form);
+
+    expect(findNoticeInjectionPoint("chatgpt")).toBe(anchor);
+  });
+
+  it("falls back to ChatGPT's unified composer form", () => {
+    const form = document.createElement("form");
+    form.setAttribute("data-type", "unified-composer");
+    document.body.appendChild(form);
+    expect(findNoticeInjectionPoint("chatgpt")).toBe(form);
+  });
+
+  it("falls back to Claude's prompt fieldset", () => {
+    const fieldset = document.createElement("fieldset");
+    fieldset.className = "w-full";
+    document.body.appendChild(fieldset);
+    expect(findNoticeInjectionPoint("claude")).toBe(fieldset);
+  });
+
+  it("falls back to Pi's prompt controls container parent", () => {
+    const parent = document.createElement("div");
+    const controls = document.createElement("div");
+    controls.id = "saypi-prompt-controls-container";
+    parent.appendChild(controls);
+    document.body.appendChild(parent);
+    expect(findNoticeInjectionPoint("pi")).toBe(parent);
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(findNoticeInjectionPoint("unknown")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why
Third step of the UI component-layer refactor (design/plan in `doc/specs/2026-06-20-preact-ui-component-layer-*`). The "notice/banner" skeleton was duplicated across three modules, and the `findInjectionPoint` host-selector chain was **byte-identical** between `AgentModeNoticeModule` and `CompatibilityNotificationUI` (already silently diverged in comments). This introduces the first real Preact component and removes the duplication. **No visual change.**

## What
- **`src/ui/Notice.tsx`** — one presentational Preact component for below-composer notices. Class names are **templated from `variant`** (`saypi-agent-notice*` / `saypi-compat-notice*`) so the existing per-variant SCSS applies unchanged. Supports the class-bearing icon SVG (or emoji fallback), rich `bodyHtml` (agent's links) vs escaped `bodyText` (compat), and the × close button → `onDismiss`.
- **`src/ui/notice/findNoticeInjectionPoint.ts`** — the extracted byte-identical injection-point finder. Both modules now delegate (kept as a thin private method so existing tests calling it directly still pass).
- **Migrated `AgentModeNoticeModule`** to render `<Notice>` via `h()` into a detached host, then operate on the rendered root — its inject / `.visible` show-hide animation / dismiss / localStorage persistence lifecycle is **untouched**.
- **First runtime `.tsx`** in the bundle — exercises the WXT/esbuild JSX path PR1 set up (build verified, +~80KB raw bundle from the Preact runtime, far under AMO budget).

## Scope
- `CompatibilityNotificationUI` migration is a **follow-up PR** (it has no tests today — it gets a test net there). `AuthPromptUI` (modal/overlay/focus-trap) composes `<Notice>` in a later PR.

## Verification
- `npm test` green: type-check + Jest + Vitest **128 files / 1012 passed, 1 skipped**. New: `Notice.spec.tsx` (9 tests, `@testing-library/preact`), `findNoticeInjectionPoint.spec.ts` (5 tests). **The existing 15 AgentMode tests (module + integration) pass unchanged** — the regression net for the migration.
- `npx wxt build` succeeds (first runtime `.tsx` compiles through the JSX transform).

## Reviewer notes
- Confirm the migration is structure-faithful (same classes/DOM the SCSS + tests expect), and that the `.visible` animation + dismiss-persistence behavior is preserved (the component is purely presentational; the module keeps its manual removeChild lifecycle — Preact unmount isn't needed since there are no effects/subscriptions, only the onClick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)