### PR TITLE
fix(claude): load SayPi chrome on full thread reload

### DIFF
--- a/src/chatbots/bootstrap.ts
+++ b/src/chatbots/bootstrap.ts
@@ -198,6 +198,43 @@ export class DOMObserver {
     // Start observing immediately only if current page is chatable
     if (this.shouldDecorateUI()) {
       this.startObservingDom();
+      // Decorate whatever is ALREADY in the DOM. The MutationObserver only reacts
+      // to nodes added *after* it attaches, and monitorForRouteChanges only fires
+      // on a URL change — so on a full page reload of an existing thread (e.g.
+      // claude.ai/chat/<uuid>), where the composer is already present when we
+      // attach and the URL never changes, neither path would ever decorate the
+      // prompt. Without this scan the call button (and the rest of the
+      // content-loaded chain) never appears. Idempotent and safe to retry.
+      this.bootstrapInitialDecoration();
+    }
+  }
+
+  /**
+   * Decorates the prompt that is already present in the DOM at startup, emitting
+   * "saypi:ui:content-loaded" once it is ready to kick off the rest of the
+   * bootstrap chain. Mirrors startChatHistoryProgressiveSearch's backoff so a
+   * composer that hydrates slightly after document_idle is still caught even if
+   * its insertion doesn't surface to the MutationObserver as an added node.
+   */
+  private bootstrapInitialDecoration(attempt = 1, maxAttempts = 10): void {
+    if (!this.shouldDecorateUI()) {
+      return;
+    }
+    const promptObs = this.findAndDecoratePrompt(document.body);
+    if (promptObs.isReady()) {
+      EventBus.emit("saypi:ui:content-loaded");
+      return;
+    }
+    // Already decorated by another path → the chain has already started; stop.
+    if (promptObs.found) {
+      return;
+    }
+    if (attempt < maxAttempts) {
+      const delay = Math.min(100 * Math.pow(1.5, attempt - 1), 3000);
+      setTimeout(
+        () => this.bootstrapInitialDecoration(attempt + 1, maxAttempts),
+        delay
+      );
     }
   }
 

