### PR TITLE
refactor(buttons): extract CallButton segment geometry to a pure, tested module

### DIFF
--- a/src/buttons/CallButton.ts
+++ b/src/buttons/CallButton.ts
@@ -6,6 +6,7 @@ import AnimationModule from "../AnimationModule";
 import { GlowColorUpdater } from "./GlowColorUpdater";
 import { addChild, createSVGElement } from "../dom/DOMModule"; // Assuming createSVGElement is okay for full SVGs now, or stick to createElementNS
 import getMessage from "../i18n";
+import { computeGeometry, computeSegmentPaths, type SegmentStatus } from "./callButtonGeometry";
 import callIconSVG from "../icons/call.svg?raw";
 import callStartingIconSVG from "../icons/call-starting.svg?raw";
 import hangupIconSVG from "../icons/hangup.svg?raw";
@@ -16,7 +17,7 @@ import { logger } from "../LoggingModule";
 
 interface Segment {
     seqNum: number;
-    status: 'capturing' | 'processing' | 'completed-success' | 'completed-error';
+    status: SegmentStatus;
     startTime: number;
     endTime?: number;
     errorType?: string;
@@ -266,13 +267,6 @@ export class CallButton {
             segmentsGroup.removeChild(segmentsGroup.firstChild);
         }
 
-        const statusColors = {
-          capturing: '#808080',
-          processing: '#42a5f5',
-          'completed-success': '#66bb6a',
-          'completed-error': '#ef5350',
-        };
-
         const allSegmentsData = [...this.segments];
         if (this.currentSegment) {
             allSegmentsData.push(this.currentSegment);
@@ -282,7 +276,7 @@ export class CallButton {
 
         // Always ensure background is visible by default, then hide only if needed
         this.ensureBackgroundVisible(originalBackground);
-        
+
         if (totalSegments === 0) {
             // No segments to draw, background should already be visible
             return; // Exit early
@@ -297,78 +291,21 @@ export class CallButton {
         const viewBox = svg.getAttribute('viewBox')?.split(' ').map(Number);
         const svgWidth = viewBox ? viewBox[2] : 80; // Default guess
         const svgHeight = viewBox ? viewBox[3] : 80; // Default guess
-        const center = svgWidth / 2; // Use width for center X assuming square/circular
-        const radius = Math.min(svgWidth, svgHeight) / 2 * 0.9; // Outer radius factor for the pie wedges
-        const segmentRadius = radius; // For filled wedges, use the full radius
 
-        const gap = 1.5; // Gap between segments in degrees
+        // Pure angle/arc geometry lives in callButtonGeometry; this method keeps
+        // the DOM application + the #progress-ring/background preservation above.
+        const geometry = computeGeometry(svgWidth, svgHeight);
+        const segmentPaths = computeSegmentPaths(
+            allSegmentsData.map((segmentData) => segmentData.status),
+            geometry,
+        );
 
-        let anglePerSegment = 0;
-        if (totalSegments > 0) {
-            if (totalSegments === 1) {
-                anglePerSegment = 360; // Single segment covers the whole circle
-            } else {
-                const totalGap = totalSegments * gap;
-                if (totalGap < 360) {
-                    anglePerSegment = (360 - totalGap) / totalSegments;
-                } else {
-                    anglePerSegment = 0;
-                    console.warn("Too many segments for the given gap size.");
-                }
-            }
-        }
-        if (anglePerSegment <= 0 && totalSegments > 1) { // Allow anglePerSegment to be 0 if totalSegments is 1 and it becomes 360, then gets reset by gap logic for >1 scenario
-            console.warn("Angle per segment is zero or negative with multiple segments.");
-            return;
-        }
-        if (totalSegments === 1 && anglePerSegment !== 360) {
-            // This case should ideally not be hit if logic above is correct for totalSegments = 1
-            // but as a fallback, ensure a single segment is 360 if it wasn't set already.
-            anglePerSegment = 360;
-        }
-
-        let startAngle = -90; // Start from the top
-
-        allSegmentsData.forEach((segmentData, index) => {
-            const endAngle = startAngle + anglePerSegment;
-            const color = statusColors[segmentData.status] || '#cccccc';
-
+        segmentPaths.forEach((spec) => {
             const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-            const wedgePath = this.describeWedge(center, center, segmentRadius, startAngle, endAngle);
-
-            path.setAttribute('d', wedgePath);
-            path.setAttribute('fill', color);
+            path.setAttribute('d', spec.d);
+            path.setAttribute('fill', spec.fill);
             segmentsGroup!.appendChild(path);
-
-            startAngle = endAngle + gap;
         });
-    }
-
-    private describeWedge(x: number, y: number, radius: number, startAngle: number, endAngle: number): string {
-        // Handle full circle case by slightly adjusting endAngle to ensure the arc is drawn
-        // For a wedge, if it's a full circle, it's just a circle path, but our segment logic shouldn't produce this for a wedge.
-        if (endAngle - startAngle >= 359.99) {
-            endAngle = startAngle + 359.99; // Prevent full overlap that might cause rendering issues for an arc
-        }
-
-        const startRad = ((startAngle - 90) * Math.PI) / 180; // -90 to make 0 degrees at the top
-        const endRad = ((endAngle - 90) * Math.PI) / 180;   // -90 to make 0 degrees at the top
-
-        const arcStartX = x + radius * Math.cos(startRad);
-        const arcStartY = y + radius * Math.sin(startRad);
-        const arcEndX = x + radius * Math.cos(endRad);
-        const arcEndY = y + radius * Math.sin(endRad);
-
-        const largeArcFlag = endAngle - startAngle <= 180 ? "0" : "1";
-
-        const d = [
-            "M", x.toFixed(3), y.toFixed(3), // Move to Center
-            "L", arcStartX.toFixed(3), arcStartY.toFixed(3), // Line to Arc Start
-            "A", radius.toFixed(3), radius.toFixed(3), 0, largeArcFlag, 1, arcEndX.toFixed(3), arcEndY.toFixed(3), // Arc
-            "Z" // Close Path (line back to center)
-        ].join(" ");
-
-        return d;
     }
 
      // --- Glow Handling ---

--- a/src/buttons/callButtonGeometry.ts
+++ b/src/buttons/callButtonGeometry.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure geometry for the call button's transcription-segment pie overlay.
+ *
+ * Extracted from `CallButton.updateButtonSegments` so the angle/arc math is
+ * unit-testable without JSDOM (the widget keeps the DOM application — locating/
+ * creating the `<g>`, appending `<path>`s, and the `#progress-ring`/background
+ * preservation). The math is byte-faithful to the original: `toFixed(3)`, the
+ * compounded −90° offset (caller starts at −90, `describeWedge` subtracts
+ * another 90), the 359.99° full-circle clamp, and the `<=180` largeArcFlag.
+ */
+export type SegmentStatus =
+  | "capturing"
+  | "processing"
+  | "completed-success"
+  | "completed-error";
+
+export interface SegmentGeometry {
+  /** Center x/y — the call-button SVG is square, so one value serves both. */
+  center: number;
+  /** Outer radius of the pie wedges. */
+  radius: number;
+}
+
+export interface PathSpec {
+  /** SVG path `d` attribute for the wedge. */
+  d: string;
+  /** Fill colour. */
+  fill: string;
+}
+
+const STATUS_COLORS: Record<SegmentStatus, string> = {
+  capturing: "#808080",
+  processing: "#42a5f5",
+  "completed-success": "#66bb6a",
+  "completed-error": "#ef5350",
+};
+
+/** Gap between segments, in degrees. */
+const GAP_DEGREES = 1.5;
+
+/** SVG path `d` for a single pie wedge. Byte-faithful to the original. */
+export function describeWedge(
+  x: number,
+  y: number,
+  radius: number,
+  startAngle: number,
+  endAngle: number,
+): string {
+  // Prevent a full-overlap arc that renders incorrectly.
+  if (endAngle - startAngle >= 359.99) {
+    endAngle = startAngle + 359.99;
+  }
+
+  const startRad = ((startAngle - 90) * Math.PI) / 180; // −90 puts 0° at the top
+  const endRad = ((endAngle - 90) * Math.PI) / 180;
+
+  const arcStartX = x + radius * Math.cos(startRad);
+  const arcStartY = y + radius * Math.sin(startRad);
+  const arcEndX = x + radius * Math.cos(endRad);
+  const arcEndY = y + radius * Math.sin(endRad);
+
+  const largeArcFlag = endAngle - startAngle <= 180 ? "0" : "1";
+
+  return [
+    "M", x.toFixed(3), y.toFixed(3),
+    "L", arcStartX.toFixed(3), arcStartY.toFixed(3),
+    "A", radius.toFixed(3), radius.toFixed(3), 0, largeArcFlag, 1, arcEndX.toFixed(3), arcEndY.toFixed(3),
+    "Z",
+  ].join(" ");
+}
+
+/** Derive the wedge geometry from the SVG viewBox dimensions. */
+export function computeGeometry(
+  viewBoxWidth: number,
+  viewBoxHeight: number,
+): SegmentGeometry {
+  return {
+    center: viewBoxWidth / 2,
+    radius: (Math.min(viewBoxWidth, viewBoxHeight) / 2) * 0.9,
+  };
+}
+
+/**
+ * Per-segment wedge specs in draw order. Returns `[]` for no segments or a
+ * degenerate layout (too many segments for the gap) — mirroring the widget's
+ * original early-return behaviour (where the background is left hidden and no
+ * wedges are drawn).
+ */
+export function computeSegmentPaths(
+  statuses: SegmentStatus[],
+  geom: SegmentGeometry,
+): PathSpec[] {
+  const totalSegments = statuses.length;
+  if (totalSegments === 0) return [];
+
+  let anglePerSegment = 0;
+  if (totalSegments === 1) {
+    anglePerSegment = 360; // single segment covers the whole circle
+  } else {
+    const totalGap = totalSegments * GAP_DEGREES;
+    anglePerSegment = totalGap < 360 ? (360 - totalGap) / totalSegments : 0;
+  }
+  if (anglePerSegment <= 0 && totalSegments > 1) return [];
+  if (totalSegments === 1 && anglePerSegment !== 360) anglePerSegment = 360;
+
+  const specs: PathSpec[] = [];
+  let startAngle = -90; // start from the top
+  for (const status of statuses) {
+    const endAngle = startAngle + anglePerSegment;
+    specs.push({
+      d: describeWedge(geom.center, geom.center, geom.radius, startAngle, endAngle),
+      fill: STATUS_COLORS[status] || "#cccccc",
+    });
+    startAngle = endAngle + GAP_DEGREES;
+  }
+  return specs;
+}

--- a/test/buttons/callButtonGeometry.spec.ts
+++ b/test/buttons/callButtonGeometry.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  describeWedge,
+  computeGeometry,
+  computeSegmentPaths,
+  type SegmentStatus,
+} from "../../src/buttons/callButtonGeometry";
+
+describe("describeWedge", () => {
+  it("emits an M/L/A/Z path with toFixed(3) coordinates", () => {
+    const d = describeWedge(40, 40, 36, -90, 0);
+    expect(d).toMatch(
+      /^M 40\.000 40\.000 L -?\d+\.\d{3} -?\d+\.\d{3} A 36\.000 36\.000 0 [01] 1 -?\d+\.\d{3} -?\d+\.\d{3} Z$/,
+    );
+  });
+
+  it("starts the line-to at the top of the circle for a wedge beginning at -90deg", () => {
+    // startAngle -90 + the internal -90 => -180 => cos=-1.. wait: ((-90-90)*PI/180) = -PI.
+    // arcStartX = 40 + 36*cos(-PI) = 40 - 36 = 4.000 ; arcStartY = 40 + 36*sin(-PI) ~= 40.000
+    const d = describeWedge(40, 40, 36, -90, 0);
+    expect(d).toContain("L 4.000 40.000");
+  });
+
+  it("uses largeArcFlag 0 for spans <= 180deg and 1 for spans > 180deg", () => {
+    expect(describeWedge(40, 40, 36, -90, 90)).toContain(" 0 1 "); // 180deg span -> flag 0
+    expect(describeWedge(40, 40, 36, -90, 180)).toContain(" 1 1 "); // 270deg span -> flag 1
+  });
+
+  it("clamps a full circle to 359.99deg (never a degenerate full-overlap arc)", () => {
+    const full = describeWedge(40, 40, 36, -90, 270); // 360deg span -> clamped
+    const clamped = describeWedge(40, 40, 36, -90, -90 + 359.99);
+    expect(full).toBe(clamped);
+  });
+});
+
+describe("computeGeometry", () => {
+  it("centers on width/2 and sets radius to 90% of half the smaller dimension", () => {
+    expect(computeGeometry(80, 80)).toEqual({ center: 40, radius: 36 });
+    expect(computeGeometry(80, 40)).toEqual({ center: 40, radius: 18 });
+  });
+});
+
+describe("computeSegmentPaths", () => {
+  const geom = { center: 40, radius: 36 };
+
+  it("returns no specs for zero segments", () => {
+    expect(computeSegmentPaths([], geom)).toEqual([]);
+  });
+
+  it("draws a single full-circle wedge for one segment, colored by status", () => {
+    const specs = computeSegmentPaths(["processing"], geom);
+    expect(specs).toHaveLength(1);
+    expect(specs[0].fill).toBe("#42a5f5"); // processing
+    expect(specs[0].d.startsWith("M 40.000 40.000")).toBe(true);
+  });
+
+  it("maps each status to its colour, in draw order", () => {
+    const statuses: SegmentStatus[] = [
+      "capturing",
+      "processing",
+      "completed-success",
+      "completed-error",
+    ];
+    const specs = computeSegmentPaths(statuses, geom);
+    expect(specs.map((s) => s.fill)).toEqual([
+      "#808080",
+      "#42a5f5",
+      "#66bb6a",
+      "#ef5350",
+    ]);
+  });
+
+  it("falls back to #cccccc for an unknown status", () => {
+    const specs = computeSegmentPaths(["mystery" as SegmentStatus], geom);
+    expect(specs[0].fill).toBe("#cccccc");
+  });
+
+  it("returns no specs when there are too many segments for the gap (degenerate)", () => {
+    // 240 segments * 1.5deg gap = 360deg of gap => anglePerSegment <= 0.
+    const many = Array.from({ length: 240 }, () => "processing" as SegmentStatus);
+    expect(computeSegmentPaths(many, geom)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why
The founder-chosen **option B** testability step for the injected CallButton: extract the pure angle/arc geometry into a unit-testable module, **leaving the animated widget imperative** (a full Preact/declarative migration is "Path A", deferred to a smaller future chunk). The arc math was previously untested and only reachable via the `Object.create` hack. **No behavior change.**

## What
- **`src/buttons/callButtonGeometry.ts`** — pure functions `describeWedge`, `computeGeometry`, `computeSegmentPaths` + `SegmentStatus`/`PathSpec`/`SegmentGeometry` types. **Byte-faithful** to the original: the compounded −90° offset (caller −90 + `describeWedge`'s internal −90), `toFixed(3)`, the 359.99° full-circle clamp, the `<=180` `largeArcFlag`, the status→colour map (`#808080`/`#42a5f5`/`#66bb6a`/`#ef5350` + `#cccccc` fallback), and the degenerate-layout early-return (now `[]`).
- **`CallButton.updateButtonSegments`** keeps all DOM work and the `#progress-ring`/background preservation; it now calls `computeGeometry` + `computeSegmentPaths` and applies the returned `PathSpec[]`. `Segment.status` references `SegmentStatus` (dependency points widget → geometry; the geometry module has no widget/DOM imports). The now-duplicated private `describeWedge` is removed.

## Verification
- `npm test` green: **137 files / 1063 passed, 1 skipped**, incl. **10 new geometry unit tests** (no jsdom: `describeWedge` structure/flag/clamp, `computeGeometry` math, `computeSegmentPaths` counts/colours/fallback/degenerate). **The existing `#203` arc-rebuild test still passes** — the render path (which calls `updateButtonSegments` → the module) is unchanged.
- `npx wxt build` succeeds.

## Notes
- Option B leaves the widget imperative — `updateButtonSegments` still builds the SVG paths via DOM; only the *math* moved. No real-host visual change (geometry output is byte-identical), so no Layer-4 verification needed for this PR.
- Follow-ups in the option-B plan: break the `VoiceMenu→Pi` import cycle (kills `VoiceMenu.spec`'s `vi.mock` hack); optionally retire the `CallButton-arc-rebuild` `Object.create` hack via a constructor/renderer change; PR6 visual-regression (Layer-4 baselines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)