### PR TITLE
feat(release): auto-verify release candidates (catch stale/unsafe builds)

### DIFF
--- a/doc/release/README.md
+++ b/doc/release/README.md
@@ -52,7 +52,8 @@ npm run release:preflight                  # = node scripts/release.mjs prefligh
 npm run release:plan                       # = … plan
 npm run release:packet                     # = … packet
 npm run release:bump -- <version> --yes    # = … bump <version> --yes
-npm run release:build -- --yes             # = … build --yes
+npm run release:build -- --yes             # = … build --yes  (clears stale output, then self-verifies)
+npm run release:verify                     # = … verify  (re-check the built candidates; read-only)
 npm run release:tag -- <version> --yes     # = … tag <version> --yes
 npm run release:finalize -- <version> --yes  # = … finalize <version> --yes
 ```
@@ -76,10 +77,15 @@ lockfile, no tag). Reconcile the stale root `manifest.json` if it drifts (legacy
 the WXT build). Commit the bump.
 
 ### 2. Build & package ⛔ (founder, loads `.env.production`)
-`node scripts/release.mjs build --yes` → `package-extension.sh chrome edge firefox` +
+`node scripts/release.mjs build --yes` → **clears stale `.output`/`dist`/`source-code.zip`**,
+prints what/where it's building, runs `package-extension.sh chrome edge firefox` +
 `source-archive` → `dist/saypi.chrome.zip`, `dist/saypi.edge.zip`, `dist/saypi.firefox.xpi`,
-`source-code.zip`. Verify the built manifest version matches and the Chrome bundle has no
-`eval` (`grep -r eval .output/chrome-mv3 --include=*.js` → 0).
+`source-code.zip`, then **auto-verifies** them and **fails the build** if anything is off.
+The verification (also runnable standalone via `release:verify`) checks: the version *inside
+each archive* matches the target (catches stale builds), Edge≡Chrome, the Firefox MV2 manifest
++ gecko id, **no dev-only `downloads`**, **no secrets in the source zip**, and **permission-set
+drift** (would have caught the missing `alarms`/`identity`). This codifies the manual checks
+from the 1.11.0 wet run — see `scripts/release-lib.mjs` (`checkChromeManifest` etc.).
 
 ### 3. Draft the "what's new" ⛔ (to apply)
 `node scripts/release.mjs plan --save` writes the factual digest to

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "release:packet": "node scripts/release.mjs packet",
     "release:bump": "node scripts/release.mjs bump",
     "release:build": "node scripts/release.mjs build",
+    "release:verify": "node scripts/release.mjs verify",
     "release:tag": "node scripts/release.mjs tag",
     "release:finalize": "node scripts/release.mjs finalize",
     "prebuild:firefox": "node scripts/validate-env.js --file .env.production --env production && npm run copy-onnx",

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -414,3 +414,96 @@ export function renderPacket({ version, dateISO, baseline, stores, releaseNotes,
   }
   return out.join("\n");
 }
+
+// ── Release-candidate verification (pure checks) ──────────────────────────────────
+//
+// These codify the manual checks that caught the 1.11.0 stale-build near-miss. The CLI
+// (scripts/release.mjs `verify`, and `build` automatically) does the unzip/IO and calls
+// these on the parsed manifests + archive entry lists. `issues` block the release;
+// `warnings` are things to confirm.
+
+/** The Chrome/Edge MV3 production permission set. Drift from this is flagged for review. */
+export const EXPECTED_PROD_PERMISSIONS = [
+  "storage",
+  "cookies",
+  "tabs",
+  "contextMenus",
+  "alarms",
+  "offscreen",
+  "audio",
+  "identity",
+];
+
+/** Permissions that must NEVER appear in a production build (dev-only). */
+export const DEV_ONLY_PERMISSIONS = ["downloads"];
+
+/** @returns {{added: string[], removed: string[]}} actual-vs-expected permission diff. */
+export function diffPermissions(actual = [], expected = EXPECTED_PROD_PERMISSIONS) {
+  const e = new Set(expected);
+  const a = new Set(actual);
+  return {
+    added: actual.filter((p) => !e.has(p)).sort(),
+    removed: expected.filter((p) => !a.has(p)).sort(),
+  };
+}
+
+/**
+ * Check a built Chrome/Edge MV3 manifest.
+ * @returns {{issues: string[], warnings: string[]}}
+ */
+export function checkChromeManifest(manifest = {}, version) {
+  const issues = [];
+  const warnings = [];
+  if (manifest.version !== version) {
+    issues.push(`Chrome manifest version is ${manifest.version}, expected ${version} (STALE BUILD?).`);
+  }
+  if (manifest.manifest_version !== 3) {
+    issues.push(`Chrome manifest_version is ${manifest.manifest_version}, expected 3.`);
+  }
+  const perms = manifest.permissions || [];
+  for (const dev of DEV_ONLY_PERMISSIONS) {
+    if (perms.includes(dev)) issues.push(`Production build contains dev-only permission "${dev}".`);
+  }
+  const { added, removed } = diffPermissions(perms.filter((p) => !DEV_ONLY_PERMISSIONS.includes(p)));
+  if (added.length) warnings.push(`Permission(s) ADDED vs the known set: ${added.join(", ")} — add justifications + expect extra review scrutiny.`);
+  if (removed.length) warnings.push(`Permission(s) REMOVED vs the known set: ${removed.join(", ")} — confirm intended.`);
+  return { issues, warnings };
+}
+
+/**
+ * Check a built Firefox MV2 manifest.
+ * @returns {{issues: string[], warnings: string[]}}
+ */
+export function checkFirefoxManifest(manifest = {}, version, geckoId = "gecko@saypi.ai") {
+  const issues = [];
+  const warnings = [];
+  if (manifest.version !== version) {
+    issues.push(`Firefox manifest version is ${manifest.version}, expected ${version} (STALE BUILD?).`);
+  }
+  if (manifest.manifest_version !== 2) {
+    issues.push(`Firefox manifest_version is ${manifest.manifest_version}, expected 2 (MV2).`);
+  }
+  const gecko = manifest.browser_specific_settings?.gecko?.id;
+  if (gecko !== geckoId) issues.push(`Firefox gecko id is "${gecko}", expected "${geckoId}".`);
+  if ((manifest.permissions || []).includes("offscreen")) {
+    issues.push(`Firefox manifest must not include the "offscreen" permission (Chrome-only).`);
+  }
+  return { issues, warnings };
+}
+
+/**
+ * Check the AMO source archive's entry list (array of path strings).
+ * @returns {{issues: string[], warnings: string[]}}
+ */
+export function checkSourceEntries(entries = []) {
+  const issues = [];
+  const warnings = [];
+  const has = (re) => entries.some((e) => re.test(e));
+  // Real secret files must never ship to AMO; templates ending in .example are fine.
+  const secret = entries.filter((e) => /(^|\/)\.env(\.production)?$/.test(e));
+  if (secret.length) issues.push(`Source archive contains secret env file(s): ${secret.join(", ")}.`);
+  if (has(/(^|\/)node_modules\//)) issues.push(`Source archive contains node_modules/ (should be excluded).`);
+  if (!has(/(^|\/)package-lock\.json$/)) issues.push(`Source archive is missing package-lock.json (AMO reviewers need it).`);
+  if (!has(/(^|\/)src\//)) warnings.push(`Source archive has no src/ entries — confirm it contains the real sources.`);
+  return { issues, warnings };
+}

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -485,8 +485,12 @@ export function checkFirefoxManifest(manifest = {}, version, geckoId = "gecko@sa
   }
   const gecko = manifest.browser_specific_settings?.gecko?.id;
   if (gecko !== geckoId) issues.push(`Firefox gecko id is "${gecko}", expected "${geckoId}".`);
-  if ((manifest.permissions || []).includes("offscreen")) {
-    issues.push(`Firefox manifest must not include the "offscreen" permission (Chrome-only).`);
+  // The Firefox MV2 build strips Chrome-only permissions (wxt.config.ts); their presence
+  // means the build didn't target Firefox correctly.
+  for (const chromeOnly of ["offscreen", "audio"]) {
+    if ((manifest.permissions || []).includes(chromeOnly)) {
+      issues.push(`Firefox manifest must not include the "${chromeOnly}" permission (Chrome-only; stripped for MV2).`);
+    }
   }
   return { issues, warnings };
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -19,7 +19,7 @@
  * loads .env.production. `tag`/`finalize` touch shared git history. The latter four refuse
  * to run without --yes and must be operated by the founder, never autonomously.
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve as resolvePath } from "node:path";
@@ -32,6 +32,9 @@ import {
   parseSemver,
   compareSemver,
   formatSemver,
+  checkChromeManifest,
+  checkFirefoxManifest,
+  checkSourceEntries,
 } from "./release-lib.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -235,15 +238,110 @@ function assertOnMain(cmd) {
   }
 }
 
-function cmdBuild({ yes }) {
+function cmdBuild({ yes, version }) {
   requireYes("build", { yes });
+  const v = version || pkgVersion();
+  // Loud, unambiguous: the stale-build near-miss happened because a build ran in a different
+  // checkout. Print exactly what/where, and clear stale output so nothing carries over.
+  log(`${C.bold}Building v${v}${C.reset} from ${repoRoot}`);
+  if (pkgVersion() !== v) {
+    bad(`package.json is ${pkgVersion()} but you asked to build ${v}. Bump first (or drop --version).`);
+    process.exit(2);
+  }
   warn(`This runs the production build (loads .env.production) and packages all stores.`);
+  for (const stale of [".output", "dist", "source-code.zip"]) {
+    rmSync(join(repoRoot, stale), { recursive: true, force: true });
+  }
   execFileSync("bash", [join(repoRoot, "package-extension.sh"), "chrome", "edge", "firefox"], {
     cwd: repoRoot,
     stdio: "inherit",
   });
   execFileSync("npm", ["run", "source-archive"], { cwd: repoRoot, stdio: "inherit" });
   ok(`Built + packaged: dist/saypi.chrome.zip, dist/saypi.edge.zip, dist/saypi.firefox.xpi, source-code.zip`);
+  log(`\n${C.bold}Verifying the release candidates…${C.reset}`);
+  const clean = verifyArtifacts(v);
+  if (!clean) {
+    bad(`Build verification FAILED — do NOT submit these artifacts. See issues above.`);
+    process.exit(1);
+  }
+}
+
+// ── Artifact verification ─────────────────────────────────────────────────────────
+
+/** Parse manifest.json out of a zip/xpi (without extracting). */
+function manifestFromZip(zipPath) {
+  const raw = execFileSync("unzip", ["-p", zipPath, "manifest.json"], { cwd: repoRoot, encoding: "utf8" });
+  return JSON.parse(raw);
+}
+
+/** List entry paths inside a zip. */
+function zipEntries(zipPath) {
+  return execFileSync("unzip", ["-Z1", zipPath], { cwd: repoRoot, encoding: "utf8" })
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Verify the built release candidates against the target version. Returns true if clean
+ * (no hard issues). Codifies the manual checks from the 1.11.0 wet run.
+ */
+function verifyArtifacts(version) {
+  const chromeZip = join(DIST, "saypi.chrome.zip");
+  const edgeZip = join(DIST, "saypi.edge.zip");
+  const firefoxXpi = join(DIST, "saypi.firefox.xpi");
+  const sourceZip = join(repoRoot, "source-code.zip");
+
+  const allIssues = [];
+  const allWarnings = [];
+  const note = (label, { issues, warnings }) => {
+    issues.forEach((i) => allIssues.push(`[${label}] ${i}`));
+    warnings.forEach((w) => allWarnings.push(`[${label}] ${w}`));
+  };
+
+  for (const [label, p] of [["chrome.zip", chromeZip], ["edge.zip", edgeZip], ["firefox.xpi", firefoxXpi], ["source-code.zip", sourceZip]]) {
+    if (!existsSync(p)) allIssues.push(`[${label}] missing — run \`build\` first.`);
+  }
+  if (allIssues.length) {
+    allIssues.forEach(bad);
+    return false;
+  }
+
+  note("chrome", checkChromeManifest(manifestFromZip(chromeZip), version));
+  note("firefox", checkFirefoxManifest(manifestFromZip(firefoxXpi), version));
+  note("source", checkSourceEntries(zipEntries(sourceZip)));
+
+  // Edge must be a byte-identical copy of Chrome.
+  try {
+    execFileSync("cmp", ["-s", chromeZip, edgeZip]);
+    ok(`edge.zip is byte-identical to chrome.zip`);
+  } catch {
+    allIssues.push(`[edge] edge.zip differs from chrome.zip (should be an identical copy).`);
+  }
+
+  // Freshness: the artifacts should be newer than package.json (else they predate the bump).
+  const pkgMtime = statSync(join(repoRoot, "package.json")).mtimeMs;
+  for (const [label, p] of [["chrome.zip", chromeZip], ["firefox.xpi", firefoxXpi]]) {
+    const m = statSync(p).mtimeMs;
+    if (m < pkgMtime) allWarnings.push(`[${label}] is OLDER than package.json — possible stale build.`);
+  }
+
+  allIssues.forEach(bad);
+  allWarnings.forEach(warn);
+  if (!allIssues.length) {
+    ok(`All archives report version ${version}; permissions, manifests, and source archive look good.`);
+  }
+  return allIssues.length === 0;
+}
+
+function cmdVerify({ version }) {
+  const v = version || gather().decision.version;
+  log(`${C.bold}Verifying release candidates for v${v}…${C.reset}\n`);
+  if (!verifyArtifacts(v)) {
+    bad(`Verification FAILED — do NOT submit these artifacts.`);
+    process.exit(1);
+  }
+  ok(`Release candidates verified.`);
 }
 
 function cmdTag({ version, yes }) {
@@ -300,12 +398,14 @@ function main() {
       return cmdBump(flags);
     case "build":
       return cmdBuild(flags);
+    case "verify":
+      return cmdVerify(flags);
     case "tag":
       return cmdTag(flags);
     case "finalize":
       return cmdFinalize(flags);
     default:
-      log(`Usage: node scripts/release.mjs <preflight|plan|packet|bump|build|tag|finalize> [--save] [--version X] [--yes]`);
+      log(`Usage: node scripts/release.mjs <preflight|plan|packet|bump|build|verify|tag|finalize> [--save] [--version X] [--yes]`);
       process.exit(command ? 1 : 0);
   }
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -111,7 +111,7 @@ function cmdPreflight() {
     warn(`could not compare HEAD to origin/main`);
   }
 
-  for (const tool of ["node", "npm", "jq", "zip"]) {
+  for (const tool of ["node", "npm", "jq", "zip", "unzip", "cmp"]) {
     try {
       execFileSync("which", [tool], { stdio: "ignore" });
       ok(`${tool} available`);
@@ -307,9 +307,14 @@ function verifyArtifacts(version) {
     return false;
   }
 
-  note("chrome", checkChromeManifest(manifestFromZip(chromeZip), version));
-  note("firefox", checkFirefoxManifest(manifestFromZip(firefoxXpi), version));
-  note("source", checkSourceEntries(zipEntries(sourceZip)));
+  // Read each archive defensively: a corrupt/unreadable zip becomes a clean failure on the
+  // same reporting path, not an uncaught stack trace.
+  try { note("chrome", checkChromeManifest(manifestFromZip(chromeZip), version)); }
+  catch (e) { allIssues.push(`[chrome] could not read manifest: ${e.message}`); }
+  try { note("firefox", checkFirefoxManifest(manifestFromZip(firefoxXpi), version)); }
+  catch (e) { allIssues.push(`[firefox] could not read manifest: ${e.message}`); }
+  try { note("source", checkSourceEntries(zipEntries(sourceZip))); }
+  catch (e) { allIssues.push(`[source] could not read entries: ${e.message}`); }
 
   // Edge must be a byte-identical copy of Chrome.
   try {

--- a/test/scripts/release-lib.spec.ts
+++ b/test/scripts/release-lib.spec.ts
@@ -10,7 +10,25 @@ import {
   renderReleaseDigest,
   renderPacket,
   INTERNAL_SCOPES,
+  EXPECTED_PROD_PERMISSIONS,
+  diffPermissions,
+  checkChromeManifest,
+  checkFirefoxManifest,
+  checkSourceEntries,
 } from "../../scripts/release-lib.mjs";
+
+// A known-good production Chrome manifest shape for the checks below.
+const goodChrome = {
+  manifest_version: 3,
+  version: "1.11.0",
+  permissions: [...EXPECTED_PROD_PERMISSIONS],
+};
+const goodFirefox = {
+  manifest_version: 2,
+  version: "1.11.0",
+  permissions: ["storage", "cookies", "tabs", "contextMenus", "alarms", "audio", "identity"],
+  browser_specific_settings: { gecko: { id: "gecko@saypi.ai" } },
+};
 
 // `git log --oneline` always prefixes a 7+ hex abbreviated hash. Build fixtures the
 // same way so the parser sees realistic input.
@@ -277,5 +295,69 @@ describe("INTERNAL_SCOPES", () => {
     for (const s of ["tooling", "dev", "ci", "test", "e2e", "layer4cdp"]) {
       expect(INTERNAL_SCOPES.has(s)).toBe(true);
     }
+  });
+});
+
+describe("diffPermissions", () => {
+  it("reports nothing for the exact expected set", () => {
+    expect(diffPermissions([...EXPECTED_PROD_PERMISSIONS])).toEqual({ added: [], removed: [] });
+  });
+  it("flags added and removed permissions", () => {
+    const d = diffPermissions(["storage", "cookies", "tabs", "contextMenus", "alarms", "offscreen", "audio", "bookmarks"]);
+    expect(d.added).toEqual(["bookmarks"]);
+    expect(d.removed).toEqual(["identity"]);
+  });
+});
+
+describe("checkChromeManifest", () => {
+  it("passes a known-good production manifest", () => {
+    const r = checkChromeManifest(goodChrome, "1.11.0");
+    expect(r.issues).toEqual([]);
+    expect(r.warnings).toEqual([]);
+  });
+  it("catches a STALE BUILD (wrong version) — the 1.11.0 near-miss", () => {
+    const r = checkChromeManifest({ ...goodChrome, version: "1.10.8" }, "1.11.0");
+    expect(r.issues.join(" ")).toMatch(/version is 1\.10\.8, expected 1\.11\.0.*STALE/i);
+  });
+  it("hard-fails on the dev-only 'downloads' permission leaking into prod", () => {
+    const r = checkChromeManifest({ ...goodChrome, permissions: [...EXPECTED_PROD_PERMISSIONS, "downloads"] }, "1.11.0");
+    expect(r.issues.join(" ")).toMatch(/dev-only permission "downloads"/);
+  });
+  it("warns (not fails) when the permission set changes", () => {
+    const r = checkChromeManifest({ ...goodChrome, permissions: [...EXPECTED_PROD_PERMISSIONS, "bookmarks"] }, "1.11.0");
+    expect(r.issues).toEqual([]);
+    expect(r.warnings.join(" ")).toMatch(/ADDED.*bookmarks/);
+  });
+  it("flags a non-MV3 manifest", () => {
+    expect(checkChromeManifest({ ...goodChrome, manifest_version: 2 }, "1.11.0").issues.join(" ")).toMatch(/manifest_version is 2/);
+  });
+});
+
+describe("checkFirefoxManifest", () => {
+  it("passes a known-good MV2 manifest", () => {
+    expect(checkFirefoxManifest(goodFirefox, "1.11.0").issues).toEqual([]);
+  });
+  it("catches wrong version, wrong manifest version, missing gecko id, and stray offscreen", () => {
+    expect(checkFirefoxManifest({ ...goodFirefox, version: "1.10.7" }, "1.11.0").issues.join(" ")).toMatch(/STALE/i);
+    expect(checkFirefoxManifest({ ...goodFirefox, manifest_version: 3 }, "1.11.0").issues.join(" ")).toMatch(/expected 2/);
+    expect(checkFirefoxManifest({ ...goodFirefox, browser_specific_settings: { gecko: { id: "x" } } }, "1.11.0").issues.join(" ")).toMatch(/gecko id/);
+    expect(checkFirefoxManifest({ ...goodFirefox, permissions: [...goodFirefox.permissions, "offscreen"] }, "1.11.0").issues.join(" ")).toMatch(/offscreen/);
+  });
+});
+
+describe("checkSourceEntries", () => {
+  const good = ["package-lock.json", "src/index.ts", ".env.example", ".env.production.example", "README.md"];
+  it("passes a clean source archive (templates OK)", () => {
+    expect(checkSourceEntries(good).issues).toEqual([]);
+  });
+  it("hard-fails on a real secret env file (but not the .example templates)", () => {
+    expect(checkSourceEntries([...good, ".env"]).issues.join(" ")).toMatch(/secret env file.*\.env/);
+    expect(checkSourceEntries([...good, ".env.production"]).issues.join(" ")).toMatch(/secret env file/);
+    // templates alone must NOT trip it
+    expect(checkSourceEntries(good).issues.join(" ")).not.toMatch(/secret/);
+  });
+  it("hard-fails on node_modules and missing lockfile", () => {
+    expect(checkSourceEntries([...good, "node_modules/x/index.js"]).issues.join(" ")).toMatch(/node_modules/);
+    expect(checkSourceEntries(["src/index.ts"]).issues.join(" ")).toMatch(/missing package-lock\.json/);
   });
 });

--- a/test/scripts/release-lib.spec.ts
+++ b/test/scripts/release-lib.spec.ts
@@ -26,7 +26,8 @@ const goodChrome = {
 const goodFirefox = {
   manifest_version: 2,
   version: "1.11.0",
-  permissions: ["storage", "cookies", "tabs", "contextMenus", "alarms", "audio", "identity"],
+  // Firefox MV2 strips the Chrome-only offscreen + audio permissions.
+  permissions: ["storage", "cookies", "tabs", "contextMenus", "alarms", "identity"],
   browser_specific_settings: { gecko: { id: "gecko@saypi.ai" } },
 };
 
@@ -342,6 +343,7 @@ describe("checkFirefoxManifest", () => {
     expect(checkFirefoxManifest({ ...goodFirefox, manifest_version: 3 }, "1.11.0").issues.join(" ")).toMatch(/expected 2/);
     expect(checkFirefoxManifest({ ...goodFirefox, browser_specific_settings: { gecko: { id: "x" } } }, "1.11.0").issues.join(" ")).toMatch(/gecko id/);
     expect(checkFirefoxManifest({ ...goodFirefox, permissions: [...goodFirefox.permissions, "offscreen"] }, "1.11.0").issues.join(" ")).toMatch(/offscreen/);
+    expect(checkFirefoxManifest({ ...goodFirefox, permissions: [...goodFirefox.permissions, "audio"] }, "1.11.0").issues.join(" ")).toMatch(/audio.*Chrome-only/);
   });
 });
 


### PR DESCRIPTION
## Why
The **1.11.0 wet run** surfaced that every safety check that mattered was run *by hand*, and the scariest moment was a **stale build** (1.10.8/1.10.7 artifacts) caught only by manually unzipping each manifest. This codifies those checks so a bad build fails loudly instead of needing eyeballs.

## What
- **`scripts/release-lib.mjs`** — pure, unit-tested checks: `checkChromeManifest`, `checkFirefoxManifest`, `checkSourceEntries`, `diffPermissions`, `EXPECTED_PROD_PERMISSIONS`.
- **`scripts/release.mjs`**
  - New **`verify`** command (`npm run release:verify`): unzips each archive and asserts the version *inside* it matches the target (**stale-build guard**), Edge≡Chrome (byte-identical), the Firefox MV2 manifest + gecko id, **no dev-only `downloads`**, **no secrets in the source zip** (`.env`/`.env.production`, templates OK), and **permission-set drift** (would have flagged the missing `alarms`/`identity`). Plus a freshness warning.
  - **`build`** now clears stale `.output`/`dist`/`source-code.zip` first, prints *what/where* it's building (the stale build came from a different checkout), and **runs `verify` at the end — failing the build** if anything is off.

## Verification
- Full gate green (1367 passed; +12 new unit tests covering every check incl. the stale-version and secret-leak cases).
- `verify` run **live against the real 1.11.0 artifacts → passes**; and **correctly fails** them when pointed at a mismatched target version (the guard working).

Part of the post-wet-run hardening. Follow-ups still open (founder's call): robust release-commit tagging, optional GH-release in `finalize`, ETA wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)