### PR TITLE
docs(release): CWS console can't be browser-automated (API-only)

### DIFF
--- a/doc/release/README.md
+++ b/doc/release/README.md
@@ -108,8 +108,15 @@ After all stores are submitted: `node scripts/release.mjs tag <version> --yes` t
 `finalize <version> --yes` (pushes the release commit + tag from main). Optionally
 `gh release create v<x> -F dist/release-notes-draft-v<x>.md`.
 
-## Future: browser-driving & publishing APIs
-`stores.json` + the packet are the contract a later phase consumes: (a) a Claude-in-Chrome
-driver that fills the dashboards (Chrome first; dry run → wet run), and (b) optional API
-automation (CWS V2 OAuth, Edge v1.1 API-key, AMO `web-ext sign --channel=listed`). Each
-store's API + auth model is documented in its per-store file.
+## Future: one-click automation via publishing APIs (#412)
+The 1.11.0 wet run established that **browser-driving is a dead end for releases:**
+- **Chrome's dev console can't be scripted by an extension at all** (extensions-gallery block —
+  *"The extensions gallery cannot be scripted"*). Edge Partner Center / AMO aren't on the gallery,
+  so they *could* be driven from Chrome, but —
+- the package upload is a **native OS file-picker** and the build is ~18 MB (over the in-browser
+  10 MB cap), so the actual upload isn't automatable from the browser on **any** store.
+
+So the real path to a (near) one-click, headless release is the **publishing APIs**, consuming the
+same `stores.json` + built artifacts: **CWS V2** (OAuth refresh token), **Edge v1.1** (API key +
+Client ID), **AMO** `web-ext sign --channel=listed` (JWT, `--upload-source-code`). Each store's API
++ auth model is in its per-store file. Tracked in **#412**.

--- a/doc/release/chrome-web-store.md
+++ b/doc/release/chrome-web-store.md
@@ -35,6 +35,17 @@ Canonical answers live in `doc/WEB_STORE_PERMISSIONS.md`. The tab is sticky but 
 - Usually a **few days**; occasionally up to **~3 weeks** (a 2026-04 submission-surge notice is posted). Broad host permissions / sensitive permissions slow it. Contact developer support if pending >3 weeks.
 - Default **auto-publishes on approval** (unless you unchecked it).
 
+## ⚠️ The dev console cannot be browser-automated
+Chrome **blocks all extensions from scripting the extensions-gallery domain**
+(`chrome.google.com/webstore/*`, incl. the dev console). Navigating Claude-in-Chrome there
+returns *"The extensions gallery cannot be scripted."* — this is categorical, not a setup
+issue. So the Chrome submission is **either manual (from the packet) or via the API below** —
+there is no browser-driving path for Chrome (unlike Edge/AMO, whose dashboards aren't on the
+gallery, though those are still gated by the native file-picker / 10 MB upload limit). The
+package upload is also a native OS file-picker and the build is ~18 MB, so the upload step
+isn't automatable from the browser on any store. Confirmed in the 1.11.0 wet run (2026-06-22).
+**API is the only real automation path for Chrome — tracked in #412.**
+
 ## Publishing API (future automation phase)
 - **V2 API** (`https://chromewebstore.googleapis.com`). **V1 sunsets 2026-10-15** — build on V2.
 - **Auth:** OAuth2 — classic client id/secret + refresh token, or a V2 **service account**. Token at `https://oauth2.googleapis.com/token`. Scope `https://www.googleapis.com/auth/chromewebstore`. 2SV required on the account.


### PR DESCRIPTION
From the **1.11.0 wet run**: trying to drive the Chrome Web Store dev console with Claude-in-Chrome returns *"The extensions gallery cannot be scripted."* — Chrome categorically blocks extensions from scripting `chrome.google.com/webstore/*`. And the package upload is a native OS file-picker (build ~18 MB, over the in-browser 10 MB cap), so the upload isn't browser-automatable on any store.

- Adds the constraint to `doc/release/chrome-web-store.md`.
- Corrects `doc/release/README.md`'s forward-looking section, which had implied a "Chrome-first" browser driver — the real automation path is the **publishing APIs** (tracked in **#412**).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)