### PR TITLE
fix(tooling): layer4cdp verify() turn-confirm on auto-submit hosts + document one-shot synthetic audio (#364)

### DIFF
--- a/doc/synthetic-voice-turn.md
+++ b/doc/synthetic-voice-turn.md
@@ -58,6 +58,20 @@ Cloudflare checkbox) → in that window enable **Developer mode** + **Load unpac
 must say **VERDICT: usable** before `verify`. Full guide:
 `doc/layer4-cdp-real-host-loop.md`.
 
+## Known limitations (#364)
+
+- **One synthetic utterance per call.** The synthetic audio source is one-shot — the
+  clip plays from a non-restartable `AudioBufferSourceNode` (`src/offscreen/synthetic-audio.ts`).
+  Re-dispatching `saypi:dev-feed-speech` **mid-call does not drive a second
+  transcribed turn**. Sanctioned workaround: drive **one** synthetic turn per call,
+  then relaunch the call (toggle `#saypi-callButton`) — or just re-run
+  `layer4cdp verify` — for the next turn. Multi-turn-in-one-call is not supported.
+- **`verify()` turn confirmation is composer-clear-safe.** On auto-submit hosts
+  (chatgpt.com / claude.ai) the composer is cleared on submit, so `verify()` confirms
+  a turn by EITHER a transcript in the composer (pi.ai) OR a new message appearing in
+  the thread (`confirmTurn` in `scripts/layer4cdp-lib.mjs`). It no longer false-reports
+  "WARN: no transcript" for a turn that actually submitted.
+
 ## Where the pieces live
 
 - **Hooks:** `src/dev/devReload.ts` (`saypi:dev-feed-speech`, `saypi:dev-reload`).

--- a/scripts/layer4cdp-lib.mjs
+++ b/scripts/layer4cdp-lib.mjs
@@ -89,3 +89,44 @@ export function isCloudflareChallenge({ title = "", url = "", html = "" } = {}) 
     h.includes("verify you are human")
   );
 }
+
+/**
+ * Generic, host-agnostic selector for conversation messages — used to detect that a
+ * synthetic voice turn was submitted on hosts that CLEAR the composer on submit
+ * (chatgpt.com / claude.ai). Covers pi.ai / Claude / ChatGPT message markers.
+ */
+export const TURN_MESSAGE_SELECTOR = [
+  "[data-message-author-role]",
+  "[data-testid='user-message']",
+  ".font-claude-message",
+  ".assistant-message",
+  "[data-turn='user']",
+  "[data-turn='assistant']",
+].join(", ");
+
+/**
+ * Decide whether a synthetic voice turn was confirmed, robust to auto-submit hosts
+ * that CLEAR the composer on submit (#364). A composer-only check false-negatives
+ * there ("WARN: no transcript") even when the turn actually submitted and the
+ * assistant replied.
+ *
+ * A turn is confirmed if EITHER a transcript is currently sitting in the composer
+ * (pi.ai retains it) OR the conversation thread has grown by at least one message
+ * since the pre-turn baseline (the transcript was submitted and cleared).
+ *
+ * @param {{composer?: string, messageCount?: number, baselineMessageCount?: number}} state
+ * @returns {{confirmed: boolean, reason: string}}
+ */
+export function confirmTurn({ composer = "", messageCount = 0, baselineMessageCount = 0 } = {}) {
+  const text = (composer || "").trim();
+  if (text.length > 0) {
+    return { confirmed: true, reason: "transcript drafted into the composer" };
+  }
+  if (messageCount > baselineMessageCount) {
+    return {
+      confirmed: true,
+      reason: "turn submitted (composer cleared on auto-submit host)",
+    };
+  }
+  return { confirmed: false, reason: "no transcript and no new message" };
+}

