### PR TITLE
refactor(ui): migrate CompatibilityNotificationUI to <Notice>

### DIFF
--- a/src/compat/CompatibilityNotificationUI.ts
+++ b/src/compat/CompatibilityNotificationUI.ts
@@ -17,6 +17,9 @@ import getMessage from "../i18n";
 import { logger } from "../LoggingModule";
 import { IconModule } from "../icons/IconModule";
 import { ChatbotService } from "../chatbots/ChatbotService";
+import { h, render } from "preact";
+import { Notice } from "../ui/Notice";
+import { findNoticeInjectionPoint } from "../ui/notice/findNoticeInjectionPoint";
 import type { Chatbot } from "../chatbots/Chatbot";
 import type { CompatibilityIssue } from "./BrowserCompatibilityModule";
 
@@ -149,52 +152,41 @@ export class CompatibilityNotificationUI {
   private async showTTSUnavailableNotice(issue: CompatibilityIssue): Promise<void> {
     await this.hideNotice(); // Remove any existing notice
 
-    const notice = document.createElement("div");
-    notice.className = "saypi-compat-notice";
-    notice.setAttribute("data-issue-key", this.getIssueKey(issue));
-
-    // Notice content
-    const content = document.createElement("div");
-    content.className = "saypi-compat-notice-content";
-
-    // Icon (Lucide info)
-    const iconContainer = document.createElement("div");
-    iconContainer.className = "saypi-compat-notice-icon";
-
+    // Build the info icon as raw SVG (carrying its class + size), emoji fallback.
+    let iconSvg: string | null = null;
     try {
       const infoIcon = IconModule.info.cloneNode(true) as SVGElement;
       infoIcon.setAttribute("class", "saypi-compat-notice-info-icon");
       infoIcon.setAttribute("width", "20");
       infoIcon.setAttribute("height", "20");
-      iconContainer.appendChild(infoIcon);
+      iconSvg = infoIcon.outerHTML;
     } catch (error) {
       logger.warn("Failed to load info icon for compat notice", error);
-      iconContainer.innerHTML = "ℹ️";
+      iconSvg = null;
     }
-
-    content.appendChild(iconContainer);
-
-    // Text content
-    const textContainer = document.createElement("div");
-    textContainer.className = "saypi-compat-notice-text";
 
     const message = getMessage('ttsUnavailableBrowserChatbot', [
       issue.browserName,
       issue.chatbotName
     ]);
-    textContainer.textContent = message;
 
-    content.appendChild(textContainer);
-
-    // Close button
-    const closeButton = document.createElement("button");
-    closeButton.className = "saypi-compat-notice-close";
-    closeButton.setAttribute("aria-label", getMessage("dismissNotice") || "Dismiss");
-    closeButton.innerHTML = "×";
-    closeButton.addEventListener("click", () => this.dismissNotice(issue));
-
-    content.appendChild(closeButton);
-    notice.appendChild(content);
+    // Render the shared <Notice> component into a detached host, then take its
+    // root element. Injection + show/hide animation + dismissal stay below,
+    // unchanged, operating on that element.
+    const host = document.createElement("div");
+    render(
+      h(Notice, {
+        variant: "compat",
+        dataAttr: { name: "data-issue-key", value: this.getIssueKey(issue) },
+        iconSvg,
+        iconFallback: "ℹ️",
+        bodyText: message,
+        dismissLabel: getMessage("dismissNotice") || "Dismiss",
+        onDismiss: () => this.dismissNotice(issue),
+      }),
+      host,
+    );
+    const notice = host.firstElementChild as HTMLElement;
 
     // Inject into DOM
     await this.injectNotice(notice);
@@ -231,30 +223,9 @@ export class CompatibilityNotificationUI {
    * Same logic as AgentModeNoticeModule
    */
   private findInjectionPoint(chatbotId: string): HTMLElement | null {
-    // Primary approach: Use universal #saypi-chat-ancestor if available
-    const chatAncestor = document.querySelector("#saypi-chat-ancestor") as HTMLElement;
-    if (chatAncestor) {
-      return chatAncestor;
-    }
-
-    // Fallback to chatbot-specific selectors
-    switch (chatbotId) {
-      case "chatgpt":
-        return document.querySelector('form[data-type="unified-composer"]') as HTMLElement;
-
-      case "claude":
-        return document.querySelector("fieldset.w-full") as HTMLElement;
-
-      case "pi":
-        return document.querySelector("#saypi-prompt-controls-container")?.parentElement as HTMLElement ||
-               document.querySelector(".saypi-prompt-container") as HTMLElement;
-
-      default:
-        // Generic fallback
-        return document.querySelector("#saypi-prompt-controls-container")?.parentElement as HTMLElement ||
-               document.querySelector(".saypi-prompt-container") as HTMLElement ||
-               document.querySelector('form[data-type="unified-composer"]') as HTMLElement;
-    }
+    // Delegates to the shared helper (formerly duplicated byte-for-byte in
+    // AgentModeNoticeModule).
+    return findNoticeInjectionPoint(chatbotId);
   }
 
   /**

--- a/test/compat/CompatibilityNotificationUI.spec.ts
+++ b/test/compat/CompatibilityNotificationUI.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CompatibilityNotificationUI } from "../../src/compat/CompatibilityNotificationUI";
+
+// Characterization tests: written against the imperative implementation and
+// kept green across the migration to the shared <Notice> Preact component.
+
+vi.mock("../../src/events/EventBus", () => ({
+  default: { on: vi.fn(), emit: vi.fn() },
+}));
+
+vi.mock("../../src/LoggingModule", () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../src/i18n", () => ({
+  default: vi.fn((key: string, params?: string[]) => {
+    const messages: Record<string, string> = {
+      ttsUnavailableBrowserChatbot: "TTS is unavailable on $1 with $2.",
+      dismissNotice: "Dismiss",
+    };
+    let message = messages[key] || key;
+    if (params && params.length >= 2) {
+      message = message.replace("$1", params[0]).replace("$2", params[1]);
+    }
+    return message;
+  }),
+}));
+
+vi.mock("../../src/icons/IconModule", () => ({
+  IconModule: {
+    info: {
+      cloneNode: vi.fn(() => {
+        const icon = document.createElement("div");
+        icon.className = "mock-info-icon";
+        return icon;
+      }),
+    },
+  },
+}));
+
+vi.mock("../../src/chatbots/ChatbotService", () => ({
+  ChatbotService: {
+    getChatbot: vi.fn().mockResolvedValue({
+      getID: () => "pi",
+      getName: () => "Pi",
+    }),
+  },
+}));
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+  configurable: true,
+});
+Object.defineProperty(global, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+  configurable: true,
+});
+
+const issue = {
+  feature: "tts",
+  browserName: "Firefox",
+  chatbotType: "claude",
+  chatbotName: "Claude",
+} as any;
+
+describe("CompatibilityNotificationUI", () => {
+  let ui: CompatibilityNotificationUI;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    localStorageMock.clear();
+    vi.clearAllMocks();
+    (CompatibilityNotificationUI as any).instance = null;
+    ui = CompatibilityNotificationUI.getInstance();
+    ui.resetDismissedState();
+  });
+
+  afterEach(() => {
+    document
+      .querySelectorAll(".saypi-compat-notice")
+      .forEach((n) => n.remove());
+  });
+
+  it("renders a structurally-correct compat notice (icon + plain text + close)", async () => {
+    await ui.forceShowNotice(issue);
+
+    const notice = document.querySelector(".saypi-compat-notice") as HTMLElement;
+    expect(notice).toBeTruthy();
+    expect(notice.getAttribute("data-issue-key")).toBe("tts:Firefox:claude");
+    expect(notice.querySelector(".saypi-compat-notice-content")).toBeTruthy();
+    expect(notice.querySelector(".saypi-compat-notice-icon")).toBeTruthy();
+
+    const text = notice.querySelector(".saypi-compat-notice-text") as HTMLElement;
+    expect(text).toBeTruthy();
+    expect(text.textContent).toContain("Firefox");
+    expect(text.textContent).toContain("Claude");
+    // Compat body is plain text — no parsed child elements.
+    expect(text.children.length).toBe(0);
+
+    expect(notice.querySelector(".saypi-compat-notice-close")).toBeTruthy();
+  });
+
+  it("persists the dismissed issue key when the close button is clicked", async () => {
+    await ui.forceShowNotice(issue);
+
+    const close = document.querySelector(
+      ".saypi-compat-notice-close",
+    ) as HTMLElement;
+    expect(close).toBeTruthy();
+    close.click();
+
+    const stored = localStorageMock.getItem("saypi-compat-notice-dismissed");
+    expect(stored).toBeTruthy();
+    expect(JSON.parse(stored!)["tts:Firefox:claude"]).toBe(true);
+  });
+
+  it("does not show a notice for an already-dismissed issue", async () => {
+    (ui as any).dismissedState.set("tts:Firefox:claude", true);
+    await (ui as any).handleCompatibilityIssue(issue);
+    expect(document.querySelector(".saypi-compat-notice")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why
Follow-up to #366, completing the notice consolidation. `CompatibilityNotificationUI` was the last module still building its notice DOM by hand and carrying a byte-identical copy of `findInjectionPoint`. **No visual change.**

## What
- Migrated `showTTSUnavailableNotice` to render the shared `<Notice>` component (`variant="compat"`, plain `bodyText`, `data-issue-key`) via `h()` into a detached host, then operate on the rendered root — its inject / `.visible` animation / dismiss / localStorage persistence lifecycle is **unchanged**.
- `findInjectionPoint` now delegates to the shared `findNoticeInjectionPoint` helper (the last byte-identical copy is gone).
- **Added the first tests this module ever had** (`test/compat/CompatibilityNotificationUI.spec.ts`) as **characterization tests**: verified green against the imperative implementation *first*, then unchanged after the migration — so they document the prior behavior and gate the refactor.

## Verification
- The 3 characterization tests pass both before and after the migration (DOM structure incl. plain-text body + `data-issue-key`, dismiss→localStorage persistence, and dismissed-issue suppression).
- `npm test` green: type-check + Jest + Vitest **129 files / 1015 passed, 1 skipped**.
- `npx wxt build` succeeds.

## Notes
After this, the only remaining notice-family module is `AuthPromptUI` (modal/overlay/focus-trap), which will *compose* `<Notice>` in a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)