### PR TITLE
feat(tooling): e2e-host-sweep auto-selects a SayPi voice on claude.ai (self-covers TTS)

### DIFF
--- a/doc/e2e-host-sweep.md
+++ b/doc/e2e-host-sweep.md
@@ -34,22 +34,24 @@ conversation, and screenshots.
    If it says blocked, re-seed (`npm run layer4cdp:seed`, pass the Cloudflare checkbox,
    Cmd-Q).
 
-### One-time seed for the TTS/voice-output path (recommended)
+### One-time seed for the TTS/voice-output path
 
-By default the sweep wants to exercise the **output** path too (TTS readback, voice
-menu, credits) — the half of the product that an unauthenticated/voice-off profile
-silently skips. To cover it, once, in the seeded profile's headed window
-(`npm run layer4cdp:seed`):
+To exercise the **output** path (TTS readback, voice menu, credits) — the half of the
+product an unauthenticated/voice-off profile silently skips — the only manual step is,
+once, in the seeded profile's headed window (`npm run layer4cdp:seed`):
 
-- **Sign into your SayPi account** (saypi.ai) so the extension has a JWT.
-- **Select a _SayPi_ voice on claude.ai** (e.g. an ElevenLabs voice) — **not** pi.ai's
-  native voice. This is the key nuance: the sweep only counts SayPi's TTS engine as
-  exercised when the active provider is **`Say, Pi`** (`isSaypiTtsProvider`). A pi.ai
-  turn logs `Speech provided by Pi` (pi.ai's *native* voice — SayPi just relays it),
-  `None` is voice-off, and ChatGPT uses native Read Aloud — none of those run SayPi's
-  synthesis/playback path. claude.ai has no native voice, so selecting a SayPi voice
-  there is the clean way to exercise the engine (offscreen audio under CSP, credits, the
-  #238/#241/#268 cluster).
+- **Sign into your SayPi account** (saypi.ai) so the extension has a JWT (interactive
+  login — can't be automated). The account needs TTS voices/quota available.
+
+You do **not** need to pick a voice by hand: the sweep **auto-selects a SayPi voice on
+claude.ai** before the turn (default on; `--no-select-voice` opts out), driving the real
+voice-menu → `setVoice` path so the active provider becomes **`Say, Pi`**. This is the
+key nuance the coverage check enforces — only `Say, Pi` counts as SayPi-TTS-exercised
+(`isSaypiTtsProvider`); pi.ai's `Speech provided by Pi` is its *native* voice (SayPi
+just relays it), `None` is voice-off, and ChatGPT uses native Read Aloud. claude.ai has
+no native voice, so it's the clean host to exercise the engine (offscreen audio under
+CSP, credits, the #238/#241/#268 cluster). If the account has no voices/quota, the
+auto-select finds nothing and the sweep notes "no SayPi voice available".
 
 Then Cmd-Q. The sweep logs `auth=` and `voice=` per host and prints a loud ⚠️ if it
 detects the account is unauthenticated **or that SayPi's TTS engine (`Say, Pi`) was never

--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -18,6 +18,7 @@ export const DEFAULT_OBSERVE_MS = 28_000;
  *   --observe=<ms>        how long to watch the conversation after the transcript lands
  *   --no-turn             decoration-only (don't drive a voice turn)
  *   --headless            opt-in headless (Cloudflare-walled on real hosts; for re-testing only)
+ *   --no-select-voice     skip auto-selecting a SayPi voice (test the voice-off path instead)
  */
 export function parseSweepArgs(argv = []) {
   const positional = argv.filter((a) => !a.startsWith("--"));
@@ -33,6 +34,10 @@ export function parseSweepArgs(argv = []) {
     observeMs,
     noTurn: flags.includes("--no-turn"),
     headed: !flags.includes("--headless"),
+    // Default ON: auto-select a SayPi voice (on hosts that support one) before the
+    // turn so the sweep actually exercises SayPi's TTS engine. --no-select-voice
+    // opts out (e.g. to test the voice-off / unauthenticated-degradation path).
+    selectVoice: !flags.includes("--no-select-voice"),
   };
 }
 

--- a/scripts/e2e-host-sweep.mjs
+++ b/scripts/e2e-host-sweep.mjs
@@ -14,7 +14,12 @@
  *   - screenshots before / at-transcript / during-observe / final
  * Writes a JSON evidence file + PNGs per host under .output/e2e-host-sweep/<run>/.
  *
- *   node scripts/e2e-host-sweep.mjs [host ...] [--observe=<ms>] [--no-turn] [--headless]
+ * To actually exercise SayPi's TTS engine, the sweep AUTO-SELECTS a SayPi voice on
+ * claude.ai before the turn (default on; --no-select-voice opts out) — no founder
+ * pre-seed needed. pi.ai uses its native voice and chatgpt.com uses native Read
+ * Aloud, so SayPi-TTS self-selection only applies to claude.ai.
+ *
+ *   node scripts/e2e-host-sweep.mjs [host ...] [--observe=<ms>] [--no-turn] [--headless] [--no-select-voice]
  *   npm run e2e-host-sweep            # all three hosts, headed (the working mode)
  *
  * Real Chrome over CDP on the SEEDED profile (extension profile-installed). HEADED
@@ -100,11 +105,46 @@ const DIAGS = {
   }),
 };
 
+/**
+ * Auto-select a SayPi voice so the turn exercises SayPi's TTS engine (provider
+ * "Say, Pi"), removing the need to pre-seed a voice by hand. claude.ai is the clean
+ * target (no native voice → SayPi synthesis takes over). Drives the REAL selection
+ * path: open the menu, click the first real voice item (which fires setVoice). Other
+ * hosts: pi.ai defaults to its own native voice and chatgpt.com uses native Read
+ * Aloud, so there's nothing to select for SayPi-TTS purposes — returns null.
+ * Returns the selected voice name, or null if none was selected.
+ */
+async function selectSaypiVoice(page, host) {
+  if (host !== "claude") return null;
+  // Open the voice menu (toggle lives inside #claude-voice-selector); items portal
+  // to document.body as div[role="menuitem"][data-voice-name].
+  await page.evaluate(() => {
+    const toggle = document.querySelector(
+      "#claude-voice-selector button[aria-expanded], #claude-voice-selector button[aria-haspopup], #claude-voice-selector button"
+    );
+    if (toggle) toggle.click();
+  }).catch(() => {});
+  await page
+    .waitForFunction(() => document.querySelectorAll("[role='menuitem'][data-voice-name]").length > 0, undefined, { timeout: 12_000 })
+    .catch(() => {});
+  return page.evaluate(() => {
+    const item = [...document.querySelectorAll("[role='menuitem'][data-voice-name]")].find(
+      (i) => i.dataset.voiceName && i.dataset.voiceName !== "voice-off" && !i.dataset.action
+    );
+    if (!item) return null; // only voice-off / sign-in / upgrade items → no SayPi voice available
+    item.click(); // real path: handleVoiceSelection → setVoice (persists + applies)
+    // close the menu so it doesn't overlay the call button
+    const toggle = document.querySelector("#claude-voice-selector button[aria-expanded]");
+    if (toggle && toggle.getAttribute("aria-expanded") === "true") toggle.click();
+    return item.dataset.voiceName;
+  }).catch(() => null);
+}
+
 async function sweepHost(ctx, host, url, opts, outDir) {
   const ev = {
     host, url, decorated: false, cloudflareBlocked: false, build: null,
     transcript: null, autoSubmitted: false, assistantReplied: false,
-    authStatus: null, voiceProvider: null,
+    authStatus: null, voiceProvider: null, selectedVoice: null,
     console: [], pageErrors: [], network: [], requestFailed: [],
     domDiagnostics: {}, errorToasts: [], notes: [],
   };
@@ -144,6 +184,17 @@ async function sweepHost(ctx, host, url, opts, outDir) {
     ev.domDiagnostics = await page.evaluate(DIAGS[host]).catch((e) => ({ error: e.message }));
 
     if (!ev.decorated) { ev.notes.push("not decorated — selector drift or logged out"); return ev; }
+
+    // Auto-select a SayPi voice (default on) so the turn exercises SayPi's TTS engine.
+    if (opts.selectVoice && !opts.noTurn) {
+      ev.selectedVoice = await selectSaypiVoice(page, host);
+      if (ev.selectedVoice) {
+        log(`${host}: selected SayPi voice "${ev.selectedVoice}"`);
+        await new Promise((r) => setTimeout(r, 2000)); // let setVoice persist + changeVoice propagate
+      } else if (host === "claude") {
+        ev.notes.push("no SayPi voice available to select (TTS quota / sign-in?) — SayPi TTS engine not exercised");
+      }
+    }
 
     if (!opts.noTurn) {
       await page.evaluate(() => window.dispatchEvent(new CustomEvent("saypi:dev-feed-speech", { detail: { loop: false } })));
@@ -225,7 +276,7 @@ async function main() {
       const ev = await sweepHost(ctx, key, url, opts, outDir);
       const s = summarize(ev);
       summaries.push(s);
-      log(`${key}: decorated=${s.decorated} cf=${s.cloudflareBlocked} transcript=${!!s.transcript} reply=${ev.assistantReplied} auth=${s.authStatus} voice=${s.voiceProvider} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures} | diag=${JSON.stringify(ev.domDiagnostics)}`);
+      log(`${key}: decorated=${s.decorated} cf=${s.cloudflareBlocked} transcript=${!!s.transcript} reply=${ev.assistantReplied} auth=${s.authStatus} voice=${s.voiceProvider}${ev.selectedVoice ? ` (selected:${ev.selectedVoice})` : ""} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures} | diag=${JSON.stringify(ev.domDiagnostics)}`);
     }
   } finally {
     writeFileSync(join(outDir, "summary.json"), JSON.stringify(summaries, null, 2));

--- a/test/scripts/e2e-host-sweep-lib.spec.ts
+++ b/test/scripts/e2e-host-sweep-lib.spec.ts
@@ -21,12 +21,16 @@ describe("HOSTS registry", () => {
 });
 
 describe("parseSweepArgs", () => {
-  it("defaults to all hosts, headed, with the default observe window and a turn", () => {
+  it("defaults to all hosts, headed, with the default observe window, a turn, and voice self-selection", () => {
     const a = parseSweepArgs([]);
     expect(a.hosts).toEqual(["pi", "claude", "chatgpt"]);
     expect(a.headed).toBe(true);
     expect(a.noTurn).toBe(false);
     expect(a.observeMs).toBe(DEFAULT_OBSERVE_MS);
+    expect(a.selectVoice).toBe(true); // auto-select a SayPi voice by default → TTS covered
+  });
+  it("--no-select-voice opts out of voice self-selection (to test the voice-off path)", () => {
+    expect(parseSweepArgs(["--no-select-voice"]).selectVoice).toBe(false);
   });
   it("selects a subset by host key, preserving the requested set", () => {
     expect(parseSweepArgs(["chatgpt", "pi"]).hosts).toEqual(["chatgpt", "pi"]);


### PR DESCRIPTION
## Why

Answering "can't the sweep select a SayPi voice itself instead of relying on me to pre-seed it?" — yes. The voice-on validation run (#372) showed the profile was authenticated but no SayPi voice was selected on Claude, so SayPi's TTS *engine* never ran. Rather than depend on a manual pre-seed, the sweep now self-selects — the same philosophy as the synthetic-mic / dev-reload hooks that removed the other founder dependencies.

## What

- **`selectSaypiVoice(page, host)`** — before the turn, on **claude.ai**, opens the voice menu and clicks the first real voice item (`[role="menuitem"][data-voice-name]`, skipping `voice-off` / sign-in / upgrade), driving the **real** `handleVoiceSelection → setVoice` path so the active provider becomes **`Say, Pi`** and the offscreen-audio/CSP TTS path runs. pi.ai uses its native voice and chatgpt.com uses native Read Aloud, so SayPi-TTS self-selection only applies to claude.ai (returns null elsewhere). Records `ev.selectedVoice`; notes when no voice is available (no quota / not signed in).
- **default on**; `--no-select-voice` opts out (to test the voice-off / `#268`/`#280` degradation path). New `selectVoice` flag in `parseSweepArgs` + unit test.
- **doc + skill** updated: the only manual seed is now signing into SayPi (interactive); the harness picks the voice.

## Verification

- Live smoke-run (claude, headed): `selected SayPi voice "Jarnathan"` → `voice=Say, Pi`, no TTS-coverage warning, `saypiErr=0`. The founder no longer needs to pre-select a voice.
- Full required gate green: `npm test` → **133 files / 1039 passed / 1 skipped** (incl. the new flag test).
- This same self-selection is what surfaced **#375** (the SayPi voice introduction fails with "is not a streaming speech URL") — i.e. the harness now reaches a TTS-path defect class it previously couldn't.

## Risk

Dev/agent tooling only — `scripts/`, `test/`, `doc/`. No `src/`, manifest, auth, or shipped-build change. Side effect: a sweep persists a selected voice in the test CDP profile (expected for a test profile; keeps subsequent runs covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)