### PR TITLE
fix(state-machines): resolve the 8 deferred #403 bugs

### DIFF
--- a/src/state-machines/AudioInputMachine.ts
+++ b/src/state-machines/AudioInputMachine.ts
@@ -522,13 +522,16 @@ export const audioInputMachine = setup({
     sendData: ({ event }) => {
       if (event.type !== "dataAvailable") return;
       const { frames, blob, duration, captureTimestamp, clientReceiveTimestamp, handlerTimestamp } = event;
-      const sizeInKb = (blob.size / 1024).toFixed(2); // Convert to kilobytes and keep 2 decimal places
+      const sizeInKb = (blob.size / 1024).toFixed(2); // for logging only
       logger.debug(`Uploading ${sizeInKb}kb of audio data`);
 
       // Use the duration directly from the event
       const speechDuration = duration;
 
-      if (Number(sizeInKb) > 0) {
+      // Gate on actual emptiness, not 2-decimal kB rounding (#403): a small
+      // non-empty blob (e.g. a few bytes) rounds to "0.00" kB but is still real
+      // audio and must be forwarded.
+      if (blob.size > 0) {
         // Upload the audio to the server for transcription
         //
         // TODO: the VAD emits `saypi:userStoppedSpeaking` events with raw frames when the user stops speaking.
@@ -571,41 +574,14 @@ export const audioInputMachine = setup({
     logMicrophoneAcquisitionError: ({ event }) => {
       // onError surfaces the rejection reason as `event.error` in v5.
       const error = (event as { type: string; error?: unknown }).error;
-      let messageKey = "microphoneErrorUnknown";
-      let detail = "";
-
-      if (isOverconstrainedError(error)) {
-        messageKey = "microphoneErrorConstraints";
-      } else if (error instanceof DOMException) {
-        switch (error.name) {
-          case "NotAllowedError":
-            messageKey = "microphoneErrorPermissionDenied";
-            break;
-          case "NotFoundError":
-            messageKey = "microphoneErrorNotFound";
-            break;
-          case "NotReadableError":
-            messageKey = "microphoneErrorInUse";
-            break;
-          default:
-            messageKey = "microphoneErrorUnexpected";
-            detail = error.message;
-        }
-      } else if (error instanceof Error) {
-        messageKey = "microphoneErrorGeneric";
-        detail = error.message;
-      }
-
-      const message = getMessage(messageKey, detail);
-
-      console.error(`Microphone error: ${message}`, error);
-
-      EventBus.emit("saypi:ui:show-notification", {
-        message: message,
-        type: "text",
-        seconds: 20,
-        icon: "microphone-muted",
-      });
+      // setupRecording already shows a specific, user-facing notification for
+      // every failure path (permission denied, VAD init failed, etc.) BEFORE
+      // rejecting, and it flattens the cause to a string — so the original
+      // DOMException never reaches this action (the NotAllowed/NotFound/InUse/
+      // OverconstrainedError branches were dead) and a second notification here
+      // would only override setupRecording's specific message with a generic one
+      // (#403). Keep diagnostics only; setupRecording owns the user-facing notice.
+      console.error("[AudioInputMachine] Microphone acquisition failed:", error);
     },
   },
   guards: {
@@ -754,17 +730,5 @@ export const audioInputMachine = setup({
     },
   },
 });
-
-interface OverconstrainedError extends DOMException {
-  constraint: string;
-  message: string;
-}
-function isOverconstrainedError(error: any): error is OverconstrainedError {
-  return (
-    error instanceof DOMException &&
-    (error.name === "OverconstrainedError" ||
-      error.name === "ConstraintNotSatisfiedError")
-  );
-}
 
 export { setupRecording };

--- a/src/state-machines/ConversationMachine.ts
+++ b/src/state-machines/ConversationMachine.ts
@@ -366,10 +366,16 @@ const machine = setup({
       }
     },
     callStartingPrompt: () => {
+      // Show the "call starting" placeholder. (#403) Previously this also tried to
+      // back up the user's draft into defaultPlaceholderText via a discarded
+      // assign() — which never ran, and would have been wrong anyway:
+      // defaultPlaceholderText is the PLACEHOLDER (restored via setMessage in
+      // clearPrompt), so a backed-up draft would have reappeared as greyed-out
+      // placeholder text rather than editable content. Removed the dead code; a
+      // real "preserve draft across a call" feature would need its own field +
+      // setDraft restore, not this path.
       const message = getMessage("callStarting");
       if (message) {
-        const initialText = getPromptOrNull()?.getDraft();
-        assign({ defaultPlaceholderText: initialText });
         getPromptOrNull()?.setMessage(message);
       }
     },
@@ -550,12 +556,10 @@ const machine = setup({
         logger.debug("Skipping speech due to this being a maintainance message");
       }
     },
-    // NOTE: this is a deliberate no-op. In v4 it called assign(...) imperatively
-    // and discarded the result, so it never cleared the flag. Preserved as-is to
-    // keep production behavior identical (see characterization spec).
-    clearMaintainanceFlag: () => {
-      assign({ isMaintainanceMessage: () => false });
-    },
+    // Reset the maintenance-message flag on exit of `responding` (#403). Previously
+    // this built an assign() and discarded it, so the flag was never cleared here
+    // and only got recomputed on the next submit via setMaintainanceFlag.
+    clearMaintainanceFlag: assign({ isMaintainanceMessage: false }),
     pauseAudio: () => {
       logger.debug("[ConversationMachine] [pauseAudio] Pausing audio for user interruption");
       EventBus.emit("audio:output:pause");

--- a/src/state-machines/DictationMachine.ts
+++ b/src/state-machines/DictationMachine.ts
@@ -1845,7 +1845,15 @@ export const machine = setup({
       hasAudio: ({ event }: GuardArgs) => {
         if (event.type === "saypi:userStoppedSpeaking") {
           const speechEvent = event as DictationSpeechStoppedEvent;
-          return speechEvent.blob !== undefined && speechEvent.duration > 0;
+          // A zero-size blob is not real audio — require blob.size > 0 so this
+          // guard is the exact complement of hasNoAudio (#403). Otherwise a
+          // zero-byte blob with duration > 0 satisfies both guards and hasAudio
+          // (listed first) wins, uploading an empty segment.
+          return (
+            speechEvent.blob !== undefined &&
+            speechEvent.blob.size > 0 &&
+            speechEvent.duration > 0
+          );
         }
         return false;
       },

--- a/src/state-machines/SessionAnalyticsMachine.ts
+++ b/src/state-machines/SessionAnalyticsMachine.ts
@@ -2,10 +2,6 @@ import { setup, assign, fromPromise } from "xstate";
 import AnalyticsService from "../AnalyticsModule";
 import { config } from "../ConfigModule";
 import { UserPreferenceModule } from "../prefs/PreferenceModule";
-import {
-  UserPromptModule,
-  AudibleNotificationsModule,
-} from "../NotificationsModule";
 import EventBus from "../events/EventBus";
 import { logger } from "../LoggingModule";
 
@@ -58,10 +54,6 @@ const analytics = analyticsConfig
     )
   : null;
 const userPreferences = UserPreferenceModule.getInstance();
-
-const MESSAGE_COUNT_THRESHOLD = 50; // number of messages to trigger the long running session prompt
-const userPrompts = new UserPromptModule();
-const audibleNotifications = AudibleNotificationsModule.getInstance();
 
 interface SessionContext {
   session_id: string;
@@ -124,10 +116,13 @@ const machine = setup({
       const transcriptionMode =
         await userPreferences.getCachedTranscriptionMode();
 
-      // calculate the real-time factor (RTF)
+      // calculate the real-time factor (RTF). With no prior transcription
+      // speech_duration_ms is 0, which would yield Infinity — emit null instead
+      // so the analytics value stays meaningful (#403).
       const processing_time_ms = sendEvent.delay_ms;
       const speech_duration_ms = context.last_message.talk_time_seconds * 1000;
-      const rtf = processing_time_ms / speech_duration_ms;
+      const rtf =
+        speech_duration_ms > 0 ? processing_time_ms / speech_duration_ms : null;
 
       analytics?.sendEvent("message_sent", {
         session_id: context.session_id,
@@ -202,25 +197,17 @@ const machine = setup({
         if (context.last_message.speech_start_time === 0) {
           updated_last_message.speech_start_time = tx.speech_start_time;
         }
-        updated_last_message.talk_time_seconds =
+        // Clamp to 0: a later transcription's end can precede the preserved
+        // start, but a turn can't have negative talk time (#403).
+        updated_last_message.talk_time_seconds = Math.max(
+          0,
           (updated_last_message.speech_end_time -
             updated_last_message.speech_start_time) /
-          1000;
+            1000
+        );
         return updated_last_message;
       },
     }),
-    promptForSessionContinuation: () => {
-      // Prompt the user to confirm that the long running session is not headless
-      // This action can be used to trigger a notification or a dialog
-      console.log("Prompting user to continue the session");
-      const countdown = 60; // duration in seconds
-      userPrompts.activityCheck(countdown);
-      audibleNotifications.activityCheck(countdown);
-    },
-  },
-  guards: {
-    longRunningSession: ({ context }) =>
-      context.message_count > MESSAGE_COUNT_THRESHOLD,
   },
 }).createMachine({
   context: {
@@ -278,15 +265,6 @@ const machine = setup({
         end_session: {
           target: "Idle",
           actions: "notifyEndSession",
-        },
-      },
-      after: {
-        "7200000": {
-          target: "Active",
-          guard: "longRunningSession",
-          description:
-            "Prompt the user to confirm that the long running session is not headless.",
-          actions: "promptForSessionContinuation",
         },
       },
     },

--- a/test/state-machines/AudioInputMachine-characterization.spec.ts
+++ b/test/state-machines/AudioInputMachine-characterization.spec.ts
@@ -340,9 +340,8 @@ describe("audioInputMachine characterization", () => {
     await vi.runAllTimersAsync();
     emitMock.mockClear();
 
-    // sendData drops anything whose size rounds to "0.00" kB. (blob.size/1024)
-    // .toFixed(2) must be > 0, so the blob needs ~>=6 bytes. See "drops tiny
-    // blob" test below for the lower-bound boundary characterization.
+    // sendData forwards any non-empty blob (gates on blob.size > 0). See the
+    // "tiny but non-empty blob" test below for the lower-bound boundary.
     const blob = new Blob(["x".repeat(64)], { type: "audio/wav" });
     const frames = new Float32Array([0.1, 0.2]);
     service.send({
@@ -391,9 +390,11 @@ describe("audioInputMachine characterization", () => {
     expect(stoppedEmits.length).toBe(0);
   });
 
-  it("CHARACTERIZATION: sendData drops a tiny (non-empty) blob whose size rounds to 0.00 kB", async () => {
-    // 4 bytes -> (4/1024).toFixed(2) === "0.00" -> Number(...) === 0 -> not > 0.
-    // So a real-but-tiny segment is silently dropped (no userStoppedSpeaking).
+  it("sendData forwards a tiny but non-empty blob (gates on blob.size, not kB rounding)", async () => {
+    // Regression for #403: sendData previously gated on
+    // (blob.size / 1024).toFixed(2) > 0, so a 4-byte blob rounded to "0.00" kB and
+    // was silently dropped. It now gates on blob.size > 0, so any real (non-empty)
+    // segment is forwarded as saypi:userStoppedSpeaking.
     await acquire(service);
     service.send("start");
     await vi.runAllTimersAsync();
@@ -412,7 +413,7 @@ describe("audioInputMachine characterization", () => {
     const stoppedEmits = emitMock.mock.calls.filter(
       (c) => c[0] === "saypi:userStoppedSpeaking"
     );
-    expect(stoppedEmits.length).toBe(0);
+    expect(stoppedEmits.length).toBe(1);
   });
 
   it("recording + stopRequested -> pendingStop, calling vadClient.stop and setting waitingToStop", async () => {
@@ -572,33 +573,33 @@ describe("audioInputMachine characterization", () => {
     expect(initializeMock).toHaveBeenCalledTimes(1);
   });
 
-  it("CHARACTERIZATION: onError event.data is always a plain Error (string-wrapped) -> microphoneErrorGeneric branch (DOMException branches are unreachable via the service)", async () => {
-    // setupRecording swallows any real DOMException and only forwards a string
-    // via completion_callback; acquireMicrophone then rejects with `new Error(string)`.
-    // So logMicrophoneAcquisitionError always sees a generic Error, never a
-    // DOMException -> the NotAllowedError/NotFoundError/etc. branches are dead.
+  it("on acquisition failure, only setupRecording's specific notification fires (no redundant generic one)", async () => {
+    // #403: logMicrophoneAcquisitionError used to emit a SECOND, generic
+    // notification (microphoneErrorGeneric, seconds:20) on top of the specific one
+    // setupRecording already shows — and its DOMException-named branches were dead
+    // (the service flattens the cause to a string). The onError action now only
+    // logs; setupRecording owns the single user-facing notification.
     vadBehavior.initializeResult = { success: false, error: "perm-denied-real" };
     service.send("acquire");
     await vi.runAllTimersAsync();
     expect(service.state.value).toBe("released");
 
-    // Two notifications fire: first from setupRecording (short VAD error,
-    // seconds:10), then from logMicrophoneAcquisitionError (the onError action,
-    // seconds:20). The LAST one is the machine action under test.
     const notifs = emitMock.mock.calls.filter(
       (c) => c[0] === "saypi:ui:show-notification"
     );
-    expect(notifs.length).toBeGreaterThanOrEqual(2);
-    const actionNotif = notifs[notifs.length - 1];
-    // getMessage is mocked to echo the i18n key; the generic Error branch is used
-    // (proving DOMException-named branches are never reached via the service).
-    expect(actionNotif[1]).toEqual(
+    // Exactly one notification — setupRecording's, carrying the specific VAD error.
+    expect(notifs.length).toBe(1);
+    expect(notifs[0][1]).toEqual(
       expect.objectContaining({
-        message: "microphoneErrorGeneric",
+        message: "perm-denied-real",
         icon: "microphone-muted",
-        seconds: 20,
       })
     );
+    // The generic onError notification is gone.
+    const generic = notifs.filter(
+      (c) => (c[1] as { message?: string })?.message === "microphoneErrorGeneric"
+    );
+    expect(generic.length).toBe(0);
   });
 
   it("after a failed acquisition the machine can be re-acquired successfully", async () => {

--- a/test/state-machines/ConversationMachine-characterization.spec.ts
+++ b/test/state-machines/ConversationMachine-characterization.spec.ts
@@ -804,7 +804,7 @@ describe('ConversationMachine characterization', () => {
       expect(service.state.context.isMaintainanceMessage).toBe(true);
     });
 
-    it('CHARACTERIZATION: clearMaintainanceFlag on responding-exit does NOT clear the flag (suspected no-op bug, see report)', () => {
+    it('clearMaintainanceFlag clears the maintenance flag on responding-exit (#403)', () => {
       prefs.discretionary = true;
       service.send({ type: 'userPreferenceChanged', discretionaryMode: true });
       driveToTranscribing(service);
@@ -812,14 +812,11 @@ describe('ConversationMachine characterization', () => {
       vi.advanceTimersByTime(USER_STOPPED_TIMEOUT_MS_LOCAL + 5);
       expect(service.state.context.isMaintainanceMessage).toBe(true);
 
-      // Exit responding via hangup. clearMaintainanceFlag (responding.exit) is a
-      // plain action that builds assign(...) and discards it -> no-op.
+      // Exit responding via hangup. clearMaintainanceFlag (responding.exit) now
+      // resets the flag — previously it built an assign() and discarded it (no-op).
       service.send('saypi:hangup');
       expect(service.state.matches('inactive')).toBe(true);
-      // CHARACTERIZATION: current behavior; the flag is NOT cleared by
-      // clearMaintainanceFlag because the assign() result is thrown away.
-      // (ConversationMachine.ts:1438-1440 — suspected bug.)
-      expect(service.state.context.isMaintainanceMessage).toBe(true);
+      expect(service.state.context.isMaintainanceMessage).toBe(false);
     });
 
     it('maintainance message emits suppression events (tts:skipCurrent on responding entry)', () => {
@@ -838,22 +835,23 @@ describe('ConversationMachine characterization', () => {
   // -------------------------------------------------------------------------
   // CHARACTERIZATION: callStartingPrompt drops its assign() (suspected no-op)
   // -------------------------------------------------------------------------
-  describe('callStarting placeholder backup', () => {
-    it('CHARACTERIZATION: callStartingPrompt does NOT persist a draft backup into defaultPlaceholderText (suspected no-op bug)', () => {
-      // Make a non-empty in-progress draft visible to callStartingPrompt's
-      // getDraft() call. If the action's assign() actually applied, the draft
-      // would be backed up into context.defaultPlaceholderText.
+  describe('callStarting placeholder', () => {
+    it('callStartingPrompt shows the placeholder and does not touch defaultPlaceholderText (#403)', () => {
+      // callStartingPrompt only sets the "call starting" placeholder message. The
+      // dead draft-backup code (a discarded assign into defaultPlaceholderText) was
+      // removed in #403 — defaultPlaceholderText is the PLACEHOLDER restored via
+      // setMessage, not a draft store, so backing a draft into it was wrong.
       const originalGetDraft = spyPrompt.getDraft;
       spyPrompt.getDraft = () => 'WORK_IN_PROGRESS';
       try {
-        // defaultPlaceholderText starts as "" and is only driven by saypi:promptReady.
+        // defaultPlaceholderText is only driven by saypi:promptReady; callStarting
+        // must leave it untouched.
         expect(service.state.context.defaultPlaceholderText).toBe('');
-        service.send('saypi:call'); // entry: callStartingPrompt runs (and discards its assign)
+        service.send('saypi:call'); // entry: callStartingPrompt runs
         expect(service.state.matches('callStarting')).toBe(true);
-        // CHARACTERIZATION: despite a real draft being present, the backup never
-        // lands in context because the assign() result is discarded.
-        // (ConversationMachine.ts:1253-1260 — suspected bug.)
         expect(service.state.context.defaultPlaceholderText).toBe('');
+        // It does set the call-starting placeholder message.
+        expect(spyPrompt.setMessage).toHaveBeenCalledWith('callStarting');
       } finally {
         spyPrompt.getDraft = originalGetDraft;
       }

--- a/test/state-machines/DictationMachine-characterization.spec.ts
+++ b/test/state-machines/DictationMachine-characterization.spec.ts
@@ -297,18 +297,22 @@ describe('DictationMachine - characterization (uncovered transitions)', () => {
     });
 
     it('userStoppedSpeaking with zero-size blob is treated as no audio (hasNoAudio)', () => {
+      // A zero-size blob is not real audio even with a positive duration: it must
+      // follow the VAD-misfire path (hasNoAudio) — stay notSpeaking, no upload —
+      // and agree with hasNoAudio (which already checks blob.size === 0).
+      // Regression test for #403: hasAudio previously ignored blob.size, so this
+      // event satisfied BOTH guards and hasAudio (listed first) wrongly won,
+      // uploading a zero-byte segment.
       const emptyBlob = new Blob([], { type: 'audio/wav' });
       service.send({
         type: 'saypi:userStoppedSpeaking',
         duration: 1000,
         blob: emptyBlob,
       });
-      // duration > 0 but the hasAudio guard only checks blob !== undefined && duration > 0,
-      // so a zero-size blob with positive duration actually satisfies hasAudio.
-      // CHARACTERIZATION: hasAudio passes here, so it transitions into transcribing.
       expect(service.state.value).toEqual({
-        listening: { recording: 'notSpeaking', converting: 'transcribing' },
+        listening: { recording: 'notSpeaking', converting: 'ready' },
       });
+      expect(TranscriptionModule.uploadAudioWithRetry).not.toHaveBeenCalled();
     });
 
     it('userStoppedSpeaking with blob but zero duration is hasNoAudio -> stays notSpeaking', () => {

--- a/test/state-machines/SessionAnalyticsMachine-characterization.spec.ts
+++ b/test/state-machines/SessionAnalyticsMachine-characterization.spec.ts
@@ -10,10 +10,9 @@
  * This suite covers the Idle/Active state graph, the assign() reducers, and the
  * analytics/EventBus/notification side-effects.
  *
- * NOTE: the machine wires `analytics`, `userPreferences`, `userPrompts` and
- * `audibleNotifications` as module-level singletons constructed at import time
- * from the (mocked) config. We mock those external modules so we can observe
- * the calls those singletons receive.
+ * NOTE: the machine wires `analytics` and `userPreferences` as module-level
+ * singletons constructed at import time from the (mocked) config. We mock those
+ * external modules so we can observe the calls those singletons receive.
  */
 import {
   describe,
@@ -42,8 +41,6 @@ const {
   analyticsInstances,
   getCachedTranscriptionMode,
   getLanguage,
-  userPromptActivityCheck,
-  audibleActivityCheck,
   emit,
 } = vi.hoisted(() => ({
   analyticsInstances: [] as Array<{
@@ -54,8 +51,6 @@ const {
   }>,
   getCachedTranscriptionMode: vi.fn(() => "online"),
   getLanguage: vi.fn(() => Promise.resolve("en")),
-  userPromptActivityCheck: vi.fn(),
-  audibleActivityCheck: vi.fn(),
   emit: vi.fn(),
 }));
 
@@ -84,29 +79,6 @@ vi.mock("../../src/prefs/PreferenceModule", () => ({
     }),
   },
 }));
-
-// Notifications: UserPromptModule is `new`-ed; AudibleNotificationsModule is a
-// singleton via getInstance(). Both expose `activityCheck`.
-vi.mock("../../src/NotificationsModule", () => {
-  class MockUserPromptModule {
-    activityCheck = userPromptActivityCheck;
-  }
-  class MockAudibleNotificationsModule {
-    static instance: MockAudibleNotificationsModule | null = null;
-    static getInstance() {
-      if (!MockAudibleNotificationsModule.instance) {
-        MockAudibleNotificationsModule.instance =
-          new MockAudibleNotificationsModule();
-      }
-      return MockAudibleNotificationsModule.instance;
-    }
-    activityCheck = audibleActivityCheck;
-  }
-  return {
-    UserPromptModule: MockUserPromptModule,
-    AudibleNotificationsModule: MockAudibleNotificationsModule,
-  };
-});
 
 // EventBus singleton — observe emits.
 vi.mock("../../src/events/EventBus", () => ({
@@ -299,11 +271,11 @@ describe("SessionAnalyticsMachine — Active: transcribing (rollupTranscription)
     expect(getAnalytics().sendEvent).not.toHaveBeenCalled();
   });
 
-  it("CHARACTERIZATION: talk_time goes NEGATIVE when a later transcription's speech_end_time precedes the preserved speech_start_time", () => {
+  it("clamps talk_time to 0 when a later transcription's speech_end_time precedes the preserved speech_start_time", () => {
     // The rollup keeps the first event's speech_start_time but always adopts the
-    // latest event's speech_end_time, computing talk = (end - start)/1000 with no
-    // clamp. A later end-time earlier than the start yields a negative talk time.
-    // Suspected bug: see report (unguarded subtraction in rollupTranscription).
+    // latest event's speech_end_time. A later end-time earlier than the start
+    // would compute a negative talk = (end - start)/1000; the rollup clamps it
+    // to 0 because a turn can't have negative talk time (#403, bug #8).
     startActive();
     service.send({
       type: "transcribing",
@@ -320,8 +292,8 @@ describe("SessionAnalyticsMachine — Active: transcribing (rollupTranscription)
     const ctx = service.state.context;
     expect(ctx.last_message.speech_start_time).toBe(5000);
     expect(ctx.last_message.speech_end_time).toBe(2000);
-    // (2000 - 5000) / 1000 = -3
-    expect(ctx.last_message.talk_time_seconds).toBe(-3);
+    // (2000 - 5000) / 1000 = -3, clamped to 0
+    expect(ctx.last_message.talk_time_seconds).toBe(0);
   });
 
   it("CHARACTERIZATION: speech_start_time of 0 in the first event is treated as 'unset' so it is overwritten by itself, yielding talk_time = speech_end/1000", () => {
@@ -404,7 +376,9 @@ describe("SessionAnalyticsMachine — Active: send_message", () => {
     dateSpy.mockRestore();
   });
 
-  it("CHARACTERIZATION: with no prior transcription, RTF is Infinity (delay/0) and talk/audio are 0", async () => {
+  it("with no prior transcription, RTF is null (not Infinity) and talk/audio are 0", async () => {
+    // speech_duration_ms is 0 with no transcription; rtf must be null rather
+    // than delay/0 === Infinity (#403, bug #6).
     startActive();
     getAnalytics().sendEvent.mockClear();
 
@@ -417,7 +391,7 @@ describe("SessionAnalyticsMachine — Active: send_message", () => {
     );
     expect(call).toBeTruthy();
     const params = call![1] as Record<string, unknown>;
-    expect(params.rtf).toBe(Infinity); // 500 / 0
+    expect(params.rtf).toBeNull(); // 500 / 0 would be Infinity; clamped to null
     expect(params.talk_time_seconds).toBe(0);
     expect(params.audio_duration_seconds).toBe(0);
   });
@@ -612,105 +586,5 @@ describe("SessionAnalyticsMachine — Active: invoked 30-minute timeout", () => 
     expect(service.state.matches("Idle")).toBe(true);
 
     dateSpy.mockRestore();
-  });
-});
-
-describe("SessionAnalyticsMachine — Active: long-running-session prompt (after + guard)", () => {
-  it("CHARACTERIZATION: the 30-min invoke ends the session before the 2-hour `after` can fire, so the activity-check prompt never runs", async () => {
-    vi.useFakeTimers();
-    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(0);
-
-    service = createTestActor(machine);
-    service.start();
-    service.send("start_session");
-
-    // Push message_count over the threshold so the guard WOULD pass.
-    for (let i = 0; i < 51; i++) {
-      service.send({ type: "send_message", delay_ms: 1, wait_time_ms: 0 });
-    }
-    expect(service.state.context.message_count).toBe(51);
-
-    // Advance only to the 30-min invoke boundary: it resolves first and moves
-    // the machine to Idle (cancelling the 2-hour `after`).
-    await vi.advanceTimersByTimeAsync(1_800_000);
-    expect(service.state.matches("Idle")).toBe(true);
-
-    // Now advance well past the 2-hour mark; the `after` is gone, no prompt.
-    await vi.advanceTimersByTimeAsync(7_200_000);
-    expect(userPromptActivityCheck).not.toHaveBeenCalled();
-    expect(audibleActivityCheck).not.toHaveBeenCalled();
-
-    dateSpy.mockRestore();
-  });
-
-  it("CHARACTERIZATION: when the 30-min invoke's onDone microtask is NOT flushed, the machine is still Active at 2h so the guarded `after` fires the activity-check prompt (countdown 60)", () => {
-    // This exercises the guarded `after`+promptForSessionContinuation action,
-    // which is otherwise unreachable in real operation: `after` is 2h but the
-    // invoke is 30min, so the invoke normally ends the session first.
-    //
-    // The reachability hinges on a subtle timer/microtask interleaving:
-    // synchronous `advanceTimersByTime` runs the invoke's setTimeout (resolving
-    // the promise) but DOES NOT flush the resulting onDone microtask, leaving
-    // the machine in Active when the 2h `after` callback runs — so the guarded
-    // prompt fires. (Compare the async test above, where microtasks ARE flushed
-    // and the prompt never runs.)
-    vi.useFakeTimers();
-    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(0);
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    service = createTestActor(machine);
-    service.start();
-    service.send("start_session");
-    for (let i = 0; i < 51; i++) {
-      service.send({ type: "send_message", delay_ms: 1, wait_time_ms: 0 });
-    }
-    expect(service.state.context.message_count).toBe(51); // guard passes
-
-    vi.advanceTimersByTime(7_200_000); // sync: no microtask flush
-
-    // internal `after` transition keeps us in Active and fires the prompt
-    expect(service.state.matches("Active")).toBe(true);
-    expect(userPromptActivityCheck).toHaveBeenCalledWith(60);
-    expect(audibleActivityCheck).toHaveBeenCalledWith(60);
-
-    logSpy.mockRestore();
-    dateSpy.mockRestore();
-  });
-
-  it("CHARACTERIZATION: below the message-count threshold the guard blocks the `after` prompt even under the no-flush timing", () => {
-    // longRunningSession guard: message_count > 50. With 50 messages the guard
-    // is false (50 > 50 === false), so the prompt action does not run.
-    vi.useFakeTimers();
-    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(0);
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    service = createTestActor(machine);
-    service.start();
-    service.send("start_session");
-    for (let i = 0; i < 50; i++) {
-      service.send({ type: "send_message", delay_ms: 1, wait_time_ms: 0 });
-    }
-    expect(service.state.context.message_count).toBe(50);
-
-    vi.advanceTimersByTime(7_200_000);
-
-    expect(userPromptActivityCheck).not.toHaveBeenCalled();
-    expect(audibleActivityCheck).not.toHaveBeenCalled();
-
-    logSpy.mockRestore();
-    dateSpy.mockRestore();
-  });
-
-  it("longRunningSession guard threshold: message_count > 50 (51 trips, 50 does not) — verified via context", () => {
-    // We can't easily isolate the `after` from the invoke (it never wins), so
-    // pin the guard's threshold semantics indirectly: message_count is what the
-    // guard reads, and send_message increments it by exactly 1 each time.
-    startActive();
-    for (let i = 0; i < 50; i++) {
-      service.send({ type: "send_message", delay_ms: 1, wait_time_ms: 0 });
-    }
-    expect(service.state.context.message_count).toBe(50); // guard 50 > 50 === false
-    service.send({ type: "send_message", delay_ms: 1, wait_time_ms: 0 });
-    expect(service.state.context.message_count).toBe(51); // guard 51 > 50 === true
   });
 });


### PR DESCRIPTION
## Why
Resolves the substantive deferred bugs the XState characterization net surfaced (#403). Each is fixed fail-first — the characterization tests that pinned the buggy behavior are flipped to assert the correct behavior.

Founder delegated the taste-call decisions ("use your best judgement, prioritise end-user experience + maintainability + testability"); the calls are documented per-commit and below.

## Fixes (per machine, per-bug commits)
- **DictationMachine** — `hasAudio` ignored `blob.size`, so a 0-byte blob with `duration>0` satisfied both guards and `hasAudio` (first) won, uploading empty audio. Now requires `blob.size > 0` (complement of `hasNoAudio`).
- **AudioInputMachine** — (a) `sendData` gated on kB rounded to 2dp, dropping sub-~6-byte non-empty blobs → now gates on `blob.size > 0`; (b) `logMicrophoneAcquisitionError` emitted a redundant generic notification on top of setupRecording's specific one, with dead `DOMException` branches → collapsed to diagnostics-only (setupRecording owns the user-facing notice); removed the dead `OverconstrainedError`/`isOverconstrainedError`.
- **ConversationMachine** — (a) `clearMaintainanceFlag` built an `assign()` and discarded it → now a real `assign({ isMaintainanceMessage: false })`; (b) `callStartingPrompt`'s discarded draft-backup `assign()` removed — it never ran *and* was semantically wrong (would have shown the draft as a greyed-out placeholder); literal "fix" would harm UX.
- **SessionAnalyticsMachine** — (a) `message_sent` RTF was `x/0 = Infinity` with no prior speech → now `null`; (b) `rollupTranscription` talk-time `Math.max(0, …)` (no negative turns); (c) removed the **unreachable** long-running-session prompt (the 30-min idle auto-end + `send_message` reentry preempt the 2h timer; the idle auto-end already handles abandoned sessions, and interrupting an active session is poor UX) + its now-dead guard/const/imports.

## Re-scoped
The 9th #403 item (snapshot-context mutation in Dictation specs) was filed as "a couple of specs" but is **106 sites across 6 specs**, all currently passing (v5 doesn't deep-freeze nested context). Per founder decision it's re-scoped to **#406** as a low-priority, migrate-when-touched follow-up rather than a 106-site churn of passing tests.

## Verification
`npm test` (tsc + Jest + Vitest) → exit 0; 1345 tests pass (1 skipped). Per-machine specs all green; characterization tests flipped, not weakened.

Relates to #403 (the 8 actionable bugs); test-debt tracked in #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)