--- a/test/chatbots/ClaudeBootstrapReload.spec.ts
+++ b/test/chatbots/ClaudeBootstrapReload.spec.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// bootstrap.ts → Claude.ts pull in MessageElements + VoiceMenu transitively;
+// stub them (mirrors ClaudeSidebarConfig.spec.ts / ClaudePlaceholderSuppression.spec.ts).
+vi.mock("../../src/dom/MessageElements", () => {
+  class AssistantResponse {}
+  class MessageControls {}
+  class UserMessage {}
+  return { AssistantResponse, MessageControls, UserMessage };
+});
+
+vi.mock("../../src/tts/VoiceMenu", () => {
+  class VoiceSelector {
+    constructor() {}
+    getId() { return "voice-selector"; }
+    getButtonClasses() { return []; }
+  }
+  return { VoiceSelector, addSvgToButton: () => {} };
+});
+
+vi.mock("../../src/prefs/PreferenceModule", () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({
+      reloadCache: vi.fn(),
+      getLanguage: vi.fn().mockResolvedValue("en-US"),
+    }),
+  },
+}));
+
+vi.mock("../../src/tts/VoiceMenuUIManager", () => ({
+  VoiceMenuUIManager: class {
+    constructor() {}
+    findAndDecorateVoiceMenu() {}
+  },
+}));
+
+// decoratePrompt fires AgentModeNoticeModule.showNoticeIfNeeded() (async, fire-and-forget);
+// stub it so the test stays hermetic and its caught rejection doesn't log noise.
+vi.mock("../../src/ui/AgentModeNoticeModule", () => ({
+  AgentModeNoticeModule: {
+    getInstance: () => ({ showNoticeIfNeeded: vi.fn().mockResolvedValue(undefined) }),
+  },
+}));
+
+vi.mock("../../src/ButtonModule.js", () => ({
+  buttonModule: {
+    createCallButton: vi.fn(),
+    createEnterButton: vi.fn(),
+    createExitButton: vi.fn(),
+    createMiniSettingsButton: vi.fn(),
+    createImmersiveModeButton: vi.fn(),
+    createSettingsButton: vi.fn(),
+  },
+}));
+
+let DOMObserver: typeof import("../../src/chatbots/bootstrap").DOMObserver;
+let ClaudeChatbot: typeof import("../../src/chatbots/Claude").ClaudeChatbot;
+let EventBus: typeof import("../../src/events/EventBus.js").default;
+let buttonModule: typeof import("../../src/ButtonModule.js").buttonModule;
+
+beforeAll(async () => {
+  DOMObserver = (await import("../../src/chatbots/bootstrap")).DOMObserver;
+  ClaudeChatbot = (await import("../../src/chatbots/Claude")).ClaudeChatbot;
+  EventBus = (await import("../../src/events/EventBus.js")).default;
+  buttonModule = (await import("../../src/ButtonModule.js")).buttonModule;
+});
+
+/**
+ * Build the real Claude composer shape as it exists on a FULLY RELOADED thread:
+ * the whole composer is already present in the DOM before SayPi attaches, and no
+ * SPA route change follows. Selectors verified against Claude.ts (Dec 2025):
+ *   fieldset.w-full                                   ← getPromptContainer
+ *     └── div.flex.gap-2.w-full.items-center          ← getPromptControlsContainer
+ *           └── div[enterkeyhint]                      ← getPromptInput → #saypi-prompt
+ */
+function buildAlreadyPresentComposer(): void {
+  document.body.innerHTML = `
+    <fieldset class="w-full">
+      <div class="flex gap-2 w-full items-center">
+        <div enterkeyhint="enter" contenteditable="true"></div>
+      </div>
+    </fieldset>`;
+}
+
+describe("Claude bootstrap on full thread reload (#defect: SayPi chrome fails to load)", () => {
+  let observer: InstanceType<typeof DOMObserver>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    EventBus.removeAllListeners("saypi:ui:content-loaded");
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    EventBus.removeAllListeners("saypi:ui:content-loaded");
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("decorates the already-present composer (creates the call button) without any DOM mutation or route change", () => {
+    // The composer is in the DOM BEFORE the observer attaches — exactly what a full
+    // page reload of https://claude.ai/chat/<uuid> produces (server-rendered/hydrated
+    // before document_idle), and the URL never changes afterwards.
+    buildAlreadyPresentComposer();
+
+    observer = new DOMObserver(new ClaudeChatbot());
+    // Simulate a chatable path (/chat/<uuid>); jsdom's location is "/" by default.
+    vi.spyOn(observer as any, "shouldDecorateUI").mockReturnValue(true);
+
+    const contentLoaded = vi.fn();
+    EventBus.on("saypi:ui:content-loaded", contentLoaded);
+
+    observer.observeDOM();
+
+    // No mutations are dispatched and no route change occurs. The call button must
+    // still appear, and the content-loaded chain (visualisations, audio, sidebar)
+    // must still fire — driven by an initial scan of the already-present DOM.
+    expect(buttonModule.createCallButton).toHaveBeenCalled();
+    expect(contentLoaded).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The defect

Reloading an existing Claude conversation (e.g. `https://claude.ai/chat/<uuid>`) left the page looking like **vanilla Claude** — no call button, no SayPi decoration, no way to start a voice turn.

**Repro:** open an existing Claude thread → reload the page → SayPi chrome is absent.

## Root cause

SayPi's entire startup decoration chain is gated on a single event, `saypi:ui:content-loaded`. `DOMObserver` emits it from only two places:

1. **The MutationObserver** — when the prompt arrives as a node *added after* the observer attaches (`domMutationCallback`).
2. **`handleRouteChange`** — fired by the 300 ms URL-change poll in `monitorForRouteChanges`.

On a **full reload of an existing thread**, neither path fires:

- The composer is already in the DOM by the time the content script attaches at `document_idle`, so the MutationObserver never sees it added.
- The URL never changes, so the route-change path never fires.

Result: the prompt is never decorated → the call button is never created → `addVisualisations`, the audio module, sidebar and chat-history decoration all stay dormant.

This is why the failure is **reload-specific**: SPA navigation into a thread works (the route change emits the event), and lighter pages like `/new` usually work (the composer hydrates *after* the observer attaches and is caught as an added node).

## The fix

`observeDOM()` now performs an **initial decoration pass against the already-present DOM** on startup, mirroring the existing `startChatHistoryProgressiveSearch` backoff so a composer that hydrates slightly after `document_idle` is still caught. It decorates the prompt and emits `saypi:ui:content-loaded` once ready, kicking off the rest of the bootstrap chain.

- **Idempotent** — `findPrompt` short-circuits on an existing `#saypi-prompt`, so it can't double-decorate or re-fire the chain.
- **Scoped** — only runs on chatable paths (`shouldDecorateUI()`), same gate as the rest of the observer.
- **Complements, not replaces** — the MutationObserver and route-change paths are untouched; this only fills the "already present at attach, no route change" gap.

## Tests

Fail-first (per the repo's mandatory TDD protocol): `test/chatbots/ClaudeBootstrapReload.spec.ts` builds the real Claude composer already present in the DOM, calls `observeDOM()` with **no** mutation and **no** route change, and asserts the call button is created and `saypi:ui:content-loaded` fires. **Red before the fix, green after.**

Full suite green locally: `tsc --noEmit` + Jest + Vitest (141 files, 1086 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)