### PR TITLE
fix(settings): restore utilities missing from base.css after Tailwind retirement

### DIFF
--- a/entrypoints/settings/styles/base.css
+++ b/entrypoints/settings/styles/base.css
@@ -100,6 +100,9 @@ button {
 .justify-center {
   justify-content: center;
 }
+.flex-grow {
+  flex-grow: 1;
+}
 
 /* sizing */
 .w-full {
@@ -124,6 +127,12 @@ button {
 }
 .mt-2 {
   margin-top: 0.5rem;
+}
+.ml-2 {
+  margin-left: 0.5rem;
+}
+.mr-2 {
+  margin-right: 0.5rem;
 }
 .px-2 {
   padding-left: 0.5rem;
@@ -157,6 +166,9 @@ button {
 }
 
 /* backgrounds */
+.bg-blue-500 {
+  background-color: #3b82f6;
+}
 .bg-blue-600 {
   background-color: #2563eb;
 }
@@ -173,6 +185,9 @@ button {
 }
 .text-gray-500 {
   color: #6b7280;
+}
+.text-gray-600 {
+  color: #4b5563;
 }
 .text-gray-700 {
   color: #374151;

--- a/test/settings/tailwind-retirement.spec.ts
+++ b/test/settings/tailwind-retirement.spec.ts
@@ -5,64 +5,95 @@ import { fileURLToPath } from "node:url";
 /**
  * Guards the retirement of the vendored Tailwind v2 dump.
  *
- * Every Tailwind-style utility class used in the settings HTML templates must
- * be defined in base.css, so dropping the dump never leaves an element
- * unstyled. Also asserts the dump is no longer imported.
+ * Every Tailwind-style utility class used anywhere in the settings surface must
+ * be styled by some settings/popup stylesheet, so dropping the dump never
+ * leaves an element unstyled. This scans not just `.html` templates but also
+ * the `.ts`/`.tsx` that render markup (e.g. `header.ts`'s template string, the
+ * `*Panel.tsx` components) and the popup `.js` helpers that mutate classes via
+ * `classList` (e.g. `status-subscription.js`'s quota-bar colours) — the gap
+ * that left the header + status dots unstyled when PR #368 scanned only HTML.
  */
-const settingsDir = fileURLToPath(
-  new URL("../../entrypoints/settings", import.meta.url),
-);
-const baseCss = readFileSync(
-  fileURLToPath(
-    new URL("../../entrypoints/settings/styles/base.css", import.meta.url),
-  ),
-  "utf-8",
-);
+const root = (p: string) => fileURLToPath(new URL(`../../${p}`, import.meta.url));
 
-function collectHtml(dir: string): string {
-  let html = "";
+function filesUnder(dir: string, exts: string[]): string[] {
+  const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const p = `${dir}/${entry.name}`;
-    if (entry.isDirectory()) html += collectHtml(p);
-    else if (entry.name.endsWith(".html")) html += readFileSync(p, "utf-8");
+    if (entry.isDirectory()) out.push(...filesUnder(p, exts));
+    else if (exts.some((e) => entry.name.endsWith(e))) out.push(p);
   }
-  return html;
+  return out;
 }
 
-const html = collectHtml(settingsDir);
-const classTokens = new Set<string>();
-for (const m of html.matchAll(/class="([^"]*)"/g)) {
-  for (const tok of m[1].split(/\s+/)) if (tok) classTokens.add(tok);
-}
+// Markup sources: templates (.html), Preact components (.tsx), controllers and
+// template strings (.ts), and the popup JS helpers that inject/toggle classes.
+const sourceFiles = [
+  ...filesUnder(root("entrypoints/settings"), [".html", ".ts", ".tsx"]),
+  ...filesUnder(root("src/popup"), [".js"]),
+];
 
-// Tokens base.css is responsible for (Tailwind-style utilities).
+// Stylesheets that together style the settings surface.
+const cssFiles = [
+  ...filesUnder(root("entrypoints/settings"), [".css"]),
+  ...filesUnder(root("src/popup"), [".css"]),
+];
+
+// Classes that look like Tailwind utilities (a settings stylesheet must define).
 const UTILITY =
-  /^(flex|hidden|items-|justify-|w-|h-|max-w-|m[trbl]?-|p[xy]?-|px-|py-|border$|rounded|bg-|text-|font-|appearance-|cursor-|focus:|hover:)/;
+  /^(flex$|flex-|items-|justify-|self-|content-|w-|h-|min-|max-|m[trblxy]?-|p[trblxy]?-|gap-|space-|text-|font-|leading-|tracking-|bg-|border$|border-|rounded|hidden$|block$|inline|grid|opacity-|shadow|ring|cursor-|appearance-|focus:|hover:)/;
 
-// Class names base.css defines (unescaping CSS \: and \. ).
-const definedClasses = new Set<string>();
-for (const m of baseCss.matchAll(/\.((?:[\w-]|\\.)+)/g)) {
-  definedClasses.add(m[1].replace(/\\(.)/g, "$1"));
+// Used in markup but never a real Tailwind v2 utility — the old dump never
+// defined these either, so they were always harmless no-ops.
+const NEVER_DEFINED = new Set(["text-normal"]);
+
+function usedClasses(): Set<string> {
+  const out = new Set<string>();
+  for (const f of sourceFiles) {
+    const src = readFileSync(f, "utf-8");
+    // class="..." | class='...' | className="..." | className='...'
+    for (const m of src.matchAll(/\bclass(?:Name)?\s*=\s*["']([^"']*)["']/g)) {
+      for (const t of m[1].split(/\s+/)) if (t) out.add(t);
+    }
+    // classList.add/toggle/remove('a', 'b', ...) — quoted literals
+    for (const m of src.matchAll(
+      /classList\.(?:add|toggle|remove)\(([^)]*)\)/g,
+    )) {
+      for (const lit of m[1].matchAll(/["']([^"']+)["']/g)) {
+        for (const t of lit[1].split(/\s+/)) if (t) out.add(t);
+      }
+    }
+  }
+  return out;
+}
+
+function definedClasses(): Set<string> {
+  const out = new Set<string>();
+  for (const f of cssFiles) {
+    const css = readFileSync(f, "utf-8");
+    for (const m of css.matchAll(/\.((?:[\w-]|\\.)+)/g)) {
+      out.add(m[1].replace(/\\(.)/g, "$1"));
+    }
+  }
+  return out;
 }
 
 describe("settings Tailwind retirement", () => {
-  it("base.css defines every Tailwind utility class used in the settings HTML", () => {
-    const used = [...classTokens].filter((t) => UTILITY.test(t)).sort();
+  it("every Tailwind utility used in the settings surface is styled by a settings stylesheet", () => {
+    const defined = definedClasses();
+    const used = [...usedClasses()]
+      .filter((t) => UTILITY.test(t) && !NEVER_DEFINED.has(t))
+      .sort();
     expect(used.length).toBeGreaterThan(0); // sanity: we actually scanned classes
-    const missing = used.filter((t) => !definedClasses.has(t));
+    const missing = used.filter((t) => !defined.has(t));
     expect(
       missing,
-      `Undefined utility classes (would render unstyled): ${missing.join(", ")}`,
+      "Utility classes used in settings markup/JS but defined in no settings " +
+        `stylesheet (would render unstyled): ${missing.join(", ")}`,
     ).toEqual([]);
   });
 
   it("no longer imports the vendored Tailwind dump", () => {
-    const indexTs = readFileSync(
-      fileURLToPath(
-        new URL("../../entrypoints/settings/index.ts", import.meta.url),
-      ),
-      "utf-8",
-    );
+    const indexTs = readFileSync(root("entrypoints/settings/index.ts"), "utf-8");
     expect(indexTs).not.toContain("tailwind.min.css");
   });
 });


### PR DESCRIPTION
## Why (regression fix)
PR #368 (Tailwind dump retirement) built `base.css` by scanning only the tab **`.html`** files — so utility classes used **elsewhere in the settings surface** lost their styling on `main`:
- **`header.ts`** renders its markup from a **TS template string** (never scanned): `flex-grow`, `ml-2`, `mr-2`, `text-gray-600` → the settings header's spacing and the "Not signed in" status colour have been rendering unstyled.
- **`status-subscription.js`** toggles quota-bar colours via `classList`: `bg-blue-500` → the "blue" quota state lost its colour (green/yellow/red survived via scoped rules in `usage.css`).

This is exactly the gap #368's reviewer flagged ("a utility added only via a TS `className`/`classList` would slip past the HTML-only guard").

## What
- Add the 5 missing utilities to `base.css` at **Tailwind v2 values**: `flex-grow:1`, `ml-2`/`mr-2` (`0.5rem`), `text-gray-600` (`#4b5563`), `bg-blue-500` (`#3b82f6`). (`text-normal` is **not** a real TW v2 utility — always a no-op — so it's allowlisted in the guard, not added.)
- **Harden `tailwind-retirement.spec.ts`:** scan `.ts`/`.tsx` + popup `.js` (`class=`/`className=`/`classList.add|toggle|remove` literals), not just `.html`, and check used utilities against the **union of all settings/popup stylesheets** (so scoped defs like the quota colours in `usage.css` aren't false-flagged). The guard now catches an unstyled utility used **anywhere** in the settings surface.

## Verification
- The hardened test **failed first** listing exactly `bg-blue-500, flex-grow, ml-2, mr-2, text-gray-600`, then **passes** after the `base.css` additions (TDD).
- `npm test` green: **135 files / 1045 passed, 1 skipped**. `npx wxt build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)