### PR TITLE
feat(transcribe): WebM/Opus upload where supported (#414 Phase 2)

### DIFF
--- a/doc/specs/2026-06-22-issue-414-opus-upload-design.md
+++ b/doc/specs/2026-06-22-issue-414-opus-upload-design.md
@@ -1,0 +1,63 @@
+# #414 Phase 2 — Opus `/transcribe` upload (design)
+
+**Status:** implemented on `fix/414-opus-upload`; needs founder sign-off + Layer-4 real-host confirmation before merge.
+**Builds on:** Phase 1 (#417, merged) — 16-bit PCM WAV upload, which becomes the fallback here.
+
+## Goal
+Cut the `/transcribe` upload further by sending **WebM/Opus @ 24 kbps** instead of WAV. Opus is ~8–11× smaller than the 16-bit PCM WAV baseline (~21× vs the original 32-bit float), pushing the p90 upload sub-second even on poor uplinks. Speech-transparent for the 16 kHz mono samples the VAD produces; the ASR is Whisper-family, trained on compressed audio.
+
+## Key decision: native WebCodecs, **not** WASM (no offscreen move)
+The issue (and the initial framing) assumed Opus needs a libopus **WASM** encoder, which — because host-page CSP blocks content-script WASM — would force encoding into the **offscreen document** and change the offscreen↔content audio bridge.
+
+That assumption is wrong. The browser-native **WebCodecs `AudioEncoder`** encodes Opus with **zero WASM**. WebCodecs is a native API, *not* gated by `wasm-unsafe-eval` CSP, so it runs **in the content script** — exactly where encoding happens today. Result:
+- **No offscreen change, no bridge contract change, no WASM asset to ship.**
+- The only dependency is a tiny **MIT** WebM muxer (`webm-muxer`, ~15–25 KB minified) to wrap the encoder's Opus chunks into a container. (We rejected `mediabunny` — 9.8 MB unpacked, MPL-2.0 — as too heavy/uncertain against AMO's 5 MB non-binary limit.)
+
+## Container & params
+- **WebM/Opus**, `audio/webm`. Matches the server's known-good fixture (`sample_audio.webm`) and the **existing default upload filename** (`audio.webm`) — so `TranscriptionForm.ts` / `TranscriptionModule.ts` need **no change** (they already default to `audio.webm` for non-wav/mp4 blobs).
+- **24 kbps, mono, 16 kHz.** Opus resamples to 48 kHz internally; 16 kHz in is fully supported and transparent.
+
+## Progressive enhancement (Key Pattern #4)
+`encodeAudioForUpload(frames): Promise<Blob>`:
+1. If WebCodecs Opus is available **and** `isConfigSupported({codec:'opus',…})` (probed once, cached) → encode to WebM/Opus.
+2. Otherwise, or on **any** encode error → fall back to `convertToWavBlob` (the merged 16-bit PCM WAV).
+
+So Firefox <130 / contexts without WebCodecs / any failure degrade to the Phase-1 PCM win — never a broken upload. Duration is unchanged (always sample-count-derived, never byte-derived).
+
+## Where the encode runs: the network boundary, NOT the audio pipeline
+The obvious place to encode is the post-VAD call sites (`AudioInputMachine`/
+`DictationMachine`, where `convertToWavBlob` is called). **That approach was
+prototyped and rejected** — it breaks the voice turn. The audio pipeline emits
+`saypi:userStoppedSpeaking` **twice**: first raw (frames, no blob), then
+re-emitted *synchronously nested* with the WAV blob inside `AudioInputMachine`'s
+`sendData` (see its own TODO). `CallButton.handleUserStoppedSpeaking` and the
+ConversationMachine rely on that second, blob-bearing emission landing in the
+**same synchronous tick**. Inserting an `await` (Opus encode) anywhere between the
+two emissions lets the raw event reach `CallButton` first, which cancels the
+segment ("No audio data, cancelling capture") before the blob arrives — and no
+upload happens. Verified at Layer 3: the in-pipeline `await` broke even the
+baseline synthetic-turn spec.
+
+So the encode happens at the **one async place that's already async and can't
+disturb pipeline timing: FormData construction, right before the POST.** There
+are exactly two `formData.append("audio", …)` sites and they cover every upload
+path (conversation, dictation Phase 1, refinement Phase 2).
+
+## Modules
+- **`src/audio/OpusEncoder.ts`** (new) — `isOpusUploadSupported()` (cached WebCodecs probe) + `encodeToOpusWebM(frames): Promise<Blob>` (WebCodecs `AudioEncoder` → `webm-muxer`).
+- **`src/audio/WavEncoder.ts`** — add `decodePcm16Wav(buffer)`: decode our 16-bit PCM WAV back to Float32 (returns `null` for any other layout). Lets the boundary transcode work from just the WAV blob, with no re-plumbing of the event pipeline.
+- **`src/audio/AudioEncoder.ts`** — add `transcodeForUpload(blob)`: if it's an `audio/wav` blob and WebCodecs Opus is supported, decode → `encodeToOpusWebM` → WebM/Opus; otherwise (non-WAV, unsupported, or any error) return the blob **unchanged**. Keep `convertToWavBlob`/`convertToWavBuffer` (the pipeline's encoder, untouched).
+- **`src/TranscriptionForm.ts` + `src/TranscriptionModule.ts`** — call `await transcodeForUpload(audioBlob)` before computing the filename + `append`. WebM/Opus → the existing default `audio.webm` filename (no other change).
+
+The WAV→Float32→Opus round-trip wastes a cheap synchronous WAV encode, but buys
+**zero** changes to the fragile synchronous event pipeline — the right trade.
+
+## Verification
+- **Layer 1 (Vitest/JSDOM) — green:** capability probe (false when `AudioEncoder` absent; true+cached when mocked supported; throwing probe → false); `transcodeForUpload` → `audio/webm` when supported (passing the decoded samples), original blob when unsupported / non-WAV / on encode error; `decodePcm16Wav` round-trips 16-bit PCM and rejects float/non-RIFF bytes. The whole `npm test` gate stays green (1415 Vitest + Jest + typecheck) — note `transcodeForUpload` is a no-op in JSDOM (no WebCodecs), so it can't perturb existing upload-path tests.
+- **Layer 3 (headless Chrome — real WebCodecs) — green:** new `e2e/specs/opus-upload.e2e.ts` drives the synthetic voice turn and asserts the mock `/transcribe` received `audio/webm` (Opus actually ran) **and** the transcript landed; environment-adaptive (asserts `audio/wav` where Opus is unsupported). The full 12-spec e2e suite passes, incl. the baseline synthetic + dictation turns (proving the pipeline timing is untouched). The mock server was extended to expose the uploaded audio Content-Type.
+- **Layer 4 (real host, founder-gated) — PENDING:** confirm pi.ai/claude.ai/chatgpt.com transcribe the Opus upload correctly with no accuracy regression. Bundle: `webm-muxer` measured at **27 KB min / 7.5 KB gzip** — negligible vs AMO's 5 MB non-binary limit.
+
+## Risks
+- WebCodecs `AudioEncoder` availability in a **content-script isolated world** on real hosts — mitigated by the PCM fallback; confirmed at Layer 4.
+- Firefox MV2 native WebCodecs Opus is uncertain (130+ only, extension-context exposure unverified) → falls back to PCM there, consistent with the existing degraded-on-Firefox model.
+- Bundle: `webm-muxer` measured against the Firefox AMO 5 MB non-binary limit in the build step.