--- a/scripts/layer4cdp.mjs
+++ b/scripts/layer4cdp.mjs
@@ -28,6 +28,8 @@ import {
   resolveCdpProfileDir,
   buildCdpChromeArgs,
   isCloudflareChallenge,
+  confirmTurn,
+  TURN_MESSAGE_SELECTOR,
 } from "./layer4cdp-lib.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -256,18 +258,45 @@ async function verify(opts) {
     const build = await page.evaluate(() => document.documentElement.dataset.saypiBuild ?? "(none)");
     log(`loaded build: ${build}`);
     if (!opts.noTurn) {
+      // Baseline the thread BEFORE the turn so we can detect a submitted message on
+      // auto-submit hosts that clear the composer (#364) — a composer-only check
+      // false-negatives there ("WARN: no transcript") even when the turn succeeded.
+      const baselineMessageCount = await page
+        .evaluate((sel) => document.querySelectorAll(sel).length, TURN_MESSAGE_SELECTOR)
+        .catch(() => 0);
       // One-shot (#349): loop:true never produces an end-of-speech gap → no transcript.
       await page.evaluate(() =>
         window.dispatchEvent(new CustomEvent("saypi:dev-feed-speech", { detail: { loop: false } })));
       await page.click("#saypi-callButton").catch(() => log("could not click call button"));
-      log("armed synthetic speech + started a call; watching the prompt…");
-      const got = await page
-        .waitForFunction(() => {
-          const el = document.querySelector("#saypi-prompt, [contenteditable='true'], textarea");
-          return !!(el && (el.value ?? el.textContent ?? "").trim().length > 0);
-        }, undefined, { timeout: 30_000 })
-        .then(() => true).catch(() => false);
-      log(got ? "OK: transcript drafted into the composer" : "WARN: no transcript (real STT/host may differ; decoration verified)");
+      log("armed synthetic speech + started a call; watching for a transcript or a submitted turn…");
+      // Poll for EITHER a transcript in the composer (pi.ai retains it) OR a new
+      // message in the thread (auto-submit hosts clear the composer on submit).
+      let verdict = { confirmed: false, reason: "no transcript and no new message" };
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        const state = await page
+          .evaluate((sel) => {
+            const el = document.querySelector("#saypi-prompt, [contenteditable='true'], textarea");
+            return {
+              composer: el ? (el.value ?? el.textContent ?? "") : "",
+              messageCount: document.querySelectorAll(sel).length,
+            };
+          }, TURN_MESSAGE_SELECTOR)
+          .catch(() => ({ composer: "", messageCount: baselineMessageCount }));
+        verdict = confirmTurn({ ...state, baselineMessageCount });
+        if (verdict.confirmed) break;
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      log(
+        verdict.confirmed
+          ? `OK: ${verdict.reason}`
+          : "WARN: no transcript (real STT/host may differ; decoration verified)"
+      );
+      // KNOWN LIMITATION (#364): the synthetic audio source is one-shot — a second
+      // `saypi:dev-feed-speech` mid-call does NOT drive another transcribed turn
+      // (src/offscreen/synthetic-audio.ts builds a non-restartable AudioBufferSourceNode).
+      // Drive ONE synthetic turn per call; relaunch the call (or re-run verify) for
+      // another. See doc/synthetic-voice-turn.md.
     }
     code = 0;
   } catch (err) {

--- a/test/scripts/layer4cdp-lib.spec.ts
+++ b/test/scripts/layer4cdp-lib.spec.ts
@@ -4,7 +4,40 @@ import {
   resolveCdpProfileDir,
   buildCdpChromeArgs,
   isCloudflareChallenge,
+  confirmTurn,
+  TURN_MESSAGE_SELECTOR,
 } from "../../scripts/layer4cdp-lib.mjs";
+
+describe("confirmTurn (#364 — composer-clear-safe turn confirmation)", () => {
+  it("confirms when a transcript is in the composer (pi.ai retains it)", () => {
+    const r = confirmTurn({ composer: "  hello there ", messageCount: 0, baselineMessageCount: 0 });
+    expect(r.confirmed).toBe(true);
+    expect(r.reason).toMatch(/composer/i);
+  });
+
+  it("confirms on auto-submit hosts where the composer is cleared but the thread grew", () => {
+    // The bug: composer is empty (cleared on submit) yet the turn DID submit.
+    const r = confirmTurn({ composer: "", messageCount: 1, baselineMessageCount: 0 });
+    expect(r.confirmed).toBe(true);
+    expect(r.reason).toMatch(/submitted/i);
+  });
+
+  it("does NOT false-positive on pre-existing messages (no growth, empty composer)", () => {
+    const r = confirmTurn({ composer: "   ", messageCount: 4, baselineMessageCount: 4 });
+    expect(r.confirmed).toBe(false);
+  });
+
+  it("is not confirmed when nothing happened", () => {
+    expect(confirmTurn({ composer: "", messageCount: 0, baselineMessageCount: 0 }).confirmed).toBe(false);
+    expect(confirmTurn().confirmed).toBe(false);
+  });
+
+  it("exposes a host-agnostic message selector covering pi/claude/chatgpt markers", () => {
+    expect(TURN_MESSAGE_SELECTOR).toContain("[data-message-author-role]");
+    expect(TURN_MESSAGE_SELECTOR).toContain(".font-claude-message");
+    expect(TURN_MESSAGE_SELECTOR).toContain("[data-turn='assistant']");
+  });
+});
 
 describe("parseLayer4CdpArgs", () => {
   it("parses seed / diagnose / self-test", () => {


### PR DESCRIPTION
Closes #364. Both DEV-only test-harness limitations.

## Limitation 1 — FIXED
`verify()` confirmed a synthetic voice turn by polling **only the composer** for non-empty text. On auto-submit hosts (chatgpt.com / claude.ai) the composer is cleared on submit → the poll timed out → false `WARN: no transcript` even though the turn submitted and the assistant replied.

**Fix:** new pure, unit-tested `confirmTurn(...)` + host-agnostic `TURN_MESSAGE_SELECTOR` in `scripts/layer4cdp-lib.mjs`. A turn is confirmed if a transcript is in the composer (pi.ai retains it) **OR** the thread grew by ≥1 message since a pre-turn baseline (transcript submitted/cleared). `verify()` baselines the thread, then polls for either signal.

## Limitation 2 — DOCUMENTED (per the AC)
The synthetic audio source is one-shot (non-restartable `AudioBufferSourceNode`), so a second `saypi:dev-feed-speech` mid-call doesn't drive another transcribed turn. Documented as a known limitation with the sanctioned workaround (one synthetic turn per call; relaunch the call / re-run `verify` for another) in `doc/synthetic-voice-turn.md` + an inline note in `verify()`. The AC explicitly allows "OR the inability … is explicitly documented as a known harness limitation with a sanctioned alternative."

## Tests
5 fail-first unit tests for `confirmTurn` (composer-retained; composer-cleared + thread-grew; no false-positive on pre-existing messages; nothing-happened; selector coverage).

## Live smoke (Layer-4 CDP, real chatgpt.com)
```
$ node scripts/layer4cdp.mjs verify https://chatgpt.com/
OK: SayPi decorated the page (#saypi-callButton present)
armed synthetic speech + started a call; watching for a transcript or a submitted turn…
OK: turn submitted (composer cleared on auto-submit host)   ← was: WARN: no transcript
```