### PR TITLE
fix(bootstrap): isolate non-essential init so it can't abort decoration

### DIFF
--- a/src/saypi.index.js
+++ b/src/saypi.index.js
@@ -52,27 +52,43 @@ import "./styles/pi.scss"; // scoped by chatbot flags, i.e. <body class="pi">
   // Initialize common modules needed by both modes
   const audioModule = AudioModule.getInstance(); // inits the audio module's offline functions
 
+  // Non-essential early init (compat notice + auth prompts). These are isolated in
+  // their own try/catch because they `await import(...)` extension chunks, and a
+  // chunk-load rejection — e.g. when the service worker is updating/restarting at
+  // reload time ("Extension context invalidated") — would otherwise abort the whole
+  // bootstrap before `initializeChatMode()` runs, leaving the page looking like
+  // vanilla Claude with no call button. The core decoration must NOT depend on these
+  // succeeding, so a failure here is logged and swallowed rather than propagated.
+
   // Initialize compatibility notification UI early to catch all compatibility events
   logger.debug("Initializing compatibility notification UI");
-  const { CompatibilityNotificationUI } = await import(/* webpackMode: "eager" */ "./compat/CompatibilityNotificationUI.ts");
-  CompatibilityNotificationUI.getInstance().initialize();
+  try {
+    const { CompatibilityNotificationUI } = await import(/* webpackMode: "eager" */ "./compat/CompatibilityNotificationUI.ts");
+    CompatibilityNotificationUI.getInstance().initialize();
+  } catch (error) {
+    logger.error("Compatibility notification UI failed to initialize (non-fatal):", error);
+  }
 
   // Body-portal tooltips for SayPi buttons (escape host overflow/stacking clipping)
   initTooltip();
 
   // Initialize progressive authentication prompt system (for chatbot overlay prompts)
   logger.debug("Initializing auth prompt system");
-  const { getAuthPromptController } = await import(/* webpackMode: "eager" */ "./auth/AuthPromptController.ts");
-  const { getAuthPromptUI } = await import(/* webpackMode: "eager" */ "./auth/AuthPromptUI.ts");
-  const { getUsageTracker } = await import(/* webpackMode: "eager" */ "./auth/UsageTracker.ts");
-  await getAuthPromptController().initialize();
-  getAuthPromptUI().initialize();
+  try {
+    const { getAuthPromptController } = await import(/* webpackMode: "eager" */ "./auth/AuthPromptController.ts");
+    const { getAuthPromptUI } = await import(/* webpackMode: "eager" */ "./auth/AuthPromptUI.ts");
+    const { getUsageTracker } = await import(/* webpackMode: "eager" */ "./auth/UsageTracker.ts");
+    await getAuthPromptController().initialize();
+    getAuthPromptUI().initialize();
 
-  // Expose debug method for resetting auth prompt tracking
-  window.saypiResetAuthPrompts = async () => {
-    await getUsageTracker().resetStats();
-    console.log("[SayPi] Auth prompt tracking reset. Reload page to take effect.");
-  };
+    // Expose debug method for resetting auth prompt tracking
+    window.saypiResetAuthPrompts = async () => {
+      await getUsageTracker().resetStats();
+      console.log("[SayPi] Auth prompt tracking reset. Reload page to take effect.");
+    };
+  } catch (error) {
+    logger.error("Auth prompt system failed to initialize (non-fatal):", error);
+  }
 
   // Initialize telemetry module
   logger.debug("Initializing telemetry module");


### PR DESCRIPTION
## Context

Follow-up to #392, from investigating *why* an existing Claude thread can load as vanilla Claude (no call button) on reload. **Read the caveat at the bottom — this is defensive hardening, not a verified fix for a reproduced trigger.**

## What the dig found

The content-script bootstrap (`src/saypi.index.js`) is a single async IIFE with **no top-level try/catch**, and `initializeChatMode()` — which decorates the page and creates `#saypi-callButton` — is sequenced **last**, behind four unguarded `await import(...)` dynamic imports (compat notification UI + the auth-prompt system, lines 57/65-67).

The auth/usage code is internally well-guarded (every `sendMessage`/`storage` call is wrapped in try/catch), so the original "service-worker await hangs/throws" hypothesis is **largely ruled out**. But the **`import()` of those modules** is not guarded, and neither is the IIFE. Those chunks load over `chrome-extension://` URLs; if a chunk load rejects — which can happen transiently when the extension's own service worker is updating/restarting at reload time (`Extension context invalidated` / chunk-load failure) — the IIFE rejects and **decoration never runs**. That's a precise match for the reported symptom (total absence of SayPi chrome), and it's invisible to a fresh-launch test (healthy SW, warm chunks).

## The change

Wrap the two non-essential early-init blocks (compat notice, auth prompts) in their own try/catch so a failure is **logged and swallowed** instead of propagating. The core decoration must not depend on them succeeding.

- **Happy path unchanged** — same modules, same order.
- **Failure mode changed** — from "whole extension silently dead" to "non-essential feature missing, error logged, call button still present."
- **Also instruments the cause** — if it ever does fire, the `logger.error` turns a silent death into a diagnosable one.

## Verification

- `tsc --noEmit` + Jest + Vitest — **141 files / 1086 tests green**.
- **Layer 4 (real Chrome over CDP, live claude.ai, logged in):** the hardened build decorates a real existing thread on full load (`#saypi-callButton` present, exit 0).

## ⚠️ Honest caveat

I **could not reproduce the original reload defect at Layer 4** — not on 6 real threads, including the exact reported URL, with *either* the pre- or post-#392 build. On live Claude, `Claude.getPromptInput` falls back to a **document-wide** `document.querySelector`, so any DOM mutation (constant on a live React app) triggers prompt decoration via the MutationObserver — the "composer already present, no mutations" gap #392 targets doesn't occur in practice.

So this PR (and #392) are **sound hardening for the symptom class**, not proven fixes for a captured trigger. Merge if you want the resilience + diagnostics; otherwise it's a clean candidate to hold until a real repro (console error from a failing session) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)