--- a/e2e/specs/opus-upload.e2e.ts
+++ b/e2e/specs/opus-upload.e2e.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "../fixtures/extension";
+import { DEFAULT_TRANSCRIPT } from "../support/transcribe-response";
+import {
+  seedAutoSubmitFalse,
+  openDecoratedPiPage,
+  getTranscribeHits,
+  getLastAudioContentType,
+} from "../support/dictation";
+import { hasOffscreenDocument } from "../support/lifecycle";
+
+/**
+ * Proves the #414 Opus upload path end-to-end in a REAL browser: the synthetic
+ * voice turn drives VAD -> onSpeechEnd -> encodeAudioForUpload -> POST /transcribe,
+ * and the mock server confirms the uploaded audio is WebM/Opus (not WAV) — which
+ * only happens if the native-WebCodecs encode actually ran and produced a valid
+ * container. JSDOM unit tests can't exercise WebCodecs; this is the layer that can.
+ *
+ * It is environment-adaptive: where this Chromium build lacks WebCodecs Opus
+ * encoding, the content script falls back to 16-bit PCM WAV (the #417 baseline),
+ * and we assert that instead. Either way a transcript must land — the encode must
+ * never break the upload.
+ */
+test("synthetic audio uploads WebM/Opus when WebCodecs supports it (else WAV), and transcribes", async ({
+  context,
+  serviceWorker,
+}) => {
+  await seedAutoSubmitFalse(serviceWorker);
+
+  const page = await openDecoratedPiPage(context);
+
+  // Does THIS browser's content-script realm support WebCodecs Opus encoding?
+  // Mirrors OpusEncoder.isOpusUploadSupported's probe; gates the assertion below.
+  const opusSupported = await page.evaluate(async () => {
+    const AE = (globalThis as { AudioEncoder?: typeof AudioEncoder }).AudioEncoder;
+    if (!AE || typeof AE.isConfigSupported !== "function") return false;
+    try {
+      const support = await AE.isConfigSupported({
+        codec: "opus",
+        sampleRate: 16000,
+        numberOfChannels: 1,
+        bitrate: 24000,
+      });
+      return support.supported === true;
+    } catch {
+      return false;
+    }
+  });
+  console.log(`[opus-upload] WebCodecs Opus supported in this browser: ${opusSupported}`);
+
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent("saypi:dev-feed-speech", { detail: { loop: false } }),
+    );
+  });
+
+  await expect
+    .poll(() => hasOffscreenDocument(serviceWorker), {
+      timeout: 10_000,
+      message: "offscreen document was never created — feed-speech bridge did not reach the SW",
+    })
+    .toBe(true);
+
+  await page.click("#saypi-callButton");
+
+  await expect
+    .poll(() => getTranscribeHits(serviceWorker), {
+      timeout: 30_000,
+      message: "mock /transcribe was never hit — synthetic audio did not drive the VAD",
+    })
+    .toBeGreaterThan(0);
+
+  // The transcript must land regardless of which encoder path was taken.
+  await page.waitForFunction(
+    (expected) =>
+      (document.getElementById("saypi-prompt") as HTMLTextAreaElement | null)?.value?.includes(
+        expected,
+      ) ?? false,
+    DEFAULT_TRANSCRIPT,
+    { timeout: 30_000 },
+  );
+  expect(await page.locator("#saypi-prompt").inputValue()).toContain(DEFAULT_TRANSCRIPT);
+
+  // The crux: when WebCodecs Opus is available, the upload MUST be WebM/Opus.
+  const contentType = await getLastAudioContentType(serviceWorker);
+  console.log(`[opus-upload] uploaded audio Content-Type: ${contentType}`);
+  if (opusSupported) {
+    expect(contentType).toMatch(/^audio\/webm/);
+  } else {
+    expect(contentType).toMatch(/^audio\/wav/);
+  }
+});

--- a/e2e/support/dictation.ts
+++ b/e2e/support/dictation.ts
@@ -39,3 +39,19 @@ export async function getTranscribeHits(serviceWorker: Worker): Promise<number> 
     return ((await res.json()) as { hits: number }).hits;
   }, TRANSCRIBE_HITS_URL);
 }
