### PR TITLE
fix(chatgpt): harden auto-read-aloud against the <button>→<div role=menuitem> drift

### DIFF
--- a/src/chatbots/chatgpt/ChatGPTResponse.ts
+++ b/src/chatbots/chatgpt/ChatGPTResponse.ts
@@ -84,8 +84,11 @@ export class ChatGPTMessageControls extends MessageControls {
   protected getExtraControlClasses(): string[] { return ["chatgpt-controls"]; }
 
   getActionBarSelector(): string {
+    // Tag-agnostic on the read-aloud testid: chatgpt.com (verified live 2026-06-21)
+    // renders the read-aloud control as a <div role="menuitem"> rather than a <button>.
+    // Anchor on the stable data-testid regardless of tag, matching findReadAloudMenuItemNear.
     return [
-      'div:has(> button[data-testid="voice-play-turn-action-button"])',
+      'div:has(> [data-testid="voice-play-turn-action-button"])',
       'div:has(> button[data-testid="copy-turn-action-button"])',
       'div:has(> button[aria-label*="Copy" i])',
       'div:has(> button[title*="Copy" i])',
@@ -93,14 +96,21 @@ export class ChatGPTMessageControls extends MessageControls {
     ].join(', ');
   }
 
-  getReadAloudButton(): HTMLButtonElement | null {
+  // Locate any direct (non-overflow-menu) read-aloud control inside the turn.
+  // Tag-agnostic: chatgpt.com no longer renders this as a <button> — the live
+  // control is a <div role="menuitem" data-testid="voice-play-turn-action-button">
+  // (verified 2026-06-21). On the current DOM the control lives only in the portaled
+  // overflow menu, so this returns null and the menu path takes over; the tag-agnostic
+  // match keeps us robust if ChatGPT ever surfaces it inline again.
+  getReadAloudButton(): HTMLElement | null {
     const byTestId = this.message.element.querySelector(
-      'button[data-testid="voice-play-turn-action-button"]'
-    ) as HTMLButtonElement | null;
+      '[data-testid="voice-play-turn-action-button"]'
+    ) as HTMLElement | null;
     if (byTestId) return byTestId;
+    // Legacy "Read aloud"/"Replay" controls were (and remain) <button> elements.
     return this.message.element.querySelector(
       'button[aria-label*="Read aloud" i], button[title*="Read aloud" i], button[aria-label*="Replay" i], button[title*="Replay" i]'
-    ) as HTMLButtonElement | null;
+    ) as HTMLElement | null;
   }
 
   getCopyButton(): HTMLButtonElement | null {
@@ -207,7 +217,7 @@ export class ChatGPTMessageControls extends MessageControls {
     }
 
     const direct = this.getReadAloudButton();
-    if (direct && !direct.disabled) {
+    if (direct && !(direct as Partial<HTMLButtonElement>).disabled) {
       if ((direct as any)._saypiClicked) return;
       (direct as any)._saypiClicked = true;
       // Clear the unread flag since we're now reading it
@@ -647,7 +657,8 @@ export class ChatGPTTextBlockCapture extends ElementTextStream {
     const sel = [
       '.message-action-bar',
       'button[data-testid="copy-turn-action-button"]',
-      'button[data-testid="voice-play-turn-action-button"]',
+      // Tag-agnostic: read-aloud is a <div role="menuitem"> on current chatgpt.com.
+      '[data-testid="voice-play-turn-action-button"]',
       'button[aria-haspopup="menu"]',
       'button[aria-label*="Copy" i]',
       'button[title*="Copy" i]'

--- a/test/chatbots/ChatGPTReadAloudMenuItemDrift.spec.ts
+++ b/test/chatbots/ChatGPTReadAloudMenuItemDrift.spec.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Mirror the mocks used by ChatGPTAutoReadAloud.spec.ts so the chatbot/message
+// controls can be constructed in isolation.
+vi.mock('../../src/tts/TTSControlsModule', () => ({
+  TTSControlsModule: {
+    getInstance: () => ({
+      createGenerateSpeechButton: () => document.createElement('button'),
+      createCopyButton: () => document.createElement('button'),
+      addCostBasis: () => undefined,
+      updateCostBasis: () => undefined,
+    }),
+  },
+}));
+
+const setCallActive = () => {
+  (globalThis as any).StateMachineService = {
+    conversationActor: {
+      getSnapshot: () => ({
+        matches: (s: string) => s === 'listening' || String(s).startsWith('responding'),
+      }),
+    },
+  };
+};
+
+vi.mock('../../src/prefs/PreferenceModule', async (orig) => {
+  const actual = await vi.importActual<any>('../../src/prefs/PreferenceModule');
+  return {
+    ...actual,
+    UserPreferenceModule: {
+      getInstance: () => ({ getCachedAutoReadAloudChatGPT: () => true }),
+    },
+  };
+});
+
+vi.mock('../../src/chatbots/Pi', () => ({ PiAIChatbot: class {} }));
+
+import ChatGPTChatbot from '../../src/chatbots/ChatGPT';
+
+/**
+ * Faithful reproduction of the live chatgpt.com DOM (verified 2026-06-21):
+ *  - The assistant turn is a <section data-turn="assistant"> (already handled by #384).
+ *  - The action bar holds copy / share / "Switch model" / "More actions" buttons.
+ *  - There is NO direct read-aloud button — read-aloud lives ONLY in the overflow menu.
+ *  - The "Read aloud" menu item is a <div role="menuitem"
+ *    data-testid="voice-play-turn-action-button"> (NOT a <button>, and with NO
+ *    aria-label). It is portaled to <body> inside a Radix menu and only exists in the
+ *    DOM while the menu is open.
+ */
+describe('ChatGPT auto Read Aloud — live overflow-menu DOM (div role=menuitem)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    setCallActive();
+  });
+
+  function buildAssistantSection() {
+    const list = document.createElement('div');
+    list.className = 'chat-history present-messages';
+    document.body.appendChild(list);
+
+    const section = document.createElement('section');
+    section.setAttribute('data-turn', 'assistant');
+    section.setAttribute('data-testid', 'conversation-turn-2');
+    section.setAttribute('data-turn-id', 'bb42e1c9-6b0d-4677-8a48-60e756717a5a');
+    const content = document.createElement('div');
+    content.className = 'markdown';
+    content.textContent = 'Good morning, Ross.';
+    section.appendChild(content);
+    list.appendChild(section);
+    return { list, section };
+  }
+
+  function buildActionBar(section: HTMLElement) {
+    // Single flex row whose direct children are all the action buttons (matches live).
+    const bar = document.createElement('div');
+
+    const copy = document.createElement('button');
+    copy.setAttribute('data-testid', 'copy-turn-action-button');
+    copy.setAttribute('aria-label', 'Copy response');
+    bar.appendChild(copy);
+
+    const share = document.createElement('button');
+    share.setAttribute('aria-label', 'Share');
+    bar.appendChild(share);
+
+    const switchModel = document.createElement('button');
+    switchModel.setAttribute('aria-haspopup', 'menu');
+    switchModel.setAttribute('aria-expanded', 'false');
+    switchModel.setAttribute('aria-label', 'Switch model');
+    bar.appendChild(switchModel);
+
+    const more = document.createElement('button');
+    more.setAttribute('aria-haspopup', 'menu');
+    more.setAttribute('aria-expanded', 'false');
+    more.setAttribute('data-state', 'closed');
+    more.setAttribute('aria-label', 'More actions');
+    bar.appendChild(more);
+
+    section.appendChild(bar);
+
+    // Radix-style portaled menu, rendered to <body> when the trigger opens.
+    const menu = document.createElement('div');
+    menu.setAttribute('role', 'menu');
+    menu.setAttribute('data-radix-menu-content', '');
+    menu.setAttribute('data-state', 'open');
+
+    const mkItem = (text: string, testid?: string) => {
+      const el = document.createElement('div');
+      el.setAttribute('role', 'menuitem');
+      // Radix menu items are programmatically focusable via tabindex="-1" (verified live).
+      el.setAttribute('tabindex', '-1');
+      if (testid) el.setAttribute('data-testid', testid);
+      el.textContent = text;
+      return el;
+    };
+    menu.appendChild(mkItem('View sources'));
+    menu.appendChild(mkItem('Branch in new chat'));
+    const readAloud = mkItem('Read aloud', 'voice-play-turn-action-button');
+    menu.appendChild(readAloud);
+
+    const readAloudClickSpy = vi.spyOn(readAloud, 'click');
+    vi.spyOn(more, 'click').mockImplementation(() => {
+      more.setAttribute('aria-expanded', 'true');
+      more.setAttribute('data-state', 'open');
+      if (!menu.parentElement) document.body.appendChild(menu);
+    });
+
+    return { more, switchModel, readAloud, readAloudClickSpy };
+  }
+
+  it('opens the overflow menu and clicks the Read aloud <div role=menuitem>', async () => {
+    const { section } = buildAssistantSection();
+
+    const chatbot = new ChatGPTChatbot();
+    chatbot.getAssistantResponse(section as HTMLElement, true, true); // streaming
+
+    // Action bar + portaled menu appear after observers attach (streaming completes).
+    const { readAloud, readAloudClickSpy, switchModel } = buildActionBar(section);
+    const switchClickSpy = vi.spyOn(switchModel, 'click');
+
+    await new Promise((r) => setTimeout(r, 700));
+
+    expect(readAloudClickSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+    // The div menu item is focused before activation (mirrors the live focusable item).
+    expect(document.activeElement === readAloud).toBe(true);
+    // The activated turn is recorded so it is not clicked again.
+    expect(section.getAttribute('data-saypi-read-aloud-clicked')).toBe('true');
+    // Must not have activated the contextual "Switch model" menu.
+    expect(switchClickSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not expose a direct read-aloud button on the turn (control lives only in the overflow menu)', () => {
+    const { section } = buildAssistantSection();
+    buildActionBar(section);
+    // The live action bar has copy/share/switch/more — but NO direct read-aloud
+    // control; the only voice-play element is the portaled <div role="menuitem">.
+    expect(
+      section.querySelector('button[data-testid="voice-play-turn-action-button"]')
+    ).toBeNull();
+    expect(
+      section.querySelector('[data-testid="copy-turn-action-button"]')
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

**Reported:** "Automatic read-aloud is not working on ChatGPT." With *Auto Read Aloud (ChatGPT)* enabled, SayPi should auto-click ChatGPT's native "Read aloud" (buried in the overflow menu) whenever a response finishes.

**Investigation (live `chatgpt.com`, 2026-06-21):**

The ChatGPT DOM *did* drift — the "Read aloud" control is now a **`<div role="menuitem" data-testid="voice-play-turn-action-button">`** inside the "More actions" overflow menu, where it used to be a `<button>`; there is no direct read-aloud button in the action bar anymore.

**But auto-read-aloud already works on current `main`.** Two independent proofs:
1. A faithful unit test mirroring the exact live DOM (`<section>` turn + portaled Radix menu + the `<div role="menuitem">` item with no `aria-label`) **passes** — the overflow-menu path (`findReadAloudMenuItemNear`) already matches the testid tag-agnostically.
2. A **live voice-call reproduction**: ChatGPT generated a response during an active SayPi call and the extension auto-clicked Read aloud — confirmed by `data-saypi-read-aloud-clicked="true"` on the turn (set only by `clickAndRecordReadAloudButton`) **and the audio played**.

**So the user-facing breakage is the stale store build, not a current code bug.** The store ships **v1.10.7 (tagged 2026-01-03)**, which predates the `<article>`→`<section>` turn-detection fix (#384, merged 2026-06-20, currently in no tag). On that build ChatGPT turn detection fails wholesale, so read-aloud (and the whole conversation flow) is dead. The fix is to ship the pending release.

## What this PR changes

Even though it works on `main`, the path only survives the drift because the *menu* selector is tag-agnostic — `getReadAloudButton()`, the first `getActionBarSelector()` entry, and `actionBarPresent()` still hard-coded `<button>`, and the test suite tested a DOM shape (`<button>` menu item) that no longer exists. This PR makes those selectors uniformly tag-agnostic and adds a faithful regression test.

- `getActionBarSelector` — anchor the voice-play testid regardless of tag
- `getReadAloudButton` — tag-agnostic testid match, returns `HTMLElement` (legacy Replay/aria-label fallback stays `<button>`-specific by design)
- `ChatGPTTextBlockCapture.actionBarPresent` — tag-agnostic voice-play marker
- **New** `test/chatbots/ChatGPTReadAloudMenuItemDrift.spec.ts` — mirrors the live overflow-menu DOM (`<div role="menuitem">`, no `aria-label`, `tabindex="-1"`), asserts the item is focused + clicked, no contextual "Switch model" activation, and that there's no direct read-aloud button on the turn

**No behavior change on the current DOM** (the control is portaled, so `getReadAloudButton` still returns null and the menu path drives the click).

## Testing

- `tsc --noEmit` ✅
- Vitest: 1113 passed ✅
- Jest ✅

## Follow-up (separate issue)

During the live call I also observed the conversation machine log **"ChatGPT stopped writing … after 2 ms"** for a multi-paragraph response — a premature `piStoppedWriting` detection unrelated to read-aloud. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)