### PR TITLE
fix(chatgpt): enter piWriting at the true start of the response (#399)

### DIFF
--- a/src/chatbots/chatgpt/ChatGPTResponse.ts
+++ b/src/chatbots/chatgpt/ChatGPTResponse.ts
@@ -628,9 +628,9 @@ export class ChatGPTTextBlockCapture extends ElementTextStream {
   // So on the first non-empty content mutation we emit a one-shot, EMPTY
   // "writing started" marker. It triggers onStart -> saypi:piWriting at the true
   // start of writing, but contributes no text to the captured block ("" + final
-  // text === final text), so emitFinalAndClose, billing, and TTS text stay
-  // exactly as before. The marker fires before speak() opens any audio stream,
-  // so it is a no-op for TTS.
+  // text === final text), so emitFinalAndClose and billing are unchanged. The
+  // empty chunk never reaches the TTS input stream: SpeechSynthesisModule drops
+  // an empty saypi:tts:text:added so it can't be mistaken for end-of-speech (#399).
   handleMutationEvent(_mutation: MutationRecord): void {
     if (this.firstTokenEmitted || this.closed()) return;
     const hasContent = (this.element.textContent || "").trim().length > 0;

--- a/src/chatbots/chatgpt/ChatGPTResponse.ts
+++ b/src/chatbots/chatgpt/ChatGPTResponse.ts
@@ -614,13 +614,29 @@ export class ChatGPTMessageControls extends MessageControls {
 export class ChatGPTTextBlockCapture extends ElementTextStream {
   private turnContainer: HTMLElement | null = null;
   private barObserver: MutationObserver | null = null;
-  private streamingStarted = false;
   private firstTokenEmitted = false;
 
-  // ElementTextStream requires a per-mutation handler; block-capture doesn't need it
-  // because it listens for action-bar completion instead.
+  // Block-capture extracts the authoritative final text once, when the action
+  // bar appears (emitFinalAndClose). It does NOT accumulate per-token deltas the
+  // way Pi/Claude do — ChatGPT re-renders its streaming DOM, which made delta
+  // accumulation unreliable. But the conversation machine derives
+  // saypi:piWriting from the stream's FIRST chunk (ChatHistory.observeChatMessageElement),
+  // so with no early chunk it sits in `piThinking` for the entire multi-second
+  // write — and any reply that takes >15s to finish trips the piThinking timeout
+  // and bails the call back to `listening` mid-write, re-opening the mic (#399).
+  //
+  // So on the first non-empty content mutation we emit a one-shot, EMPTY
+  // "writing started" marker. It triggers onStart -> saypi:piWriting at the true
+  // start of writing, but contributes no text to the captured block ("" + final
+  // text === final text), so emitFinalAndClose, billing, and TTS text stay
+  // exactly as before. The marker fires before speak() opens any audio stream,
+  // so it is a no-op for TTS.
   handleMutationEvent(_mutation: MutationRecord): void {
-    // no-op
+    if (this.firstTokenEmitted || this.closed()) return;
+    const hasContent = (this.element.textContent || "").trim().length > 0;
+    if (!hasContent) return;
+    this.firstTokenEmitted = true;
+    this.next(new AddedText(""));
   }
 
   constructor(element: HTMLElement, options?: InputStreamOptions) {

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -391,6 +391,13 @@ class SpeechSynthesisModule {
   }
 
   private addSpeechToStreamIfOpen(utteranceId: string, text: string): void {
+    // An empty string is InputBuffer's end-of-speech sentinel
+    // (END_OF_SPEECH_MARKER): appending it to an open stream closes the stream.
+    // A non-final empty text:added is never legitimate (real end-of-speech flows
+    // through endSpeechStream), so drop it here — otherwise ChatGPT's empty
+    // writing-started marker (#399) would silently end the stream and swallow
+    // the rest of the reply for a SayPi-voice-on-ChatGPT user.
+    if (!text) return;
     if (this.isStreamOpen(utteranceId)) {
       this.addSpeechToStream(utteranceId, text);
     }

--- a/test/chatbots/ChatGPTTextBlockCapture.spec.ts
+++ b/test/chatbots/ChatGPTTextBlockCapture.spec.ts
@@ -1,5 +1,159 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
+// Mock TTSControlsModule early to avoid the SpeechSynthesisModule/config chain
+// when we import the real ChatGPTResponse module (mirrors ChatGPTAutoReadAloud.spec).
+vi.mock('../../src/tts/TTSControlsModule', () => ({
+  TTSControlsModule: {
+    getInstance: () => ({
+      createGenerateSpeechButton: () => document.createElement('button'),
+      createCopyButton: () => document.createElement('button'),
+      addCostBasis: () => undefined,
+      updateCostBasis: () => undefined,
+    }),
+  },
+}));
+
+// Avoid the VoiceMenu -> Pi circular import pulled in via MessageElements.
+vi.mock('../../src/chatbots/Pi', () => ({
+  PiAIChatbot: class {},
+  PiTextStream: class {},
+}));
+
+// Keep ElementTextStream's constructor (getLanguage) off the network.
+vi.mock('../../src/prefs/PreferenceModule', () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({
+      getLanguage: () => Promise.resolve('en-US'),
+      reloadCache: () => undefined,
+      getStoredValue: (_key: string, defaultValue: unknown) => Promise.resolve(defaultValue),
+    }),
+  },
+}));
+
+// Import the real classes lazily so the mocks above take effect first.
+async function importChatGPTStream() {
+  const responseModule = await import('../../src/chatbots/chatgpt/ChatGPTResponse');
+  const inputModule = await import('../../src/tts/InputStream');
+  return {
+    ChatGPTTextBlockCapture: (responseModule as any).ChatGPTTextBlockCapture,
+    AddedText: (inputModule as any).AddedText,
+  };
+}
+
+// A streaming ChatGPT assistant turn: the .markdown content node fills with
+// tokens *before* the post-turn action bar appears (live DOM per #362/#384).
+function buildStreamingAssistantTurn() {
+  const list = document.createElement('div');
+  list.className = 'present-messages';
+  const turn = document.createElement('section');
+  turn.setAttribute('data-turn', 'assistant');
+  turn.setAttribute('data-testid', 'conversation-turn-2');
+  const content = document.createElement('div');
+  content.className = 'markdown';
+  turn.appendChild(content);
+  list.appendChild(turn);
+  document.body.appendChild(list);
+  return { turn, content };
+}
+
+// The signal block-capture waits for: ChatGPT's post-completion action bar.
+function appendActionBar(turn: HTMLElement) {
+  const bar = document.createElement('div');
+  const copy = document.createElement('button');
+  copy.setAttribute('data-testid', 'copy-turn-action-button');
+  bar.appendChild(copy);
+  turn.appendChild(bar);
+}
+
+const flushMutations = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('ChatGPT piWriting window (#399)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('signals writing-started on the first streamed content, before the response completes', async () => {
+    const { ChatGPTTextBlockCapture } = await importChatGPTStream();
+    const { turn, content } = buildStreamingAssistantTurn();
+
+    // Construct while still streaming (no action bar yet) -> block-capture
+    // registers its action-bar observer and otherwise stays quiet.
+    const stream = new ChatGPTTextBlockCapture(content, { includeInitialText: false });
+
+    const chunks: string[] = [];
+    let completed = false;
+    const subscription = stream.getStream().subscribe({
+      next: (value: any) => chunks.push(value.text),
+      complete: () => {
+        completed = true;
+      },
+    });
+
+    // ChatGPT streams tokens into the .markdown node over several seconds,
+    // long before the action bar appears.
+    content.textContent = 'Not a whole lot on my end —';
+    await flushMutations();
+
+    // The conversation machine derives saypi:piWriting from the stream's first
+    // chunk (ChatHistory.observeChatMessageElement). It must learn the assistant
+    // started writing NOW so it leaves piThinking and isn't bailed out by the
+    // 15s piThinking timeout on long replies. Before the fix, block-capture
+    // emits nothing until the action bar, so no chunk has arrived here yet.
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    expect(completed).toBe(false);
+
+    // Streaming finishes and the action bar appears -> block-capture emits the
+    // authoritative full text and completes (saypi:piStoppedWriting).
+    content.textContent = 'Not a whole lot on my end — just here and ready to help.';
+    appendActionBar(turn);
+    await flushMutations();
+
+    expect(completed).toBe(true);
+
+    // Billing/TTS integrity: the captured transcript is the full final text,
+    // uncorrupted by the writing-started marker (the marker contributes nothing).
+    expect(chunks.join('')).toBe(
+      'Not a whole lot on my end — just here and ready to help.'
+    );
+
+    subscription.unsubscribe();
+  });
+
+  it('keeps the collapsed window for an already-complete turn (no false writing window)', async () => {
+    const { ChatGPTTextBlockCapture } = await importChatGPTStream();
+    const { turn, content } = buildStreamingAssistantTurn();
+
+    // A turn that is already finished at decoration time (history / pre-rendered):
+    // text present AND action bar present. The window *should* collapse here —
+    // nothing is being written live.
+    content.textContent = 'Already finished reply.';
+    appendActionBar(turn);
+
+    const stream = new ChatGPTTextBlockCapture(content, { includeInitialText: false });
+
+    const chunks: string[] = [];
+    let completed = false;
+    const subscription = stream.getStream().subscribe({
+      next: (value: any) => chunks.push(value.text),
+      complete: () => {
+        completed = true;
+      },
+    });
+    await flushMutations();
+
+    expect(completed).toBe(true);
+    expect(chunks.join('')).toBe('Already finished reply.');
+
+    subscription.unsubscribe();
+  });
+});
+
 describe('ChatGPT Text Block Capture Logic', () => {
   beforeEach(() => {
     // Clear the DOM before each test

--- a/test/chatbots/ChatGPTTextBlockCapture.spec.ts
+++ b/test/chatbots/ChatGPTTextBlockCapture.spec.ts
@@ -116,11 +116,42 @@ describe('ChatGPT piWriting window (#399)', () => {
 
     expect(completed).toBe(true);
 
+    // The writing-started marker is the FIRST chunk (so onStart -> piWriting
+    // fires before the real text) and is emitted exactly ONCE across the many
+    // content mutations of a streaming reply.
+    expect(chunks[0]).toBe('');
+    expect(chunks.filter((c) => c === '').length).toBe(1);
+
     // Billing/TTS integrity: the captured transcript is the full final text,
     // uncorrupted by the writing-started marker (the marker contributes nothing).
     expect(chunks.join('')).toBe(
       'Not a whole lot on my end — just here and ready to help.'
     );
+
+    subscription.unsubscribe();
+  });
+
+  it('opens the window when content arrives via an in-place characterData re-render', async () => {
+    const { ChatGPTTextBlockCapture } = await importChatGPTStream();
+    const { content } = buildStreamingAssistantTurn();
+
+    // Seed an empty text node so the first token lands as a characterData
+    // mutation (ChatGPT re-renders markdown in place) rather than a childList
+    // insertion — the base observer watches both.
+    const textNode = document.createTextNode('');
+    content.appendChild(textNode);
+
+    const stream = new ChatGPTTextBlockCapture(content, { includeInitialText: false });
+    const chunks: string[] = [];
+    const subscription = stream.getStream().subscribe({
+      next: (value: any) => chunks.push(value.text),
+    });
+
+    textNode.data = 'first streamed token';
+    await flushMutations();
+
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    expect(chunks[0]).toBe('');
 
     subscription.unsubscribe();
   });

--- a/test/tts/SpeechSynthesisModule.spec.ts
+++ b/test/tts/SpeechSynthesisModule.spec.ts
@@ -7,6 +7,7 @@ import { mockVoices } from "../data/Voices";
 import { UserPreferenceModule } from "../../src/prefs/PreferenceModule";
 import { BillingModule } from "../../src/billing/BillingModule";
 import { audioProviders, isPlaceholderUtterance } from "../../src/tts/SpeechModel";
+import EventBus from "../../src/events/EventBus";
 
 describe("SpeechSynthesisModule", () => {
   let speechSynthesisModule: SpeechSynthesisModule;
@@ -295,6 +296,35 @@ describe("SpeechSynthesisModule", () => {
 
     expect(provider).toEqual(
       audioProviders.getDefaultForChatbot("chatgpt")
+    );
+  });
+
+  // "" is InputBuffer's end-of-speech sentinel (END_OF_SPEECH_MARKER). ChatGPT's
+  // writing-started marker (#399) emits an empty stream chunk to open the
+  // piWriting window at the true start of the response. If that empty chunk were
+  // appended to an already-open SayPi stream (a SayPi-voice-on-ChatGPT user) it
+  // would be read as end-of-speech and silently close the stream, dropping the
+  // rest of the reply's audio. A non-final empty text:added is never legitimate
+  // — real end-of-speech flows through endSpeechStream — so it must be a no-op.
+  it("does not forward an empty saypi:tts:text:added chunk to an open stream (#399)", () => {
+    (audioStreamManagerMock.isOpen as Mock).mockReturnValue(true);
+
+    EventBus.emit("saypi:tts:text:added", {
+      utterance: { id: "utterance-1" },
+      text: "",
+    } as any);
+
+    expect(audioStreamManagerMock.addSpeechToStream).not.toHaveBeenCalled();
+
+    // Real reply text still flows to the (still-open) stream.
+    EventBus.emit("saypi:tts:text:added", {
+      utterance: { id: "utterance-1" },
+      text: "Real reply text.",
+    } as any);
+
+    expect(audioStreamManagerMock.addSpeechToStream).toHaveBeenCalledWith(
+      "utterance-1",
+      "Real reply text."
     );
   });
 });


### PR DESCRIPTION
## Why

On ChatGPT, the conversation machine's `responding:piWriting` window collapsed to ~2ms (#399). The root cause: `ChatGPTTextBlockCapture` is a *block-capture* stream — it waits for the post-turn action bar, then emits the whole reply and `complete()`s in the same tick. Downstream, `ChatHistory.observeChatMessageElement` derives `saypi:piWriting` from the stream's **first chunk** and `saypi:piStoppedWriting` from **completion**, so both fired back-to-back. During ChatGPT's *actual* multi-second write the machine sat in `piThinking` the entire time.

That's not just cosmetic. `piThinking` has a 15s timeout (`PI_THINKING_TIMEOUT_MS`) that bails the call back to `listening` — **re-opening the mic and clearing the prompt mid-write on any reply that takes >15s to finish**. The "is writing…" indicator also only flashed for ~2ms, and `piWriting→piSpeaking` was unreachable. (Billing and telemetry were *not* affected — billing charges off the full text payload; telemetry anchors on `saypi:llm:first-token`.)

The founder chose the minimal, ChatGPT-scoped fix: fire `piWriting` at the **true start** of writing while leaving block-capture's authoritative full-text extraction + completion untouched.

## What

1. **`ChatGPTTextBlockCapture.handleMutationEvent`** (was a no-op) now emits a **one-shot, empty** "writing started" marker on the first non-empty content mutation. This triggers `onStart → saypi:piWriting` at the real start of writing (so the machine leaves `piThinking` and is no longer exposed to the 15s timeout), while contributing **no text** to the captured block (`"" + final text === final text`). `emitFinalAndClose`, billing, and the final transcript are byte-for-byte unchanged. Already-complete (history/pre-rendered) turns still collapse — nothing is being written live.

2. **`SpeechSynthesisModule.addSpeechToStreamIfOpen`** now drops an **empty** `saypi:tts:text:added`. This is a root-cause guard surfaced by independent review: `""` is `InputBuffer`'s end-of-speech sentinel (`END_OF_SPEECH_MARKER`), so for a *SayPi-voice-on-ChatGPT* user (stream already open at decoration) the empty marker would have closed the stream and **silently dropped the reply's audio**. A non-final empty append is never legitimate (real EOS flows through `endSpeechStream`), so the guard is correct, host-agnostic hardening — inert for Pi/Claude, which never emit empty chunks. Default ChatGPT native read-aloud was never affected (placeholder utterance → `speak()` no-op).

## Verification

- **Fail-first TDD**: `test/chatbots/ChatGPTTextBlockCapture.spec.ts` instantiates the real `ChatGPTTextBlockCapture`, asserts a chunk arrives during streaming **before** completion (failed `0 >= 1` before the fix), that the marker is first + emitted exactly once, the characterData re-render path, and that the captured transcript is uncorrupted. `test/tts/SpeechSynthesisModule.spec.ts` proves the empty chunk closed the stream before the guard and is dropped after.
- Full `npm test` green: `tsc --noEmit` + Jest (2) + Vitest (1115 passed, 1 pre-existing skip).
- **Independent multi-lens review** (subagents): correctness ✅, test-quality ✅ (suggested cases added), silent-failure 🔴→✅ (the EOS collision above was caught here, fixed, and re-verified CONFIRMED-RESOLVED end-to-end).

Tested at Layer 1–2 (unit/contract) — the behavior is reproducible against a controlled DOM, so it belongs here per the test-layer guidance. No manifest/permissions/auth/contract surface touched.

Fixes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)