+
+/**
+ * Read the Content-Type the mock /transcribe saw on the last uploaded audio part
+ * — `audio/webm` (WebM/Opus) or `audio/wav` (PCM fallback). Proves which encoder
+ * path the content script actually took (#414). Read via the SW for the same
+ * reason as the hit counter.
+ */
+export async function getLastAudioContentType(
+  serviceWorker: Worker
+): Promise<string | null> {
+  return serviceWorker.evaluate(async (url) => {
+    const res = await fetch(url);
+    return ((await res.json()) as { lastAudioContentType: string | null })
+      .lastAudioContentType;
+  }, TRANSCRIBE_HITS_URL);
+}

--- a/e2e/support/mock-servers.ts
+++ b/e2e/support/mock-servers.ts
@@ -14,6 +14,7 @@ export interface MockServers {
   piPort: number;
   apiPort: number;
   transcribeHits: () => number;
+  lastAudioContentType: () => string | null;
   close: () => Promise<void>;
 }
 
@@ -23,8 +24,18 @@ function extractSequenceNumber(body: Buffer): number {
   return m ? Number(m[1]) : 1;
 }
 
+function extractAudioContentType(body: Buffer): string | null {
+  // tolerant scan of the multipart form for the audio part's Content-Type
+  // (proves whether the client uploaded WebM/Opus or fell back to PCM WAV — #414)
+  const m = body
+    .toString("latin1")
+    .match(/name="audio";\s*filename="[^"]*"\r?\nContent-Type:\s*([^\r\n]+)/i);
+  return m ? m[1].trim() : null;
+}
+
 export async function startMockServers(): Promise<MockServers> {
   let hits = 0;
+  let lastAudioContentType: string | null = null;
 
   // One page server backs both decorated hosts; the Host header picks the page.
   // claude.ai and pi.ai both resolve here via --host-resolver-rules, and the
@@ -46,7 +57,7 @@ export async function startMockServers(): Promise<MockServers> {
         "content-type": "application/json",
         "access-control-allow-origin": "*",
       });
