### PR TITLE
feat(release): robust commit tagging + GH release in finalize + ETA refresh

### DIFF
--- a/doc/release/README.md
+++ b/doc/release/README.md
@@ -111,8 +111,11 @@ Detail + gotchas in `chrome-web-store.md`, `edge-addons.md`, `firefox-amo.md`. K
 
 ### 6. Finalize ⛔ (founder)
 After all stores are submitted: `node scripts/release.mjs tag <version> --yes` then
-`finalize <version> --yes` (pushes the release commit + tag from main). Optionally
-`gh release create v<x> -F dist/release-notes-draft-v<x>.md`.
+`finalize <version> --yes`. `tag` resolves the **actual release commit** (the `Version bump
+to v<x>` commit whose package.json matches) and tags *that* — not `HEAD`, which concurrent
+merges may have moved past — and refuses if it can't find a matching commit. `finalize` pushes
+origin/main + the tag, then **cuts the GitHub release** from `_locales/en/release_notes.txt`
+(pass `--no-gh-release` to skip; refine the release title/body on GitHub afterward).
 
 ## Future: one-click automation via publishing APIs (#412)
 The 1.11.0 wet run established that **browser-driving is a dead end for releases:**

--- a/doc/release/chrome-web-store.md
+++ b/doc/release/chrome-web-store.md
@@ -32,7 +32,7 @@ Canonical answers live in `doc/WEB_STORE_PERMISSIONS.md`. The tab is sticky but 
 - Listing limits (only relevant if editing copy): **name ≤ 75**, **summary ≤ 132**, **detailed description ≤ ~16,000** (widely documented; verify on the live field). Screenshots 1280×800 (≥1), small promo tile 440×280, marquee 1400×560 (optional). Assets carry over on an update.
 
 ## Review timing
-- Usually a **few days**; occasionally up to **~3 weeks** (a 2026-04 submission-surge notice is posted). Broad host permissions / sensitive permissions slow it. Contact developer support if pending >3 weeks.
+- **Often fast** — frequently within **a few hours to a day** (v1.11.0 published ~1–2h after submission, 2026-06). Occasionally **a few days to ~3 weeks** when broad host permissions / sensitive permissions trigger manual review. Variable; contact developer support if pending >3 weeks.
 - Default **auto-publishes on approval** (unless you unchecked it).
 
 ## ⚠️ The dev console cannot be browser-automated

--- a/doc/release/stores.json
+++ b/doc/release/stores.json
@@ -11,7 +11,7 @@
       "hasReleaseNotesField": false,
       "releaseNotesFallback": "Chrome has no changelog field. Optionally fold highlights into the detailed description; otherwise the version simply ships.",
       "autoPublishOnApproval": true,
