### PR TITLE
perf(transcribe): 16-bit PCM upload instead of 32-bit float WAV (#414)

### DIFF
--- a/src/audio/AudioEncoder.ts
+++ b/src/audio/AudioEncoder.ts
@@ -6,7 +6,17 @@ import { encodeWAV } from "./WavEncoder";
  * @returns - The audio in WAV format as an ArrayBuffer
  */
 export function convertToWavBuffer(audioData: Float32Array): ArrayBuffer {
-  const arrayBuffer = encodeWAV(audioData);
+  // Encode as 16-bit PCM (format 1) rather than encodeWAV's 32-bit-float
+  // default (format 3). This halves the bytes uploaded to POST /transcribe and
+  // is speech-lossless for the 16 kHz mono samples the VAD produces — the
+  // single biggest lever on transcription upload latency. See #414.
+  const arrayBuffer = encodeWAV(
+    audioData,
+    /* format: PCM */ 1,
+    /* sampleRate */ 16000,
+    /* numChannels */ 1,
+    /* bitDepth */ 16
+  );
   return arrayBuffer;
 }
 

--- a/test/audio/AudioEncoder.spec.ts
+++ b/test/audio/AudioEncoder.spec.ts
@@ -81,6 +81,35 @@ describe("AudioEncoder — transcribe upload format (#414)", () => {
     });
   });
 