-      res.end(JSON.stringify({ hits }));
+      res.end(JSON.stringify({ hits, lastAudioContentType }));
       return;
     }
     if (req.method === "POST" && req.url && req.url.startsWith("/transcribe")) {
@@ -54,7 +65,9 @@ export async function startMockServers(): Promise<MockServers> {
       req.on("data", (c) => chunks.push(c));
       req.on("end", () => {
         hits++;
-        const seq = extractSequenceNumber(Buffer.concat(chunks));
+        const body = Buffer.concat(chunks);
+        lastAudioContentType = extractAudioContentType(body) ?? lastAudioContentType;
+        const seq = extractSequenceNumber(body);
         const payload = JSON.stringify(buildTranscribeResponse({ sequenceNumber: seq }));
         res.writeHead(200, {
           "content-type": "application/json",
@@ -90,6 +103,7 @@ export async function startMockServers(): Promise<MockServers> {
     piPort: (piServer.address() as import("node:net").AddressInfo).port,
     apiPort: (apiServer.address() as import("node:net").AddressInfo).port,
     transcribeHits: () => hits,
+    lastAudioContentType: () => lastAudioContentType,
     close: async () => {
       await new Promise((r) => piServer.close(() => r(null)));
       await new Promise((r) => apiServer.close(() => r(null)));

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "rxjs": "^7.8.1",
         "serve-handler": "^6.1.5",
         "wasm-feature-detect": "^1.8.0",
+        "webm-muxer": "^5.1.4",
         "xstate": "^5.20.1"
       },
       "devDependencies": {
@@ -5038,6 +5039,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.18.tgz",
+      "integrity": "sha512-vAvE8C9DGWR+tkb19xyjk1TSUlJ7RUzzp4a9Anu7mwBT+fpyePWK1UxmH14tMO5zHmrnrRIMg5NutnnDztLxgg==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5223,6 +5230,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.8",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
+      "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -20951,6 +20964,17 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webm-muxer": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/webm-muxer/-/webm-muxer-5.1.4.tgz",
+      "integrity": "sha512-ditzgFVFbfqPaugkIr4mGhAdob5K9HY6Rzlh7TRsA368yA1sp/m5O7nQCcMLdgFDeNGtFPg8B+MeXLtpzKWX6Q==",
+      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "^0.1.4",
+        "@types/wicg-file-system-access": "^2020.9.5"
       }
     },
     "node_modules/webpack-virtual-modules": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "rxjs": "^7.8.1",
     "serve-handler": "^6.1.5",
     "wasm-feature-detect": "^1.8.0",
+    "webm-muxer": "^5.1.4",
     "xstate": "^5.20.1"
   },
   "devDependencies": {

--- a/src/TranscriptionForm.ts
+++ b/src/TranscriptionForm.ts
@@ -2,6 +2,7 @@ import { logger } from "./LoggingModule.js";
 import { UserPreferenceModule } from "./prefs/PreferenceModule";
 import { ChatbotService } from "./chatbots/ChatbotService";
 import { buildUsageMetadata } from "./usage/UsageMetadata";
+import { transcodeForUpload } from "./audio/AudioEncoder";
 
 const userPreferences = UserPreferenceModule.getInstance();
 
@@ -16,22 +17,26 @@ export async function constructTranscriptionFormData(
   inputLabel?: string
 ) {
   const formData = new FormData();
-  let audioFilename = "audio.webm";
 
-  if (audioBlob.type === "audio/mp4") {
+  // Compress to WebM/Opus where the browser supports it (#414); a no-op that
+  // returns the original blob for unsupported contexts or non-WAV input.
+  const uploadBlob = await transcodeForUpload(audioBlob);
+
+  let audioFilename = "audio.webm";
+  if (uploadBlob.type === "audio/mp4") {
     audioFilename = "audio.mp4";
-  } else if (audioBlob.type === "audio/wav") {
+  } else if (uploadBlob.type === "audio/wav") {
     audioFilename = "audio.wav";
   }
 
   logger.debug(
-    `Transcribing audio Blob with MIME type: ${audioBlob.type}, size: ${(
-      audioBlob.size / 1024
+    `Transcribing audio Blob with MIME type: ${uploadBlob.type}, size: ${(
+      uploadBlob.size / 1024
     ).toFixed(2)}kb`
   );
 
   // Add the audio and other input parameters to the FormData object
-  formData.append("audio", audioBlob, audioFilename);
+  formData.append("audio", uploadBlob, audioFilename);
   formData.append("duration", audioDurationSeconds.toString());
   formData.append("sequenceNumber", (sequenceNumber ?? 0).toString());
   formData.append("messages", JSON.stringify(messages));

--- a/src/TranscriptionModule.ts
+++ b/src/TranscriptionModule.ts
@@ -7,6 +7,7 @@ import EventBus from "./events/EventBus";
 import { ChatbotService } from "./chatbots/ChatbotService";
 import { buildUsageMetadata } from "./usage/UsageMetadata";
 import { constructTranscriptionFormData } from "./TranscriptionForm";
+import { transcodeForUpload } from "./audio/AudioEncoder";
 import { parseServerTiming } from "./telemetry/serverTiming";
 
 /**
@@ -437,14 +438,18 @@ async function uploadAudioForRefinementInternal(
 
     // Build minimal FormData (no sequence number, no messages, no acceptsMerge)
     const formData = new FormData();
+
+    // Compress to WebM/Opus where supported (#414); no-op otherwise.
+    const uploadBlob = await transcodeForUpload(audioBlob);
+
     let audioFilename = "audio.webm";
-    if (audioBlob.type === "audio/mp4") {
+    if (uploadBlob.type === "audio/mp4") {
       audioFilename = "audio.mp4";
-    } else if (audioBlob.type === "audio/wav") {
+    } else if (uploadBlob.type === "audio/wav") {
       audioFilename = "audio.wav";
     }
 
-    formData.append("audio", audioBlob, audioFilename);
+    formData.append("audio", uploadBlob, audioFilename);
     formData.append("duration", (audioDurationMillis / 1000).toString());
     formData.append("requestId", requestId); // UUID for correlation
 

--- a/src/audio/AudioEncoder.ts
+++ b/src/audio/AudioEncoder.ts
@@ -1,4 +1,6 @@
-import { encodeWAV } from "./WavEncoder";
+import { encodeWAV, decodePcm16Wav } from "./WavEncoder";
+import { isOpusUploadSupported, encodeToOpusWebM } from "./OpusEncoder";
+import { logger } from "../LoggingModule";
 
 /**
  * Convert a Float32Array of audio samples to a WAV array buffer
@@ -28,4 +30,41 @@ export function convertToWavBuffer(audioData: Float32Array): ArrayBuffer {
 export function convertToWavBlob(audioData: Float32Array): Blob {
   const arrayBuffer = convertToWavBuffer(audioData);
   return new Blob([arrayBuffer], { type: "audio/wav" });
+}
+
+/**
+ * Transcode a 16-bit PCM WAV upload blob to WebM/Opus where WebCodecs supports
+ * it, for the /transcribe POST (#414). Opus (~24 kbps, native WebCodecs) is
+ * ~8-11x smaller than the PCM WAV baseline (#417) — the highest-leverage cut on
+ * transcription upload latency.
+ *
+ * This runs at the network boundary (FormData construction), NOT in the audio
+ * event pipeline: that pipeline emits `saypi:userStoppedSpeaking` twice — raw
+ * then re-emitted *synchronously* with the WAV blob — and the call-button /
+ * conversation machines depend on that synchronous nesting, which an async encode
+ * upstream would break. Transcoding the finished WAV blob here keeps the pipeline
+ * untouched and localizes Opus to the one async place that matters: the upload.
+ *
+ * Progressive enhancement: a non-WAV blob, an unsupported context (Firefox <130,
+ * etc.), or any encode error returns the original blob unchanged, so the upload
+ * never fails. Duration is sent as a separate sample-count-derived field, so the
+ * format switch can't perturb billing or accuracy.
+ *
+ * @param audioBlob - the upload blob (an `audio/wav` 16-bit PCM blob to transcode)
+ * @returns an `audio/webm` (Opus) blob, or the original blob unchanged
+ */
+export async function transcodeForUpload(audioBlob: Blob): Promise<Blob> {
+  if (audioBlob.type !== "audio/wav") return audioBlob;
+  if (!(await isOpusUploadSupported())) return audioBlob;
+  try {
+    const samples = decodePcm16Wav(await audioBlob.arrayBuffer());
+    if (!samples || samples.length === 0) return audioBlob;
+    return await encodeToOpusWebM(samples);
+  } catch (e) {
+    logger.warn(
+      "[AudioEncoder] Opus transcode failed; uploading 16-bit PCM WAV",
+      e
+    );
+    return audioBlob;
+  }
 }

--- a/src/audio/OpusEncoder.ts
+++ b/src/audio/OpusEncoder.ts
@@ -20,6 +20,10 @@ import { logger } from "../LoggingModule";
 const SAMPLE_RATE = 16000;
 const NUM_CHANNELS = 1;
 const OPUS_BITRATE = 24000; // 24 kbps — speech-transparent for 16 kHz mono
+// A real encode of a few seconds of 16 kHz audio takes ~tens of ms; this only
+// trips if the codec stalls and never fires `error` (rare, but it would
+// otherwise hang the upload forever — the caller then falls back to WAV).
+const ENCODE_TIMEOUT_MS = 5000;
 
 const OPUS_CONFIG: AudioEncoderConfig = {
   codec: "opus",
@@ -80,14 +84,33 @@ export async function encodeToOpusWebM(audioData: Float32Array): Promise<Blob> {
   });
 
   await new Promise<void>((resolve, reject) => {
-    const encoder = new AudioEncoder({
-      // `meta` carries the OpusHead (decoderConfig.description) webm-muxer needs.
-      output: (chunk, meta) => muxer.addAudioChunk(chunk, meta),
-      error: (e) => reject(e),
-    });
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    let encoder: AudioEncoder | null = null;
+    let frame: AudioData | null = null;
+
+    // Close codec resources on every exit path (success, error, timeout) so a
+    // failed encode can't leak an AudioEncoder/AudioData.
+    const settle = (err?: unknown) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try { frame?.close(); } catch { /* already closed */ }
+      try { encoder?.close(); } catch { /* already closed */ }
+      if (err) reject(err instanceof Error ? err : new Error(String(err)));
+      else resolve();
+    };
+
+    timer = setTimeout(() => settle(new Error("Opus encode timed out")), ENCODE_TIMEOUT_MS);
+
     try {
+      encoder = new AudioEncoder({
+        // `meta` carries the OpusHead (decoderConfig.description) webm-muxer needs.
+        output: (chunk, meta) => muxer.addAudioChunk(chunk, meta),
+        error: (e) => settle(e),
+      });
       encoder.configure(OPUS_CONFIG);
-      const frame = new AudioData({
+      frame = new AudioData({
         format: "f32",
         sampleRate: SAMPLE_RATE,
         numberOfFrames: audioData.length,
@@ -98,13 +121,9 @@ export async function encodeToOpusWebM(audioData: Float32Array): Promise<Blob> {
         data: audioData as unknown as BufferSource,
       });
       encoder.encode(frame);
-      frame.close();
-      encoder.flush().then(() => {
-        encoder.close();
-        resolve();
-      }, reject);
+      encoder.flush().then(() => settle(), (e) => settle(e));
     } catch (e) {
-      reject(e);
+      settle(e);
     }
   });
 

--- a/src/audio/OpusEncoder.ts
+++ b/src/audio/OpusEncoder.ts
@@ -1,0 +1,113 @@
+import { Muxer, ArrayBufferTarget } from "webm-muxer";
+import { logger } from "../LoggingModule";
+
+/**
+ * Native-WebCodecs Opus encoder for the /transcribe upload (#414).
+ *
+ * The post-VAD audio is a 16 kHz mono Float32Array of raw PCM. Encoding it to
+ * WebM/Opus @ 24 kbps cuts the upload ~8-11x vs the 16-bit PCM WAV baseline
+ * (#417). We use the browser-native WebCodecs `AudioEncoder` — which compiles no
+ * WebAssembly, so it is NOT gated by host-page `wasm-unsafe-eval` CSP and runs
+ * directly in the content script — plus the tiny MIT `webm-muxer` to wrap the
+ * encoder's Opus chunks into a container. WebM/Opus matches the server's
+ * known-good fixture (`sample_audio.webm`) and the default upload filename.
+ *
+ * Callers must treat Opus as a progressive enhancement: where WebCodecs/Opus is
+ * unavailable (Firefox <130, some extension contexts) or encoding errors, fall
+ * back to the PCM WAV path. See `encodeAudioForUpload` in AudioEncoder.ts.
+ */
+
+const SAMPLE_RATE = 16000;
+const NUM_CHANNELS = 1;
+const OPUS_BITRATE = 24000; // 24 kbps — speech-transparent for 16 kHz mono
+
+const OPUS_CONFIG: AudioEncoderConfig = {
+  codec: "opus",
+  sampleRate: SAMPLE_RATE,
+  numberOfChannels: NUM_CHANNELS,
+  bitrate: OPUS_BITRATE,
+};
+
+let opusSupportPromise: Promise<boolean> | undefined;
+
+/**
+ * Whether this context can encode Opus via native WebCodecs. Probed once and
+ * cached (the answer is fixed for the lifetime of the page/document).
+ */
+export function isOpusUploadSupported(): Promise<boolean> {
+  if (!opusSupportPromise) {
+    opusSupportPromise = probeOpusSupport();
+  }
+  return opusSupportPromise;
+}
+
+async function probeOpusSupport(): Promise<boolean> {
+  try {
+    if (
+      typeof AudioEncoder === "undefined" ||
+      typeof AudioData === "undefined" ||
+      typeof AudioEncoder.isConfigSupported !== "function"
+    ) {
+      return false;
+    }
+    const support = await AudioEncoder.isConfigSupported(OPUS_CONFIG);
+    return support.supported === true;
+  } catch (e) {
+    logger.debug("[OpusEncoder] WebCodecs Opus capability probe failed", e);
+    return false;
+  }
+}
+
+/**
+ * Encode 16 kHz mono Float32 PCM samples to a WebM/Opus Blob.
+ *
+ * @throws if WebCodecs Opus is unavailable or encoding fails — callers fall back
+ *   to PCM WAV rather than failing the upload.
+ */
+export async function encodeToOpusWebM(audioData: Float32Array): Promise<Blob> {
+  if (!(await isOpusUploadSupported())) {
+    throw new Error("WebCodecs Opus encoding is not supported in this context");
+  }
+
+  const target = new ArrayBufferTarget();
+  const muxer = new Muxer({
+    target,
+    audio: {
+      codec: "A_OPUS",
+      numberOfChannels: NUM_CHANNELS,
+      sampleRate: SAMPLE_RATE,
+    },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const encoder = new AudioEncoder({
+      // `meta` carries the OpusHead (decoderConfig.description) webm-muxer needs.
+      output: (chunk, meta) => muxer.addAudioChunk(chunk, meta),
+      error: (e) => reject(e),
+    });
+    try {
+      encoder.configure(OPUS_CONFIG);
+      const frame = new AudioData({
+        format: "f32",
+        sampleRate: SAMPLE_RATE,
+        numberOfFrames: audioData.length,
+        numberOfChannels: NUM_CHANNELS,
+        timestamp: 0,
+        // Float32Array<ArrayBufferLike> vs BufferSource is a TS 5.7 typed-array
+        // generics quirk; the VAD samples are always ArrayBuffer-backed at runtime.
+        data: audioData as unknown as BufferSource,
+      });
+      encoder.encode(frame);
+      frame.close();
+      encoder.flush().then(() => {
+        encoder.close();
+        resolve();
+      }, reject);
+    } catch (e) {
+      reject(e);
+    }
+  });
+
+  muxer.finalize();
+  return new Blob([target.buffer], { type: "audio/webm" });
+}

--- a/src/audio/WavEncoder.ts
+++ b/src/audio/WavEncoder.ts
@@ -71,6 +71,34 @@ export function encodeWAV(
   return buffer;
 }
 
+/**
+ * Decode a 16-bit PCM mono WAV (as produced by `encodeWAV(..., 1, 16000, 1, 16)`)
+ * back to Float32 samples. Returns null if the bytes are not the expected
+ * 16-bit-PCM layout, so callers can leave non-matching blobs untouched. Used to
+ * transcode the upload to Opus at the network boundary (#414) without re-plumbing
+ * the synchronous audio-event pipeline that carries the WAV blob.
+ */
+export function decodePcm16Wav(buffer: ArrayBuffer): Float32Array | null {
+  if (buffer.byteLength < 44) return null;
+  const view = new DataView(buffer);
+  const isRiffWave =
+    view.getUint32(0, false) === 0x52494646 /* "RIFF" */ &&
+    view.getUint32(8, false) === 0x57415645 /* "WAVE" */;
+  const audioFormat = view.getUint16(20, true);
+  const bitsPerSample = view.getUint16(34, true);
+  if (!isRiffWave || audioFormat !== 1 || bitsPerSample !== 16) return null;
+
+  const declaredDataLength = view.getUint32(40, true);
+  const available = buffer.byteLength - 44;
+  const dataLength = Math.min(declaredDataLength, available);
+  const sampleCount = Math.floor(dataLength / 2);
+  const out = new Float32Array(sampleCount);
+  for (let i = 0; i < sampleCount; i++) {
+    out[i] = view.getInt16(44 + i * 2, true) / 0x8000;
+  }
+  return out;
+}
+
 function interleave(inputL: Float32Array, inputR: Float32Array) {
   var length = inputL.length + inputR.length;
   var result = new Float32Array(length);

--- a/test/audio/AudioEncoder.spec.ts
+++ b/test/audio/AudioEncoder.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { convertToWavBuffer, convertToWavBlob } from "../../src/audio/AudioEncoder";
-import { encodeWAV } from "../../src/audio/WavEncoder";
+import { encodeWAV, decodePcm16Wav } from "../../src/audio/WavEncoder";
 
 /**
  * Minimal WAV header reader so the tests can assert the on-the-wire format
@@ -115,6 +115,31 @@ describe("AudioEncoder — transcribe upload format (#414)", () => {
       const header = readWavHeader(encodeWAV(samples, 3, 16000, 1, 32));
       expect(header.audioFormat).toBe(3);
       expect(header.bitsPerSample).toBe(32);
+    });
+  });
+
+  // decodePcm16Wav is the inverse used to transcode the WAV upload to Opus (#414).
+  describe("decodePcm16Wav", () => {
+    it("round-trips 16-bit PCM WAV samples back to ~Float32", () => {
+      const src = new Float32Array([0, 0.5, -0.5, 1, -1]);
+      const decoded = decodePcm16Wav(convertToWavBuffer(src));
+      expect(decoded).not.toBeNull();
+      expect(decoded!.length).toBe(src.length);
+      expect(decoded![0]).toBeCloseTo(0, 4);
+      expect(decoded![1]).toBeCloseTo(0.5, 3);
+      expect(decoded![2]).toBeCloseTo(-0.5, 4);
+      expect(decoded![3]).toBeCloseTo(1, 3); // 32767/32768 ≈ 0.99997
+      expect(decoded![4]).toBeCloseTo(-1, 4);
+    });
+
+    it("returns null for a 32-bit float WAV (not 16-bit PCM)", () => {
+      const floatWav = encodeWAV(new Float32Array([0.1, 0.2]), 3, 16000, 1, 32);
+      expect(decodePcm16Wav(floatWav)).toBeNull();
+    });
+
+    it("returns null for non-RIFF / too-short bytes", () => {
+      expect(decodePcm16Wav(new ArrayBuffer(8))).toBeNull();
+      expect(decodePcm16Wav(new ArrayBuffer(64))).toBeNull(); // 64 zero bytes: not RIFF
     });
   });
 });

--- a/test/audio/OpusEncoder.spec.ts
+++ b/test/audio/OpusEncoder.spec.ts
@@ -22,6 +22,7 @@ describe("OpusEncoder — WebCodecs capability probe (#414)", () => {
   afterEach(() => {
     g.AudioEncoder = originalAudioEncoder;
     g.AudioData = originalAudioData;
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -73,5 +74,26 @@ describe("OpusEncoder — WebCodecs capability probe (#414)", () => {
     delete g.AudioData;
     const { encodeToOpusWebM } = await import("../../src/audio/OpusEncoder");
     await expect(encodeToOpusWebM(new Float32Array([0, 0.1, -0.1]))).rejects.toThrow();
+  });
+
+  it("encodeToOpusWebM rejects on timeout if the codec stalls (never resolves, never errors)", async () => {
+    vi.useFakeTimers();
+    g.AudioEncoder = class {
+      static isConfigSupported = vi.fn().mockResolvedValue({ supported: true });
+      configure() {}
+      encode() {}
+      flush() {
+        return new Promise<void>(() => {}); // never settles, never fires error()
+      }
+      close() {}
+    };
+    g.AudioData = class {
+      close() {}
+    };
+    const { encodeToOpusWebM } = await import("../../src/audio/OpusEncoder");
+    const p = encodeToOpusWebM(new Float32Array([0.1, 0.2, 0.3]));
+    p.catch(() => {}); // avoid an unhandled rejection while advancing timers
+    await vi.advanceTimersByTimeAsync(5001);
+    await expect(p).rejects.toThrow(/timed out/);
   });
 });

--- a/test/audio/OpusEncoder.spec.ts
+++ b/test/audio/OpusEncoder.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Capability-probe tests for the native-WebCodecs Opus encoder (#414).
+ *
+ * JSDOM has no WebCodecs, so we drive the probe with a stubbed global
+ * `AudioEncoder`/`AudioData`. The real encode (producing a valid WebM/Opus the
+ * server can decode) needs a real browser and is covered at Layer 3.
+ *
+ * Each test re-imports the module (`vi.resetModules`) so the module-level
+ * capability cache starts fresh.
+ */
+describe("OpusEncoder — WebCodecs capability probe (#414)", () => {
+  const g = globalThis as any;
+  const originalAudioEncoder = g.AudioEncoder;
+  const originalAudioData = g.AudioData;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    g.AudioEncoder = originalAudioEncoder;
+    g.AudioData = originalAudioData;
+    vi.restoreAllMocks();
+  });
+
+  it("reports unsupported when WebCodecs AudioEncoder is absent (JSDOM / Firefox <130)", async () => {
+    delete g.AudioEncoder;
+    delete g.AudioData;
+    const { isOpusUploadSupported } = await import("../../src/audio/OpusEncoder");
+    expect(await isOpusUploadSupported()).toBe(false);
+  });
+
+  it("reports supported when isConfigSupported approves the opus config", async () => {
+    const isConfigSupported = vi.fn().mockResolvedValue({ supported: true, config: {} });
+    g.AudioEncoder = { isConfigSupported };
+    g.AudioData = function () {};
+    const { isOpusUploadSupported } = await import("../../src/audio/OpusEncoder");
+    expect(await isOpusUploadSupported()).toBe(true);
+    expect(isConfigSupported).toHaveBeenCalledWith(
+      expect.objectContaining({ codec: "opus", sampleRate: 16000, numberOfChannels: 1 })
+    );
+  });
+
+  it("reports unsupported when the opus config is rejected", async () => {
+    g.AudioEncoder = { isConfigSupported: vi.fn().mockResolvedValue({ supported: false }) };
+    g.AudioData = function () {};
+    const { isOpusUploadSupported } = await import("../../src/audio/OpusEncoder");
+    expect(await isOpusUploadSupported()).toBe(false);
+  });
+
+  it("caches the probe result rather than re-probing on every clip", async () => {
+    const isConfigSupported = vi.fn().mockResolvedValue({ supported: true });
+    g.AudioEncoder = { isConfigSupported };
+    g.AudioData = function () {};
+    const { isOpusUploadSupported } = await import("../../src/audio/OpusEncoder");
+    await isOpusUploadSupported();
+    await isOpusUploadSupported();
+    await isOpusUploadSupported();
+    expect(isConfigSupported).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a throwing capability probe as unsupported", async () => {
+    g.AudioEncoder = { isConfigSupported: vi.fn().mockRejectedValue(new Error("boom")) };
+    g.AudioData = function () {};
+    const { isOpusUploadSupported } = await import("../../src/audio/OpusEncoder");
+    expect(await isOpusUploadSupported()).toBe(false);
+  });
+
+  it("encodeToOpusWebM rejects when WebCodecs Opus is unavailable", async () => {
+    delete g.AudioEncoder;
+    delete g.AudioData;
+    const { encodeToOpusWebM } = await import("../../src/audio/OpusEncoder");
+    await expect(encodeToOpusWebM(new Float32Array([0, 0.1, -0.1]))).rejects.toThrow();
+  });
+});

--- a/test/audio/transcodeForUpload.spec.ts
+++ b/test/audio/transcodeForUpload.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the Opus path so the transcode orchestration can be exercised without
+// real WebCodecs (JSDOM has none). The real encode is covered at Layer 3.
+vi.mock("../../src/audio/OpusEncoder", () => ({
+  isOpusUploadSupported: vi.fn(),
+  encodeToOpusWebM: vi.fn(),
+}));
+
+import {
+  transcodeForUpload,
+  convertToWavBlob,
+  convertToWavBuffer,
+} from "../../src/audio/AudioEncoder";
+import { isOpusUploadSupported, encodeToOpusWebM } from "../../src/audio/OpusEncoder";
+
+const frames = new Float32Array([0, 0.5, -0.5, 0.25, -0.25, 1, -1]);
+
+// JSDOM's Blob lacks arrayBuffer(); real browsers (and the content script) have
+// it. Provide it so the transcode path can read the WAV bytes under test.
+const wavBlob = () => {
+  const blob = convertToWavBlob(frames);
+  if (typeof blob.arrayBuffer !== "function") {
+    const buf = convertToWavBuffer(frames);
+    (blob as { arrayBuffer: () => Promise<ArrayBuffer> }).arrayBuffer = async () => buf;
+  }
+  return blob;
+};
+
+describe("transcodeForUpload — WAV→Opus at the network boundary (#414)", () => {
+  beforeEach(() => {
+    vi.mocked(isOpusUploadSupported).mockReset();
+    vi.mocked(encodeToOpusWebM).mockReset();
+  });
+
+  it("transcodes a 16-bit PCM WAV to WebM/Opus when supported, passing decoded samples", async () => {
+    vi.mocked(isOpusUploadSupported).mockResolvedValue(true);
+    vi.mocked(encodeToOpusWebM).mockResolvedValue(
+      new Blob(["opus"], { type: "audio/webm" })
+    );
+
+    const out = await transcodeForUpload(wavBlob());
+
+    expect(out.type).toBe("audio/webm");
+    const passed = vi.mocked(encodeToOpusWebM).mock.calls[0][0];
+    expect(passed).toBeInstanceOf(Float32Array);
+    expect(passed.length).toBe(frames.length); // decoded sample count matches
+    expect(passed[1]).toBeCloseTo(0.5, 2); // values survive the 16-bit round-trip
+    expect(passed[2]).toBeCloseTo(-0.5, 2);
+  });
+
+  it("returns the WAV unchanged when Opus is unsupported (Firefox <130 etc.)", async () => {
+    vi.mocked(isOpusUploadSupported).mockResolvedValue(false);
+    const input = wavBlob();
+    const out = await transcodeForUpload(input);
+    expect(out).toBe(input);
+    expect(encodeToOpusWebM).not.toHaveBeenCalled();
+  });
+
+  it("leaves a non-WAV blob untouched (no probe, no encode)", async () => {
+    const input = new Blob(["x"], { type: "audio/webm" });
+    const out = await transcodeForUpload(input);
+    expect(out).toBe(input);
+    expect(isOpusUploadSupported).not.toHaveBeenCalled();
+    expect(encodeToOpusWebM).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the original WAV when the Opus encode throws (never fails the upload)", async () => {
+    vi.mocked(isOpusUploadSupported).mockResolvedValue(true);
+    vi.mocked(encodeToOpusWebM).mockRejectedValue(new Error("encoder blew up"));
+    const input = wavBlob();
+    const out = await transcodeForUpload(input);
+    expect(out).toBe(input);
+    expect(out.type).toBe("audio/wav");
+  });
+});


### PR DESCRIPTION
> ⚠️ **Needs founder sign-off + Layer-4 real-host confirmation before merge.** Dependency-bearing (adds `webm-muxer`) and exercises WebCodecs on the live hosts — fallback-protected but unconfirmed there. Per the [Opus go-ahead decision], the founder asked to sign off before this merges. **Do not auto-merge.**

## Why
Phase 2 of #414, on top of the merged 16-bit PCM WAV baseline (#417). Compress the `/transcribe` upload to **WebM/Opus @ 24 kbps** — **~8–11× smaller** than the PCM WAV (~21× vs the original 32-bit float), pushing the p90 upload **sub-second** even on poor uplinks. Opus is speech-transparent for 16 kHz mono; the ASR is Whisper-family.

## Key decision: native WebCodecs, not WASM
The browser-native **WebCodecs `AudioEncoder`** encodes Opus with **zero WebAssembly**, so it isn't gated by host-page `wasm-unsafe-eval` CSP and runs **in the content script** — **no offscreen move, no audio-bridge change, no WASM asset to ship**. The only dependency is the tiny **MIT** `webm-muxer` (**27 KB min / 7.5 KB gzip**) to wrap the encoder's Opus chunks into a container — negligible vs AMO's 5 MB non-binary limit. (Rejected `mediabunny`: 9.8 MB unpacked, MPL-2.0.)

WebM/Opus matches the server's known-good fixture (`sample_audio.webm`) and the existing default upload filename, so **no server change** (confirmed in saypi-api #269) and no `TranscriptionForm`/`TranscriptionModule` filename change.

## Where it runs: the network boundary, not the audio pipeline
The obvious spot — the post-VAD encode sites — **was prototyped and rejected.** The pipeline emits `saypi:userStoppedSpeaking` **twice** (raw, then re-emitted *synchronously* with the WAV blob inside `AudioInputMachine.sendData`), and `CallButton`/`ConversationMachine` depend on that synchronous nesting. An `await` (Opus encode) between the two lets the raw event reach `CallButton` first → "No audio data, cancelling capture" → **no upload**. This was caught at Layer 3 (it broke even the baseline synthetic turn).

So the encode runs at **FormData construction** — the one already-async place that can't disturb pipeline timing. `transcodeForUpload(blob)` decodes the finished 16-bit PCM WAV and re-encodes to Opus; the two `append("audio", …)` sites cover **conversation, dictation Phase 1, and refinement Phase 2**.

**Progressive enhancement:** non-WAV blob, unsupported context (Firefox <130, etc.), or any encode error → the original WAV blob, unchanged. The upload never fails. Duration is a separate sample-count field, so billing/accuracy are untouched.

## Changes
- **`src/audio/OpusEncoder.ts`** (new) — cached WebCodecs capability probe + `encodeToOpusWebM` (`AudioEncoder` → `webm-muxer`).
- **`src/audio/WavEncoder.ts`** — `decodePcm16Wav` (inverse of our 16-bit PCM encoder; `null` for any other layout).
- **`src/audio/AudioEncoder.ts`** — `transcodeForUpload(blob)` (try-Opus-then-passthrough).
- **`src/TranscriptionForm.ts` + `src/TranscriptionModule.ts`** — `await transcodeForUpload(audioBlob)` before append.
- E2E: mock server now exposes the uploaded audio Content-Type; new `opus-upload.e2e.ts`.

## Verification
- **Layer 1** — `npm test` green (typecheck + Jest + **1415** Vitest). New unit tests: capability probe (absent/supported/cached/throwing), `decodePcm16Wav` round-trip + rejects float/non-RIFF, and `transcodeForUpload` fallback orchestration (webm when supported, original blob when unsupported/non-WAV/on error). `transcodeForUpload` is a no-op in JSDOM (no WebCodecs), so it can't perturb existing upload tests.
- **Layer 3** (real WebCodecs in headless Chrome) — new `opus-upload.e2e.ts` asserts the mock `/transcribe` received **`audio/webm`** and the transcript landed; **full 12-spec e2e suite green**, incl. the baseline synthetic + dictation turns (pipeline timing untouched).
- **Layer 4** (real host, founder-gated) — **PENDING.** Recommend `npm run layer4cdp:verify <host>` against pi.ai/claude.ai/chatgpt.com to confirm the live server transcribes the Opus upload. I can drive this once a build of this branch is loaded into the dedicated profile.

Design rationale: `doc/specs/2026-06-22-issue-414-opus-upload-design.md`. Addresses #414 (keeps it open until merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)