### PR TITLE
refactor(auth): render AuthPromptUI content with Preact

### DIFF
--- a/src/auth/AuthModalContent.tsx
+++ b/src/auth/AuthModalContent.tsx
@@ -52,7 +52,7 @@ export function AuthModalContent(props: AuthModalContentProps) {
       {props.variant === "full" && (
         <ul class="saypi-auth-modal-benefits">
           {props.benefits.map((benefit) => (
-            <li>{benefit}</li>
+            <li key={benefit}>{benefit}</li>
           ))}
         </ul>
       )}

--- a/src/auth/AuthModalContent.tsx
+++ b/src/auth/AuthModalContent.tsx
@@ -1,0 +1,70 @@
+/**
+ * Auth-prompt modal content (Preact), soft + full variants.
+ *
+ * Faithful render of AuthPromptUI.createModalContent: same classes, the
+ * `#saypi-auth-title` id (referenced by the modal's `aria-labelledby`), the
+ * "Say, Pi" brand header, the sized brand icon, title/description, the
+ * full-variant benefits list, and the sign-in / maybe-later buttons. The modal
+ * + overlay elements, show animation, and focus trap stay in AuthPromptUI.
+ */
+export interface AuthModalContentProps {
+  variant: "soft" | "full";
+  /** Raw SVG markup for the brand icon (sized), or null for the emoji fallback. */
+  iconSvg: string | null;
+  title: string;
+  description: string;
+  /** Benefit lines; rendered only for the full variant. */
+  benefits: string[];
+  signInLabel: string;
+  laterLabel: string;
+  dismissLabel: string;
+  onSignIn: () => void;
+  onDismiss: () => void;
+}
+
+export function AuthModalContent(props: AuthModalContentProps) {
+  return (
+    <div class="saypi-auth-modal-content">
+      <button
+        class="saypi-auth-modal-close"
+        aria-label={props.dismissLabel}
+        onClick={props.onDismiss}
+      >
+        ×
+      </button>
+
+      <div class="saypi-auth-modal-brand">Say, Pi</div>
+
+      {props.iconSvg ? (
+        <div
+          class="saypi-auth-modal-icon saypi-brand-icon"
+          dangerouslySetInnerHTML={{ __html: props.iconSvg }}
+        />
+      ) : (
+        <div class="saypi-auth-modal-icon saypi-brand-icon">🗣️</div>
+      )}
+
+      <h2 id="saypi-auth-title" class="saypi-auth-modal-title">
+        {props.title}
+      </h2>
+      <p class="saypi-auth-modal-description">{props.description}</p>
+
+      {props.variant === "full" && (
+        <ul class="saypi-auth-modal-benefits">
+          {props.benefits.map((benefit) => (
+            <li>{benefit}</li>
+          ))}
+        </ul>
+      )}
+
+      <div class="saypi-auth-modal-buttons">
+        <button class="saypi-auth-modal-signin" onClick={props.onSignIn}>
+          {props.signInLabel}
+        </button>
+        <button class="saypi-auth-modal-later" onClick={props.onDismiss}>
+          {props.laterLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/auth/AuthPromptUI.ts
+++ b/src/auth/AuthPromptUI.ts
@@ -21,6 +21,10 @@ import { ChatbotService } from "../chatbots/ChatbotService";
 import type { Chatbot } from "../chatbots/Chatbot";
 import type { PromptLevel } from "./AuthPromptController";
 import { getAuthPromptController } from "./AuthPromptController";
+import { h } from "preact";
+import { mountInto, unmountFrom } from "../ui/preact/mount";
+import { AuthToastContent } from "./AuthToastContent";
+import { AuthModalContent } from "./AuthModalContent";
 
 /**
  * Event data for showing auth prompts
@@ -117,8 +121,19 @@ export class AuthPromptUI {
     toast.setAttribute("role", "alert");
     toast.setAttribute("aria-live", "polite");
 
-    const content = this.createToastContent(event);
-    toast.appendChild(content);
+    mountInto(
+      toast,
+      h(AuthToastContent, {
+        iconSvg: this.brandIconSvg(24),
+        text:
+          getMessage("authPromptToast") ||
+          "Sign in to track your voice usage and sync settings",
+        signInLabel: getMessage("signIn") || "Sign In",
+        dismissLabel: getMessage("dismissNotice") || "Dismiss",
+        onSignIn: () => this.handleSignIn(),
+        onDismiss: () => this.handleDismiss(),
+      }),
+    );
 
     document.body.appendChild(toast);
     this.currentPrompt = toast;
@@ -155,8 +170,7 @@ export class AuthPromptUI {
     modal.setAttribute("aria-labelledby", "saypi-auth-title");
     modal.addEventListener("click", (e) => e.stopPropagation());
 
-    const content = this.createModalContent(event, "soft");
-    modal.appendChild(content);
+    mountInto(modal, this.modalContentVnode(event, "soft"));
 
     document.body.appendChild(overlay);
     document.body.appendChild(modal);
@@ -190,8 +204,7 @@ export class AuthPromptUI {
     modal.setAttribute("aria-labelledby", "saypi-auth-title");
     modal.addEventListener("click", (e) => e.stopPropagation());
 
-    const content = this.createModalContent(event, "full");
-    modal.appendChild(content);
+    mountInto(modal, this.modalContentVnode(event, "full"));
 
     document.body.appendChild(overlay);
     document.body.appendChild(modal);
@@ -212,146 +225,60 @@ export class AuthPromptUI {
   }
 
   /**
-   * Create toast content
+   * Build the SayPi brand icon as raw SVG at the given size (or null on failure).
    */
-  private createToastContent(event: AuthPromptShowEvent): HTMLElement {
-    const content = document.createElement("div");
-    content.className = "saypi-auth-prompt-content";
-
-    // Icon - use SayPi bubble logo for brand recognition
-    const iconContainer = document.createElement("div");
-    iconContainer.className = "saypi-auth-prompt-icon saypi-brand-icon";
+  private brandIconSvg(size: number): string | null {
     try {
       const icon = IconModule.bubbleBw.cloneNode(true) as SVGElement;
-      icon.setAttribute("width", "24");
-      icon.setAttribute("height", "24");
-      iconContainer.appendChild(icon);
+      icon.setAttribute("width", String(size));
+      icon.setAttribute("height", String(size));
+      return icon.outerHTML;
     } catch {
-      iconContainer.textContent = "🗣️";
+      return null;
     }
-    content.appendChild(iconContainer);
-
-    // Text
-    const textContainer = document.createElement("div");
-    textContainer.className = "saypi-auth-prompt-text";
-    textContainer.textContent = getMessage("authPromptToast") ||
-      "Sign in to track your voice usage and sync settings";
-    content.appendChild(textContainer);
-
-    // Sign in button
-    const signInButton = document.createElement("button");
-    signInButton.className = "saypi-auth-prompt-signin";
-    signInButton.textContent = getMessage("signIn") || "Sign In";
-    signInButton.addEventListener("click", () => this.handleSignIn());
-    content.appendChild(signInButton);
-
-    // Close button
-    const closeButton = document.createElement("button");
-    closeButton.className = "saypi-auth-prompt-close";
-    closeButton.setAttribute("aria-label", getMessage("dismissNotice") || "Dismiss");
-    closeButton.innerHTML = "×";
-    closeButton.addEventListener("click", () => this.handleDismiss());
-    content.appendChild(closeButton);
-
-    return content;
   }
 
   /**
-   * Create modal content
+   * Build the modal content vnode for the given variant. Faithful to the prior
+   * createModalContent (same title / description / benefits / button labels).
    */
-  private createModalContent(event: AuthPromptShowEvent, variant: "soft" | "full"): HTMLElement {
-    const content = document.createElement("div");
-    content.className = "saypi-auth-modal-content";
+  private modalContentVnode(
+    event: AuthPromptShowEvent,
+    variant: "soft" | "full",
+  ) {
+    const description =
+      variant === "full"
+        ? getMessage("authPromptModalFull") ||
+          "You've used SayPi for " +
+            event.transcriptionCount +
+            " voice messages! Sign in to unlock usage tracking, sync your settings across devices, and get personalized voice features."
+        : getMessage("authPromptModalSoft") ||
+          "Sign in to track your voice usage and sync your settings across all your devices.";
 
-    // Close button (top right)
-    const closeButton = document.createElement("button");
-    closeButton.className = "saypi-auth-modal-close";
-    closeButton.setAttribute("aria-label", getMessage("dismissNotice") || "Dismiss");
-    closeButton.innerHTML = "×";
-    closeButton.addEventListener("click", () => this.handleDismiss());
-    content.appendChild(closeButton);
+    const benefits =
+      variant === "full"
+        ? [
+            getMessage("authBenefitLimits") ||
+              "Higher usage limits with free account",
+            getMessage("authBenefitTTS") ||
+              "Text-to-speech voices (paid plans)",
+            getMessage("authBenefitPremium") ||
+              "Premium features & chatbot support",
+          ]
+        : [];
 
-    // Brand header - SayPi identification
-    const brandHeader = document.createElement("div");
-    brandHeader.className = "saypi-auth-modal-brand";
-    brandHeader.textContent = "Say, Pi";
-    content.appendChild(brandHeader);
-
-    // Icon - use SayPi bubble logo for brand recognition
-    const iconContainer = document.createElement("div");
-    iconContainer.className = "saypi-auth-modal-icon saypi-brand-icon";
-    try {
-      const icon = IconModule.bubbleBw.cloneNode(true) as SVGElement;
-      icon.setAttribute("width", "56");
-      icon.setAttribute("height", "56");
-      iconContainer.appendChild(icon);
-    } catch {
-      iconContainer.textContent = "🗣️";
-    }
-    content.appendChild(iconContainer);
-
-    // Title
-    const title = document.createElement("h2");
-    title.id = "saypi-auth-title";
-    title.className = "saypi-auth-modal-title";
-    title.textContent = getMessage("authPromptTitle") ||
-      "Unlock More Voice Features";
-    content.appendChild(title);
-
-    // Description
-    const description = document.createElement("p");
-    description.className = "saypi-auth-modal-description";
-
-    if (variant === "full") {
-      description.textContent = getMessage("authPromptModalFull") ||
-        "You've used SayPi for " + event.transcriptionCount + " voice messages! Sign in to unlock usage tracking, sync your settings across devices, and get personalized voice features.";
-    } else {
-      description.textContent = getMessage("authPromptModalSoft") ||
-        "Sign in to track your voice usage and sync your settings across all your devices.";
-    }
-    content.appendChild(description);
-
-    // Benefits list (only for full modal)
-    if (variant === "full") {
-      const benefitsList = document.createElement("ul");
-      benefitsList.className = "saypi-auth-modal-benefits";
-
-      const benefits = [
-        getMessage("authBenefitLimits") || "Higher usage limits with free account",
-        getMessage("authBenefitTTS") || "Text-to-speech voices (paid plans)",
-        getMessage("authBenefitPremium") || "Premium features & chatbot support"
-      ];
-
-      benefits.forEach(benefit => {
-        const li = document.createElement("li");
-        li.textContent = benefit;
-        benefitsList.appendChild(li);
-      });
-
-      content.appendChild(benefitsList);
-    }
-
-    // Buttons container
-    const buttonsContainer = document.createElement("div");
-    buttonsContainer.className = "saypi-auth-modal-buttons";
-
-    // Sign in button (primary)
-    const signInButton = document.createElement("button");
-    signInButton.className = "saypi-auth-modal-signin";
-    signInButton.textContent = getMessage("signIn") || "Sign In";
-    signInButton.addEventListener("click", () => this.handleSignIn());
-    buttonsContainer.appendChild(signInButton);
-
-    // Maybe later button (secondary)
-    const laterButton = document.createElement("button");
-    laterButton.className = "saypi-auth-modal-later";
-    laterButton.textContent = getMessage("maybeLater") || "Maybe Later";
-    laterButton.addEventListener("click", () => this.handleDismiss());
-    buttonsContainer.appendChild(laterButton);
-
-    content.appendChild(buttonsContainer);
-
-    return content;
+    return h(AuthModalContent, {
+      variant,
+      iconSvg: this.brandIconSvg(56),
+      title: getMessage("authPromptTitle") || "Unlock More Voice Features",
+      description,
+      benefits,
+      signInLabel: getMessage("signIn") || "Sign In",
+      laterLabel: getMessage("maybeLater") || "Maybe Later",
+      dismissLabel: getMessage("dismissNotice") || "Dismiss",
+      onSignIn: () => this.handleSignIn(),
+      onDismiss: () => this.handleDismiss(),
+    });
   }
 
   /**
@@ -390,6 +317,9 @@ export class AuthPromptUI {
     // Remove from DOM after animation
     await new Promise<void>(resolve => {
       setTimeout(() => {
+        if (promptToRemove) {
+          unmountFrom(promptToRemove);
+        }
         if (promptToRemove?.parentNode) {
           promptToRemove.parentNode.removeChild(promptToRemove);
         }

--- a/src/auth/AuthToastContent.tsx
+++ b/src/auth/AuthToastContent.tsx
@@ -1,0 +1,43 @@
+/**
+ * Auth-prompt toast content (Preact).
+ *
+ * Faithful render of AuthPromptUI.createToastContent: same classes and the
+ * icon (SayPi bubble) + text + sign-in + close structure. The toast element
+ * itself, its show/auto-dismiss animation, and the sign-in/dismiss handlers
+ * stay in AuthPromptUI; this component is the inner `.saypi-auth-prompt-content`.
+ */
+export interface AuthToastContentProps {
+  /** Raw SVG markup for the brand icon (sized), or null for the emoji fallback. */
+  iconSvg: string | null;
+  text: string;
+  signInLabel: string;
+  dismissLabel: string;
+  onSignIn: () => void;
+  onDismiss: () => void;
+}
+
+export function AuthToastContent(props: AuthToastContentProps) {
+  return (
+    <div class="saypi-auth-prompt-content">
+      {props.iconSvg ? (
+        <div
+          class="saypi-auth-prompt-icon saypi-brand-icon"
+          dangerouslySetInnerHTML={{ __html: props.iconSvg }}
+        />
+      ) : (
+        <div class="saypi-auth-prompt-icon saypi-brand-icon">🗣️</div>
+      )}
+      <div class="saypi-auth-prompt-text">{props.text}</div>
+      <button class="saypi-auth-prompt-signin" onClick={props.onSignIn}>
+        {props.signInLabel}
+      </button>
+      <button
+        class="saypi-auth-prompt-close"
+        aria-label={props.dismissLabel}
+        onClick={props.onDismiss}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/test/auth/AuthPromptContent.spec.tsx
+++ b/test/auth/AuthPromptContent.spec.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/preact";
+import { AuthToastContent } from "../../src/auth/AuthToastContent";
+import { AuthModalContent } from "../../src/auth/AuthModalContent";
+
+afterEach(() => cleanup());
+
+describe("AuthToastContent", () => {
+  const base = {
+    iconSvg: null,
+    text: "Sign in to track usage",
+    signInLabel: "Sign In",
+    dismissLabel: "Dismiss",
+    onSignIn: () => {},
+    onDismiss: () => {},
+  };
+
+  it("renders the content structure (icon + text + sign-in + close)", () => {
+    const { container } = render(<AuthToastContent {...base} />);
+    expect(container.querySelector(".saypi-auth-prompt-content")).toBeTruthy();
+    expect(container.querySelector(".saypi-auth-prompt-icon.saypi-brand-icon")).toBeTruthy();
+    expect(container.querySelector(".saypi-auth-prompt-text")?.textContent).toBe(
+      "Sign in to track usage",
+    );
+    expect(container.querySelector(".saypi-auth-prompt-signin")?.textContent).toBe("Sign In");
+    expect(
+      container.querySelector(".saypi-auth-prompt-close")?.getAttribute("aria-label"),
+    ).toBe("Dismiss");
+  });
+
+  it("renders the brand SVG when provided, else the emoji fallback", () => {
+    const withSvg = render(
+      <AuthToastContent {...base} iconSvg='<svg class="bubble"></svg>' />,
+    );
+    expect(withSvg.container.querySelector(".saypi-auth-prompt-icon svg.bubble")).toBeTruthy();
+    cleanup();
+    const fallback = render(<AuthToastContent {...base} iconSvg={null} />);
+    expect(fallback.container.querySelector(".saypi-auth-prompt-icon")?.textContent).toContain("🗣️");
+  });
+
+  it("fires onSignIn / onDismiss on click", () => {
+    const onSignIn = vi.fn();
+    const onDismiss = vi.fn();
+    const { container } = render(
+      <AuthToastContent {...base} onSignIn={onSignIn} onDismiss={onDismiss} />,
+    );
+    fireEvent.click(container.querySelector(".saypi-auth-prompt-signin") as HTMLElement);
+    fireEvent.click(container.querySelector(".saypi-auth-prompt-close") as HTMLElement);
+    expect(onSignIn).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AuthModalContent", () => {
+  const base = {
+    iconSvg: null,
+    title: "Unlock More",
+    description: "desc",
+    benefits: ["a", "b", "c"],
+    signInLabel: "Sign In",
+    laterLabel: "Maybe Later",
+    dismissLabel: "Dismiss",
+    onSignIn: () => {},
+    onDismiss: () => {},
+  };
+
+  it("renders the common modal structure with the aria-labelledby title id", () => {
+    const { container } = render(<AuthModalContent {...base} variant="soft" />);
+    expect(container.querySelector(".saypi-auth-modal-content")).toBeTruthy();
+    expect(container.querySelector(".saypi-auth-modal-close")).toBeTruthy();
+    expect(container.querySelector(".saypi-auth-modal-brand")?.textContent).toBe("Say, Pi");
+    expect(container.querySelector("h2#saypi-auth-title.saypi-auth-modal-title")?.textContent).toBe(
+      "Unlock More",
+    );
+    expect(container.querySelector(".saypi-auth-modal-signin")?.textContent).toBe("Sign In");
+    expect(container.querySelector(".saypi-auth-modal-later")?.textContent).toBe("Maybe Later");
+  });
+
+  it("omits the benefits list for the soft variant, includes it for full", () => {
+    const soft = render(<AuthModalContent {...base} variant="soft" />);
+    expect(soft.container.querySelector(".saypi-auth-modal-benefits")).toBeNull();
+    cleanup();
+    const full = render(<AuthModalContent {...base} variant="full" />);
+    const items = [...full.container.querySelectorAll(".saypi-auth-modal-benefits li")];
+    expect(items.map((li) => li.textContent)).toEqual(["a", "b", "c"]);
+  });
+
+  it("fires onSignIn / onDismiss (sign-in, maybe-later, close)", () => {
+    const onSignIn = vi.fn();
+    const onDismiss = vi.fn();
+    const { container } = render(
+      <AuthModalContent {...base} variant="full" onSignIn={onSignIn} onDismiss={onDismiss} />,
+    );
+    fireEvent.click(container.querySelector(".saypi-auth-modal-signin") as HTMLElement);
+    fireEvent.click(container.querySelector(".saypi-auth-modal-later") as HTMLElement);
+    fireEvent.click(container.querySelector(".saypi-auth-modal-close") as HTMLElement);
+    expect(onSignIn).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(2); // later + close
+  });
+});


### PR DESCRIPTION
## Why
Migrates the last imperative SayPi-owned-chrome UI (the progressive auth prompts) to Preact, completing the owned-chrome refactor (settings + notices + auth prompts). **No visual change.**

## What
- **`AuthToastContent.tsx`** + **`AuthModalContent.tsx`** — faithful Preact renders of the former `createToastContent` / `createModalContent`: same classes, the `#saypi-auth-title` id (referenced by the modal's `aria-labelledby`), the "Say, Pi" brand header, the sized bubble icon (24/56), the full-variant benefits list, and the sign-in / maybe-later / close buttons.
- **`AuthPromptUI`** `showToast`/`showSoftModal`/`showModal` render the components via `mountInto`; the toast/modal/overlay elements, show + 20s auto-dismiss animation, focus trap, and `hidePrompt` lifecycle stay imperative (`hidePrompt` now `unmountFrom`s the prompt before removing it). A shared `brandIconSvg()` helper replaces the duplicated icon cloning; the two content-builder methods are removed.

## Verification
- `npm test` green: **136 files / 1052 passed, 1 skipped**, incl. 6 new component tests (toast structure + icon/fallback + callbacks; modal structure + soft-vs-full benefits + callbacks). Typecheck confirms no dangling references to the removed builders. The existing `AuthPromptController` tests (controller logic) are unaffected.
- `npx wxt build` succeeds.

## Notes
- Not composing `<Notice>`: the auth prompts (toast + 2 modal variants with overlay/focus-trap/benefits) have a distinct structure/class vocabulary from the below-composer notices, so they become their own components rather than a forced `<Notice>` composition.
- The injected host widgets (CallButton/voice menus, the original PR5) remain — those are host-DOM-coupled and benefit from Layer-4 real-host verification; flagged for that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)