### PR TITLE
fix(tts): make the SayPi voice-selection introduction actually play (#375)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -556,6 +556,16 @@
     "message": "Hola! Привет! 你好! I'm Pi, your polyglot AI assistant. With 32 languages at my command, we can explore ideas and cultures from around the world. What do you think of this voice?",
     "description": "Introduction for the Joey voice."
   },
+  "voiceIntroductionGeneric": {
+    "message": "Hi, I'm $voice$. This is how I sound. I hope you like this voice!",
+    "description": "Generic spoken introduction played when a selected SayPi voice has no voice-specific introduction script (and there is no recent message to read back).",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "soundEffectsFirefoxDisabled": {
     "message": "Sound effects are disabled in Firefox to prevent audio feedback issues."
   },

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -292,6 +292,36 @@ class SpeechSynthesisModule {
     EventBus.emit("saypi:tts:speechStreamEnded", utterance);
   }
 
+  /**
+   * Synthesize a known-complete string (e.g. a voice-selection introduction) as a
+   * single, fully-finalized speech stream, ready to hand to `speak()`.
+   *
+   * Uses the SAME streaming contract as conversation-turn TTS — open the stream
+   * (POST), send the full text (PUT), finalize (PUT final-chunk) — so the resulting
+   * `…/speak/<id>/stream` source plays through the audio-output path. (#375)
+   *
+   * Why not the simpler calls: `createSpeech(text, false)` yields a non-streaming
+   * `…/speak/<id>` URL that the source parser rejects ("is not a streaming speech
+   * URL"); `createSpeech(text, true)` opens a stream URL the parser accepts but never
+   * sends the text via the PUT-chunk protocol, so the audio GET returns 405 and
+   * nothing plays. Both leave the intro silent.
+   *
+   * Returns a silent placeholder/failed utterance unchanged when voice is off or
+   * synthesis can't start (no text is sent, nothing to finalize).
+   */
+  async createCompletedSpeechStream(
+    text: string,
+    chatbot?: Chatbot
+  ): Promise<SpeechUtterance> {
+    const utterance = await this.createSpeechStream(chatbot);
+    if (isPlaceholderUtterance(utterance) || isFailedUtterance(utterance)) {
+      return utterance;
+    }
+    await this.addSpeechToStream(utterance.id, text);
+    await this.endSpeechStream(utterance);
+    return utterance;
+  }
+
   speak(speech: SpeechUtterance, chatbot?: Chatbot): void {
     if (isPlaceholderUtterance(speech)) {
       // Expected whenever voice is off (the auto-TTS path yields a placeholder):

--- a/src/tts/VoiceMenu.ts
+++ b/src/tts/VoiceMenu.ts
@@ -279,8 +279,16 @@ export abstract class VoiceSelector {
   introduceVoice(voice: SpeechSynthesisVoiceRemote): void {
     const lastMessage = getMostRecentAssistantMessage(this.chatbot);
     const name = voice.name.toLowerCase().replace(" ", "_");
+    // Most SayPi voices have no voice-specific `voiceIntroduction_<name>` script
+    // (only a couple do). On a fresh chat (no recent message to read back),
+    // chrome.i18n.getMessage returns "" for the missing key, leaving the intro text
+    // EMPTY — which synthesizes nothing (a blank stream the server 405s) and was a
+    // root cause of the silent intro alongside the non-streaming URL (#375). Fall
+    // back to a generic spoken introduction so every voice actually says something.
     const introduction =
-      lastMessage?.text || getMessage(`voiceIntroduction_${name}`);
+      lastMessage?.text ||
+      getMessage(`voiceIntroduction_${name}`) ||
+      getMessage("voiceIntroductionGeneric", [voice.name]);
     if (voice.default && isBuiltInVoiceProvider(this.chatbot)) {
       const introductionUrl = this.chatbot.getVoiceIntroductionUrl(voice.id);
       if (introductionUrl) {
@@ -288,11 +296,20 @@ export abstract class VoiceSelector {
         EventBus.emit("audio:load", { url: introductionUrl });
       }
     } else {
-      // introduce the custom voice
+      // Introduce the custom voice through the SAME finalized streaming path the
+      // conversation-turn TTS uses (open → send text → finalize), so the resulting
+      // `…/speak/<id>/stream` source plays. A plain non-streaming createSpeech yields
+      // a `…/speak/<id>` URL the audio-output parser rejects ("is not a streaming
+      // speech URL"); an un-finalized stream 405s on playback — both left the intro
+      // silent (#375). introduceVoice runs after setVoice persists, so the stream's
+      // preferred voice is the just-selected voice.
+      if (!introduction || !introduction.trim()) {
+        // Nothing to say — don't synthesize an empty stream (no audio + a 405).
+        return;
+      }
       const speechSynthesis = SpeechSynthesisModule.getInstance();
-      const notEnglish = "";
       speechSynthesis
-        .createSpeech(introduction, false, notEnglish)
+        .createCompletedSpeechStream(introduction, this.chatbot)
         .then((utterance) => {
           utterance.voice = voice;
           speechSynthesis.speak(utterance);

--- a/test/tts/SpeechSynthesisModule.spec.ts
+++ b/test/tts/SpeechSynthesisModule.spec.ts
@@ -137,6 +137,46 @@ describe("SpeechSynthesisModule", () => {
     expect(audioStreamManagerMock.createStream).toHaveBeenCalled();
   });
 
+  it("createCompletedSpeechStream opens, sends the full text, and finalizes a one-shot stream (#375)", async () => {
+    const mockUtterance = {
+      id: "intro-uuid",
+      text: " ",
+      lang: "en-US",
+      voice: mockVoices[0],
+      uri: "https://api.saypi.ai/speak/intro-uuid/stream?voice_id=x",
+      provider: audioProviders.SayPi,
+    };
+    (audioStreamManagerMock.createStream as Mock).mockResolvedValue(mockUtterance);
+
+    const utterance = await speechSynthesisModule.createCompletedSpeechStream(
+      "Hi, I'm Jarnathan.",
+      { getID: () => "claude" } as any
+    );
+
+    expect(audioStreamManagerMock.createStream).toHaveBeenCalled();
+    // Full text sent via the PUT-chunk protocol, then finalized — so the stream's
+    // `…/speak/<id>/stream` GET returns audio (a bare createSpeech 405s).
+    expect(audioStreamManagerMock.addSpeechToStream).toHaveBeenCalledWith(
+      "intro-uuid",
+      "Hi, I'm Jarnathan."
+    );
+    expect(audioStreamManagerMock.endStream).toHaveBeenCalledWith("intro-uuid");
+    expect(utterance).toBe(mockUtterance);
+  });
+
+  it("createCompletedSpeechStream sends no text and finalizes nothing when voice is off (#375)", async () => {
+    (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(null);
+
+    const utterance = await speechSynthesisModule.createCompletedSpeechStream(
+      "Hi.",
+      { getID: () => "claude" } as any
+    );
+
+    expect(isPlaceholderUtterance(utterance)).toBe(true);
+    expect(audioStreamManagerMock.addSpeechToStream).not.toHaveBeenCalled();
+    expect(audioStreamManagerMock.endStream).not.toHaveBeenCalled();
+  });
+
   it("reuses an open stream when the same messageId is provided", async () => {
     const mockVoice = mockVoices[0];
     const mockUtterance = {

--- a/test/tts/VoiceIntroduction.spec.ts
+++ b/test/tts/VoiceIntroduction.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/ConfigModule", () => ({
+  config: { appServerUrl: "https://app.example.com", apiServerUrl: "https://api.saypi.ai" },
+}));
+
+// Break the VoiceMenu -> Pi -> PiVoiceMenu -> VoiceMenu import cycle.
+vi.mock("../../src/chatbots/Pi", () => ({ PiAIChatbot: class {} }));
+
+vi.mock("../../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({ isAuthenticated: () => true, getClaims: () => null }),
+}));
+
+// No recent assistant message → introduceVoice falls back to the per-voice intro string.
+vi.mock("../../src/dom/ChatHistory", () => ({ getMostRecentAssistantMessage: () => undefined }));
+const getMessageMock = vi.fn((key: string, _subs?: string[]) => `intro:${key}`);
+vi.mock("../../src/i18n", () => ({ default: (key: string, subs?: string[]) => getMessageMock(key, subs) }));
+
+const createCompletedSpeechStreamMock = vi.fn();
+const createSpeechMock = vi.fn();
+const speakMock = vi.fn();
+vi.mock("../../src/tts/SpeechSynthesisModule", () => ({
+  SpeechSynthesisModule: {
+    getInstance: () => ({
+      createCompletedSpeechStream: createCompletedSpeechStreamMock,
+      createSpeech: createSpeechMock,
+      speak: speakMock,
+    }),
+  },
+}));
+
+import { VoiceSelector } from "../../src/tts/VoiceMenu";
+
+class TestVoiceSelector extends VoiceSelector {
+  getId(): string {
+    return "test-voice-selector";
+  }
+  getButtonClasses(): string[] {
+    return [];
+  }
+}
+
+/**
+ * #375: introducing a SayPi custom voice must request a STREAMING speech source.
+ * The non-streaming `createSpeech(text, false)` builds a `…/speak/<id>` URL (no
+ * `/stream` segment), which the audio-output source parser rejects with
+ * "is not a streaming speech URL" → the intro is silent + an error is logged.
+ */
+describe("VoiceSelector.introduceVoice — streaming source (#375)", () => {
+  let selector: TestVoiceSelector;
+  const customVoice: any = { id: "vabc", name: "Jarnathan", default: false, powered_by: "inflection.ai" };
+
+  beforeEach(() => {
+    createCompletedSpeechStreamMock.mockReset().mockResolvedValue({ voice: null });
+    createSpeechMock.mockReset().mockResolvedValue({ voice: null });
+    speakMock.mockReset();
+    getMessageMock.mockReset().mockImplementation((key: string) => `intro:${key}`);
+    const el = document.createElement("div");
+    // A non-Pi chatbot so introduceVoice takes the custom-voice branch.
+    const chatbot: any = { getID: () => "claude" };
+    selector = new TestVoiceSelector(chatbot, {} as any, el);
+  });
+
+  it("introduces the custom voice via a finalized streaming source, not non-streaming createSpeech", async () => {
+    selector.introduceVoice(customVoice);
+    // allow the createCompletedSpeechStream promise chain to settle
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The finalized-streaming path (open → send text → finalize) is what produces a
+    // playable `…/speak/<id>/stream` source; the non-streaming createSpeech is not used.
+    expect(createCompletedSpeechStreamMock).toHaveBeenCalledTimes(1);
+    expect(createSpeechMock).not.toHaveBeenCalled();
+    const [textArg] = createCompletedSpeechStreamMock.mock.calls[0];
+    expect(textArg).toBe(`intro:voiceIntroduction_jarnathan`);
+    expect(speakMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the generic introduction when the voice has no voice-specific script", async () => {
+    // chrome.i18n returns "" for a missing voiceIntroduction_<name> key.
+    getMessageMock.mockImplementation((key: string, subs?: string[]) =>
+      key === "voiceIntroductionGeneric" ? `Hi, I'm ${subs?.[0]}.` : ""
+    );
+
+    selector.introduceVoice(customVoice);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(createCompletedSpeechStreamMock).toHaveBeenCalledTimes(1);
+    const [textArg] = createCompletedSpeechStreamMock.mock.calls[0];
+    expect(textArg).toBe("Hi, I'm Jarnathan."); // non-empty → something to synthesize
+    expect(speakMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT synthesize an empty intro (no blank stream / 405) when there is no text at all", async () => {
+    getMessageMock.mockImplementation(() => ""); // every i18n lookup empty
+
+    selector.introduceVoice(customVoice);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(createCompletedSpeechStreamMock).not.toHaveBeenCalled();
+    expect(createSpeechMock).not.toHaveBeenCalled();
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #375.

## Root causes (both confirmed live on claude.ai via Layer-4 CDP)
1. **Non-streaming source.** `introduceVoice` called `createSpeech(text, /*stream=*/false)` → a `…/speak/<id>` URL. The audio-output source parser (`AudioOutputMachine` → `SayPiSpeechSourceParser`) only accepts `…/speak/<id>/stream` and threw `is not a streaming speech URL` (the reported error) → silent intro.
2. **Empty intro text.** Most SayPi voices have no `voiceIntroduction_<name>` script (only `joey`/`paola`). On a fresh chat (no recent message to read back), `chrome.i18n.getMessage` returns `""` for the missing key → empty text → nothing to synthesize (a blank stream the server 405s). Confirmed live: the first attempt streamed a `length=0` chunk.

## Fix
- New `SpeechSynthesisModule.createCompletedSpeechStream(text, chatbot)` — synthesizes a known-complete string through the **same finalized streaming contract** conversation-turn TTS uses (open → send full text → finalize), so the resulting `…/speak/<id>/stream` source plays. Returns the placeholder unchanged when voice is off.
- `introduceVoice` uses it (runs after `setVoice` persists → the stream's preferred voice is the just-selected voice).
- New en i18n `voiceIntroductionGeneric` (`"Hi, I'm $voice$. …"`) fallback so every voice says something, plus a guard that skips synthesis entirely when there's no text (no blank stream / 405). _31-locale MT is the usual founder-run follow-up; non-en falls back to en._

Why not the simpler one-liners (both tried + live-disproven): `createSpeech(text, false)` → parser rejects; `createSpeech(text, true)` → opens a stream but never sends text via the PUT-chunk protocol → audio GET 405s.

## Tests
- `test/tts/VoiceIntroduction.spec.ts` (fail-first): uses the finalized streaming path (not non-streaming createSpeech); generic fallback when no voice-specific script; skips empty synthesis.
- `test/tts/SpeechSynthesisModule.spec.ts`: helper opens→sends full text→finalizes; voice-off sends nothing.

## Live verification (Layer-4 CDP, real claude.ai, fix build, Jarnathan selected)
```
chunk seq=1 length=67   "Hi, I'm Jarnathan. This is how I sound…"
Pi started speaking as Jarnathan by ElevenLabs   (parser accepted the /stream URL)
AUDIO_PLAYING → loaded:playing → AUDIO_ENDED      (plays to completion)
no "is not a streaming speech URL" error · saypiErr=0 · conversation-turn TTS unchanged
```

## Note
The regenerate-speech button (`src/dom/regenerateSpeech.ts`) shares the same non-streaming `createSpeech(text, false)` root cause and is a candidate sibling fix — left out of this PR to keep it scoped to the reported intro bug; can adopt `createCompletedSpeechStream` in a follow-up once its playback is separately verified.