### PR TITLE
fix(chatgpt): detect assistant turns after <article>→<section> drift (#362)

### DIFF
--- a/src/chatbots/ChatGPT.ts
+++ b/src/chatbots/ChatGPT.ts
@@ -111,26 +111,69 @@ class ChatGPTChatbot extends AbstractChatbot {
   getChatHistory(searchRoot: HTMLElement): HTMLElement {
     const thread = findThreadRoot(searchRoot) as HTMLElement | null;
     const scope: ParentNode = (thread as ParentNode) || (searchRoot as ParentNode) || document;
-    const firstTurn = (scope as Element | Document).querySelector?.(
-      'article[data-testid^="conversation-turn"], article[data-testid^="conversation-turn-"]'
+    const scopeEl = scope as Element | Document;
+    // Tag-agnostic: chatgpt.com changed the turn container from <article> to
+    // <section> (2026-06) while keeping data-testid="conversation-turn-N". Anchoring
+    // on the stable data attribute is robust to that tag change (#362).
+    const firstTurn = scopeEl.querySelector?.(
+      '[data-testid^="conversation-turn"]'
     ) as HTMLElement | null;
-    if (firstTurn && firstTurn.parentElement) {
-      return firstTurn.parentElement as HTMLElement;
+    if (!firstTurn || !firstTurn.parentElement) {
+      return null as unknown as HTMLElement;
     }
-    return null as unknown as HTMLElement;
+    // ChatGPT wraps each conversation turn in its own <div> under a shared list
+    // container. Return that shared container — NOT a single turn's wrapper — so the
+    // subtree message observer (ChatHistoryAdditionsObserver, registered on
+    // #saypi-chat-history with subtree:true) sees every existing turn AND future
+    // turns appended to the list. Returning firstTurn.parentElement (the old
+    // behavior) only observes the first turn's wrapper, so later turns (e.g. the
+    // assistant reply) are never detected → no saypi:piWriting → 15s piThinking hang.
+    const turns = Array.from(
+      scopeEl.querySelectorAll('[data-testid^="conversation-turn"]')
+    );
+    const containsAll = (el: Element | null) =>
+      !!el && turns.every((t) => el.contains(t));
+    let container: HTMLElement | null = firstTurn.parentElement;
+    let guard = 0;
+    while (
+      container &&
+      (container as Node) !== (scope as Node) &&
+      !containsAll(container) &&
+      guard++ < 8
+    ) {
+      container = container.parentElement;
+    }
+    // With a single turn, climb one extra level past its wrapper to the shared list
+    // container the next turn (e.g. the assistant reply) will be appended into.
+    if (
+      turns.length <= 1 &&
+      container &&
+      container.parentElement &&
+      (container.parentElement as Node) !== (scope as Node)
+    ) {
+      container = container.parentElement;
+    }
+    return (container || firstTurn.parentElement) as HTMLElement;
   }
 
   getChatHistorySelector(): string {
-    const listByArticles = 'div:has(> article[data-testid^="conversation-turn"])';
-    return ['#thread ' + listByArticles, listByArticles].join(', ');
+    // Tag-agnostic (see getChatHistory): the turn container is a <section> as of
+    // 2026-06 (was <article>); match the stable data-testid regardless of tag.
+    const listByTurns = 'div:has(> [data-testid^="conversation-turn"])';
+    return ['#thread ' + listByTurns, listByTurns].join(', ');
   }
 
   getPastChatHistorySelector(): string {
-    return this.getChatHistorySelector();
+    // Mirror Claude: the chat-history element itself is the past/recent container,
+    // decorated via the subtree ChatHistoryAdditionsObserver on #saypi-chat-history.
+    // (getChatHistory now returns the shared turn-list container, so the per-turn
+    // wrappers must NOT be treated as separate past/recent containers — that would
+    // attach the observer to a single turn and miss the rest.)
+    return "#saypi-chat-history";
   }
 
   getRecentChatHistorySelector(): string {
-    return this.getChatHistorySelector();
+    return "#saypi-chat-history";
   }
 
   getDiscoveryPanelSelector(): string {
@@ -138,7 +181,7 @@ class ChatGPTChatbot extends AbstractChatbot {
   }
 
   getAssistantResponseSelector(): string {
-    const sel = 'article[data-turn="assistant"]';
+    const sel = '[data-turn="assistant"]';
     return ['#thread ' + sel, sel].join(', ');
   }
 
@@ -147,7 +190,7 @@ class ChatGPTChatbot extends AbstractChatbot {
   }
 
   getUserPromptSelector(): string {
-    return 'article[data-turn="user"]';
+    return '[data-turn="user"]';
   }
 
   getUserMessageContentSelector(): string {
@@ -322,8 +365,7 @@ class ChatGPTChatbot extends AbstractChatbot {
 
   protected createAssistantResponse(element: HTMLElement, includeInitialText?: boolean, isStreaming?: boolean): AssistantResponse {
     const container = (element.closest('[data-message-author-role="assistant"]') ||
-      element.closest('article[data-testid^="conversation-turn-"]') ||
-      element.closest('article[data-testid^="conversation-turn"]') ||
+      element.closest('[data-testid^="conversation-turn"]') ||
       element) as HTMLElement;
     try {
       const nodes = Array.from(document.querySelectorAll('[data-saypi-shielded]')) as HTMLElement[];

--- a/src/chatbots/chatgpt/ChatGPTResponse.ts
+++ b/src/chatbots/chatgpt/ChatGPTResponse.ts
@@ -657,7 +657,7 @@ export class ChatGPTTextBlockCapture extends ElementTextStream {
 
   private findTurnContainer(start: HTMLElement): HTMLElement | null {
     return (
-      start.closest('article[data-turn="assistant"]') as HTMLElement | null ||
+      start.closest('[data-turn="assistant"]') as HTMLElement | null ||
       start.closest('[data-message-author-role="assistant"]') as HTMLElement | null ||
       start.closest('.assistant-message') as HTMLElement | null ||
       start.parentElement
@@ -682,7 +682,7 @@ export class ChatGPTTextBlockCapture extends ElementTextStream {
         replacement = document.querySelector(`[data-testid="${testId}"]`);
       }
       if (!replacement && turnAttr) {
-        replacement = document.querySelector(`article[data-turn="${turnAttr}"]`);
+        replacement = document.querySelector(`[data-turn="${turnAttr}"]`);
       }
       if (replacement && replacement !== this.turnContainer) {
         text = (replacement.textContent || "").trimEnd();

--- a/test/chatbots/ChatGPTChatHistoryDrift.spec.ts
+++ b/test/chatbots/ChatGPTChatHistoryDrift.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Avoid the VoiceMenu->Pi->PiVoiceMenu->VoiceMenu circular import (same shim the
+// other ChatGPT specs use).
+import { vi } from "vitest";
+vi.mock("../../src/chatbots/Pi", () => ({ PiAIChatbot: class {} }));
+
+import ChatGPTChatbot from "../../src/chatbots/ChatGPT";
+
+/**
+ * Contract/fixture test for #362: chatgpt.com changed the conversation-turn
+ * container from <article> to <section> (2026-06, captured live via Layer-4 CDP),
+ * while KEEPING data-testid="conversation-turn-N", data-turn="assistant|user",
+ * data-turn-id, and the inner [data-message-author-role]/.markdown/.whitespace-pre-wrap
+ * content. ChatGPT also wraps each turn in its own <div> under a shared list
+ * container.
+ *
+ * The pre-fix selectors hard-qualified `article`, so detection matched nothing →
+ * "Failed to find chat history" → no saypi:piWriting → 15s piThinking hang.
+ */
+
+// Build the live structure: #thread > main > listContainer > [perTurnWrapper > section]
+function buildThread(turnTag: "article" | "section") {
+  document.body.innerHTML = "";
+  const thread = document.createElement("div");
+  thread.id = "thread";
+  const main = document.createElement("main");
+  const list = document.createElement("div");
+  list.className = "conv-list-root"; // analog of ChatGPT's hashed list container (no id)
+  main.appendChild(list);
+  thread.appendChild(main);
+  document.body.appendChild(thread);
+
+  const makeTurn = (n: number, role: "user" | "assistant", contentCls: string, text: string) => {
+    const wrapper = document.createElement("div"); // ChatGPT wraps each turn in its own div
+    const turn = document.createElement(turnTag);
+    turn.setAttribute("data-testid", `conversation-turn-${n}`);
+    turn.setAttribute("data-turn", role);
+    turn.setAttribute("data-turn-id", `id-${n}`);
+    const roleEl = document.createElement("div");
+    roleEl.setAttribute("data-message-author-role", role);
+    const content = document.createElement("div");
+    content.className = contentCls;
+    content.textContent = text;
+    roleEl.appendChild(content);
+    turn.appendChild(roleEl);
+    wrapper.appendChild(turn);
+    list.appendChild(wrapper);
+    return { wrapper, turn };
+  };
+
+  const user = makeTurn(1, "user", "whitespace-pre-wrap", "hello there");
+  const assistant = makeTurn(2, "assistant", "markdown", "general kenobi");
+  return { thread, main, list, user, assistant };
+}
+
+describe("ChatGPT chat-history detection — section drift (#362)", () => {
+  let gpt: ChatGPTChatbot;
+  beforeEach(() => {
+    gpt = new ChatGPTChatbot();
+  });
+
+  it("matches the assistant turn when it is a <section> (not <article>)", () => {
+    const { assistant } = buildThread("section");
+    const matches = document.querySelectorAll(gpt.getAssistantResponseSelector());
+    expect([...matches]).toContain(assistant.turn);
+  });
+
+  it("matches the user turn when it is a <section> (not <article>)", () => {
+    const { user } = buildThread("section");
+    const matches = document.querySelectorAll(gpt.getUserPromptSelector());
+    expect([...matches]).toContain(user.turn);
+  });
+
+  it("getChatHistory returns a container holding ALL turns, not a single turn's wrapper", () => {
+    const { list, user, assistant } = buildThread("section");
+    const history = gpt.getChatHistory(document.body);
+    expect(history).toBeTruthy();
+    // Must contain BOTH turns so the subtree message observer sees every turn and
+    // future turns. The pre-fix code returned firstTurn.parentElement (one wrapper),
+    // which contains only the first turn.
+    expect(history.contains(user.turn)).toBe(true);
+    expect(history.contains(assistant.turn)).toBe(true);
+    expect(history).toBe(list);
+  });
+
+  it("resolves the assistant content (.markdown) inside the section turn", () => {
+    const { assistant } = buildThread("section");
+    const content = assistant.turn.querySelector(gpt.getAssistantResponseContentSelector());
+    expect(content).toBeTruthy();
+    expect(content?.textContent).toBe("general kenobi");
+  });
+
+  it("remains backward-compatible with the legacy <article> turn markup", () => {
+    const { assistant, user, list } = buildThread("article");
+    expect([...document.querySelectorAll(gpt.getAssistantResponseSelector())]).toContain(assistant.turn);
+    expect([...document.querySelectorAll(gpt.getUserPromptSelector())]).toContain(user.turn);
+    const history = gpt.getChatHistory(document.body);
+    expect(history.contains(assistant.turn)).toBe(true);
+    expect(history).toBe(list);
+  });
+});


### PR DESCRIPTION
Closes #362.

## Root cause (corrected from the issue's premise)
chatgpt.com didn't *remove* the turn markup — it changed the turn container from `<article>` to **`<section>`** (verified live 2026-06-20 via Layer-4 CDP), while **keeping** `data-testid="conversation-turn-N"`, `data-turn="assistant|user"`, `data-turn-id`, and the inner `[data-message-author-role]` / `.markdown` / `.whitespace-pre-wrap` content. SayPi's ChatGPT adapter hard-qualified `article`, so `getChatHistory`/`getAssistantResponseSelector`/`getUserPromptSelector` matched **0** → "Failed to find chat history after 10 attempts" → no `saypi:piWriting` → `ConversationMachine` hung 15s in `responding.piThinking` even though ChatGPT replied.

A second, subtler change: ChatGPT now wraps **each** turn in its own `<div>` under a shared list container, so the old `getChatHistory` (`firstTurn.parentElement`) returned only the *first* turn's wrapper — the subtree message observer then never saw later turns.

## Fix — tag-agnostic, anchored on the stable `data-*` attributes
- **`getChatHistory`**: drop `article`; return the shared turn-**list** container (climb from the first turn to the ancestor containing all turns) so the subtree `ChatHistoryAdditionsObserver` on `#saypi-chat-history` sees every turn + future ones.
- **`getPastChatHistorySelector` / `getRecentChatHistorySelector`** → `"#saypi-chat-history"` (mirrors Claude's working pattern — the chat-history element is itself the past/recent container, decorated via the subtree observer; the per-turn wrappers must not be treated as separate containers).
- **`getChatHistorySelector` / `getAssistantResponseSelector` / `getUserPromptSelector`** and the **`createAssistantResponse`** `closest()`-chain: tag-agnostic (`[data-testid^="conversation-turn"]`, `[data-turn="assistant|user"]`).
- **`ChatGPTResponse.findTurnContainer` / `emitFinalAndClose`** re-anchor: tag-agnostic.

## Tests
New fail-first L2 contract test `test/chatbots/ChatGPTChatHistoryDrift.spec.ts` mirrors the live `<section>` + per-turn-wrapper structure (asserts assistant/user detection, content resolution, and that `getChatHistory` returns the all-turns container — not a single wrapper), plus a backward-compat `<article>` case. Existing ChatGPT specs (article fixtures) stay green because `[data-turn]` matches any tag.

## Live verification (Layer-4 CDP, real chatgpt.com, fix build loaded)
```
chatHistoryFound: true            (was: "Failed to find chat history")
chatHistoryContainsAllTurns: true (list-container climb works on the real DOM)
assistantHasMessageClass: true    SayPi decorated the assistant turn
saypiControlCount: 3              TTS/copy/telemetry controls rendered
```
Build stamp confirmed `fix/issue-362-chatgpt-detection`. The AC asked for a contract/fixture test capturing the current ChatGPT thread DOM — added.