### PR TITLE
feat(release): headless store submission via the publishing APIs (#412)

### DIFF
--- a/doc/release/README.md
+++ b/doc/release/README.md
@@ -56,6 +56,8 @@ npm run release:build -- --yes             # = … build --yes  (clears stale ou
 npm run release:verify                     # = … verify  (re-check the built candidates; read-only)
 npm run release:tag -- <version> --yes     # = … tag <version> --yes
 npm run release:finalize -- <version> --yes  # = … finalize <version> --yes
+npm run release:submit -- <store> --dry-run  # ⛔ #412: auth-check a store's publishing API
+npm run release:submit -- <store> --yes      # ⛔ #412: headless API submission (founder-only)
 ```
 
 Run from the **main checkout on `main`** — a real release is cut from main and the build
@@ -108,6 +110,12 @@ Detail + gotchas in `chrome-web-store.md`, `edge-addons.md`, `firefox-amo.md`. K
   `stores.json` on first run.
 - **AMO** requires uploading **`source-code.zip`** (+ build steps in Notes for Reviewers);
   the onnxruntime `eval` warning is non-blocking.
+
+**Or — headless via the publishing APIs (#412).** Once credentials are provisioned (one-time, per
+`publishing-credentials.md`), skip the dashboards entirely: `release:submit -- <store> --dry-run`
+to auth-check, then `release:submit -- <store> --yes` to upload + submit via each store's API
+(CWS V2 / Edge v1.1 / AMO `web-ext sign`). Founder-only and irreversible. This is the long-term
+"one-button" path; the manual packet above remains the fallback and for any listing-copy changes.
 
 ### 6. Finalize ⛔ (founder)
 After all stores are submitted: `node scripts/release.mjs tag <version> --yes` then

--- a/doc/release/publishing-credentials.md
+++ b/doc/release/publishing-credentials.md
@@ -1,0 +1,86 @@
+# Publishing-API credentials & submission (#412)
+
+`node scripts/release.mjs submit <chrome|edge|firefox>` submits a built artifact to a store's
+**publishing API** — no dashboard, no browser. This is the headless alternative to the manual
+packet. It's **founder-only and irreversible**: a real submit publishes to a live store, so it
+requires `--yes`; `--dry-run` only auth-checks (no upload/publish).
+
+> ⚠️ **Browser-driving is impossible** for Chrome (extensions-gallery block) and file-picker-gated
+> everywhere — the API is the only real automation path. See `chrome-web-store.md`.
+
+Credentials are **never** stored in the repo. Provide them as **environment variables** at submit
+time (e.g. a local, gitignored `.env.publish` you `set -a; source .env.publish; set +a`, or your
+shell/CI secret store). The tool only *reads* `process.env`; it never reads `.env.production` or
+echoes secret values.
+
+## Usage
+
+```bash
+# Always dry-run first (auth check only — safe, no upload/publish):
+npm run release:submit -- chrome  --dry-run
+npm run release:submit -- edge    --dry-run
+npm run release:submit -- firefox --dry-run
+
+# Real submission (founder-only; publishes to the live store):
+npm run release:submit -- chrome  --yes
+npm run release:submit -- edge    --yes
+npm run release:submit -- firefox --yes
+```
+
+Requires the built artifacts (`release:build` first): `dist/saypi.chrome.zip`,
+`dist/saypi.edge.zip`, `.output/firefox-mv2/` + `source-code.zip`. Release notes are read from
+`_locales/en/release_notes.txt` (AMO version notes) automatically.
+
+## 🟢 Chrome Web Store — env vars
+
+| Env var | What it is |
+|---|---|
+| `CWS_EXTENSION_ID` | `glhhgglpalmjjkoiigojligncepccdei` (the item id) |
+| `CWS_PUBLISHER_ID` | your publisher id — Developer Dashboard → Account settings (NEW: V2 requires it) |
+| `CWS_CLIENT_ID` / `CWS_CLIENT_SECRET` | OAuth2 client (Google Cloud Console → Credentials) |
+| `CWS_REFRESH_TOKEN` | long-lived refresh token (one-time, below) |
+
+**One-time setup:** Google Cloud Console → new project → **enable the Chrome Web Store API** →
+create an **OAuth client (Web application)** with redirect `https://developers.google.com/oauthplayground`
+→ OAuth Playground (use your own creds) → authorize scope `https://www.googleapis.com/auth/chromewebstore`
+**signed in as the account that owns the extension** → exchange for a **refresh token**. The owning
+account **must have 2-Step Verification on** or publish returns 403. (Flow: `using-api` guide.)
+
+API V2 (`chromewebstore.googleapis.com`) is current; V1 sunsets 2026-10-15. V2 can't create items or
+change visibility (fine — Say, Pi exists).
+
+## 🔵 Microsoft Edge Add-ons — env vars
+
+| Env var | What it is |
+|---|---|
+| `EDGE_PRODUCT_ID` | `824c36fe-fd03-4656-8d32-67b0ae2cbdad` |
+| `EDGE_API_KEY` | API key — Partner Center → Edge → **Publish API** → Create API credentials |
+| `EDGE_CLIENT_ID` | Client ID (same page) |
+
+**Auth is v1.1** (header `Authorization: ApiKey <key>`, `X-ClientID: <id>`); the old v1 Entra/OAuth
+model ended 2024-12-31. ⚠️ **API keys expire every ~72 days** — a `401` means "rotate the key in
+Partner Center." Edge has **no deferred publish**: a real submit goes straight to certification.
+
+## 🟠 Firefox AMO — env vars
+
+| Env var | What it is |
+|---|---|
+| `WEB_EXT_API_KEY` | AMO JWT **issuer** (e.g. `user:12345:67`) |
+| `WEB_EXT_API_SECRET` | AMO JWT **secret** |
+
+Create both at `https://addons.mozilla.org/developers/addon/api/key/`. Submission uses
+`web-ext sign --channel=listed` (already a devDependency) and signs from **`.output/firefox-mv2/`**
+(the build dir — `web-ext sign` rebuilds from source, it does not take the prebuilt `.xpi`).
+`--upload-source-code=source-code.zip` satisfies the minified-build source requirement; build steps
+go into the reviewer notes automatically. Listed submissions enter the AMO review queue (not
+instantly public). Ensure `.output/firefox-mv2/manifest.json` carries `gecko@saypi.ai`.
+
+## How `--dry-run` checks each store
+- **Chrome:** real OAuth token exchange + a read-only `fetchStatus` (prints the current published version).
+- **Edge:** a credentials probe (a poll-URL GET with a dummy operation id — `401` = bad key, else accepted). Edge has no read-only status endpoint, so this is the safest check short of uploading.
+- **Firefox:** confirms the JWT env vars are present and `web-ext` runs (`web-ext sign` itself submits, so it isn't invoked in a dry run).
+
+## Status
+The machinery is built + unit-tested (`scripts/release-publish.mjs`, `scripts/release-lib.mjs`).
+The remaining steps are founder-only: provision the credentials above, then `--dry-run` each store,
+then run a real `--yes` submission on the next release. Tracked in **#412**.

--- a/doc/release/publishing-credentials.md
+++ b/doc/release/publishing-credentials.md
@@ -77,7 +77,7 @@ instantly public). Ensure `.output/firefox-mv2/manifest.json` carries `gecko@say
 
 ## How `--dry-run` checks each store
 - **Chrome:** real OAuth token exchange + a read-only `fetchStatus` (prints the current published version).
-- **Edge:** a credentials probe (a poll-URL GET with a dummy operation id — `401` = bad key, else accepted). Edge has no read-only status endpoint, so this is the safest check short of uploading.
+- **Edge:** a credentials probe (a poll-URL GET with a dummy operation id — `401` = bad key, else accepted). Edge has no read-only status endpoint, so this is the safest check short of uploading. (Caveat: a wrong `EDGE_PRODUCT_ID` returns `404`, which the probe treats as "creds accepted" — it only surfaces on the real upload.)
 - **Firefox:** confirms the JWT env vars are present and `web-ext` runs (`web-ext sign` itself submits, so it isn't invoked in a dry run).
 
 ## Status

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "release:verify": "node scripts/release.mjs verify",
     "release:tag": "node scripts/release.mjs tag",
     "release:finalize": "node scripts/release.mjs finalize",
+    "release:submit": "node scripts/release.mjs submit",
     "prebuild:firefox": "node scripts/validate-env.js --file .env.production --env production && npm run copy-onnx",
     "build:firefox": "wxt build -b firefox",
     "source-archive": "git archive --format=zip -o source-code.zip HEAD",

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -530,3 +530,132 @@ export function chooseReleaseCommit(candidates = [], version) {
   });
   return match ? match.sha : null;
 }
+
+// ── Publishing-API helpers (pure) — for #412 store-submission automation ──────────
+//
+// Pure request builders + response interpreters for the three stores' publishing APIs.
+// The I/O (fetch/spawn, credentials, polling) lives in scripts/release-publish.mjs; these
+// are extracted so they're unit-tested without secrets or network. Specs verified 2026-06
+// from official docs — see doc/release/publishing-credentials.md.
+
+/**
+ * Validate that the given env var names are all present; throw a clear error listing the
+ * missing ones (never echoes values). Returns an object of the requested vars.
+ * @param {string[]} names
+ * @param {Record<string,string|undefined>} env
+ */
+export function requireEnv(names, env = {}) {
+  const missing = names.filter((n) => !env[n]);
+  if (missing.length) {
+    throw new Error(`Missing required env var(s): ${missing.join(", ")}. See doc/release/publishing-credentials.md.`);
+  }
+  return Object.fromEntries(names.map((n) => [n, env[n]]));
+}
+
+// — Chrome Web Store API V2 —
+export const CWS_API = "https://chromewebstore.googleapis.com";
+export const CWS_TOKEN_URL = "https://oauth2.googleapis.com/token";
+export const CWS_SCOPE = "https://www.googleapis.com/auth/chromewebstore";
+export const CWS_ENV = ["CWS_CLIENT_ID", "CWS_CLIENT_SECRET", "CWS_REFRESH_TOKEN", "CWS_PUBLISHER_ID", "CWS_EXTENSION_ID"];
+
+export function cwsTokenBody({ clientId, clientSecret, refreshToken }) {
+  return new URLSearchParams({
+    grant_type: "refresh_token",
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+  }).toString();
+}
+export function cwsUploadUrl(publisherId, extensionId) {
+  return `${CWS_API}/upload/v2/publishers/${publisherId}/items/${extensionId}:upload`;
+}
+export function cwsPublishUrl(publisherId, extensionId) {
+  return `${CWS_API}/v2/publishers/${publisherId}/items/${extensionId}:publish`;
+}
+export function cwsStatusUrl(publisherId, extensionId) {
+  return `${CWS_API}/v2/publishers/${publisherId}/items/${extensionId}:fetchStatus`;
+}
+/** Interpret an upload (or fetchStatus.lastAsyncUploadState) state. V2 enums: SUCCEEDED|IN_PROGRESS|FAILED|NOT_FOUND. */
+export function interpretCwsUpload(json = {}) {
+  const state = json.uploadState || json.lastAsyncUploadState;
+  return { ok: state === "SUCCEEDED", inProgress: state === "IN_PROGRESS", state, version: json.crxVersion, raw: json };
+}
+/** A publish is accepted once it reaches a review/published state (PENDING_REVIEW is normal for an update). */
+export function interpretCwsPublish(json = {}) {
+  const state = json.state;
+  return { ok: ["PENDING_REVIEW", "STAGED", "PUBLISHED", "PUBLISHED_TO_TESTERS"].includes(state), state, warnings: json.warningInfo?.warnings || [], raw: json };
+}
+/** V2 surfaces failures as {error:{code,status,message}} — format for a clear CI message. */
+export function cwsErrorMessage(json = {}) {
+  const e = json.error;
+  if (e) return `${e.status || e.code}: ${e.message}`;
+  if (json.error_description || json.error) return json.error_description || json.error; // oauth token error shape
+  return "unknown error";
+}
+
+// — Edge Add-ons API v1.1 —
+export const EDGE_API = "https://api.addons.microsoftedge.microsoft.com";
+export const EDGE_ENV = ["EDGE_PRODUCT_ID", "EDGE_API_KEY", "EDGE_CLIENT_ID"];
+
+export function edgeHeaders({ apiKey, clientId }) {
+  return { Authorization: `ApiKey ${apiKey}`, "X-ClientID": clientId };
+}
+export function edgeUploadUrl(productId) {
+  return `${EDGE_API}/v1/products/${productId}/submissions/draft/package`;
+}
+export function edgeUploadPollUrl(productId, operationId) {
+  return `${EDGE_API}/v1/products/${productId}/submissions/draft/package/operations/${operationId}`;
+}
+export function edgePublishUrl(productId) {
+  return `${EDGE_API}/v1/products/${productId}/submissions`;
+}
+export function edgePublishPollUrl(productId, operationId) {
+  return `${EDGE_API}/v1/products/${productId}/submissions/operations/${operationId}`;
+}
+/** The operation id arrives in the Location header — may be a bare id or a URL/path; take the last segment. */
+export function operationIdFromLocation(location = "") {
+  const clean = String(location).split("?")[0].replace(/\/+$/, "");
+  return clean.split("/").filter(Boolean).pop() || "";
+}
+/** Edge operation polling: status InProgress|Succeeded|Failed. */
+export function interpretEdgeOperation(json = {}) {
+  const status = json.status;
+  return {
+    ok: status === "Succeeded",
+    inProgress: status === "InProgress",
+    failed: status === "Failed" || (!status && Boolean(json.message)),
+    status,
+    message: json.message,
+    errorCode: json.errorCode,
+    errors: json.errors,
+    raw: json,
+  };
+}
+
+// — Firefox AMO via web-ext (v8: `sign` submits via AMO API v5) —
+export const AMO_ENV = ["WEB_EXT_API_KEY", "WEB_EXT_API_SECRET"]; // JWT issuer + secret
+
+/**
+ * Build the amo-metadata.json object. release_notes/approval_notes nest under `version`.
+ * @param {{releaseNotes?: string, approvalNotes?: string, license?: string, locale?: string}} [opts]
+ */
+export function buildAmoMetadata({ releaseNotes, approvalNotes, license = "MPL-2.0", locale = "en-US" } = {}) {
+  const version = {};
+  if (releaseNotes) version.release_notes = { [locale]: releaseNotes };
+  if (approvalNotes) version.approval_notes = approvalNotes;
+  if (license) version.license = license;
+  return { version };
+}
+/**
+ * Build the `web-ext sign` argv for a LISTED update. Signs from --source-dir (NOT a pre-built xpi).
+ * @param {{sourceDir?: string, artifactsDir?: string, sourceCode?: string, metadataFile?: string, approvalTimeout?: number}} [opts]
+ */
+export function webExtSignArgs({ sourceDir, artifactsDir, sourceCode, metadataFile, approvalTimeout = 0 } = {}) {
+  const args = ["web-ext", "sign", "--channel=listed", `--source-dir=${sourceDir}`, `--artifacts-dir=${artifactsDir}`];
+  if (sourceCode) args.push(`--upload-source-code=${sourceCode}`);
+  if (metadataFile) args.push(`--amo-metadata=${metadataFile}`);
+  args.push(`--approval-timeout=${approvalTimeout}`);
+  return args;
+}
+
+export const PUBLISH_STORES = ["chrome", "edge", "firefox"];

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -78,7 +78,7 @@ export async function chromeSubmit({ zipPath, env = process.env, dryRun = false,
     up = interpretCwsUpload(s);
   }
   if (!up.ok) throw new Error(`Chrome upload did not succeed (state: ${up.state}).`);
-  log(`  ✓ uploaded ${up.version || ""}`.trimEnd());
+  log("  ✓ package uploaded"); // crxVersion isn't on the upload response; the version is verified pre-build by `verify`
 
   const pubRes = await fetch(cwsPublishUrl(e.CWS_PUBLISHER_ID, e.CWS_EXTENSION_ID), {
     method: "POST",
@@ -101,7 +101,9 @@ async function pollEdge(url, headers, label, log) {
     const op = interpretEdgeOperation(json);
     if (op.ok) return;
     if (op.failed) {
-      throw new Error(`Edge ${label} failed: ${[op.errorCode, op.message, ...(op.errors || [])].filter(Boolean).join(" — ")}`);
+      // Edge `errors` can be strings OR objects ({message}); normalize so we don't print [object Object].
+      const errs = (op.errors || []).map((x) => (x && typeof x === "object" ? x.message ?? JSON.stringify(x) : x));
+      throw new Error(`Edge ${label} failed: ${[op.errorCode, op.message, ...errs].filter(Boolean).join(" — ")}`);
     }
     await sleep(POLL_INTERVAL_MS);
   }

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -1,0 +1,193 @@
+/**
+ * release-publish — headless store submission via the official publishing APIs (#412).
+ *
+ * The I/O layer for the `release.mjs submit` command: authenticates and uploads/publishes a
+ * built artifact to each store's API. Pure request builders + response interpreters live in
+ * release-lib.mjs (unit-tested without secrets); this file does the fetch/spawn + polling.
+ *
+ * Credentials come from env vars the FOUNDER provides (see doc/release/publishing-credentials.md);
+ * this code never reads .env.production or hardcodes secrets. Real submission is irreversible and
+ * founder-gated — `release.mjs submit` requires --yes; `--dry-run` only auth-checks (no publish).
+ *
+ * API specs verified 2026-06: CWS V2, Edge v1.1, AMO via `web-ext sign` (v8).
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve as resolvePath } from "node:path";
+import {
+  requireEnv,
+  CWS_ENV,
+  CWS_TOKEN_URL,
+  cwsTokenBody,
+  cwsUploadUrl,
+  cwsPublishUrl,
+  cwsStatusUrl,
+  interpretCwsUpload,
+  interpretCwsPublish,
+  cwsErrorMessage,
+  EDGE_ENV,
+  edgeHeaders,
+  edgeUploadUrl,
+  edgeUploadPollUrl,
+  edgePublishUrl,
+  edgePublishPollUrl,
+  operationIdFromLocation,
+  interpretEdgeOperation,
+  AMO_ENV,
+  buildAmoMetadata,
+  webExtSignArgs,
+} from "./release-lib.mjs";
+
+const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const POLL_INTERVAL_MS = 5000;
+const POLL_MAX = 60; // ~5 min
+
+// ── Chrome Web Store (API V2) ─────────────────────────────────────────────────────
+export async function chromeSubmit({ zipPath, env = process.env, dryRun = false, log = console.log }) {
+  const e = requireEnv(CWS_ENV, env);
+  const tokRes = await fetch(CWS_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: cwsTokenBody({ clientId: e.CWS_CLIENT_ID, clientSecret: e.CWS_CLIENT_SECRET, refreshToken: e.CWS_REFRESH_TOKEN }),
+  });
+  const tok = await tokRes.json().catch(() => ({}));
+  if (!tokRes.ok || !tok.access_token) throw new Error(`Chrome auth failed: ${cwsErrorMessage(tok)}`);
+  const auth = { Authorization: `Bearer ${tok.access_token}` };
+  log("  ✓ authenticated");
+
+  const stRes = await fetch(cwsStatusUrl(e.CWS_PUBLISHER_ID, e.CWS_EXTENSION_ID), { headers: auth });
+  const st = await stRes.json().catch(() => ({}));
+  if (!stRes.ok) throw new Error(`Chrome status check failed: ${cwsErrorMessage(st)}`);
+  const published = st.publishedItemRevisionStatus?.distributionChannels?.[0]?.crxVersion;
+  log(`  current published version: ${published || "unknown"}`);
+  if (dryRun) {
+    log("  dry run — auth + status OK; not uploading or publishing.");
+    return `Chrome dry-run OK (published ${published || "?"})`;
+  }
+
+  if (!existsSync(zipPath)) throw new Error(`${zipPath} not found — run \`build\` first.`);
+  const upRes = await fetch(cwsUploadUrl(e.CWS_PUBLISHER_ID, e.CWS_EXTENSION_ID), { method: "POST", headers: auth, body: readFileSync(zipPath) });
+  const upJson = await upRes.json().catch(() => ({}));
+  if (!upRes.ok) throw new Error(`Chrome upload failed: ${cwsErrorMessage(upJson)}`);
+  let up = interpretCwsUpload(upJson);
+  for (let i = 0; up.inProgress && i < POLL_MAX; i++) {
+    await sleep(POLL_INTERVAL_MS);
+    const s = await fetch(cwsStatusUrl(e.CWS_PUBLISHER_ID, e.CWS_EXTENSION_ID), { headers: auth }).then((r) => r.json()).catch(() => ({}));
+    up = interpretCwsUpload(s);
+  }
+  if (!up.ok) throw new Error(`Chrome upload did not succeed (state: ${up.state}).`);
+  log(`  ✓ uploaded ${up.version || ""}`.trimEnd());
+
+  const pubRes = await fetch(cwsPublishUrl(e.CWS_PUBLISHER_ID, e.CWS_EXTENSION_ID), {
+    method: "POST",
+    headers: { ...auth, "Content-Type": "application/json" },
+    body: "{}",
+  });
+  const pubJson = await pubRes.json().catch(() => ({}));
+  if (!pubRes.ok) throw new Error(`Chrome publish failed: ${cwsErrorMessage(pubJson)}`);
+  const pub = interpretCwsPublish(pubJson);
+  if (!pub.ok) throw new Error(`Chrome publish returned unexpected state: ${pub.state}`);
+  if (pub.warnings.length) log(`  ⚠ ${pub.warnings.length} publish warning(s) — review on the dashboard`);
+  return `Chrome submitted — state: ${pub.state}`;
+}
+
+// ── Microsoft Edge Add-ons (API v1.1) ─────────────────────────────────────────────
+async function pollEdge(url, headers, label, log) {
+  for (let i = 0; i < POLL_MAX; i++) {
+    const res = await fetch(url, { headers });
+    const json = await res.json().catch(() => ({}));
+    const op = interpretEdgeOperation(json);
+    if (op.ok) return;
+    if (op.failed) {
+      throw new Error(`Edge ${label} failed: ${[op.errorCode, op.message, ...(op.errors || [])].filter(Boolean).join(" — ")}`);
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(`Edge ${label} polling timed out.`);
+}
+
+export async function edgeSubmit({ zipPath, notes = "", env = process.env, dryRun = false, log = console.log }) {
+  const e = requireEnv(EDGE_ENV, env);
+  const headers = edgeHeaders({ apiKey: e.EDGE_API_KEY, clientId: e.EDGE_CLIENT_ID });
+  if (dryRun) {
+    // Auth probe: GET a poll URL with a dummy operation id — 401 = bad creds; anything else = accepted.
+    const probe = await fetch(edgeUploadPollUrl(e.EDGE_PRODUCT_ID, "00000000-0000-0000-0000-000000000000"), { headers });
+    if (probe.status === 401) throw new Error("Edge auth failed (401) — check EDGE_API_KEY/EDGE_CLIENT_ID (keys expire every ~72 days).");
+    log(`  ✓ credentials accepted (probe HTTP ${probe.status})`);
+    log("  dry run — not uploading or publishing.");
+    return "Edge dry-run OK";
+  }
+
+  if (!existsSync(zipPath)) throw new Error(`${zipPath} not found — run \`build\` first.`);
+  const upRes = await fetch(edgeUploadUrl(e.EDGE_PRODUCT_ID), {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/zip" },
+    body: readFileSync(zipPath),
+  });
+  if (upRes.status !== 202) throw new Error(`Edge upload rejected (HTTP ${upRes.status}).`);
+  const upOp = operationIdFromLocation(upRes.headers.get("location"));
+  log(`  uploading (op ${upOp})…`);
+  await pollEdge(edgeUploadPollUrl(e.EDGE_PRODUCT_ID, upOp), headers, "upload", log);
+  log("  ✓ package uploaded");
+
+  // Publish body is PLAIN TEXT certification notes (NOT JSON) per the Edge v1.1 reference.
+  const pubRes = await fetch(edgePublishUrl(e.EDGE_PRODUCT_ID), { method: "POST", headers, body: notes || "Automated release." });
+  if (pubRes.status !== 202) throw new Error(`Edge publish rejected (HTTP ${pubRes.status}).`);
+  const pubOp = operationIdFromLocation(pubRes.headers.get("location"));
+  log(`  publishing (op ${pubOp})…`);
+  await pollEdge(edgePublishPollUrl(e.EDGE_PRODUCT_ID, pubOp), headers, "publish", log);
+  return "Edge submitted to certification";
+}
+
+// ── Firefox AMO (via web-ext sign) ────────────────────────────────────────────────
+export function firefoxSubmit({ sourceDir, sourceCode, releaseNotes, approvalNotes, env = process.env, dryRun = false, log = console.log }) {
+  requireEnv(AMO_ENV, env);
+  const bin = join(repoRoot, "node_modules", ".bin", "web-ext");
+  const webExt = existsSync(bin) ? bin : "web-ext";
+
+  if (dryRun) {
+    const check = spawnSync(webExt, ["--version"], { cwd: repoRoot, encoding: "utf8" });
+    if (check.status !== 0) throw new Error("web-ext is not runnable — run `npm install`.");
+    if (!existsSync(sourceDir)) log(`  ⚠ source dir ${sourceDir} not present yet — run \`build:firefox\` before a real submit.`);
+    log(`  ✓ AMO credentials present; web-ext ${String(check.stdout).trim()} available`);
+    log("  dry run — not submitting (web-ext sign would submit to AMO).");
+    return "Firefox dry-run OK";
+  }
+
+  if (!existsSync(sourceDir)) throw new Error(`Firefox source dir ${sourceDir} not found — run \`build:firefox\` first.`);
+  const distDir = join(repoRoot, "dist");
+  mkdirSync(distDir, { recursive: true });
+  const metaFile = join(distDir, "amo-metadata.json");
+  writeFileSync(metaFile, JSON.stringify(buildAmoMetadata({ releaseNotes, approvalNotes }), null, 2));
+
+  const argv = webExtSignArgs({
+    sourceDir,
+    artifactsDir: join(distDir, "web-ext-artifacts"),
+    sourceCode: existsSync(sourceCode) ? sourceCode : undefined,
+    metadataFile: metaFile,
+  });
+  log(`  running: web-ext ${argv.slice(1).join(" ")}`);
+  const res = spawnSync(webExt, argv.slice(1), { cwd: repoRoot, stdio: "inherit", env });
+  if (res.status !== 0) throw new Error(`web-ext sign failed (exit ${res.status}).`);
+  return "Firefox submitted to AMO review queue";
+}
+
+// ── Dispatcher ────────────────────────────────────────────────────────────────────
+export function submitToStore(store, opts = {}) {
+  switch (store) {
+    case "chrome":
+      return chromeSubmit({ zipPath: join(repoRoot, "dist", "saypi.chrome.zip"), ...opts });
+    case "edge":
+      return edgeSubmit({ zipPath: join(repoRoot, "dist", "saypi.edge.zip"), ...opts });
+    case "firefox":
+      return firefoxSubmit({
+        sourceDir: join(repoRoot, ".output", "firefox-mv2"),
+        sourceCode: join(repoRoot, "source-code.zip"),
+        ...opts,
+      });
+    default:
+      throw new Error(`Unknown store "${store}". Use: chrome | edge | firefox.`);
+  }
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -36,7 +36,9 @@ import {
   checkFirefoxManifest,
   checkSourceEntries,
   chooseReleaseCommit,
+  PUBLISH_STORES,
 } from "./release-lib.mjs";
+import { submitToStore } from "./release-publish.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
 const STORES_PATH = join(repoRoot, "doc", "release", "stores.json");
@@ -425,15 +427,50 @@ function createGhRelease(v, tag) {
   }
 }
 
+/**
+ * ⛔ Submit a built artifact to a store via its publishing API (#412). The most dangerous
+ * command: a real submit publishes to a live store. `--dry-run` only auth-checks (no publish);
+ * a real submit requires --yes and is founder-only. Credentials come from env (founder-provided).
+ */
+async function cmdSubmit({ store, version, yes, dryRun }) {
+  if (!PUBLISH_STORES.includes(store)) {
+    bad(`\`submit\` needs a store: ${PUBLISH_STORES.join(" | ")} (e.g. \`submit chrome --dry-run\`).`);
+    process.exit(2);
+  }
+  if (!dryRun) requireYes(`submit ${store}`, { yes });
+  const v = version || pkgVersion();
+  log(`${C.bold}${dryRun ? "Dry-run" : "Submitting"} ${store} — v${v}${C.reset}`);
+  const releaseNotes = existsSync(RELEASE_NOTES_PATH) ? readFileSync(RELEASE_NOTES_PATH, "utf8").trim() : "";
+  const approvalNotes =
+    "Built with Node >=22 / npm >=10: `npm ci && npm run build:firefox`. Source in source-code.zip " +
+    "(pre-minification). The onnxruntime eval() is in the WASM-unused fallback path and is never executed.";
+  try {
+    const result = await submitToStore(store, {
+      env: process.env,
+      dryRun,
+      log,
+      notes: `Automated release of v${v}.`,
+      releaseNotes,
+      approvalNotes,
+    });
+    ok(result);
+  } catch (e) {
+    bad(`${store} submission failed: ${e.message}`);
+    process.exit(1);
+  }
+}
+
 // ── Entry ───────────────────────────────────────────────────────────────────────
 
-function main() {
+async function main() {
   const argv = process.argv.slice(2);
   const command = argv[0];
   const flags = {
     yes: argv.includes("--yes"),
     save: argv.includes("--save"),
+    dryRun: argv.includes("--dry-run"),
     ghRelease: !argv.includes("--no-gh-release"),
+    store: argv[1] && !argv[1].startsWith("-") ? argv[1] : null,
     version: (() => {
       const i = argv.indexOf("--version");
       if (i >= 0 && argv[i + 1]) return argv[i + 1].replace(/^v/, "");
@@ -462,10 +499,16 @@ function main() {
       return cmdTag(flags);
     case "finalize":
       return cmdFinalize(flags);
+    case "submit":
+      return cmdSubmit(flags);
     default:
-      log(`Usage: node scripts/release.mjs <preflight|plan|packet|bump|build|verify|tag|finalize> [--save] [--version X] [--yes]`);
+      log(`Usage: node scripts/release.mjs <preflight|plan|packet|bump|build|verify|tag|finalize|submit> [--save] [--version X] [--dry-run] [--yes]`);
+      log(`       submit <chrome|edge|firefox> [--dry-run | --yes]   # ⛔ founder-only API submission (#412)`);
       process.exit(command ? 1 : 0);
   }
 }
 
-main();
+main().catch((e) => {
+  bad(e?.message || String(e));
+  process.exit(1);
+});

--- a/test/scripts/release-lib.spec.ts
+++ b/test/scripts/release-lib.spec.ts
@@ -16,6 +16,21 @@ import {
   checkFirefoxManifest,
   checkSourceEntries,
   chooseReleaseCommit,
+  requireEnv,
+  cwsTokenBody,
+  cwsUploadUrl,
+  cwsPublishUrl,
+  interpretCwsUpload,
+  interpretCwsPublish,
+  cwsErrorMessage,
+  edgeHeaders,
+  edgeUploadUrl,
+  edgePublishPollUrl,
+  operationIdFromLocation,
+  interpretEdgeOperation,
+  buildAmoMetadata,
+  webExtSignArgs,
+  PUBLISH_STORES,
 } from "../../scripts/release-lib.mjs";
 
 // A known-good production Chrome manifest shape for the checks below.
@@ -380,5 +395,79 @@ describe("chooseReleaseCommit", () => {
   it("returns null when no candidate matches (so the CLI refuses to tag the wrong commit)", () => {
     expect(chooseReleaseCommit(candidates, "1.12.0")).toBe(null);
     expect(chooseReleaseCommit([], "1.11.0")).toBe(null);
+  });
+});
+
+// ── Publishing-API helpers (#412) ──────────────────────────────────────────────────
+
+describe("requireEnv", () => {
+  it("returns the requested vars when present", () => {
+    expect(requireEnv(["A", "B"], { A: "1", B: "2", C: "3" })).toEqual({ A: "1", B: "2" });
+  });
+  it("throws listing the missing ones (never the values)", () => {
+    expect(() => requireEnv(["A", "B", "C"], { A: "1" })).toThrow(/Missing required env var\(s\): B, C/);
+  });
+});
+
+describe("Chrome Web Store API helpers", () => {
+  it("builds a url-encoded refresh-token body", () => {
+    const body = cwsTokenBody({ clientId: "cid", clientSecret: "sec", refreshToken: "rt" });
+    expect(body).toContain("grant_type=refresh_token");
+    expect(body).toContain("client_id=cid");
+    expect(body).toContain("refresh_token=rt");
+  });
+  it("builds the V2 upload/publish URLs with the /upload prefix on upload only", () => {
+    expect(cwsUploadUrl("pub", "ext")).toBe("https://chromewebstore.googleapis.com/upload/v2/publishers/pub/items/ext:upload");
+    expect(cwsPublishUrl("pub", "ext")).toBe("https://chromewebstore.googleapis.com/v2/publishers/pub/items/ext:publish");
+  });
+  it("interprets upload state (SUCCEEDED ok, IN_PROGRESS keeps polling)", () => {
+    expect(interpretCwsUpload({ uploadState: "SUCCEEDED", crxVersion: "1.11.0" })).toMatchObject({ ok: true, version: "1.11.0" });
+    expect(interpretCwsUpload({ uploadState: "IN_PROGRESS" })).toMatchObject({ ok: false, inProgress: true });
+    expect(interpretCwsUpload({ lastAsyncUploadState: "FAILED" })).toMatchObject({ ok: false, inProgress: false });
+  });
+  it("treats PENDING_REVIEW as an accepted publish; formats Google + oauth errors", () => {
+    expect(interpretCwsPublish({ state: "PENDING_REVIEW" }).ok).toBe(true);
+    expect(interpretCwsPublish({ state: "REJECTED" }).ok).toBe(false);
+    expect(cwsErrorMessage({ error: { status: "PERMISSION_DENIED", message: "nope" } })).toBe("PERMISSION_DENIED: nope");
+    expect(cwsErrorMessage({ error_description: "bad refresh token" })).toBe("bad refresh token");
+  });
+});
+
+describe("Edge Add-ons API helpers", () => {
+  it("builds ApiKey + X-ClientID headers and the operation URLs", () => {
+    expect(edgeHeaders({ apiKey: "k", clientId: "c" })).toEqual({ Authorization: "ApiKey k", "X-ClientID": "c" });
+    expect(edgeUploadUrl("p")).toBe("https://api.addons.microsoftedge.microsoft.com/v1/products/p/submissions/draft/package");
+    expect(edgePublishPollUrl("p", "op9")).toBe("https://api.addons.microsoftedge.microsoft.com/v1/products/p/submissions/operations/op9");
+  });
+  it("extracts the operation id from a bare id OR a URL Location header", () => {
+    expect(operationIdFromLocation("abc-123")).toBe("abc-123");
+    expect(operationIdFromLocation("/v1/products/p/submissions/operations/op-7?x=1")).toBe("op-7");
+  });
+  it("interprets operation status (Succeeded ok, Failed surfaces errorCode)", () => {
+    expect(interpretEdgeOperation({ status: "Succeeded" })).toMatchObject({ ok: true });
+    expect(interpretEdgeOperation({ status: "InProgress" })).toMatchObject({ inProgress: true, ok: false });
+    expect(interpretEdgeOperation({ status: "Failed", errorCode: "NoModulesUpdated" })).toMatchObject({ failed: true, errorCode: "NoModulesUpdated" });
+  });
+});
+
+describe("Firefox AMO (web-ext) helpers", () => {
+  it("nests release_notes/approval_notes under `version` (top-level is ignored by AMO)", () => {
+    const m = buildAmoMetadata({ releaseNotes: "Reliability fixes.", approvalNotes: "build steps" });
+    expect(m).toEqual({ version: { release_notes: { "en-US": "Reliability fixes." }, approval_notes: "build steps", license: "MPL-2.0" } });
+  });
+  it("builds a listed-channel web-ext sign argv from --source-dir (not the prebuilt xpi)", () => {
+    const args = webExtSignArgs({ sourceDir: ".output/firefox-mv2", artifactsDir: "dist/web-ext-artifacts", sourceCode: "source-code.zip", metadataFile: "dist/amo-metadata.json" });
+    expect(args).toEqual([
+      "web-ext", "sign", "--channel=listed",
+      "--source-dir=.output/firefox-mv2", "--artifacts-dir=dist/web-ext-artifacts",
+      "--upload-source-code=source-code.zip", "--amo-metadata=dist/amo-metadata.json", "--approval-timeout=0",
+    ]);
+    expect(args).not.toContain("--source-dir=dist/saypi.firefox.xpi");
+  });
+});
+
+describe("PUBLISH_STORES", () => {
+  it("is the three supported stores", () => {
+    expect(PUBLISH_STORES).toEqual(["chrome", "edge", "firefox"]);
   });
 });


### PR DESCRIPTION
Builds the automation the 1.11.0 wet run proved we need: browser-driving is impossible for Chrome (extensions-gallery block) and file-picker-gated everywhere, so the real one-button path is the official **publishing APIs**. Adds `release.mjs submit <chrome|edge|firefox>`.

## What
- **`scripts/release-lib.mjs`** — pure, unit-tested request builders + response interpreters for **CWS V2**, **Edge v1.1**, and **AMO** (web-ext), plus `requireEnv`.
- **`scripts/release-publish.mjs`** — the I/O: `chromeSubmit` (OAuth → upload → poll → publish), `edgeSubmit` (upload → poll → publish → poll), `firefoxSubmit` (`web-ext sign --channel=listed` from `.output/firefox-mv2` + `--upload-source-code`). Native `fetch`; web-ext shelled out.
- **`scripts/release.mjs`** — gated `submit` command. **`--dry-run` only auth-checks** (Chrome: real token + `fetchStatus`; Edge: 401-vs-not probe; Firefox: env + web-ext presence). A real submit needs `--yes` and is **founder-only/irreversible**. `npm run release:submit`.
- **`doc/release/publishing-credentials.md`** — per-store env vars + one-time credential setup.

## Specs
Verified 2026-06 from official docs (3 parallel research passes): CWS V2 `uploadState` enums + the new `PUBLISHER_ID`; Edge's plain-text publish body + 72-day API-key expiry; web-ext signing from `--source-dir` (not the prebuilt `.xpi`).

## Boundary (AGENTS.md)
The **machinery** is built + tested here. Credentials are **never** in the repo — read from env, founder-provided, never loaded by an agent. The **first live API submission stays founder-only**; the remaining steps (provision creds → `--dry-run` → real `--yes` submit on the next release) are the founder's.

## Verification
Full gate green (**1382 passed**; +12 helper tests covering URLs, state interpreters, the Location→opId parse, the amo-metadata nesting, and the web-ext argv). `submit` with no creds fails cleanly with a "missing env var(s)" message — no crash.

Tracked in #412 (stays open until the first live submission confirms it end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)