### PR TITLE
chore(release): record the Edge Add-ons Product ID

### DIFF
--- a/doc/release/stores.json
+++ b/doc/release/stores.json
@@ -40,8 +40,9 @@
     },
     "edge": {
       "displayName": "🔵 Microsoft Edge Add-ons",
-      "idTodo": "capture the Product ID from Partner Center → Extension overview → Extension identity on first run, then record it here as \"id\"",
-      "dashboardUrl": "https://partner.microsoft.com/dashboard/microsoftedge/",
+      "id": "824c36fe-fd03-4656-8d32-67b0ae2cbdad",
+      "dashboardUrl": "https://partner.microsoft.com/dashboard/microsoftedge/824c36fe-fd03-4656-8d32-67b0ae2cbdad/packages",
+      "listingUrl": "https://microsoftedge.microsoft.com/addons/detail/jabjanmkommeachipnbiggdohahbfgpj",
       "packageFile": "dist/saypi.edge.zip",
       "hasReleaseNotesField": false,
       "releaseNotesFallback": "Edge has no changelog field; put a short summary of what changed into \"Notes for certification\".",


### PR DESCRIPTION
Captures the Microsoft Edge **Product ID** (`824c36fe-fd03-4656-8d32-67b0ae2cbdad`, provided by the founder from Partner Center) into `doc/release/stores.json`, replacing the first-run TODO left by #394.

Also:
- Sets the Edge `dashboardUrl` to the extension's **Packages deep link** (straight to the upload page).
- Records the live Edge **listing URL** (`microsoftedge.microsoft.com/addons/detail/jabjanmkommeachipnbiggdohahbfgpj`).

The submission packet now resolves the real ID + both URLs for the Edge section (verified by regenerating it locally). Closes the one known gap noted in #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)