### PR TITLE
refactor(settings): render the SettingsHeader with Preact

### DIFF
--- a/entrypoints/settings/components/HeaderView.tsx
+++ b/entrypoints/settings/components/HeaderView.tsx
@@ -1,0 +1,57 @@
+/**
+ * Settings header bar (Preact).
+ *
+ * Faithful render of the former SettingsHeader template string: same element
+ * ids, classes, `data-i18n` / `data-i18n-attr` keys, and the `data-icon` logo
+ * placeholder — so auth.js (which binds `#auth-button` and updates
+ * `#profile-status` / `#profile-name` / `#unauthenticated-message` by id) and
+ * the orchestrator's i18n + static-icon passes are untouched.
+ *
+ * The dead `text-normal` class is dropped (not a Tailwind v2 utility — it never
+ * styled anything).
+ */
+export function HeaderView() {
+  return (
+    <div id="profile" class="profile-banner">
+      <div class="flex items-center w-full">
+        <a
+          href="https://www.saypi.ai"
+          id="saypi-logo-link"
+          data-i18n-attr="title:dashboardLinkTitle"
+          title="Open Say, Pi Dashboard"
+          target="_blank"
+        >
+          <img class="logo mr-2" data-icon="bubble-green.svg" alt="Say, Pi" />
+        </a>
+        <div class="flex items-center flex-grow">
+          <span class="label-text hidden" data-i18n="profile">
+            Profile
+          </span>
+          <span
+            id="profile-status"
+            class="ml-2 text-sm text-gray-600"
+            data-i18n="notSignedIn"
+          >
+            Not signed in
+          </span>
+          <span id="profile-name" class="ml-2 hidden"></span>
+          <span class="header-divider" aria-hidden="true"></span>
+          <span
+            id="unauthenticated-message"
+            class="unauthenticated-inline hidden"
+            data-i18n="quotaUnauthenticatedMessage"
+          >
+            Log in to access voice generation and other premium features
+          </span>
+        </div>
+        <button
+          id="auth-button"
+          class="control px-4 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          data-i18n="signIn"
+        >
+          Sign In
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/entrypoints/settings/components/header.ts
+++ b/entrypoints/settings/components/header.ts
@@ -1,3 +1,7 @@
+import { h } from 'preact';
+import { mountInto, unmountFrom } from '../../../src/ui/preact/mount';
+import { HeaderView } from './HeaderView';
+
 export class SettingsHeader {
   private rendered = false;
 
@@ -9,55 +13,15 @@ export class SettingsHeader {
 
   render(): void {
     if (this.rendered) return;
-
-    this.root.innerHTML = `
-      <div id="profile" class="profile-banner">
-        <div class="flex items-center w-full">
-          <a
-            href="https://www.saypi.ai"
-            id="saypi-logo-link"
-            data-i18n-attr="title:dashboardLinkTitle"
-            title="Open Say, Pi Dashboard"
-            target="_blank"
-          >
-            <img class="logo mr-2" data-icon="bubble-green.svg" alt="Say, Pi" />
-          </a>
-          <div class="flex items-center flex-grow">
-            <span class="label-text hidden" data-i18n="profile">Profile</span>
-            <span
-              id="profile-status"
-              class="ml-2 text-sm text-gray-600"
-              data-i18n="notSignedIn"
-            >
-              Not signed in
-            </span>
-            <span id="profile-name" class="ml-2 text-normal hidden"></span>
-            <span class="header-divider" aria-hidden="true"></span>
-            <span
-              id="unauthenticated-message"
-              class="unauthenticated-inline hidden"
-              data-i18n="quotaUnauthenticatedMessage"
-            >
-              Log in to access voice generation and other premium features
-            </span>
-          </div>
-          <button
-            id="auth-button"
-            class="control px-4 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-            data-i18n="signIn"
-          >
-            Sign In
-          </button>
-        </div>
-      </div>
-    `;
-
+    // Render the header bar with Preact; auth.js binds #auth-button and updates
+    // #profile-status / #profile-name by id after this (behaviour unchanged).
+    mountInto(this.root, h(HeaderView, {}));
     this.rendered = true;
   }
 
   destroy(): void {
     if (!this.rendered) return;
-    this.root.innerHTML = '';
+    unmountFrom(this.root);
     this.rendered = false;
   }
 }


### PR DESCRIPTION
## Why
Continues the settings → Preact componentization (after all four tabs). The header was the remaining `innerHTML` template-string renderer. **No visual change.**

## What
- **`HeaderView.tsx`** — faithful Preact render of the former `SettingsHeader` template: same ids (`#profile`, `#auth-button`, `#profile-status`, `#profile-name`, `#unauthenticated-message`, `#saypi-logo-link`), classes, `data-i18n`/`data-i18n-attr` keys, and the `data-icon` logo placeholder.
- **`header.ts`** — `SettingsHeader.render()` now `mountInto`s `<HeaderView>` (keeps its rendered-once guard); `destroy()` unmounts via `unmountFrom`. auth.js (binds `#auth-button`, updates `#profile-status`/`#profile-name` by id) and the orchestrator's i18n + static-icon passes are unchanged.
- Drops the dead `text-normal` class (not a Tailwind v2 utility — never styled anything; now also caught by #377's hardened guard).

## Verification
- The **existing `SettingsHeader.spec.ts`** (render produces the ids; idempotent on repeat render; `destroy()` clears the root) **stays green** as the regression net — confirms `mountInto`/`unmountFrom` preserve the contract.
- `npm test` green: **135 files / 1046 passed, 1 skipped**. `npx wxt build` succeeds.

## Notes
TabNavigator (`components/tabs.ts`) is intentionally left as-is — it's already a clean, well-tested vanilla component; migrating it would be churn without a maintainability/testability gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)