### PR TITLE
fix: guard exitFullscreen() on fullscreenElement (#363)

### DIFF
--- a/src/FullscreenModule.ts
+++ b/src/FullscreenModule.ts
@@ -56,8 +56,12 @@ export function enterFullscreen() {
 }
 
 export function exitFullscreen() {
-  // Check if the API is available
-  if (document.fullscreenEnabled) {
+  // Only exit when the API is available AND the document is actually in
+  // fullscreen. Without the fullscreenElement guard, the load-time
+  // exitImmersiveMode() path (ImmersionService) calls this on every page load,
+  // which on a non-active document rejects with "Document not active" (#363).
+  // Mirrors the already-guarded Escape-key path in ImmersionService.
+  if (document.fullscreenEnabled && document.fullscreenElement) {
     // Request full-screen mode
     document
       .exitFullscreen()

--- a/test/immersive/FullscreenGuard.spec.ts
+++ b/test/immersive/FullscreenGuard.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// isMobileDevice() is consulted inside the exitFullscreen().then() callback. Force
+// it to true so the post-exit focus-mode teardown is skipped, keeping this unit
+// test hermetic and focused on the guard itself.
+vi.mock("../../src/UserAgentModule", () => ({
+  isMobileDevice: () => true,
+}));
+
+import { exitFullscreen } from "../../src/FullscreenModule";
+
+/**
+ * Regression guard for #363: exitFullscreen() must only call
+ * document.exitFullscreen() when the document is actually in fullscreen
+ * (document.fullscreenElement is set), mirroring the Escape-key path in
+ * ImmersionService. The load-time exitImmersiveMode() path previously called it
+ * on every page load, which on a non-active document rejects with
+ * "Document not active".
+ */
+describe("exitFullscreen guard (#363)", () => {
+  let exitFullscreenSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    exitFullscreenSpy = vi.fn(() => Promise.resolve());
+    Object.defineProperty(document, "exitFullscreen", {
+      configurable: true,
+      writable: true,
+      value: exitFullscreenSpy,
+    });
+    Object.defineProperty(document, "fullscreenEnabled", {
+      configurable: true,
+      writable: true,
+      value: true,
+    });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      writable: true,
+      value: null,
+    });
+  });
+
+  it("does NOT call document.exitFullscreen() when not in fullscreen", () => {
+    (document as any).fullscreenElement = null;
+
+    exitFullscreen();
+
+    expect(exitFullscreenSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls document.exitFullscreen() when a fullscreen element is active", () => {
+    (document as any).fullscreenElement = document.documentElement;
+
+    exitFullscreen();
+
+    expect(exitFullscreenSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call document.exitFullscreen() when the Fullscreen API is unavailable", () => {
+    (document as any).fullscreenEnabled = false;
+    (document as any).fullscreenElement = document.documentElement;
+
+    exitFullscreen();
+
+    expect(exitFullscreenSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #363.

## Problem
`exitFullscreen()` (`src/FullscreenModule.ts`) guarded only `document.fullscreenEnabled`, so the load-time `exitImmersiveMode()` path (`ImmersionService.js:195`, which `initMode()` runs on every page load for the default non-immersive view) called `document.exitFullscreen()` unconditionally. On a non-active document this rejects with `TypeError: Document not active` (caught/debug-logged); in a normal foreground tab it's a redundant no-op.

## Fix
Add the `document.fullscreenElement` guard, mirroring the already-correct Escape-key path (`ImmersionService.js:108` — `if (document.fullscreenElement) exitFullscreen()`). One-line change.

## Tests
New fail-first unit test `test/immersive/FullscreenGuard.spec.ts` exercises the **real** `exitFullscreen()`:
- not in fullscreen → `document.exitFullscreen()` NOT called (this case fails against `main`, proving the bug)
- fullscreen element active → called once
- API unavailable → not called

The existing `ImmersiveEscape.spec.ts` mocks `exitFullscreen` wholesale, so it never covered this guard (noted in #363's ACs).

## Note re: #379
The fork PR #379 proposed the same guard but ships no test (CI can't run on it — it's a fork branch, no required checks). This PR is a strict superset (same guard + the fail-first test the AC demands) and runs the full required gate.