### PR TITLE
fix(chatgpt): read aloud the first reply in a new-chat voice call (#408)

### DIFF
--- a/src/chatbots/ChatGPT.ts
+++ b/src/chatbots/ChatGPT.ts
@@ -9,6 +9,7 @@ import { findControlsContainerInComposer, findPromptInputInComposer, getScopedSu
 import { getAssistantContentSelector } from "./chatgpt/MessageSelectors";
 import { findThreadRoot } from "./chatgpt/HistorySelectors";
 import { ChatGPTResponse } from "./chatgpt/ChatGPTResponse";
+import { initCallStartTracking } from "./chatgpt/readAloudGating";
 
 export const CHATGPT_FEATURES = {
   enableControlPanel: false,
@@ -16,6 +17,14 @@ export const CHATGPT_FEATURES = {
 
 class ChatGPTChatbot extends AbstractChatbot {
   private promptCache: Map<HTMLElement, ChatGPTPrompt> = new Map();
+
+  constructor() {
+    super();
+    // Snapshot which messages exist when a call starts so auto-read-aloud can tell
+    // a genuinely new reply (#200/#408) from one already on screen (#245). Wiring is
+    // idempotent, so repeated construction (host detection) registers it just once.
+    initCallStartTracking();
+  }
 
   getName(): string {
     return "ChatGPT";

--- a/src/chatbots/chatgpt/ChatGPTResponse.ts
+++ b/src/chatbots/chatgpt/ChatGPTResponse.ts
@@ -4,12 +4,19 @@ import { UserPreferenceModule } from "../../prefs/PreferenceModule";
 import { logger } from "../../LoggingModule";
 import { ElementTextStream, InputStreamOptions, AddedText } from "../../tts/InputStream";
 import { TTSControlsModule } from "../../tts/TTSControlsModule";
+import { isMessageNewSinceCallStart } from "./readAloudGating";
 
 export class ChatGPTResponse extends AssistantResponse {
   constructor(element: HTMLElement, includeInitialText?: boolean, isStreaming?: boolean) {
     super(element, includeInitialText);
-    // Mark streaming messages as unread for auto-read aloud functionality
-    if (isStreaming) {
+    // Mark new replies unread so auto-read-aloud picks them up. A reply is "new"
+    // if it streamed in under our chat-history observer (isStreaming) OR it first
+    // appeared after the current voice call started. The latter covers the
+    // new-chat / route-change race (#200/#408): there the chat-history container
+    // is found late, so the reply is decorated via the old-message path and never
+    // gets the streaming flag — yet it is the awaited reply and must be read aloud.
+    // Messages already present when the call started stay silent (#245).
+    if (isStreaming || isMessageNewSinceCallStart(element.getAttribute('data-turn-id'))) {
       element.setAttribute('data-saypi-unread', 'true');
     }
   }

--- a/src/chatbots/chatgpt/readAloudGating.ts
+++ b/src/chatbots/chatgpt/readAloudGating.ts
@@ -1,0 +1,86 @@
+import EventBus from "../../events/EventBus";
+
+/**
+ * Tracks which ChatGPT assistant messages were already on screen when the current
+ * voice call started, so auto-read-aloud can tell a *genuinely new* reply (which
+ * should be read aloud — #200/#408) apart from a *pre-existing* message (which must
+ * stay silent — #245).
+ *
+ * Why a call-start snapshot instead of the streaming flag alone: new replies are
+ * normally marked `data-saypi-unread` while they stream in under our chat-history
+ * observer. But on a brand-new chat the chat-history container is only discovered
+ * by the progressive backoff search *after* the reply has finished streaming and
+ * the SPA has route-changed to `/c/<id>`. The reply is then decorated through the
+ * old-message path, which never sets that flag, so every auto-click path skips it
+ * as "already read". The decoration path can't distinguish new from old in that
+ * race; "was this turn present when the call started" can.
+ *
+ * Identity is the turn's `data-turn-id` — the same id `ChatGPTResponse.messageId`
+ * uses — because it survives ChatGPT's React node replacements (an element-identity
+ * snapshot would treat a re-rendered existing message as new and re-read it).
+ */
+let presentAtCallStart: Set<string> | null = null;
+// The thread the call was placed in, or null if it began on a new chat / project
+// page (where the conversation only gets its `/c/<id>` once the first reply arrives).
+let callStartThreadId: string | null = null;
+let trackingRegistered = false;
+
+/** The `/c/<id>` thread id in a ChatGPT path (also matches `/g/.../c/<id>`), or null. */
+function threadIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/\/c\/([^/?#]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Snapshot the turn ids currently in the DOM. Called when a call starts; on a
+ * brand-new chat this captures nothing, so the first reply is correctly "new".
+ */
+export function captureMessagesPresentAtCallStart(
+  root: ParentNode = document,
+  pathname: string = window.location.pathname
+): void {
+  const ids = new Set<string>();
+  root.querySelectorAll("[data-turn-id]").forEach((el) => {
+    const id = el.getAttribute("data-turn-id")?.trim();
+    if (id) ids.add(id);
+  });
+  presentAtCallStart = ids;
+  callStartThreadId = threadIdFromPath(pathname);
+}
+
+/** Drop the snapshot. Called when a call ends so stale state can't read messages. */
+export function clearMessagesPresentAtCallStart(): void {
+  presentAtCallStart = null;
+  callStartThreadId = null;
+}
+
+/**
+ * True only when a call is active (a snapshot exists) and this turn was NOT present
+ * when the call started. Without a snapshot, or without a usable id, returns false
+ * — staying silent rather than risk re-reading an existing message (#245).
+ *
+ * Also returns false once the user has navigated to a DIFFERENT existing thread than
+ * the one the call began in: that thread's messages predate the call and would
+ * otherwise be re-read (a #245-style regression). The new-chat → `/c/<id>` and
+ * project → thread transitions are exempt because the call began with no thread id.
+ */
+export function isMessageNewSinceCallStart(
+  turnId: string | null | undefined,
+  pathname: string = window.location.pathname
+): boolean {
+  if (!presentAtCallStart) return false;
+  if (callStartThreadId !== null && threadIdFromPath(pathname) !== callStartThreadId) {
+    return false;
+  }
+  const id = turnId?.trim();
+  if (!id) return false;
+  return !presentAtCallStart.has(id);
+}
+
+/** Idempotently wire the snapshot to the call lifecycle. */
+export function initCallStartTracking(): void {
+  if (trackingRegistered) return;
+  trackingRegistered = true;
+  EventBus.on("session:started", () => captureMessagesPresentAtCallStart());
+  EventBus.on("session:ended", () => clearMessagesPresentAtCallStart());
+}

--- a/test/chatbots/ChatGPTAutoReadAloud.spec.ts
+++ b/test/chatbots/ChatGPTAutoReadAloud.spec.ts
@@ -43,11 +43,16 @@ vi.mock('../../src/chatbots/Pi', () => ({
 
 // Import after mocks so they take effect
 import ChatGPTChatbot from '../../src/chatbots/ChatGPT';
+import {
+  captureMessagesPresentAtCallStart,
+  clearMessagesPresentAtCallStart,
+} from '../../src/chatbots/chatgpt/readAloudGating';
 
 
 describe('ChatGPT auto Read Aloud', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
+    clearMessagesPresentAtCallStart();
     setCallActive();
   });
 
@@ -303,6 +308,77 @@ describe('ChatGPT auto Read Aloud', () => {
     expect(readAloudClickSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
     expect(overflowClickSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
     expect(switchClickSpy).not.toHaveBeenCalled();
+  });
+
+  it('auto-clicks a new-chat reply decorated via the old-message path during a call (#408/#200)', async () => {
+    // New chat: no assistant turns exist when the call starts → empty snapshot.
+    captureMessagesPresentAtCallStart();
+    setCallActive();
+
+    const list = document.createElement('div');
+    list.className = 'present-messages';
+    document.body.appendChild(list);
+
+    // The reply streamed in *after* the call started and is discovered late, so it
+    // is decorated through the OLD-message path (isStreaming omitted/false) — the
+    // exact #408 race. It carries a fresh turn id absent from the call-start snapshot.
+    const msg = document.createElement('article');
+    msg.setAttribute('data-turn', 'assistant');
+    msg.setAttribute('data-turn-id', 'turn-new-reply');
+    const content = document.createElement('div');
+    content.className = 'markdown';
+    msg.appendChild(content);
+    list.appendChild(msg);
+
+    const chatbot = new ChatGPTChatbot();
+    chatbot.getAssistantResponse(msg as HTMLElement, true, false); // old-message path
+
+    const actionBar = document.createElement('div');
+    msg.appendChild(actionBar);
+    const btn = document.createElement('button');
+    btn.setAttribute('data-testid', 'voice-play-turn-action-button');
+    const clickSpy = vi.spyOn(btn, 'click');
+    actionBar.appendChild(btn);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    // It must be read aloud even though it arrived via the old-message path.
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT auto-click a message already present when the call started (#245 not regressed)', async () => {
+    const list = document.createElement('div');
+    list.className = 'present-messages';
+    document.body.appendChild(list);
+
+    // Existing reply already on screen *before* the user starts the call.
+    const msg = document.createElement('article');
+    msg.setAttribute('data-turn', 'assistant');
+    msg.setAttribute('data-turn-id', 'turn-existing');
+    const content = document.createElement('div');
+    content.className = 'markdown';
+    msg.appendChild(content);
+    list.appendChild(msg);
+
+    // Call starts now → snapshot includes the existing turn.
+    captureMessagesPresentAtCallStart();
+    setCallActive();
+
+    // Decorated via the old-message path during the active call.
+    const chatbot = new ChatGPTChatbot();
+    chatbot.getAssistantResponse(msg as HTMLElement, true, false);
+
+    const actionBar = document.createElement('div');
+    msg.appendChild(actionBar);
+    const btn = document.createElement('button');
+    btn.setAttribute('data-testid', 'voice-play-turn-action-button');
+    const clickSpy = vi.spyOn(btn, 'click');
+    actionBar.appendChild(btn);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    // A message present at call start must stay silent.
+    expect(clickSpy).toHaveBeenCalledTimes(0);
   });
 
   it.skip('cleans up/shuts down prior shielded menu when a newer message starts playback', async () => {

--- a/test/chatbots/chatgpt/readAloudGating.spec.ts
+++ b/test/chatbots/chatgpt/readAloudGating.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import EventBus from "../../../src/events/EventBus";
+import {
+  captureMessagesPresentAtCallStart,
+  clearMessagesPresentAtCallStart,
+  isMessageNewSinceCallStart,
+  initCallStartTracking,
+} from "../../../src/chatbots/chatgpt/readAloudGating";
+
+describe("ChatGPT read-aloud call-start gating", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    clearMessagesPresentAtCallStart();
+  });
+
+  it("treats nothing as new when no call snapshot is active", () => {
+    // Outside a call there is no snapshot, so a message can never be "new" — this
+    // is what keeps page-load decoration (#245) from marking existing messages.
+    expect(isMessageNewSinceCallStart("turn-1")).toBe(false);
+  });
+
+  it("treats a message absent from the call-start snapshot as new (new chat → #408)", () => {
+    captureMessagesPresentAtCallStart(); // empty: brand-new chat at call start
+    expect(isMessageNewSinceCallStart("turn-new")).toBe(true);
+  });
+
+  it("treats a message present at call start as not new (#245)", () => {
+    const existing = document.createElement("article");
+    existing.setAttribute("data-turn-id", "turn-old");
+    document.body.appendChild(existing);
+
+    captureMessagesPresentAtCallStart();
+
+    expect(isMessageNewSinceCallStart("turn-old")).toBe(false);
+    expect(isMessageNewSinceCallStart("turn-new")).toBe(true);
+  });
+
+  it("is conservative when the message has no usable id", () => {
+    captureMessagesPresentAtCallStart();
+    expect(isMessageNewSinceCallStart(null)).toBe(false);
+    expect(isMessageNewSinceCallStart(undefined)).toBe(false);
+    expect(isMessageNewSinceCallStart("")).toBe(false);
+    expect(isMessageNewSinceCallStart("   ")).toBe(false);
+  });
+
+  it("does not consider a thread navigated-to mid-call as new (avoids #245 on cross-thread nav)", () => {
+    // Call starts in an existing thread A (its turns are snapshotted).
+    const a = document.createElement("article");
+    a.setAttribute("data-turn-id", "turn-A");
+    document.body.appendChild(a);
+    captureMessagesPresentAtCallStart(document, "/c/threadA");
+
+    // Same thread: a freshly-arrived reply is still new.
+    expect(isMessageNewSinceCallStart("turn-A-reply", "/c/threadA")).toBe(true);
+
+    // Navigated to a DIFFERENT existing thread mid-call: its last message predates
+    // this call and must not be treated as new (it would otherwise be re-read).
+    expect(isMessageNewSinceCallStart("turn-B-last", "/c/threadB")).toBe(false);
+  });
+
+  it("still treats the first reply as new across the new-chat → /c/<id> route change (#408/#200)", () => {
+    // Call starts on a brand-new chat (no thread id) → empty snapshot.
+    captureMessagesPresentAtCallStart(document, "/");
+    // The reply is decorated AFTER the SPA assigns the thread id; it must stay new.
+    expect(isMessageNewSinceCallStart("turn-first-reply", "/c/brand-new")).toBe(true);
+    // Same for the project → thread route change in #200.
+    captureMessagesPresentAtCallStart(document, "/g/g-p-abc/project");
+    expect(isMessageNewSinceCallStart("turn-first-reply", "/g/g-p-abc/c/xyz")).toBe(true);
+  });
+
+  it("clears the snapshot when the call ends so nothing is considered new again", () => {
+    captureMessagesPresentAtCallStart();
+    expect(isMessageNewSinceCallStart("x")).toBe(true);
+    clearMessagesPresentAtCallStart();
+    expect(isMessageNewSinceCallStart("x")).toBe(false);
+  });
+
+  it("captures on session:started and clears on session:ended", () => {
+    const present = document.createElement("article");
+    present.setAttribute("data-turn-id", "turn-present");
+    document.body.appendChild(present);
+
+    initCallStartTracking();
+
+    EventBus.emit("session:started");
+    expect(isMessageNewSinceCallStart("turn-present")).toBe(false);
+    expect(isMessageNewSinceCallStart("turn-later")).toBe(true);
+
+    EventBus.emit("session:ended");
+    expect(isMessageNewSinceCallStart("turn-later")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

On a brand-new ChatGPT chat (`chatgpt.com/`), the **first** assistant reply during a SayPi voice call was never auto-read-aloud — a hands-free user heard nothing and the conversation stalled in `responding:piThinking` until a 15s timeout. This is a regression of #200, caused by the #245 unread-guard.

**Root cause.** New replies are normally marked `data-saypi-unread` while they stream in under our chat-history observer (the only path that passes `isStreaming=true`). On a new chat the chat-history container is only found by the progressive backoff search *after* the reply has finished streaming and the SPA has route-changed to `/c/<id>`. The reply is therefore decorated through the **old-message path**, which never sets that flag, so all three auto-read-aloud paths skip it as "already read". The flag keyed off the *decoration path*, not the distinction the bug actually needs:

> did this reply arrive **after the call started** (new → read it, #200/#408) or was it **already on screen when the call started** (#245 → stay silent)?

## The fix

A small `src/chatbots/chatgpt/readAloudGating.ts` module snapshots the assistant turn ids present when a call starts (`session:started`) and clears them when it ends (`session:ended`). `ChatGPTResponse` now marks a reply unread if it streamed in **or** is new since the call started:

- The late-decorated new-chat reply (turn id absent from the call-start snapshot) → read aloud ✅ (#200/#408)
- A message present at call start (turn id in the snapshot) → stays silent ✅ (#245 preserved)
- Identity is `data-turn-id` (same id `messageId` uses) so it survives ChatGPT's React node replacements.
- A URL guard keeps a thread **navigated-to mid-call** (a different `/c/<id>`) from being re-read, while exempting the new-chat → thread and project → thread transitions (which begin with no thread id).

It reuses the existing `data-saypi-unread` flag + click-dedup machinery (the runtime guards still key off the attribute, which is removed on click), so there is **no re-click loop**. Wiring is ChatGPT-scoped (`initCallStartTracking()` from the `ChatGPTChatbot` constructor) and idempotent; no effect on Pi.ai/Claude.ai.

## Testing

Proven at the lowest feasible layer (the discriminator is timing-race logic best modelled in unit/contract tests):

- `test/chatbots/chatgpt/readAloudGating.spec.ts` — gating logic incl. empty-snapshot (new chat), present-at-call-start (#245), cross-thread nav guard, new-chat/project route-change exemption, and `session:started`/`session:ended` wiring.
- `test/chatbots/ChatGPTAutoReadAloud.spec.ts` — contract tests reproducing the #408 new-chat reply (now auto-clicked) and the #245 non-regression (present-at-call-start stays silent).
- ✅ `tsc --noEmit` clean · Vitest 143 files / 1121 passed · Jest passed.

A three-lens adversarial review (resolution / #245-regression / loops-edges-crosshost) traced the full production chain and returned **resolves** on all three.

## Known limitations (bounded, follow-up candidates)

- Starting a call on a *new* chat and then navigating to a *different existing* thread mid-call could still read that thread's last message (the call began with no thread id, so the URL guard can't anchor). Rare; the common thread→thread case is guarded.
- Depends on the host contract that `data-turn-id` sits on the `[data-turn="assistant"]` turn. Fail-safe direction is correct (missing id → silent, never mis-fire). Worth a Layer-4 real-host spot-check per the repo's no-real-host caveat.

Closes #408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)