### PR TITLE
feat(claude): subtle hover kick on the Voice settings icon

### DIFF
--- a/src/styles/claude.scss
+++ b/src/styles/claude.scss
@@ -229,11 +229,24 @@ html body.claude {
         width: 20px;
         height: 20px;
         color: currentColor;
+        transform-origin: center;
 
         path[fill="#000000"],
         path[fill="#000"],
         path[fill="#000000ff"] {
           fill: currentColor;
+        }
+      }
+
+      /* A quick, springy one-shot "kick" on the icon when the row is hovered or
+         keyboard-focused — echoes Claude's own playful sidebar-icon micro-motions
+         (their native icons morph on hover; our π is a fixed mark, so it gets a
+         tilt-and-settle instead). It replays each time hover is re-entered, which
+         matches the native feel. Skipped under prefers-reduced-motion. */
+      @media (prefers-reduced-motion: no-preference) {
+        &:hover svg,
+        &:focus-visible svg {
+          animation: saypi-claude-icon-kick 0.45s ease-out;
         }
       }
 
@@ -243,6 +256,24 @@ html body.claude {
         letter-spacing: normal;
       }
     }
+  }
+}
+
+/* One-shot hover "kick" for the SayPi sidebar icon (see .settings-button above).
+   Top-level @keyframes (names are global); only the Claude-scoped rule above
+   references it, so it's inert on other hosts. */
+@keyframes saypi-claude-icon-kick {
+  0% {
+    transform: rotate(0) scale(1);
+  }
+  30% {
+    transform: rotate(-15deg) scale(1.08);
+  }
+  60% {
+    transform: rotate(7deg) scale(1.03);
+  }
+  100% {
+    transform: rotate(0) scale(1);
   }
 }
 


### PR DESCRIPTION
## Why

Claude's native sidebar rows have a lovely detail: hovering a row gives its icon a quick, playful micro-motion (the briefcase handle tilts, the folder lifts, etc.). SayPi's *Voice settings* row already matches Claude's hover **background**, but its icon stayed static — a small seam in an otherwise seamless integration. This adds matching flair.

## What I observed (live on claude.ai)

I drove the browser to study the native effect first:
- The icons are **bespoke, per-icon morphs** — no inline `<svg>` in the row, no CSS `group-hover` transform rules; they're JS-driven (Framer Motion). Not something to copy mechanically.
- The motion language is consistent: **subtle, fast, springy, settles back to rest** — "a little kick".

Our π is a fixed logo mark (it can't morph like a briefcase), so the faithful analog is a quick whole-icon **tilt-and-settle**, in the same spirit.

## The change

One small block in `claude.scss` — pure CSS, no JS:

```scss
@media (prefers-reduced-motion: no-preference) {
  &:hover svg,
  &:focus-visible svg { animation: saypi-claude-icon-kick 0.45s ease-out; }
}

@keyframes saypi-claude-icon-kick {
  0%   { transform: rotate(0) scale(1); }
  30%  { transform: rotate(-15deg) scale(1.08); }
  60%  { transform: rotate(7deg) scale(1.03); }
  100% { transform: rotate(0) scale(1); }
}
```

- **One-shot**, replays on each hover-enter (and keyboard focus) — matches the native feel.
- **Scoped under `html body.claude`** → Pi and ChatGPT are untouched (their icons keep their existing behaviour).
- **`prefers-reduced-motion` aware** → no motion for users who opt out.
- Maintainable: ~20 lines of CSS, no per-icon logic.

## Verification

- **Live on claude.ai (Layer 4, real Chrome):** held the icon at the kick's peak — the π leans playfully and scales up a touch, reading exactly like Claude's own settle-back motions. Then confirmed the **exact compiled rule** fires on a *real* hover: `:hover` → `animation-name: saypi-claude-icon-kick`, `0.45s`, `transform-origin` dead-centre.
- `sass` compiles `claude.scss` clean; the rule resolves to `html body.claude #saypi-sidebar .settings-button:hover svg` inside the reduced-motion guard, keyframes at top level (inert on other hosts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)