### PR TITLE
fix(pi): add native hover effect to sidebar Focus & Voice settings

### DIFF
--- a/src/styles/pi.scss
+++ b/src/styles/pi.scss
@@ -289,6 +289,22 @@ html body.pi {
     /* Match Pi's sidebar menu button text styling */
     .immersive-mode-button,
     .settings-button {
+      /* Hover/press fill to match Pi's native nav rows (New chat, My stuff, …),
+         which use `hover:bg-secondary-hover active:bg-fill-default transition-colors`.
+         We can't lean on the `hover:bg-neutral-100` utility createMenuButton sets:
+         Pi's Tailwind build never compiles that hover variant (verified: no
+         `.hover\:bg-neutral-100:hover` rule on the page), so it's a silent no-op.
+         Reusing Pi's own tokens here also tracks light/dark automatically. */
+      transition: background-color 0.15s ease;
+
+      &:hover {
+        background-color: var(--color-secondary-hover, #e9ddcd);
+      }
+
+      &:active {
+        background-color: var(--color-fill-default, #ece1d2);
+      }
+
       span {
         font-family: var(--font-oracle), ui-sans-serif, system-ui, -apple-system,
           BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,


### PR DESCRIPTION
## Why

On pi.ai, every native sidebar nav row (New chat, My stuff, Discover, …) gets a cream highlight on hover — **except SayPi's two injected rows, Focus and Voice settings**, which stayed flat. The same effect already works on Claude and ChatGPT.

## Root cause

The shared `createMenuButton` (`src/ButtonModule.js`) styles the row with the Tailwind utility `hover:bg-neutral-100`. But Pi's Tailwind build only ships the variants Pi's own source uses — and it **never compiles `hover:bg-neutral-100`**. Verified live on pi.ai: there is no `.hover\:bg-neutral-100:hover` rule on the page, so the class is a silent no-op. (Native rows use `hover:bg-secondary-hover active:bg-fill-default` with `transition-colors`.)

Claude and ChatGPT don't hit this because each defines its hover fill explicitly in its own host SCSS (`claude.scss`, `chatgpt.scss`). `pi.scss` simply never got that rule.

## Fix

Add the missing hover (plus a matching active/press) fill to `pi.scss`, reusing **Pi's own design tokens** — `--color-secondary-hover` and `--color-fill-default`, the exact ones the native rows use — so it tracks Pi's light/dark theme automatically. A short `transition` matches the native smooth fade. Everything is scoped under `html body.pi`, so Claude and ChatGPT are untouched.

```scss
.immersive-mode-button,
.settings-button {
  transition: background-color 0.15s ease;
  &:hover  { background-color: var(--color-secondary-hover, #e9ddcd); }
  &:active { background-color: var(--color-fill-default, #ece1d2); }
}
```

## Verification

- **Live on pi.ai (Layer 4, real Chrome):** injected the exact rule and confirmed both Focus and Voice settings now highlight identically to the native nav rows on hover.
- `sass` compiles `pi.scss` clean; output is correctly scoped to `html body.pi #saypi-sidebar/#saypi-side-panel …:hover`.
- Covers the collapsed (icon-only) sidebar too, matching native collapsed-row behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)