+  describe("edge cases", () => {
+    const pcmValues = (buffer: ArrayBuffer) => {
+      const view = new DataView(buffer);
+      const count = (buffer.byteLength - 44) / 2;
+      return Array.from({ length: count }, (_, i) => view.getInt16(44 + i * 2, true));
+    };
+
+    it("emits a valid header-only WAV for a zero-length clip (VAD misfire)", () => {
+      const buffer = convertToWavBuffer(new Float32Array([]));
+      expect(buffer.byteLength).toBe(44);
+      const header = readWavHeader(buffer);
+      expect(header.audioFormat).toBe(1);
+      expect(header.dataLength).toBe(0);
+    });
+
+    it("clamps out-of-range samples to the int16 extremes", () => {
+      // floatTo16BitPCM clamps to [-1, 1] before scaling
+      expect(pcmValues(convertToWavBuffer(new Float32Array([2, -2])))).toEqual([
+        32767, -32768,
+      ]);
+    });
+
+    it("coerces non-finite samples safely (NaN → 0, ±Infinity → extremes)", () => {
+      expect(
+        pcmValues(convertToWavBuffer(new Float32Array([NaN, Infinity, -Infinity])))
+      ).toEqual([0, 32767, -32768]);
+    });
+  });
+
   describe("encodeWAV low-level encoder", () => {
     it("still supports explicit 32-bit float output (format 3)", () => {
       const header = readWavHeader(encodeWAV(samples, 3, 16000, 1, 32));

--- a/test/audio/AudioEncoder.spec.ts
+++ b/test/audio/AudioEncoder.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { convertToWavBuffer, convertToWavBlob } from "../../src/audio/AudioEncoder";
+import { encodeWAV } from "../../src/audio/WavEncoder";
+
+/**
+ * Minimal WAV header reader so the tests can assert the on-the-wire format
+ * the server receives (see #414 — we switched the upload from 32-bit float to
+ * 16-bit PCM to halve the transcribe upload size).
+ */
+function readWavHeader(buffer: ArrayBuffer) {
+  const view = new DataView(buffer);
+  const ascii = (offset: number, length: number) =>
+    String.fromCharCode(
+      ...Array.from({ length }, (_, i) => view.getUint8(offset + i))
+    );
+  return {
+    riff: ascii(0, 4),
+    wave: ascii(8, 4),
+    fmt: ascii(12, 4),
+    audioFormat: view.getUint16(20, true), // 1 = PCM, 3 = IEEE float
+    numChannels: view.getUint16(22, true),
+    sampleRate: view.getUint32(24, true),
+    byteRate: view.getUint32(28, true),
+    blockAlign: view.getUint16(32, true),
+    bitsPerSample: view.getUint16(34, true),
+    data: ascii(36, 4),
+    dataLength: view.getUint32(40, true),
+  };
+}
+
+describe("AudioEncoder — transcribe upload format (#414)", () => {
+  const samples = new Float32Array([0, 1, -1, 0.5, -0.5]);
+
+  describe("convertToWavBuffer", () => {
+    it("encodes 16-bit PCM, not 32-bit float", () => {
+      const header = readWavHeader(convertToWavBuffer(samples));
+      expect(header.audioFormat).toBe(1); // PCM, not 3 (float)
+      expect(header.bitsPerSample).toBe(16);
+    });
+
+    it("keeps the 16 kHz mono shape the ASR pipeline expects", () => {
+      const header = readWavHeader(convertToWavBuffer(samples));
+      expect(header.numChannels).toBe(1);
+      expect(header.sampleRate).toBe(16000);
+      expect(header.blockAlign).toBe(2); // 1 channel * 2 bytes
+      expect(header.byteRate).toBe(32000); // 16000 * 2 — half the old float rate
+    });
+
+    it("produces a well-formed RIFF/WAVE container", () => {
+      const header = readWavHeader(convertToWavBuffer(samples));
+      expect(header.riff).toBe("RIFF");
+      expect(header.wave).toBe("WAVE");
+      expect(header.fmt).toBe("fmt ");
+      expect(header.data).toBe("data");
+    });
+
+    it("halves the byte size versus 32-bit float", () => {
+      const buffer = convertToWavBuffer(samples);
+      // 44-byte header + 2 bytes/sample (vs 4 bytes/sample for float)
+      expect(buffer.byteLength).toBe(44 + samples.length * 2);
+      const header = readWavHeader(buffer);
+      expect(header.dataLength).toBe(samples.length * 2);
+    });
+
+    it("converts float samples to the expected int16 values", () => {
+      const buffer = convertToWavBuffer(samples);
+      const view = new DataView(buffer);
+      const pcm = Array.from({ length: samples.length }, (_, i) =>
+        view.getInt16(44 + i * 2, true)
+      );
+      // floatTo16BitPCM: negatives scale by 0x8000, non-negatives by 0x7fff
+      expect(pcm).toEqual([0, 32767, -32768, 16383, -16384]);
+    });
+  });
+
+  describe("convertToWavBlob", () => {
+    it("returns an audio/wav blob of the 16-bit PCM size", () => {
+      const blob = convertToWavBlob(samples);
+      expect(blob.type).toBe("audio/wav");
+      expect(blob.size).toBe(44 + samples.length * 2);
+    });
+  });
+
+  describe("encodeWAV low-level encoder", () => {
+    it("still supports explicit 32-bit float output (format 3)", () => {
+      const header = readWavHeader(encodeWAV(samples, 3, 16000, 1, 32));
+      expect(header.audioFormat).toBe(3);
+      expect(header.bitsPerSample).toBe(32);
+    });
+  });
+});


### PR DESCRIPTION
## Why

The post-VAD audio we POST to `/transcribe` was encoded as **uncompressed 32-bit-float WAV** — `convertToWavBuffer` called `encodeWAV` with its defaults (`format=3`, `bitDepth=32`), i.e. **64 KB/s**. Upload bytes are the single biggest contributor to user-perceived transcription latency: production telemetry (saypi-api `http_time_to_handler_seconds{route="transcribe"}`, n≈3,300) puts the **p90 upload at ~7s**, tracking clip size ~1:1 over the user's uplink.

## What

Encode the WAV as **16-bit PCM** (`format=1`, `bitDepth=16`) at the `convertToWavBuffer` chokepoint — the one place every transcribe/dictation upload funnels through (`AudioInputMachine`, `DictationMachine`).

- **Instant 2× size cut**: 64 → 32 KB/s. p90 upload ~7s → **~3.5s**.
- **Speech-lossless**: the samples are already 16 kHz mono `Float32Array` from the VAD; `floatTo16BitPCM` (clamp to [-1,1], scale to int16) is transparent for speech. The ASR models are Whisper-family, trained on compressed audio.
- **No new code path**: the `format===1` branch already existed in `encodeWAV`; this just selects it. Zero new deps, zero bundle impact.
- **Bonus**: 16-bit PCM is a more universally playable `.wav` than 32-bit float, so persisted debug segments (`AudioSegmentPersistence`) improve too.

## Server impact: none

`/transcribe` is format-agnostic and probes duration from the container plus the `duration` form field already sent — confirmed in **saypi-api #269**. No API/billing/accuracy change. The multipart filename already adapts to the blob MIME (`audio.wav`), which is unchanged here.

## Verification

Fail-first TDD. New `test/audio/AudioEncoder.spec.ts` asserts the on-the-wire format by parsing the WAV header:
- format code `1` (PCM) + `bitsPerSample 16` (was `3`/`32`)
- 16 kHz mono shape preserved (`blockAlign 2`, `byteRate 32000`)
- byte size halved (`44 + N*2`, was `44 + N*4`)
- known float → int16 conversions (`1.0→32767`, `-1.0→-32768`, `0.5→16383`, `-0.5→-16384`)
- `convertToWavBlob` still `audio/wav`
- regression guard: `encodeWAV` still emits float when explicitly asked

```
npm test  →  tsc ✓  ·  Jest 2/2 ✓  ·  Vitest 1375 (1374 passed, 1 skipped) ✓
```

The test was confirmed RED against the old float encoder before the one-line format switch turned it GREEN.

## Scope

Addresses #414 at the **"at minimum 16-bit PCM"** bar — a safe, fully unit-testable win with no dependency footprint. The larger **Opus** option (~15–20×, needs a WASM encoder) is a separate, dependency-bearing follow-up; #414 stays open for that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)