-      "reviewEta": "usually a few days; occasionally up to ~3 weeks (submission-surge notice as of 2026-04)",
+      "reviewEta": "often fast — frequently within a few hours to a day (v1.11.0 published ~1–2h after submission, 2026-06); occasionally a few days to ~3 weeks for broad/sensitive permissions. Variable.",
       "declarations": [
         "Remote code: select \"No, I am not using remote code\".",
         "Per-permission justifications (storage, cookies, tabs, contextMenus, alarms, offscreen, audio, identity) — canonical text in doc/WEB_STORE_PERMISSIONS.md.",

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -511,3 +511,22 @@ export function checkSourceEntries(entries = []) {
   if (!has(/(^|\/)src\//)) warnings.push(`Source archive has no src/ entries — confirm it contains the real sources.`);
   return { issues, warnings };
 }
+
+/**
+ * Pick the release commit for a version from a list of candidates. The CLI gathers candidates
+ * (commits whose message is the version bump) and reads each one's package.json version; this
+ * returns the SHA of the first candidate whose version matches — so we tag the EXACT commit a
+ * release was built from, not whatever HEAD happens to be after later merges moved main.
+ *
+ * @param {{sha: string, version: string}[]} candidates
+ * @param {string} version
+ * @returns {string|null}
+ */
+export function chooseReleaseCommit(candidates = [], version) {
+  const target = parseSemver(version) ? formatSemver(parseSemver(version)) : version;
+  const match = candidates.find((c) => {
+    const v = parseSemver(c.version) ? formatSemver(parseSemver(c.version)) : c.version;
+    return v === target;
+  });
+  return match ? match.sha : null;
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -35,6 +35,7 @@ import {
   checkChromeManifest,
   checkFirefoxManifest,
   checkSourceEntries,
+  chooseReleaseCommit,
 } from "./release-lib.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -349,17 +350,48 @@ function cmdVerify({ version }) {
   ok(`Release candidates verified.`);
 }
 
+function versionAtCommit(ref) {
+  try {
+    return JSON.parse(execFileSync("git", ["show", `${ref}:package.json`], { cwd: repoRoot, encoding: "utf8" })).version;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the EXACT commit a release was built from — the version-bump commit (matched by message)
+ * whose package.json equals the version. Falls back to HEAD only if HEAD's package.json matches.
+ * Returns null if nothing matches, so we never tag the wrong commit after concurrent merges move main.
+ */
+function resolveReleaseCommit(version) {
+  const shas = git(["log", "--grep", `Version bump to v${version}`, "--format=%H", "-n", "30"], { allowFail: true })
+    .split("\n")
+    .filter(Boolean);
+  const candidates = shas.map((sha) => ({ sha, version: versionAtCommit(sha) })).filter((c) => c.version);
+  const chosen = chooseReleaseCommit(candidates, version);
+  if (chosen) return chosen;
+  const head = git(["rev-parse", "HEAD"], { allowFail: true });
+  if (head && versionAtCommit("HEAD") === version) return head;
+  return null;
+}
+
 function cmdTag({ version, yes }) {
   requireYes("tag", { yes });
   assertOnMain("tag");
   const v = version || pkgVersion();
   const tag = `v${v}`;
-  // `git tag` (no -f) refuses to clobber an existing tag — re-tagging a released version fails loudly.
-  execFileSync("git", ["tag", tag], { cwd: repoRoot, stdio: "inherit" });
-  ok(`Created tag ${tag} (local). Push with \`finalize\` after all stores are submitted.`);
+  const commit = resolveReleaseCommit(v);
+  if (!commit) {
+    bad(`Could not find the v${v} release commit (no "Version bump to v${v}" commit and HEAD's package.json isn't ${v}). Bump + commit the release first.`);
+    process.exit(2);
+  }
+  // Tag the resolved release commit explicitly (NOT HEAD — concurrent merges may have moved main).
+  // `git tag` (no -f) refuses to clobber an existing tag, so re-tagging a released version fails loudly.
+  execFileSync("git", ["tag", tag, commit], { cwd: repoRoot, stdio: "inherit" });
+  ok(`Created tag ${tag} → ${commit.slice(0, 7)} (the v${v} release commit). Push with \`finalize\`.`);
 }
 
-function cmdFinalize({ version, yes }) {
+function cmdFinalize({ version, yes, ghRelease }) {
   requireYes("finalize", { yes });
   assertOnMain("finalize");
   const v = version || pkgVersion();
@@ -370,7 +402,27 @@ function cmdFinalize({ version, yes }) {
   }
   // Push the release commit and tag together, explicitly to origin/main (not the default remote).
   execFileSync("git", ["push", "origin", "main", tag], { cwd: repoRoot, stdio: "inherit" });
-  ok(`Pushed the release commit and tag ${tag}. Optionally: gh release create ${tag} -F dist/release-notes-draft-v${v}.md`);
+  ok(`Pushed origin/main and tag ${tag}.`);
+  if (ghRelease) createGhRelease(v, tag);
+  else log(`${C.dim}  (skipped GitHub release; create with \`gh release create ${tag} --notes-file _locales/en/release_notes.txt\`)${C.reset}`);
+}
+
+/** Cut a GitHub release from the voiced notes (best-effort; --no-gh-release opts out). */
+function createGhRelease(v, tag) {
+  const notes = existsSync(RELEASE_NOTES_PATH) ? RELEASE_NOTES_PATH : join(DIST, `release-notes-draft-v${v}.md`);
+  if (!existsSync(notes)) {
+    warn(`No release notes found (${RELEASE_NOTES_PATH} or dist draft) — skipping GitHub release.`);
+    return;
+  }
+  try {
+    execFileSync("gh", ["release", "create", tag, "--title", tag, "--notes-file", notes, "--verify-tag", "--latest"], {
+      cwd: repoRoot,
+      stdio: "inherit",
+    });
+    ok(`Created GitHub release ${tag} (you can refine its title/body on GitHub).`);
+  } catch (e) {
+    warn(`Could not create the GitHub release (${e.message}); create it manually if wanted.`);
+  }
 }
 
 // ── Entry ───────────────────────────────────────────────────────────────────────
@@ -381,6 +433,7 @@ function main() {
   const flags = {
     yes: argv.includes("--yes"),
     save: argv.includes("--save"),
+    ghRelease: !argv.includes("--no-gh-release"),
     version: (() => {
       const i = argv.indexOf("--version");
       if (i >= 0 && argv[i + 1]) return argv[i + 1].replace(/^v/, "");

--- a/test/scripts/release-lib.spec.ts
+++ b/test/scripts/release-lib.spec.ts
@@ -15,6 +15,7 @@ import {
   checkChromeManifest,
   checkFirefoxManifest,
   checkSourceEntries,
+  chooseReleaseCommit,
 } from "../../scripts/release-lib.mjs";
 
 // A known-good production Chrome manifest shape for the checks below.
@@ -361,5 +362,23 @@ describe("checkSourceEntries", () => {
   it("hard-fails on node_modules and missing lockfile", () => {
     expect(checkSourceEntries([...good, "node_modules/x/index.js"]).issues.join(" ")).toMatch(/node_modules/);
     expect(checkSourceEntries(["src/index.ts"]).issues.join(" ")).toMatch(/missing package-lock\.json/);
+  });
+});
+
+describe("chooseReleaseCommit", () => {
+  const candidates = [
+    { sha: "aaaaaaa", version: "1.11.1" }, // a later bump commit
+    { sha: "de64dc4", version: "1.11.0" }, // the v1.11.0 release commit
+  ];
+  it("picks the commit whose package.json matches the version (not just the newest)", () => {
+    expect(chooseReleaseCommit(candidates, "1.11.0")).toBe("de64dc4");
+    expect(chooseReleaseCommit(candidates, "1.11.1")).toBe("aaaaaaa");
+  });
+  it("is v-prefix tolerant on both sides", () => {
+    expect(chooseReleaseCommit([{ sha: "abc1234", version: "v2.0.0" }], "2.0.0")).toBe("abc1234");
+  });
+  it("returns null when no candidate matches (so the CLI refuses to tag the wrong commit)", () => {
+    expect(chooseReleaseCommit(candidates, "1.12.0")).toBe(null);
+    expect(chooseReleaseCommit([], "1.11.0")).toBe(null);
   });
 });


### PR DESCRIPTION
The three post-wet-run follow-ups you selected.

**1. Robust release-commit tagging.** `tag` now resolves the *exact* release commit — the `Version bump to v<x>` commit whose `package.json` matches — and tags that, **not `HEAD`**. In the 1.11.0 run I had to tag `de64dc4` by hash manually because concurrent merges had moved `main` past the release commit. New pure `chooseReleaseCommit` (unit-tested); `tag` refuses if it can't find a matching commit (so it can never tag the wrong one).

**2. GitHub release in `finalize`.** After pushing, `finalize` cuts the GitHub release from `_locales/en/release_notes.txt` (best-effort; `--no-gh-release` to skip). One-command wrap-up.

**3. Review-ETA refresh.** Chrome reviews have sped up — v1.11.0 published ~1–2h after submission — so `stores.json` + `chrome-web-store.md` now say "often within hours to a day" instead of "a few days / up to 3 weeks", while noting it's variable.

**Verified:** full gate green (1370 passed; +3 `chooseReleaseCommit` tests covering match / v-prefix / no-match). The resolver's git query finds `de64dc4`/1.11.0 against real history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)