### PR TITLE
fix(tooling): e2e-host-sweep counts only SayPi's TTS engine as TTS-covered

### DIFF
--- a/doc/e2e-host-sweep.md
+++ b/doc/e2e-host-sweep.md
@@ -26,7 +26,10 @@ conversation, and screenshots.
 3. **Dev build at HEAD:** `npm run e2e:build` (the profile-installed unpacked extension
    re-reads `.output/chrome-mv3-dev` from disk on each launch, so rebuilding at HEAD =
    the sweep tests current `main`; confirm via the `data-saypi-build` stamp the sweep
-   logs).
+   logs). **If the build fails with `Rollup failed to resolve import "<pkg>"` (e.g.
+   `preact`), your local `node_modules` is stale after a recent merge — run `npm install`
+   and rebuild.** A stale build that loads but doesn't decorate shows up as
+   `layer4cdp:diagnose` reporting "extension loaded YES, no decoration".
 4. **`cf_clearance` fresh:** `npm run layer4cdp:diagnose` must say **VERDICT: usable**.
    If it says blocked, re-seed (`npm run layer4cdp:seed`, pass the Cloudflare checkbox,
    Cmd-Q).
@@ -39,11 +42,19 @@ silently skips. To cover it, once, in the seeded profile's headed window
 (`npm run layer4cdp:seed`):
 
 - **Sign into your SayPi account** (saypi.ai) so the extension has a JWT.
