### PR TITLE
feat(tooling): e2e-host-sweep selects a fast claude.ai model (default Haiku) for in-window turns

### DIFF
--- a/doc/e2e-host-sweep.md
+++ b/doc/e2e-host-sweep.md
@@ -74,8 +74,19 @@ npm run e2e-host-sweep            # 3. sweep all three hosts (headed)
 node scripts/e2e-host-sweep.mjs chatgpt pi          # subset of hosts
 node scripts/e2e-host-sweep.mjs --no-turn           # decoration-only (fast)
 node scripts/e2e-host-sweep.mjs --observe=40000     # watch the conversation longer
+node scripts/e2e-host-sweep.mjs --claude-model=keep # leave Claude's current model (verify Max/slow settings)
+node scripts/e2e-host-sweep.mjs --claude-model=opus # force a specific model
 node scripts/e2e-host-sweep.mjs --headless          # re-test headless (Cloudflare-walled; expect blocks)
 ```
+
+**Model selection (claude.ai):** by default the sweep picks **Haiku 4.5** (fastest) on
+claude.ai before the turn, so the reply + TTS readback finish inside the observe window.
+Opus-Max extended-thinking can exceed it, leaving the turn stuck in `piThinking` until
+its 15s safety-net — a *latency* artifact, not a SayPi defect. SayPi's code path
+(decoration, readback) is model-independent, so this is purely a faster-iteration choice.
+**SayPi must still work on the slowest/Max settings** — verify that explicitly with
+`--claude-model=keep` (uses whatever the profile is set to) or `--claude-model=opus`,
+accepting longer turns / a possible `piThinking` timeout window.
 
 Per host the harness writes to `.output/e2e-host-sweep/<run>/<host>/`:
 `evidence.json` (console / pageErrors / network / requestFailed / domDiagnostics /

--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -19,7 +19,13 @@ export const DEFAULT_OBSERVE_MS = 28_000;
  *   --no-turn             decoration-only (don't drive a voice turn)
  *   --headless            opt-in headless (Cloudflare-walled on real hosts; for re-testing only)
  *   --no-select-voice     skip auto-selecting a SayPi voice (test the voice-off path instead)
+ *   --claude-model=<m>    claude.ai model to select before the turn: haiku (default, fastest —
+ *                         avoids Opus-Max extended-thinking latency that times the turn out),
+ *                         sonnet, opus, or keep (leave the profile's current model — use this
+ *                         to verify SayPi works on the slow/Max settings too)
  */
+export const CLAUDE_MODELS = ["haiku", "sonnet", "opus", "keep"];
+export const DEFAULT_CLAUDE_MODEL = "haiku";
 export function parseSweepArgs(argv = []) {
   const positional = argv.filter((a) => !a.startsWith("--"));
   const flags = argv.filter((a) => a.startsWith("--"));
@@ -28,6 +34,9 @@ export function parseSweepArgs(argv = []) {
   const unknown = positional.filter((p) => !known.includes(p));
   const observeFlag = flags.find((f) => f.startsWith("--observe="));
   const observeMs = observeFlag ? Math.max(0, Number(observeFlag.split("=")[1]) || 0) : DEFAULT_OBSERVE_MS;
+  const modelFlag = flags.find((f) => f.startsWith("--claude-model="));
+  const requestedModel = modelFlag ? modelFlag.split("=")[1]?.trim().toLowerCase() : DEFAULT_CLAUDE_MODEL;
+  const claudeModel = CLAUDE_MODELS.includes(requestedModel) ? requestedModel : DEFAULT_CLAUDE_MODEL;
   return {
     hosts: requested.length ? requested : known,
     unknownHosts: unknown,
@@ -38,6 +47,11 @@ export function parseSweepArgs(argv = []) {
     // turn so the sweep actually exercises SayPi's TTS engine. --no-select-voice
     // opts out (e.g. to test the voice-off / unauthenticated-degradation path).
     selectVoice: !flags.includes("--no-select-voice"),
+    // claude.ai model to pick before the turn. Default 'haiku' so the assistant
+    // replies fast enough for the turn + TTS readback to complete within the observe
+    // window (Opus-Max extended-thinking can exceed it). 'keep' = test the current
+    // (possibly Max) model. Unknown values fall back to the default.
+    claudeModel,
   };
 }
 

--- a/scripts/e2e-host-sweep.mjs
+++ b/scripts/e2e-host-sweep.mjs
@@ -17,9 +17,13 @@
  * To actually exercise SayPi's TTS engine, the sweep AUTO-SELECTS a SayPi voice on
  * claude.ai before the turn (default on; --no-select-voice opts out) — no founder
  * pre-seed needed. pi.ai uses its native voice and chatgpt.com uses native Read
- * Aloud, so SayPi-TTS self-selection only applies to claude.ai.
+ * Aloud, so SayPi-TTS self-selection only applies to claude.ai. It also selects a
+ * FAST claude.ai model (default Haiku; --claude-model=keep|opus|sonnet) so the reply
+ * + TTS readback finish within the observe window (Opus-Max extended-thinking can
+ * time the turn out) — SayPi's code path is model-independent, so this is a latency
+ * convenience, not a correctness compromise (use --claude-model=keep to test Max).
  *
- *   node scripts/e2e-host-sweep.mjs [host ...] [--observe=<ms>] [--no-turn] [--headless] [--no-select-voice]
+ *   node scripts/e2e-host-sweep.mjs [host ...] [--observe=<ms>] [--no-turn] [--headless] [--no-select-voice] [--claude-model=<m>]
  *   npm run e2e-host-sweep            # all three hosts, headed (the working mode)
  *
  * Real Chrome over CDP on the SEEDED profile (extension profile-installed). HEADED
@@ -106,6 +110,40 @@ const DIAGS = {
 };
 
 /**
+ * Select a faster claude.ai model (Claude-native UI) before the turn so the reply +
+ * TTS readback complete within the observe window — Opus-Max extended-thinking can
+ * exceed it (the turn then times out in piThinking). NOT a correctness compromise:
+ * SayPi's code path (decoration, readback) is the same regardless of model; this only
+ * removes host latency as a test obstacle. modelPref "keep" leaves the current model
+ * (use it to verify SayPi works on the slow/Max settings). claude.ai only.
+ * Returns the model label now shown, or null if unchanged/not applicable.
+ */
+async function selectClaudeModel(page, host, modelPref) {
+  if (host !== "claude" || modelPref === "keep") return null;
+  await page.evaluate(() => {
+    const trigger = document.querySelector("button[data-testid='model-selector-dropdown']");
+    if (trigger) trigger.click();
+  }).catch(() => {});
+  await page
+    .waitForFunction(() => document.querySelectorAll("[role='menuitemradio']").length > 0, undefined, { timeout: 8_000 })
+    .catch(() => {});
+  const picked = await page.evaluate((pref) => {
+    const radios = [...document.querySelectorAll("[role='menuitemradio']")]
+      .filter((r) => !/currently unavailable/i.test(r.textContent || ""));
+    const match = radios.find((r) => new RegExp(pref, "i").test(r.textContent || ""));
+    if (!match) return null;
+    match.click(); // real path: switches the conversation model
+    return (match.textContent || "").trim().slice(0, 40);
+  }, modelPref).catch(() => null);
+  // Read the (possibly updated) model label; close any open menu by pressing Escape.
+  await page.keyboard.press("Escape").catch(() => {});
+  if (!picked) return null;
+  return page
+    .evaluate(() => document.querySelector("[data-testid='model-selector-dropdown']")?.getAttribute("aria-label") || null)
+    .catch(() => null);
+}
+
+/**
  * Auto-select a SayPi voice so the turn exercises SayPi's TTS engine (provider
  * "Say, Pi"), removing the need to pre-seed a voice by hand. claude.ai is the clean
  * target (no native voice → SayPi synthesis takes over). Drives the REAL selection
@@ -144,7 +182,7 @@ async function sweepHost(ctx, host, url, opts, outDir) {
   const ev = {
     host, url, decorated: false, cloudflareBlocked: false, build: null,
     transcript: null, autoSubmitted: false, assistantReplied: false,
-    authStatus: null, voiceProvider: null, selectedVoice: null,
+    authStatus: null, voiceProvider: null, selectedVoice: null, selectedModel: null,
     console: [], pageErrors: [], network: [], requestFailed: [],
     domDiagnostics: {}, errorToasts: [], notes: [],
   };
@@ -184,6 +222,13 @@ async function sweepHost(ctx, host, url, opts, outDir) {
     ev.domDiagnostics = await page.evaluate(DIAGS[host]).catch((e) => ({ error: e.message }));
 
     if (!ev.decorated) { ev.notes.push("not decorated — selector drift or logged out"); return ev; }
+
+    // Select a faster claude.ai model (default) so the reply + readback finish in-window.
+    if (!opts.noTurn && host === "claude" && opts.claudeModel !== "keep") {
+      ev.selectedModel = await selectClaudeModel(page, host, opts.claudeModel);
+      if (ev.selectedModel) log(`${host}: model → ${ev.selectedModel} (pref: ${opts.claudeModel})`);
+      else ev.notes.push(`could not select claude model "${opts.claudeModel}" (selector drift / unavailable) — using current`);
+    }
 
     // Auto-select a SayPi voice (default on) so the turn exercises SayPi's TTS engine.
     if (opts.selectVoice && !opts.noTurn) {
@@ -276,7 +321,7 @@ async function main() {
       const ev = await sweepHost(ctx, key, url, opts, outDir);
       const s = summarize(ev);
       summaries.push(s);
-      log(`${key}: decorated=${s.decorated} cf=${s.cloudflareBlocked} transcript=${!!s.transcript} reply=${ev.assistantReplied} auth=${s.authStatus} voice=${s.voiceProvider}${ev.selectedVoice ? ` (selected:${ev.selectedVoice})` : ""} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures} | diag=${JSON.stringify(ev.domDiagnostics)}`);
+      log(`${key}: decorated=${s.decorated} cf=${s.cloudflareBlocked} transcript=${!!s.transcript} reply=${ev.assistantReplied} auth=${s.authStatus} voice=${s.voiceProvider}${ev.selectedVoice ? ` (selected:${ev.selectedVoice})` : ""}${ev.selectedModel ? ` model=${ev.selectedModel}` : ""} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures} | diag=${JSON.stringify(ev.domDiagnostics)}`);
     }
   } finally {
     writeFileSync(join(outDir, "summary.json"), JSON.stringify(summaries, null, 2));

--- a/scripts/e2e-host-sweep.mjs
+++ b/scripts/e2e-host-sweep.mjs
@@ -138,9 +138,12 @@ async function selectClaudeModel(page, host, modelPref) {
   // Read the (possibly updated) model label; close any open menu by pressing Escape.
   await page.keyboard.press("Escape").catch(() => {});
   if (!picked) return null;
-  return page
+  const label = await page
     .evaluate(() => document.querySelector("[data-testid='model-selector-dropdown']")?.getAttribute("aria-label") || null)
     .catch(() => null);
+  // Fall back to the picked radio's label if the trigger has no aria-label, so a
+  // successful switch is never mislabelled "could not select".
+  return label || picked;
 }
 
 /**

--- a/test/scripts/e2e-host-sweep-lib.spec.ts
+++ b/test/scripts/e2e-host-sweep-lib.spec.ts
@@ -28,9 +28,18 @@ describe("parseSweepArgs", () => {
     expect(a.noTurn).toBe(false);
     expect(a.observeMs).toBe(DEFAULT_OBSERVE_MS);
     expect(a.selectVoice).toBe(true); // auto-select a SayPi voice by default → TTS covered
+    expect(a.claudeModel).toBe("haiku"); // fastest model by default → reply + readback finish in-window
   });
   it("--no-select-voice opts out of voice self-selection (to test the voice-off path)", () => {
     expect(parseSweepArgs(["--no-select-voice"]).selectVoice).toBe(false);
+  });
+  it("honors --claude-model= (haiku/sonnet/opus/keep), defaulting/falling back to haiku", () => {
+    expect(parseSweepArgs(["--claude-model=sonnet"]).claudeModel).toBe("sonnet");
+    expect(parseSweepArgs(["--claude-model=opus"]).claudeModel).toBe("opus");
+    expect(parseSweepArgs(["--claude-model=keep"]).claudeModel).toBe("keep"); // test the Max/current model
+    expect(parseSweepArgs(["--claude-model=KEEP"]).claudeModel).toBe("keep"); // case-insensitive
+    expect(parseSweepArgs(["--claude-model=bogus"]).claudeModel).toBe("haiku"); // unknown → default
+    expect(parseSweepArgs([]).claudeModel).toBe("haiku");
   });
   it("selects a subset by host key, preserving the requested set", () => {
     expect(parseSweepArgs(["chatgpt", "pi"]).hosts).toEqual(["chatgpt", "pi"]);


### PR DESCRIPTION
## Why

Per the founder: the sweep "may select a different model and lower reasoning effort if response latency is an obstacle." It was — under **Opus 4.8 Max**, Claude's extended-thinking exceeded the observe window, so the turn sat in `responding:piThinking` until SayPi's 15s safety-net and the reply + TTS readback were never observed (showed up as `reply=false`). That's *host latency*, not a SayPi defect: SayPi's code path (decoration, readback) is identical regardless of model. So the sweep now picks a fast model to get reliable end-to-end observation.

## What

- **`selectClaudeModel(page, host, pref)`** — before the turn, on claude.ai, opens the model dropdown (`[data-testid="model-selector-dropdown"]`) and clicks the first available `[role="menuitemradio"]` matching the preference (default **Haiku 4.5**, "Fastest for quick answers"). Records `ev.selectedModel`.
- **`--claude-model=<haiku|sonnet|opus|keep>`** (default `haiku`). `keep` leaves the profile's current model — **use it to verify SayPi works on the slow/Max settings** (the founder's explicit caveat). Unknown values fall back to `haiku`. New `claudeModel` flag in `parseSweepArgs` + unit test.
- **doc + skill** document the option and state plainly that Max must still be verified (`--claude-model=keep`/`opus`).

Effort-lowering (the `effort-menu-trigger` submenu) was deliberately **not** added: switching to Haiku alone resolved the latency (full turn + readback completed in testing), so the extra submenu-driving fragility wasn't warranted. Easy to add later if needed.

## Verification

- Live smoke-run (claude): `model → Haiku 4.5`, `voice → Say, Pi`, **`reply=true` in-window** (vs `reply=false` under Opus-Max) — and an earlier probe confirmed the full readback path runs (`piWriting` → `piSpeaking` → 5 `/speak/<id>/stream` POSTs).
- Full required gate green: `npm test` → **1047 passed / 1 skipped** (incl. the new flag test).

## Risk

Dev/agent tooling only — `scripts/`/`test/`/`doc/`; no `src`/manifest/auth/build. Side effect: a sweep changes the test profile's Claude model to Haiku (use `--claude-model=keep` to avoid). Drives claude.ai's own model UI (drifts; selector-failure is non-fatal — the sweep notes it and proceeds on the current model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)