### PR TITLE
refactor(tts): break VoiceMenu→Pi import cycle via capability guard

### DIFF
--- a/src/tts/VoiceMenu.ts
+++ b/src/tts/VoiceMenu.ts
@@ -2,7 +2,6 @@
 // This file now contains only the generic/abstract base for voice controls.
 import { getResourceUrl } from "../ResourceModule";
 import { Chatbot } from "../chatbots/Chatbot";
-import { PiAIChatbot } from "../chatbots/Pi";
 import { getMostRecentAssistantMessage } from "../dom/ChatHistory";
 import { Observation } from "../dom/Observation";
 import EventBus from "../events/EventBus";
@@ -12,6 +11,28 @@ import { audioProviders, SpeechSynthesisVoiceRemote } from "./SpeechModel";
 import { SpeechSynthesisModule } from "./SpeechSynthesisModule";
 import { getJwtManagerSync } from "../JwtManager";
 
+/**
+ * A chatbot that ships its own set of built-in voices, with introduction audio
+ * for the default voice (currently only Pi.ai). Declared structurally so the
+ * generic {@link VoiceSelector} base class can detect the capability without
+ * importing the concrete `PiAIChatbot` — that import created a
+ * `VoiceMenu -> Pi -> PiVoiceMenu -> VoiceMenu` cycle.
+ */
+export interface BuiltInVoiceProvider {
+  getExtraVoices(): SpeechSynthesisVoiceRemote[];
+  getVoiceIntroductionUrl(voiceId: string): string;
+}
+
+/** Structural type guard for {@link BuiltInVoiceProvider}. */
+export function isBuiltInVoiceProvider(
+  chatbot: Chatbot
+): chatbot is Chatbot & BuiltInVoiceProvider {
+  const candidate = chatbot as Partial<BuiltInVoiceProvider>;
+  return (
+    typeof candidate.getExtraVoices === "function" &&
+    typeof candidate.getVoiceIntroductionUrl === "function"
+  );
+}
 
 export abstract class VoiceSelector {
   protected chatbot: Chatbot;
@@ -260,9 +281,8 @@ export abstract class VoiceSelector {
     const name = voice.name.toLowerCase().replace(" ", "_");
     const introduction =
       lastMessage?.text || getMessage(`voiceIntroduction_${name}`);
-    if (voice.default && this.chatbot instanceof PiAIChatbot) {
-      const pi = this.chatbot as PiAIChatbot;
-      const introductionUrl = pi.getVoiceIntroductionUrl(voice.id);
+    if (voice.default && isBuiltInVoiceProvider(this.chatbot)) {
+      const introductionUrl = this.chatbot.getVoiceIntroductionUrl(voice.id);
       if (introductionUrl) {
         // play the introduction audio
         EventBus.emit("audio:load", { url: introductionUrl });
@@ -327,11 +347,10 @@ export abstract class VoiceSelector {
   }
 
   addMissingPiVoices(voiceSelector: HTMLElement) {
-    // only for Pi.ai
-    if (!(this.chatbot instanceof PiAIChatbot)) {
+    // only for chatbots that ship their own built-in voices (Pi.ai)
+    if (!isBuiltInVoiceProvider(this.chatbot)) {
       return;
     }
-    const pi = this.chatbot as PiAIChatbot;
     // count the number of original Pi voices in the menu
     let piVoices = 0;
     const voiceButtons = Array.from(voiceSelector.querySelectorAll("button"));
@@ -342,7 +361,7 @@ export abstract class VoiceSelector {
     });
     // if fewer than 8 Pi voices, add the missing Pi voices to the menu
     if (piVoices < 8) {
-      this.populateVoices(pi.getExtraVoices(), voiceSelector);
+      this.populateVoices(this.chatbot.getExtraVoices(), voiceSelector);
     }
   }
 

--- a/test/tts/VoiceMenu.spec.ts
+++ b/test/tts/VoiceMenu.spec.ts
@@ -11,10 +11,6 @@ vi.mock("../../src/ConfigModule", () => ({
   },
 }));
 
-// Break the VoiceMenu -> Pi -> PiVoiceMenu -> VoiceMenu import cycle in the test
-// env (the base class imports a concrete chatbot). We don't use PiAIChatbot here.
-vi.mock("../../src/chatbots/Pi", () => ({ PiAIChatbot: class {} }));
-
 const isAuthenticatedMock = vi.fn();
 vi.mock("../../src/JwtManager", () => ({
   getJwtManagerSync: () => ({
@@ -58,6 +54,42 @@ describe("VoiceSelector.ttsRequiresSignIn", () => {
   it("does NOT require sign-in when authenticated, even before voices have loaded", () => {
     isAuthenticatedMock.mockReturnValue(true);
     expect((selector as any).ttsRequiresSignIn(true)).toBe(false);
+  });
+});
+
+describe("VoiceSelector built-in-voice-provider capability detection", () => {
+  // The base class adds a chatbot's own built-in voices (e.g. Pi.ai's native
+  // voices + introduction audio) when the chatbot can provide them. This used
+  // to be gated on `instanceof PiAIChatbot`, which forced VoiceMenu to import
+  // the concrete Pi chatbot and created a VoiceMenu -> Pi -> PiVoiceMenu ->
+  // VoiceMenu import cycle. The gate is now a structural capability check, so
+  // any chatbot exposing getExtraVoices()/getVoiceIntroductionUrl() qualifies.
+  function makeSelector(chatbot: unknown): TestVoiceSelector {
+    return new TestVoiceSelector(
+      chatbot as any,
+      {} as any,
+      document.createElement("div"),
+    );
+  }
+
+  it("requests extra voices from a chatbot that provides its own built-in voices", () => {
+    const getExtraVoices = vi.fn(() => []);
+    const chatbot = {
+      getExtraVoices,
+      getVoiceIntroductionUrl: vi.fn(() => ""),
+    };
+    const selector = makeSelector(chatbot);
+    // An empty menu has 0 built-in voices, i.e. below the 8-voice threshold.
+    selector.addMissingPiVoices(document.createElement("div"));
+    expect(getExtraVoices).toHaveBeenCalled();
+  });
+
+  it("does nothing for a chatbot without built-in voices (e.g. Claude)", () => {
+    const chatbot = { getName: () => "Claude" };
+    const selector = makeSelector(chatbot);
+    const populateSpy = vi.spyOn(selector as any, "populateVoices");
+    selector.addMissingPiVoices(document.createElement("div"));
+    expect(populateSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What & why

The abstract `VoiceSelector` base class (`src/tts/VoiceMenu.ts`) gated its two Pi-specific behaviours on `instanceof PiAIChatbot`:

- playing the default voice's **introduction audio** (`introduceVoice`)
- topping up the menu with Pi.ai's **own built-in voices** (`addMissingPiVoices`)

That forced the base class to `import { PiAIChatbot }`, creating a real import cycle:

```
VoiceMenu → Pi → PiVoiceMenu → VoiceMenu
```

(`PiVoiceMenu extends VoiceSelector` at class-definition time, so the cycle bit at load.) It leaked into tests — `test/tts/VoiceMenu.spec.ts` had to `vi.mock("../../src/chatbots/Pi", () => ({ PiAIChatbot: class {} }))` purely to load the base class.

## Change

Replace the concrete-class check with a **structural capability guard** keyed on the two methods the base class actually calls:

```ts
export interface BuiltInVoiceProvider {
  getExtraVoices(): SpeechSynthesisVoiceRemote[];
  getVoiceIntroductionUrl(voiceId: string): string;
}
export function isBuiltInVoiceProvider(chatbot: Chatbot): chatbot is Chatbot & BuiltInVoiceProvider { … }
```

The base class no longer imports any concrete chatbot — the cycle and the test mock are both gone.

## Behaviour preserved

`PiAIChatbot` is still the **only** chatbot exposing both methods (verified by grep), so the exact same code paths fire for Pi and stay inert for Claude/ChatGPT. Capability detection is also strictly more correct than `instanceof`: a future built-in-voice chatbot qualifies without the base class knowing about it.

## TDD (fail-first)

1. Added a capability test: a plain object with the two methods must trigger the Pi voice path. **Failed** under `instanceof` (`expected "spy" to be called at least once`) — proving the gate was concrete-class-bound.
2. Implemented the guard → test passes.
3. Removed the now-unnecessary `vi.mock("../../src/chatbots/Pi")`; the spec still loads, proving the cycle is broken.

## Verification

- `npm test` (tsc + Jest + Vitest): **green** — 1068 passed, 1 skipped.
- `wxt build` (real bundler import graph — the relevant signal for a cycle fix): **clean**.

Part of the Preact UI foundation series (follows #385 / PR5a). This is PR5b of the deferred CallButton "Option B" path — pure-refactor hygiene retiring test hacks left by the import cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)