### PR TITLE
fix(tts): stop reading Claude's extended-thinking preamble so speech caches (#383)

### DIFF
--- a/src/chatbots/claude/ClaudeResponse.ts
+++ b/src/chatbots/claude/ClaudeResponse.ts
@@ -10,9 +10,24 @@ import { logger } from "../../LoggingModule";
  * logic cohesive and easy to test in isolation.
  */
 
-// Reusable text extractor so all Claude entry points share filters
+// Reusable text extractor so all Claude entry points share filters.
+//
+// `sr-only` is Tailwind's visually-hidden utility: text present only for screen
+// readers. SayPi reads the *visible* response aloud, so sr-only content must be
+// skipped. Critically, claude.ai's extended-thinking disclosure mirrors its
+// streaming summary headline ("Thinking about…", "Deciphering…") into a sibling
+// `span.sr-only` that sits OUTSIDE the `transition-colors` toggle button. Without
+// this filter that announcer leaks into the spoken stream — read aloud and
+// charged — and, because it cycles through a sequence of headlines while only the
+// final one survives into the settled message text, the streamed-vs-message hash
+// never matches and the speech is never cached (issue #383).
 export function extractClaudeReadableText(node: Node): string {
-  const BLOCKED_CLASSES = new Set(["transition-all", "transition-colors", "code-block__code"]);
+  const BLOCKED_CLASSES = new Set([
+    "transition-all",
+    "transition-colors",
+    "code-block__code",
+    "sr-only",
+  ]);
   const BLOCKED_CLASS_COMBINATIONS = [["ease-out", "border-border-300"]];
   const SKIPPED_ELEMENTS = new Set(["pre"]);
 

--- a/test/chatbots/ClaudeTextStream.spec.ts
+++ b/test/chatbots/ClaudeTextStream.spec.ts
@@ -275,3 +275,90 @@ test("keeps tool-use active while tool content updates and stops when removed", 
   subscription.unsubscribe();
   message.remove();
 });
+
+// Faithful reproduction of claude.ai's extended-thinking disclosure (captured
+// live 2026-06-20, see issue #383). The visible headline lives in a
+// `transition-colors` button (already filtered), but a *sibling* `span.sr-only`
+// mirrors the same headline and—prior to the fix—leaked through the text filter.
+function buildClaudeThinkingDisclosure(headline: string): HTMLElement {
+  const block = document.createElement("div");
+  block.className = "min-w-0 pl-2 py-1.5";
+
+  const row = document.createElement("div");
+  row.className = "flex items-center gap-2";
+  const button = document.createElement("button");
+  // The collapse toggle carries `transition-colors`, so extractClaudeReadableText
+  // drops everything inside it (including the visible summary label).
+  button.className =
+    "group/status flex items-center gap-2 py-1 text-sm transition-colors cursor-pointer text-left text-text-500";
+  const labelWrap = document.createElement("div");
+  labelWrap.className = "inline-flex items-center gap-1 min-w-0";
+  const label = document.createElement("span");
+  label.className = "truncate font-base";
+  label.textContent = headline;
+  labelWrap.appendChild(label);
+  button.appendChild(labelWrap);
+  row.appendChild(button);
+  block.appendChild(row);
+
+  // The screen-reader announcer sits OUTSIDE the transition-colors button.
+  const srOnly = document.createElement("span");
+  srOnly.className = "sr-only";
+  srOnly.textContent = headline;
+  block.appendChild(srOnly);
+
+  // Collapsed thinking body (empty when settled, present throughout).
+  const collapsible = document.createElement("div");
+  collapsible.className = "grid transition-[grid-template-rows] duration-300 ease-out";
+  const inner = document.createElement("div");
+  inner.className = "overflow-hidden min-w-0";
+  collapsible.appendChild(inner);
+  block.appendChild(collapsible);
+
+  return block;
+}
+
+test("getNestedText excludes the extended-thinking sr-only summary preamble (#383)", async () => {
+  const { ClaudeTextStream } = await importClaude();
+
+  const root = document.createElement("div");
+  root.appendChild(buildClaudeThinkingDisclosure("Thinking about voice activity detection"));
+  const answer = document.createElement("p");
+  answer.textContent = "The answer is 408.";
+  root.appendChild(answer);
+
+  const stream = new ClaudeTextStream(root, { includeInitialText: false });
+  const extracted = stream.getNestedText(root).replace(/\s+/g, " ").trim();
+
+  // Only the answer is read aloud — not the thinking preamble (sr-only or label).
+  expect(extracted).toBe("The answer is 408.");
+  expect(extracted.includes("Thinking about voice activity detection")).toBe(false);
+});
+
+test("getNestedText stays stable as the thinking preamble cycles, so streamed text matches the message text (#383)", async () => {
+  const { ClaudeTextStream } = await importClaude();
+
+  const root = document.createElement("div");
+  const disclosure = buildClaudeThinkingDisclosure("Thinking about the question");
+  root.appendChild(disclosure);
+  const answer = document.createElement("p");
+  answer.textContent = "The answer is 408.";
+  root.appendChild(answer);
+
+  const stream = new ClaudeTextStream(root, { includeInitialText: false });
+  const first = stream.getNestedText(root).replace(/\s+/g, " ").trim();
+
+  // While Claude streams, the summary headline cycles through a sequence; the
+  // hash mismatch arises because the spoken stream accumulates every headline
+  // while the settled message text keeps only the last. After the fix the
+  // extracted text ignores the preamble entirely, so it never changes.
+  const label = disclosure.querySelector("span.truncate") as HTMLElement;
+  const srOnly = disclosure.querySelector("span.sr-only") as HTMLElement;
+  label.textContent = "Deciphering the details";
+  srOnly.textContent = "Deciphering the details";
+  const second = stream.getNestedText(root).replace(/\s+/g, " ").trim();
+
+  expect(first).toBe("The answer is 408.");
+  expect(second).toBe("The answer is 408.");
+  expect(first).toBe(second);
+});