-- **Select a voice** in the SayPi voice menu on one host.
+- **Select a _SayPi_ voice on claude.ai** (e.g. an ElevenLabs voice) — **not** pi.ai's
+  native voice. This is the key nuance: the sweep only counts SayPi's TTS engine as
+  exercised when the active provider is **`Say, Pi`** (`isSaypiTtsProvider`). A pi.ai
+  turn logs `Speech provided by Pi` (pi.ai's *native* voice — SayPi just relays it),
+  `None` is voice-off, and ChatGPT uses native Read Aloud — none of those run SayPi's
+  synthesis/playback path. claude.ai has no native voice, so selecting a SayPi voice
+  there is the clean way to exercise the engine (offscreen audio under CSP, credits, the
+  #238/#241/#268 cluster).
 
 Then Cmd-Q. The sweep logs `auth=` and `voice=` per host and prints a loud ⚠️ if it
-detects the account is unauthenticated or no voice is selected — so a run always tells
-you whether it actually covered TTS. (Caveat: auth/voice state is read from SayPi's
+detects the account is unauthenticated **or that SayPi's TTS engine (`Say, Pi`) was never
+the active provider** (a native `Pi`/`None`/Read-Aloud run does NOT satisfy it) — so a
+run always tells you, honestly, whether it actually covered SayPi TTS. (Caveat: auth/voice state is read from SayPi's
 **debug** console logs, which the dev build emits — `npm run e2e:build` sets
 `VITE_DEBUG_LOGS=true`. If debug logging is off, both stay `null` and the warning may
 fire even when authed; treat the warning as "couldn't confirm coverage", and corroborate

--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -54,6 +54,37 @@ export function classifyConsoleLine(text = "") {
 }
 
 /**
+ * SayPi's own TTS engine (synthesis served from the SayPi domain) reports this
+ * provider name in the "Speech provided by …" log (src/tts/SpeechModel.ts). It is
+ * the ONLY value that means SayPi's synthesis/playback path actually ran. By
+ * contrast "Pi" is pi.ai's NATIVE voice (SayPi just relays Pi's own audio), "None"
+ * is voice-off, and ChatGPT uses its native Read Aloud — none of those exercise
+ * SayPi's TTS engine. Lenient about case/whitespace.
+ */
+export const SAYPI_TTS_PROVIDER = "Say, Pi";
+export function isSaypiTtsProvider(name) {
+  return typeof name === "string" && name.trim().toLowerCase() === SAYPI_TTS_PROVIDER.toLowerCase();
+}
+
+/**
+ * Decide, across a run's per-host summaries, whether the sweep actually exercised
+ * SayPi's TTS engine, and whether it was authenticated. Pure. Drives the honest
+ * end-of-run coverage warnings — a native "Pi" voice must NOT read as TTS-covered.
+ */
+export function ttsCoverage(summaries = []) {
+  const perHost = summaries.map((s) => ({
+    host: s.host ?? null,
+    voiceProvider: s.voiceProvider ?? null,
+    saypiTtsExercised: isSaypiTtsProvider(s.voiceProvider),
+  }));
+  return {
+    perHost,
+    anySaypiTts: perHost.some((h) => h.saypiTtsExercised),
+    anyAuthed: summaries.some((s) => s.authStatus === true),
+  };
+}
+
+/**
  * Reduce a captured evidence object to a flat, comparable summary. Pure — takes
  * the shape the harness writes (console[], pageErrors[], requestFailed[], ...).
  */

--- a/scripts/e2e-host-sweep.mjs
+++ b/scripts/e2e-host-sweep.mjs
@@ -30,7 +30,7 @@ import { createServer } from "node:net";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveCdpProfileDir, buildCdpChromeArgs, isCloudflareChallenge } from "./layer4cdp-lib.mjs";
-import { HOSTS, parseSweepArgs, summarize } from "./e2e-host-sweep-lib.mjs";
+import { HOSTS, parseSweepArgs, summarize, ttsCoverage, SAYPI_TTS_PROVIDER } from "./e2e-host-sweep-lib.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
 const EXT_DIR = join(repoRoot, ".output", "chrome-mv3-dev");
@@ -232,10 +232,12 @@ async function main() {
     log(`wrote ${join(outDir, "summary.json")}`);
     await shutdown();
   }
-  const anyAuthed = summaries.some((s) => s.authStatus === true);
-  const anyVoice = summaries.some((s) => s.voiceProvider && s.voiceProvider !== "None");
-  if (!anyAuthed) log("⚠️  SayPi account is UNAUTHENTICATED in this profile — the TTS/voice-output path was NOT exercised. Sign in (saypi.ai) in the seeded profile to cover it.");
-  if (!anyVoice) log("⚠️  No voice selected (Speech provided by None) — TTS readback NOT exercised. Pick a voice in the seeded profile to cover it.");
+  const cov = ttsCoverage(summaries);
+  if (!cov.anyAuthed) log("⚠️  SayPi account is UNAUTHENTICATED in this profile — sign in (saypi.ai) in the seeded profile to cover the authenticated + TTS path.");
+  if (!cov.anySaypiTts) {
+    const perHost = cov.perHost.map((h) => `${h.host}=${h.voiceProvider ?? "?"}`).join(", ");
+    log(`⚠️  SayPi's TTS engine (provider "${SAYPI_TTS_PROVIDER}") was NOT exercised — voice providers this run: ${perHost}. "Pi" is pi.ai's NATIVE voice, "None" is voice-off, and ChatGPT uses native Read Aloud — none run SayPi synthesis. To cover SayPi TTS, select a SayPi voice (e.g. an ElevenLabs voice) on claude.ai and re-run.`);
+  }
   log(`SWEEP DONE — evidence under ${outDir}`);
   process.exit(0);
 }

--- a/test/scripts/e2e-host-sweep-lib.spec.ts
+++ b/test/scripts/e2e-host-sweep-lib.spec.ts
@@ -5,6 +5,9 @@ import {
   parseSweepArgs,
   classifyConsoleLine,
   summarize,
+  isSaypiTtsProvider,
+  ttsCoverage,
+  SAYPI_TTS_PROVIDER,
 } from "../../scripts/e2e-host-sweep-lib.mjs";
 
 describe("HOSTS registry", () => {
@@ -93,5 +96,43 @@ describe("summarize", () => {
     expect(s.saypiErrors).toBe(0);
     expect(s.decorated).toBe(false);
     expect(s.transcript).toBeNull();
+  });
+});
+
+describe("isSaypiTtsProvider", () => {
+  it("recognizes only SayPi's own TTS engine — NOT the native Pi voice or None", () => {
+    expect(isSaypiTtsProvider(SAYPI_TTS_PROVIDER)).toBe(true); // "Say, Pi"
+    expect(isSaypiTtsProvider("say, pi")).toBe(true); // lenient case/whitespace
+    expect(isSaypiTtsProvider("  Say, Pi  ")).toBe(true);
+    expect(isSaypiTtsProvider("Pi")).toBe(false); // pi.ai NATIVE voice — must not count
+    expect(isSaypiTtsProvider("None")).toBe(false);
+    expect(isSaypiTtsProvider(null)).toBe(false);
+    expect(isSaypiTtsProvider(undefined)).toBe(false);
+  });
+});
+
+describe("ttsCoverage", () => {
+  it("reports SayPi TTS as NOT exercised when only a native Pi voice / None / null are present", () => {
+    const cov = ttsCoverage([
+      { host: "pi", voiceProvider: "Pi", authStatus: true },
+      { host: "claude", voiceProvider: "None", authStatus: true },
+      { host: "chatgpt", voiceProvider: null, authStatus: true },
+    ]);
+    expect(cov.anyAuthed).toBe(true);
+    expect(cov.anySaypiTts).toBe(false); // the bug this fixes: "Pi" must not read as covered
+    expect(cov.perHost.map((h) => h.saypiTtsExercised)).toEqual([false, false, false]);
+  });
+  it("reports SayPi TTS as exercised when its provider is active on some host", () => {
+    const cov = ttsCoverage([
+      { host: "claude", voiceProvider: "Say, Pi", authStatus: true },
+      { host: "pi", voiceProvider: "Pi", authStatus: true },
+    ]);
+    expect(cov.anySaypiTts).toBe(true);
+    expect(cov.perHost.find((h) => h.host === "claude")?.saypiTtsExercised).toBe(true);
+    expect(cov.perHost.find((h) => h.host === "pi")?.saypiTtsExercised).toBe(false);
+  });
+  it("flags unauthenticated runs", () => {
+    expect(ttsCoverage([{ host: "pi", voiceProvider: "None", authStatus: false }]).anyAuthed).toBe(false);
+    expect(ttsCoverage([]).anyAuthed).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

Found while running a **voice-on validation sweep** of the new `/e2e-host-sweep` skill (PR #369). The seeded profile was authenticated (`auth=true` on all three hosts ✅), but the voice providers were `pi=Pi`, `claude=None`, `chatgpt=null` — so SayPi's own TTS **engine** was never exercised, yet the harness printed **no** warning.

Root cause: the coverage check counted any voice provider `!== "None"` as "TTS covered". But `Pi` is pi.ai's **native** voice (SayPi just relays Pi's own audio); `None` is voice-off; ChatGPT uses native Read Aloud. None of those run SayPi's synthesis/playback path — only the **`Say, Pi`** provider (`src/tts/SpeechModel.ts`) does. So the tool gave a false-positive on TTS coverage.

## What

- `scripts/e2e-host-sweep-lib.mjs`: new pure helpers `isSaypiTtsProvider(name)` (matches only `Say, Pi`, lenient on case/space) and `ttsCoverage(summaries)` (`perHost` flags + `anySaypiTts` + `anyAuthed`).
- `scripts/e2e-host-sweep.mjs`: the end-of-run ⚠️ now fires unless `Say, Pi` was the active provider on some host, and reports the per-host providers + how to cover it (select a SayPi voice on claude.ai, which has no native voice so SayPi's engine takes over).
- `test/scripts/e2e-host-sweep-lib.spec.ts`: +4 tests — `Pi`/`None`/`null` must NOT read as covered; `Say, Pi` must; auth flagging.
- `doc/e2e-host-sweep.md`: seed clarified (a **SayPi** voice on claude.ai, not native Pi); added an `npm install` precondition note (a stale local `node_modules` — e.g. missing `preact` after the Preact migration — makes `e2e:build` fail or load undecorated, which `diagnose` shows as "loaded YES, no decoration"). Both hit during the validation run.

The local `/e2e-host-sweep` skill (gitignored) is updated to match.

## Verification

Full required gate green: `npm test` → **131 files / 1032 passed / 1 skipped** (incl. the 4 new lib tests). Pure-logic change to dev/agent tooling — no `src/`, no manifest/permissions/auth, no shipped artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)