### PR DESCRIPTION
## Why

On claude.ai, **every** TTS readback of an extended-thinking reply logged `Hash mismatch` and **never cached** the synthesized speech — so each replay/re-decoration re-synthesized the audio (re-spending credits + latency). Worse, Claude's "Thinking…" preamble was itself **spoken aloud and charged** as part of the answer. Reproduced 3/3 in the Layer-4 host sweep that filed #383.

## Root cause (confirmed against the live claude.ai DOM)

The streaming TTS capture (`ClaudeTextStream`) and the message `.text`/hash path **share one extractor**, `extractClaudeReadableText`, so in principle they agree. They didn't — and capturing the real claude.ai extended-thinking DOM showed why:

- The thinking disclosure's visible summary headline lives in a `button.group/status` carrying **`transition-colors`**, which the filter already drops. ✅
- But a **sibling `span.sr-only`** (the screen-reader announcer) sits *outside* that button and mirrors the same headline — and the filter **kept** it. ❌

While Claude thinks, that announcer cycles through a *sequence* of headlines. Captured live:

```
"Systematizing sorting algorithm comparison…"
→ "Dissecting bubble sort's time complexity…"
→ "Analyzed three sorting algorithms across complexity, stability…"
```

The streaming capture emits **every** headline (→ spoken + charged); the settled `.text` keeps only the **final** one. So accumulated-spoken-text ≠ message-text → `completedHash !== messageHash` → `handleSpeechCompletion` returns before `addSpeechToHistory`.

## Fix

Add `sr-only` to the blocked classes in `extractClaudeReadableText` (one Set entry). `sr-only` is Tailwind's visually-hidden utility — accessibility text SayPi should never read aloud anyway. Because the streaming capture **and** the message-text/hash path use this same function, they stay byte-identical → the hash matches, the speech caches, and the preamble is no longer spoken or charged.

Considered but scoped out: excluding the whole thinking block structurally. The reported/reproduced defect is exactly the `sr-only` announcer leak (default-collapsed thinking); the surgical change is the smallest safe fix and avoids risking the answer-text boundary.

## Acceptance criteria

- [x] Spoken/completed text and message `.text` use the same filtering → `completedHash === messageHash` → `addSpeechToHistory` runs, no `Hash mismatch`.
- [x] Extended-thinking preamble is not read aloud or charged (the `sr-only` announcer is now excluded from the stream).
- [x] Non-extended-thinking Claude replies unaffected; pi.ai / chatgpt.com unaffected (Claude-only extractor; no sr-only thinking announcer elsewhere).

## Verification

- **Fail-first unit tests** (`test/chatbots/ClaudeTextStream.spec.ts`, built from the captured DOM): reproduce the accumulate-the-preamble mechanism — the extracted text carried `"Thinking about…"` exactly **once** (proving the visible label was already filtered and only the `sr-only` leaked), and stayed unstable as the headline cycled. Both pass after the fix; the 7 existing tests stay green.
- **Full required gate green**: `tsc --noEmit` + Jest + Vitest (1085 passed / 1 skipped).
- **Real-host DOM fidelity**: running the fixed filter against the *actual live claude.ai extended-thinking response* now excludes the preamble (`"Analyzed three sorting algorithms…"` → empty) and yields the clean answer (`"I'll break down these three sorting algorithms…"`), where the old filter leaked the preamble.

Fixes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)