### PR TITLE
feat(vad): admission gate on the VAD's own confidence to cut silence hallucinations (#420)

### DIFF
--- a/src/offscreen/vad_handler.ts
+++ b/src/offscreen/vad_handler.ts
@@ -4,6 +4,12 @@ import { logger } from "../LoggingModule.js";
 import { debounce } from "../utils/debounce";
 import { incrementUsage, decrementUsage, resetUsageCounter, registerMessageHandler } from "./media_coordinator";
 import { VAD_CONFIGS, VADPreset } from "../vad/VADConfigs";
+import {
+  SegmentStatsTracker,
+  admitSegment,
+  DEFAULT_ADMISSION_CONFIG,
+  SILERO_V5_DEFAULT_POSITIVE_THRESHOLD,
+} from "../vad/segmentAdmission";
 import { resolveVadStream, type SyntheticAudioLatch } from "./synthetic-audio";
 
 const globalScope = globalThis as Record<PropertyKey, unknown>;
@@ -57,6 +63,11 @@ let speechStartTime = 0;
 let lastFrameProbabilities: { isSpeech: number; notSpeech: number } | null = null;
 let activePreset: VADPreset = "none";
 
+// #420 — accumulates each segment's peak/mean speech probability + speech-frame count
+// from the per-frame VAD callbacks, so the admission gate can drop near-threshold
+// non-speech BEFORE the audio is serialised across the offscreen→content IPC.
+const segmentStats = new SegmentStatsTracker(SILERO_V5_DEFAULT_POSITIVE_THRESHOLD);
+
 // DEV-only: when armed (via VAD_USE_SYNTHETIC_AUDIO), the next VAD init is fed a
 // bundled WAV instead of the live mic, so the agent can drive a voice turn with
 // no human speaking. See src/offscreen/synthetic-audio.ts.
@@ -82,6 +93,7 @@ const vadCallbackOptions: Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks =
   onSpeechStart: () => {
     logger.debug("[SayPi VAD Handler] Speech started.");
     speechStartTime = Date.now();
+    segmentStats.beginSegment();
     if (currentVadTabId !== null) {
       const confidence = lastFrameProbabilities?.isSpeech ?? null;
       chrome.runtime.sendMessage({
@@ -103,16 +115,39 @@ const vadCallbackOptions: Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks =
     const frameCount = rawAudioData.length;
     const frameRate = 16000;
     const duration = frameCount / frameRate;
+    // #420 — summarise the segment's speech-probability before deciding to upload.
+    const stats = segmentStats.endSegment();
+    const decision = admitSegment(stats, DEFAULT_ADMISSION_CONFIG);
     console.debug(`[SayPi VAD Handler] Speech duration: ${speechDuration}ms, Frame count: ${frameCount}, Frame rate: ${frameRate}, Duration: ${duration}s`);
     logger.debug(`[SayPi VAD Handler] Speech ended. Duration: ${speechDuration}ms`);
     if (currentVadTabId !== null) {
-      // Convert Float32Array to regular Array for proper serialization
-      const audioArray = Array.from(rawAudioData);
-      
-      // Add precise timestamp of when audio was captured
       const captureTimestamp = speechStopTime;
       const confidence = lastFrameProbabilities?.isSpeech ?? null;
-      
+
+      // #420 — gate at the cheapest point: a segment that never cleared the speech
+      // bar is dropped as a misfire so its audio is NEVER serialised across the IPC.
+      // (Reuses the existing non-speech/misfire path end-to-end.)
+      if (!decision.admit) {
+        logger.info(
+          `[SayPi VAD Handler] Admission gate dropped a segment (${decision.reason}): ` +
+          `peak=${stats.peakSpeechProb.toFixed(3)}, mean=${stats.meanSpeechProb.toFixed(3)}, ` +
+          `speechFrames=${stats.speechFrameCount}. Not uploading.`
+        );
+        chrome.runtime.sendMessage({
+          type: "VAD_MISFIRE",
+          reason: `admission-gate:${decision.reason}`,
+          peakSpeechProb: stats.peakSpeechProb,
+          meanSpeechProb: stats.meanSpeechProb,
+          speechFrameCount: stats.speechFrameCount,
+          targetTabId: currentVadTabId,
+          origin: "offscreen-document",
+        });
+        return;
+      }
+
+      // Convert Float32Array to regular Array for proper serialization
+      const audioArray = Array.from(rawAudioData);
+
       chrome.runtime.sendMessage({
         type: "VAD_SPEECH_END",
         duration: speechDuration,
@@ -120,16 +155,22 @@ const vadCallbackOptions: Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks =
         frameCount: frameCount,
         captureTimestamp: captureTimestamp,
         confidence,
+        // #420 — per-segment speech-probability stats forwarded for observability and
+        // future threshold calibration (the gate that admitted this segment used them).
+        peakSpeechProb: stats.peakSpeechProb,
+        meanSpeechProb: stats.meanSpeechProb,
+        speechFrameCount: stats.speechFrameCount,
         targetTabId: currentVadTabId,
         origin: "offscreen-document",
       });
-      
+
       // Log message sending delays if they exceed thresholds
       logMessageDelay(captureTimestamp);
     }
   },
   onVADMisfire: () => {
     logger.debug("[SayPi VAD Handler] VAD misfire.");
+    segmentStats.reset();
     if (currentVadTabId !== null) {
       chrome.runtime.sendMessage({
         type: "VAD_MISFIRE",
@@ -140,6 +181,7 @@ const vadCallbackOptions: Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks =
   },
   onFrameProcessed: (probabilities: { isSpeech: number; notSpeech: number }) => {
     lastFrameProbabilities = probabilities;
+    segmentStats.observe(probabilities.isSpeech);
     debouncedSendFrameProcessed(probabilities);
   },
 };
@@ -245,6 +287,11 @@ async function initializeVAD(initOptions: { preset?: VADPreset } = {}) {
     logger.log("[SayPi VAD Handler] Initializing VAD with default options...");
     const preset: VADPreset = initOptions.preset && VAD_CONFIGS[initOptions.preset] ? initOptions.preset : "none";
     const mergedOptions = { ...vadCallbackOptions, ...VAD_CONFIGS[preset], ...vadBundleOptions };
+    // #420 — count speech frames against the active preset's positive threshold
+    // (the "none" preset has no override, so fall back to the Silero v5 default).
+    segmentStats.setPositiveSpeechThreshold(
+      VAD_CONFIGS[preset]?.positiveSpeechThreshold ?? SILERO_V5_DEFAULT_POSITIVE_THRESHOLD
+    );
 
     const existingOrtConfig = mergedOptions.ortConfig;
     mergedOptions.ortConfig = (runtime: typeof ort) => {
@@ -375,6 +422,9 @@ export async function stopVAD(sourceTabId?: number) {
     try {
       logger.log("[SayPi VAD Handler] Stopping VAD...");
       vadInstance.pause(); // Use pause, or destroy if it's a full stop
+      // #420 — pause() with submitUserSpeechOnPause:false fires no callback, so reset
+      // the tracker here to keep it idle between segments if a call stops mid-utterance.
+      segmentStats.reset();
       decrementUsage('vad');
       return { success: true };
     } catch (error: any) {
@@ -394,6 +444,7 @@ export function destroyVAD(sourceTabId?: number) {
     return { success: true, ignored: true };
   }
   logger.log("[SayPi VAD Handler] Destroying VAD...");
+  segmentStats.reset(); // #420 — don't carry segment state across a destroy
   if (vadInstance) {
     vadInstance.destroy();
     vadInstance = null;

--- a/src/state-machines/AudioInputMachine.ts
+++ b/src/state-machines/AudioInputMachine.ts
@@ -73,17 +73,26 @@ function setupVADEventListeners() {
     EventBus.emit("saypi:userSpeaking");
   });
 
-  vadClient.on('onSpeechEnd', (data: { 
-    duration: number; 
-    audioBuffer: ArrayBuffer; 
-    captureTimestamp: number; 
-    clientReceiveTimestamp: number 
+  vadClient.on('onSpeechEnd', (data: {
+    duration: number;
+    audioBuffer: ArrayBuffer;
+    captureTimestamp: number;
+    clientReceiveTimestamp: number;
+    // #420 — per-segment speech-probability stats forwarded from the VAD client (the
+    // admission gate that admitted this segment ran upstream; these are for visibility).
+    peakSpeechProb?: number;
+    meanSpeechProb?: number;
+    speechFrameCount?: number;
   }) => {
-    logger.debug(`[AudioInputMachine] User speech ended. Duration: ${data.duration}ms`);
-    
+    const stats =
+      data.peakSpeechProb !== undefined
+        ? ` (peak=${data.peakSpeechProb.toFixed(3)}, speechFrames=${data.speechFrameCount})`
+        : "";
+    logger.debug(`[AudioInputMachine] User speech ended. Duration: ${data.duration}ms${stats}`);
+
     // Log processing delays only if they exceed thresholds
     logProcessingDelay(data.captureTimestamp, data.clientReceiveTimestamp);
-    
+
     EventBus.emit("saypi:userStoppedSpeaking", {
       audioBuffer: data.audioBuffer,
       duration: data.duration,
@@ -92,8 +101,23 @@ function setupVADEventListeners() {
     });
   });
 
-  vadClient.on('onVADMisfire', () => {
-    logger.debug("[AudioInputMachine] VAD misfire detected.");
+  vadClient.on('onVADMisfire', (info?: {
+    reason?: string;
+    peakSpeechProb?: number;
+    meanSpeechProb?: number;
+    speechFrameCount?: number;
+  }) => {
+    // #420 — distinguish an admission-gate drop (real-ish audio dropped for low peak
+    // confidence) from a genuine library misfire (sub-minSpeechFrames blip), so a
+    // dropped-quiet-speech regression is visible in the logs rather than silent.
+    if (info?.reason?.startsWith("admission-gate")) {
+      logger.info(
+        `[AudioInputMachine] Admission gate dropped a segment (${info.reason}): ` +
+        `peak=${info.peakSpeechProb}, speechFrames=${info.speechFrameCount}.`
+      );
+    } else {
+      logger.debug("[AudioInputMachine] VAD misfire detected.");
+    }
     EventBus.emit("saypi:vadMisfire");
   });
 

--- a/src/vad/OffscreenVADClient.ts
+++ b/src/vad/OffscreenVADClient.ts
@@ -85,17 +85,36 @@ export class OffscreenVADClient implements VADClientInterface {
           logTransferDelay(captureTimestamp, receiveTimestamp);
 
           // Pass the reconstructed Float32Array's buffer as ArrayBuffer
-          this.callbacks.onSpeechEnd?.({ 
-            duration: message.duration, 
+          this.callbacks.onSpeechEnd?.({
+            duration: message.duration,
             audioBuffer: rawAudioData.buffer,
             captureTimestamp: captureTimestamp,
-            clientReceiveTimestamp: receiveTimestamp
+            clientReceiveTimestamp: receiveTimestamp,
+            // #420 — forward the VAD's per-segment speech-probability stats instead of
+            // dropping them at this boundary (the gap the issue identifies).
+            peakSpeechProb: message.peakSpeechProb,
+            meanSpeechProb: message.meanSpeechProb,
+            speechFrameCount: message.speechFrameCount,
           });
           break;
         case "VAD_MISFIRE":
           this.statusIndicator.updateStatus(getMessage('vadStatusMisfire'), getMessage('vadDetailNonSpeechAudioDetected'));
           setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
-          this.callbacks.onVADMisfire?.();
+          // #420 — surface an admission-gate drop in the content-script log too (not just
+          // the offscreen one) and forward its reason/stats so it stays distinguishable
+          // from a genuine non-speech misfire for any downstream counter.
+          if (typeof message.reason === "string" && message.reason.startsWith("admission-gate")) {
+            logger.info(
+              `[SayPi OffscreenVADClient] Admission gate dropped a segment (${message.reason}): ` +
+              `peak=${message.peakSpeechProb}, speechFrames=${message.speechFrameCount}.`
+            );
+          }
+          this.callbacks.onVADMisfire?.({
+            reason: message.reason,
+            peakSpeechProb: message.peakSpeechProb,
+            meanSpeechProb: message.meanSpeechProb,
+            speechFrameCount: message.speechFrameCount,
+          });
           break;
         case "VAD_FRAME_PROCESSED":
           this.callbacks.onFrameProcessed?.(message.probabilities);

--- a/src/vad/OnscreenVADClient.ts
+++ b/src/vad/OnscreenVADClient.ts
@@ -7,6 +7,12 @@ import { VADClientInterface, VADClientCallbacks } from './VADClientInterface';
 import { getBrowserInfo } from '../UserAgentModule';
 import { ChatbotIdentifier } from '../chatbots/ChatbotIdentifier';
 import { VAD_CONFIGS, VADPreset } from "./VADConfigs";
+import {
+  SegmentStatsTracker,
+  admitSegment,
+  DEFAULT_ADMISSION_CONFIG,
+  SILERO_V5_DEFAULT_POSITIVE_THRESHOLD,
+} from "./segmentAdmission";
 
 logger.debug("[SayPi OnscreenVADClient] Client loaded.");
 
@@ -87,6 +93,10 @@ export class OnscreenVADClient implements VADClientInterface {
   private isStarted: boolean = false;
   private preset: VADPreset = "balanced";
 
+  // #420 — accumulates each segment's speech-probability stats so the admission gate
+  // (shared with the offscreen handler) can drop near-threshold non-speech.
+  private statsTracker = new SegmentStatsTracker(SILERO_V5_DEFAULT_POSITIVE_THRESHOLD);
+
   // Debounced sender for VAD frame events, max once per 100ms
   private debouncedSendFrameProcessed = debounce(
     (probabilities: { isSpeech: number; notSpeech: number }) => {
@@ -100,164 +110,113 @@ export class OnscreenVADClient implements VADClientInterface {
     this.statusIndicator = new VADStatusIndicator();
   }
 
-  private getVADOptions(): Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks {
-    // Base VAD options without asset paths (similar to offscreen implementation)
-    const presetConfig = VAD_CONFIGS[this.preset] || {};
-    const baseOptions = {
+  /**
+   * The VAD event callbacks, shared by all three init strategies (primary / fallback /
+   * minimal) which previously each carried an identical copy — the triplication was a
+   * standing drift hazard and, after #420, the one place per-segment accumulation +
+   * the admission gate must live. The strategies now differ ONLY in their asset-path /
+   * model options.
+   */
+  private buildSegmentCallbacks(): MyRealTimeVADCallbacks {
+    return {
       onSpeechStart: () => {
         logger.debug("[SayPi OnscreenVADClient] Speech started.");
         this.speechStartTime = Date.now();
+        this.statsTracker.beginSegment();
         this.statusIndicator.updateStatus(getMessage('vadStatusListening'), getMessage('vadDetailSpeechDetected'));
         this.callbacks.onSpeechStart?.();
       },
       onSpeechEnd: (rawAudioData: Float32Array) => {
         const speechStopTime = Date.now();
         const speechDuration = speechStopTime - this.speechStartTime;
-        const frameCount = rawAudioData.length;
-        const frameRate = 16000;
-        const duration = frameCount / frameRate;
-        
-        logger.debug(`[SayPi OnscreenVADClient] Speech duration: ${speechDuration}ms, Frame count: ${frameCount}, Frame rate: ${frameRate}, Duration: ${duration}s`);
+        // #420 — summarise the segment and run the admission gate before uploading.
+        const stats = this.statsTracker.endSegment();
+        const decision = admitSegment(stats, DEFAULT_ADMISSION_CONFIG);
+
+        if (!decision.admit) {
+          // A segment that never cleared the speech bar: treat it exactly like a VAD
+          // misfire (non-speech) so it is never sent for transcription.
+          logger.info(
+            `[SayPi OnscreenVADClient] Admission gate dropped a segment (${decision.reason}): ` +
+            `peak=${stats.peakSpeechProb.toFixed(3)}, mean=${stats.meanSpeechProb.toFixed(3)}, ` +
+            `speechFrames=${stats.speechFrameCount}. Not uploading.`
+          );
+          this.statusIndicator.updateStatus(getMessage('vadStatusMisfire'), getMessage('vadDetailNonSpeechAudioDetected'));
+          setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
+          this.callbacks.onVADMisfire?.({
+            reason: `admission-gate:${decision.reason}`,
+            peakSpeechProb: stats.peakSpeechProb,
+            meanSpeechProb: stats.meanSpeechProb,
+            speechFrameCount: stats.speechFrameCount,
+          });
+          return;
+        }
+
         logger.debug(`[SayPi OnscreenVADClient] Speech ended. Duration: ${speechDuration}ms`);
-        
         this.statusIndicator.updateStatus(getMessage('vadStatusProcessing'), getMessage('vadDetailSpeechEndedDuration', speechDuration.toString()));
         setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
-        
-        // Add precise timestamp of when audio was captured
+
+        // In onscreen mode capture and receive timestamps are essentially the same.
         const captureTimestamp = speechStopTime;
-        const clientReceiveTimestamp = Date.now(); // In onscreen mode, this is essentially the same
-        
-        // Log processing delays only if they exceed thresholds
+        const clientReceiveTimestamp = Date.now();
         logProcessingDelay(captureTimestamp, clientReceiveTimestamp);
 
         // Ensure we pass a concrete ArrayBuffer (handle potential SharedArrayBuffer)
         const audioArrayBuffer = rawAudioData.buffer instanceof ArrayBuffer
           ? rawAudioData.buffer
           : rawAudioData.slice().buffer;
-        this.callbacks.onSpeechEnd?.({ 
-          duration: speechDuration, 
+        this.callbacks.onSpeechEnd?.({
+          duration: speechDuration,
           audioBuffer: audioArrayBuffer,
           captureTimestamp: captureTimestamp,
-          clientReceiveTimestamp: clientReceiveTimestamp
+          clientReceiveTimestamp: clientReceiveTimestamp,
+          // #420 — forward the per-segment speech-probability stats for observability.
+          peakSpeechProb: stats.peakSpeechProb,
+          meanSpeechProb: stats.meanSpeechProb,
+          speechFrameCount: stats.speechFrameCount,
         });
       },
       onVADMisfire: () => {
         logger.debug("[SayPi OnscreenVADClient] VAD misfire.");
+        this.statsTracker.reset();
         this.statusIndicator.updateStatus(getMessage('vadStatusMisfire'), getMessage('vadDetailNonSpeechAudioDetected'));
         setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
         this.callbacks.onVADMisfire?.();
       },
       onFrameProcessed: (probabilities: { isSpeech: number; notSpeech: number }) => {
+        this.statsTracker.observe(probabilities.isSpeech);
         this.debouncedSendFrameProcessed(probabilities);
       },
     };
+  }
 
-    // Bundle options for asset paths (separate like in offscreen implementation)
-    const bundleOptions = {
+  private getVADOptions(): Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks {
+    // Primary: shared callbacks + preset + explicit asset paths.
+    const presetConfig = VAD_CONFIGS[this.preset] || {};
+    return {
+      ...this.buildSegmentCallbacks(),
+      ...presetConfig,
       baseAssetPath: chrome.runtime.getURL("public/"),
       onnxWASMBasePath: chrome.runtime.getURL("public/"),
-    };
-
-    // Merge options (same pattern as offscreen implementation)
-    return {
-      ...baseOptions,
-      ...presetConfig,
-      ...bundleOptions,
     } as Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks;
   }
 
   private getFallbackVADOptions(): Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks {
-    // Fallback options with minimal configuration but still with asset paths
+    // Fallback: base asset path only (no explicit WASM path).
     const presetConfig = VAD_CONFIGS[this.preset] || {};
     return {
-      baseAssetPath: chrome.runtime.getURL("public/"),
+      ...this.buildSegmentCallbacks(),
       ...presetConfig,
-      onSpeechStart: () => {
-        logger.debug("[SayPi OnscreenVADClient] Speech started (fallback)");
-        this.speechStartTime = Date.now();
-        this.statusIndicator.updateStatus(getMessage('vadStatusListening'), getMessage('vadDetailSpeechDetected'));
-        this.callbacks.onSpeechStart?.();
-      },
-      onSpeechEnd: (rawAudioData: Float32Array) => {
-        const speechStopTime = Date.now();
-        const speechDuration = speechStopTime - this.speechStartTime;
-        
-        logger.debug(`[SayPi OnscreenVADClient] Speech ended (fallback). Duration: ${speechDuration}ms`);
-        
-        this.statusIndicator.updateStatus(getMessage('vadStatusProcessing'), getMessage('vadDetailSpeechEndedDuration', speechDuration.toString()));
-        setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
-        
-        const captureTimestamp = speechStopTime;
-        const clientReceiveTimestamp = Date.now();
-        
-        logProcessingDelay(captureTimestamp, clientReceiveTimestamp);
-
-        const audioArrayBuffer = rawAudioData.buffer instanceof ArrayBuffer
-          ? rawAudioData.buffer
-          : rawAudioData.slice().buffer;
-        this.callbacks.onSpeechEnd?.({ 
-          duration: speechDuration, 
-          audioBuffer: audioArrayBuffer,
-          captureTimestamp: captureTimestamp,
-          clientReceiveTimestamp: clientReceiveTimestamp
-        });
-      },
-      onVADMisfire: () => {
-        logger.debug("[SayPi OnscreenVADClient] VAD misfire (fallback)");
-        this.statusIndicator.updateStatus(getMessage('vadStatusMisfire'), getMessage('vadDetailNonSpeechAudioDetected'));
-        setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
-        this.callbacks.onVADMisfire?.();
-      },
-      onFrameProcessed: (probabilities: { isSpeech: number; notSpeech: number }) => {
-        this.debouncedSendFrameProcessed(probabilities);
-      },
+      baseAssetPath: chrome.runtime.getURL("public/"),
     } as Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks;
   }
 
   private getMinimalVADOptions(): Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks {
-    // Minimal options - no custom paths, legacy model, let VAD use defaults
+    // Minimal: no custom paths, let the VAD use its defaults.
     const presetConfig = VAD_CONFIGS[this.preset] || {};
     return {
+      ...this.buildSegmentCallbacks(),
       ...presetConfig,
-      onSpeechStart: () => {
-        logger.debug("[SayPi OnscreenVADClient] Speech started (minimal)");
-        this.speechStartTime = Date.now();
-        this.statusIndicator.updateStatus(getMessage('vadStatusListening'), getMessage('vadDetailSpeechDetected'));
-        this.callbacks.onSpeechStart?.();
-      },
-      onSpeechEnd: (rawAudioData: Float32Array) => {
-        const speechStopTime = Date.now();
-        const speechDuration = speechStopTime - this.speechStartTime;
-        
-        logger.debug(`[SayPi OnscreenVADClient] Speech ended (minimal). Duration: ${speechDuration}ms`);
-        
-        this.statusIndicator.updateStatus(getMessage('vadStatusProcessing'), getMessage('vadDetailSpeechEndedDuration', speechDuration.toString()));
-        setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
-        
-        const captureTimestamp = speechStopTime;
-        const clientReceiveTimestamp = Date.now();
-        
-        logProcessingDelay(captureTimestamp, clientReceiveTimestamp);
-
-        const audioArrayBuffer = rawAudioData.buffer instanceof ArrayBuffer
-          ? rawAudioData.buffer
-          : rawAudioData.slice().buffer;
-        this.callbacks.onSpeechEnd?.({ 
-          duration: speechDuration, 
-          audioBuffer: audioArrayBuffer,
-          captureTimestamp: captureTimestamp,
-          clientReceiveTimestamp: clientReceiveTimestamp
-        });
-      },
-      onVADMisfire: () => {
-        logger.debug("[SayPi OnscreenVADClient] VAD misfire (minimal)");
-        this.statusIndicator.updateStatus(getMessage('vadStatusMisfire'), getMessage('vadDetailNonSpeechAudioDetected'));
-        setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
-        this.callbacks.onVADMisfire?.();
-      },
-      onFrameProcessed: (probabilities: { isSpeech: number; notSpeech: number }) => {
-        this.debouncedSendFrameProcessed(probabilities);
-      },
     } as Partial<RealTimeVADOptions> & MyRealTimeVADCallbacks;
   }
 
@@ -272,7 +231,13 @@ export class OnscreenVADClient implements VADClientInterface {
     if (options.preset && VAD_CONFIGS[options.preset]) {
       this.preset = options.preset;
     }
-    
+
+    // #420 — count speech frames against the active preset's positive threshold
+    // (presets with no override fall back to the Silero v5 default).
+    this.statsTracker.setPositiveSpeechThreshold(
+      VAD_CONFIGS[this.preset]?.positiveSpeechThreshold ?? SILERO_V5_DEFAULT_POSITIVE_THRESHOLD
+    );
+
     // Progressive fallback strategy for VAD initialization
     const fallbackStrategies = [
       {
@@ -392,6 +357,10 @@ export class OnscreenVADClient implements VADClientInterface {
     try {
       logger.log("[SayPi OnscreenVADClient] Stopping VAD...");
       this.vadInstance.pause(); // Use pause, same as offscreen implementation
+      // #420 — pause() with submitUserSpeechOnPause:false fires no callback, so an
+      // in-flight segment's tracker state would otherwise persist; reset it so the
+      // "idle between segments" invariant holds even if a call stops mid-utterance.
+      this.statsTracker.reset();
       this.isStarted = false;
       
       this.statusIndicator.updateStatus(getMessage('vadStatusStopped'), getMessage('vadDetailVADProcessingStopped'));
@@ -423,7 +392,8 @@ export class OnscreenVADClient implements VADClientInterface {
       this.vadInstance.destroy();
       this.vadInstance = null;
     }
-    
+
+    this.statsTracker.reset(); // #420 — don't carry segment state across a destroy
     this.isInitialized = false;
     this.isStarted = false;
     

--- a/src/vad/VADClientInterface.ts
+++ b/src/vad/VADClientInterface.ts
@@ -3,15 +3,35 @@
  * This ensures both clients provide the same API for the AudioInputMachine
  */
 
+/**
+ * #420 — Detail attached to a VAD misfire when it was the admission gate (not the
+ * library) that dropped the segment. `reason` is prefixed `admission-gate:` so a
+ * consumer can count gate drops separately from genuine non-speech misfires.
+ */
+export interface VADMisfireInfo {
+  reason?: string;
+  peakSpeechProb?: number;
+  meanSpeechProb?: number;
+  speechFrameCount?: number;
+}
+
 export interface VADClientCallbacks {
   onSpeechStart?: () => void;
-  onSpeechEnd?: (data: { 
-    duration: number; 
-    audioBuffer: ArrayBuffer; 
-    captureTimestamp: number; 
-    clientReceiveTimestamp: number 
+  onSpeechEnd?: (data: {
+    duration: number;
+    audioBuffer: ArrayBuffer;
+    captureTimestamp: number;
+    clientReceiveTimestamp: number;
+    // #420 — per-segment speech-probability stats from the VAD. Optional because not
+    // every code path (older offscreen builds, some tests) supplies them.
+    peakSpeechProb?: number;
+    meanSpeechProb?: number;
+    speechFrameCount?: number;
   }) => void;
-  onVADMisfire?: () => void;
+  // #420 — onVADMisfire fires for both a library misfire (sub-minSpeechFrames blip,
+  // no info) AND an admission-gate drop (info present: reason + the segment's stats),
+  // so a dropped-real-speech regression is distinguishable from genuine non-speech.
+  onVADMisfire?: (info?: VADMisfireInfo) => void;
   onError?: (error: string) => void;
   // Fired when another tab claims the single shared offscreen mic, displacing
   // this tab's VAD session. Offscreen VAD only — onscreen VAD is per-tab. (#320)

--- a/src/vad/VADConfigs.ts
+++ b/src/vad/VADConfigs.ts
@@ -2,6 +2,26 @@ import { RealTimeVADOptions } from "@ricky0123/vad-web";
 
 /**
  * Preset names for tuning Silero VAD v5 parameters.
+ *
+ * Frame timing: at the v5 frame size of 512 samples @ 16 kHz, **1 frame = 32 ms**, so
+ * every frame-count below is annotated with its wall-clock equivalent. The Silero v5
+ * defaults each value departs from (`defaultV5FrameProcessorOptions`) are: positive
+ * 0.5, negative 0.35, redemptionFrames 24 (768 ms), minSpeechFrames 9 (288 ms),
+ * preSpeechPadFrames 3 (96 ms). Our tuned presets are uniformly MORE aggressive
+ * (lower thresholds, shorter redemption, far fewer min-speech-frames) — the right
+ * direction for short, latency-sensitive conversational clips, at the cost of more
+ * false-accepts. The #420 admission gate (`segmentAdmission.ts`) backstops that
+ * false-accept risk; a VAD-quality benchmark to re-tune these numbers is #420 item 3.
+ *
+ * Wiring status (which presets a code path actually selects):
+ *  - `highSensitivity` / `balanced`: selected by AudioInputMachine from the host —
+ *    dictation/generic pages get `highSensitivity`, dedicated chat sites get `balanced`
+ *    (revisiting that mapping is #420 item 4).
+ *  - `conservative`: a valid noisy-environment preset that **no code path selects yet**.
+ *    Kept (not deleted) because #420 item 4 plans to wire it to a noise/SNR estimate;
+ *    its values are locked by test so it can't rot in the meantime.
+ *  - `none`: the no-override fallback `initializeVAD` resolves to when no (or an
+ *    unknown) preset is requested — it inherits the library's v5 defaults verbatim.
  */
 export type VADPreset = "highSensitivity" | "balanced" | "conservative" | "none";
 
@@ -9,39 +29,42 @@ export type VADPreset = "highSensitivity" | "balanced" | "conservative" | "none"
  * Parameter presets for different use-cases.
  * Only a subset of RealTimeVADOptions dealing with FrameProcessorOptions are included here.
  * These objects are spread on top of the base MicVAD options when a preset is selected.
+ *
+ * NOTE: these exact values are locked by `test/vad/VADConfigs.spec.ts` (#420 item 2) —
+ * changing any of them is a deliberate, reviewed decision, not an accidental drift.
  */
 export const VAD_CONFIGS: Record<VADPreset, Partial<RealTimeVADOptions>> = {
   highSensitivity: {
     model: "v5",
-    // Highly responsive – ideal for dictation / very short utterances
-    positiveSpeechThreshold: 0.35,
-    negativeSpeechThreshold: 0.2,
-    redemptionFrames: 12,
-    minSpeechFrames: 2,
-    preSpeechPadFrames: 3,
+    // Highly responsive – ideal for dictation / very short utterances.
+    positiveSpeechThreshold: 0.35, // vs v5 default 0.5 — opens on quieter speech
+    negativeSpeechThreshold: 0.2, //  vs v5 default 0.35
+    redemptionFrames: 12, //          384 ms tail (vs v5 768 ms) — ends sooner
+    minSpeechFrames: 2, //            64 ms min (vs v5 288 ms) — accepts very short phrases
+    preSpeechPadFrames: 3, //         96 ms pre-roll (= v5 default)
     submitUserSpeechOnPause: false,
   },
   balanced: {
     model: "v5",
-    // Default – good general-purpose trade-off
-    positiveSpeechThreshold: 0.4,
-    negativeSpeechThreshold: 0.25,
-    redemptionFrames: 10,
-    minSpeechFrames: 3,
-    preSpeechPadFrames: 2,
+    // Default – good general-purpose trade-off.
+    positiveSpeechThreshold: 0.4, //  vs v5 default 0.5
+    negativeSpeechThreshold: 0.25, // vs v5 default 0.35
+    redemptionFrames: 10, //          320 ms tail (vs v5 768 ms)
+    minSpeechFrames: 3, //            96 ms min (vs v5 288 ms)
+    preSpeechPadFrames: 2, //         64 ms pre-roll (vs v5 96 ms)
     submitUserSpeechOnPause: false,
   },
   conservative: {
     model: "v5",
-    // Noisy environments – lower sensitivity
-    positiveSpeechThreshold: 0.6,
-    negativeSpeechThreshold: 0.45,
-    redemptionFrames: 8,
-    minSpeechFrames: 4,
-    preSpeechPadFrames: 1,
+    // Noisy environments – lower sensitivity (reserved; not yet selected — see header).
+    positiveSpeechThreshold: 0.6, //  vs v5 default 0.5 — needs clearer speech to open
+    negativeSpeechThreshold: 0.45, // vs v5 default 0.35
+    redemptionFrames: 8, //           256 ms tail (vs v5 768 ms)
+    minSpeechFrames: 4, //            128 ms min (vs v5 288 ms)
+    preSpeechPadFrames: 1, //         32 ms pre-roll (vs v5 96 ms)
     submitUserSpeechOnPause: false,
   },
   none: {
-    // inherit all base options from Silero VAD v5
+    // No-override fallback: inherit all base options from Silero VAD v5.
   },
-}; 
+};

--- a/src/vad/segmentAdmission.ts
+++ b/src/vad/segmentAdmission.ts
@@ -1,0 +1,192 @@
+/**
+ * #420 — Put the Silero VAD's own per-frame speech probability to work.
+ *
+ * The VAD scores every 32 ms frame with a speech probability (`isSpeech`, 0..1).
+ * Historically SayPi forwarded only the *last* frame's score (noisy) and dropped it
+ * before any gate could use it. This module turns that signal into a per-segment
+ * summary (peak / mean / speech-frame count) and a conservative admission gate that
+ * stops near-threshold non-speech from reaching the server — the cheapest place to
+ * cut the "Thank you"/"you" silence hallucinations the ASR backend produces on
+ * non-speech clips.
+ *
+ * The gate floor is anchored to the active preset's OWN opening threshold plus a small
+ * margin (not a fixed absolute value). The VAD admits a segment as soon as enough
+ * frames clear that preset threshold, so anchoring there guarantees the gate never
+ * rejects a segment far above the bar the VAD itself used — a quiet utterance on the
+ * trigger-happy `highSensitivity` preset (which opens at 0.35) is kept, while a
+ * barely-opened blip that never climbed past its own threshold is dropped.
+ *
+ * Both VAD clients (offscreen `vad_handler.ts`, in-page `OnscreenVADClient.ts`) share
+ * this logic so the gate behaves identically on Chrome/Edge and Firefox/mobile.
+ */
+
+/** A 16 kHz Silero v5 frame is 512 samples = 32 ms. Exposed for ms↔frame reasoning. */
+export const VAD_FRAME_MS = 32;
+
+/** Silero v5's own default positive ("this is speech") threshold; the fallback bar. */
+export const SILERO_V5_DEFAULT_POSITIVE_THRESHOLD = 0.5;
+
+export interface SegmentSpeechStats {
+  /** Highest per-frame speech probability across the segment (0..1). The most robust signal. */
+  peakSpeechProb: number;
+  /** Mean per-frame speech probability across the segment's frames (0 when the segment is empty). */
+  meanSpeechProb: number;
+  /**
+   * Number of frames whose probability cleared the active positiveSpeechThreshold,
+   * matching how vad-web tallies speech frames. This is the *actual* speech length,
+   * distinct from the redemption/pre-roll-padded blob length.
+   */
+  speechFrameCount: number;
+  /** Total frames accumulated for the segment (speech frames + the redemption tail). */
+  frameCount: number;
+  /** The positiveSpeechThreshold the segment was scored against (the active preset's bar). */
+  positiveSpeechThreshold: number;
+}
+
+export interface SegmentAdmissionConfig {
+  /**
+   * How far ABOVE the active preset's positiveSpeechThreshold a segment's peak must
+   * reach to be admitted. The floor is `positiveSpeechThreshold + minPeakMarginOverThreshold`,
+   * so the gate is always relative to the bar the VAD used — it can never reject a
+   * segment that confidently cleared its own preset, only the barely-opened ones.
+   */
+  minPeakMarginOverThreshold: number;
+  /**
+   * Optional extra floor on `speechFrameCount`. 0 disables it — the default — so a
+   * short-but-loud utterance ("yes"/"no"/"stop") is never clipped on duration alone.
+   * Reserved for calibration once the VAD-quality benchmark (#420 item 3) exists.
+   */
+  minSpeechFrames: number;
+}
+
+/**
+ * Conservative defaults, intentionally chosen to favour NOT clipping real short/quiet
+ * speech over catching every non-speech blip. The peak floor sits just 0.05 above each
+ * preset's own opening bar; the duration floor is off. To be calibrated against a
+ * labelled corpus (#420 item 3).
+ */
+export const DEFAULT_ADMISSION_CONFIG: SegmentAdmissionConfig = {
+  minPeakMarginOverThreshold: 0.05,
+  minSpeechFrames: 0,
+};
+
+export type SegmentAdmissionReason =
+  | "admitted"
+  | "low-peak-confidence"
+  | "too-few-speech-frames";
+
+export interface SegmentAdmissionDecision {
+  admit: boolean;
+  reason: SegmentAdmissionReason;
+}
+
+const toFiniteProb = (value: number): number =>
+  Number.isFinite(value) ? value : 0;
+
+/** The effective peak floor for a segment: its preset threshold + the configured margin. */
+export function admissionPeakFloor(
+  stats: SegmentSpeechStats,
+  config: SegmentAdmissionConfig = DEFAULT_ADMISSION_CONFIG
+): number {
+  return stats.positiveSpeechThreshold + config.minPeakMarginOverThreshold;
+}
+
+/**
+ * Decide whether a finished speech segment should be uploaded. Pure: same stats +
+ * config always yield the same decision, so it is trivially unit-testable and the
+ * floor lives in one reviewable place.
+ */
+export function admitSegment(
+  stats: SegmentSpeechStats,
+  config: SegmentAdmissionConfig = DEFAULT_ADMISSION_CONFIG
+): SegmentAdmissionDecision {
+  if (toFiniteProb(stats.peakSpeechProb) < admissionPeakFloor(stats, config)) {
+    return { admit: false, reason: "low-peak-confidence" };
+  }
+  if (config.minSpeechFrames > 0 && stats.speechFrameCount < config.minSpeechFrames) {
+    return { admit: false, reason: "too-few-speech-frames" };
+  }
+  return { admit: true, reason: "admitted" };
+}
+
+/**
+ * Accumulates a single segment's speech-probability stats from the VAD's per-frame
+ * callbacks. The vad-web pipeline fires `onFrameProcessed` for EVERY frame and fires
+ * `onSpeechStart` *after* the frame that crossed the threshold — so callers:
+ *   1. `observe(prob)` on every `onFrameProcessed`,
+ *   2. `beginSegment()` on `onSpeechStart` (seeds the segment with that triggering frame),
+ *   3. `endSegment()` on `onSpeechEnd` to read the summary,
+ *   4. `reset()` on `onVADMisfire`, and defensively when the VAD is stopped/destroyed.
+ * Mutable by design (one instance per client, hot path), but free of any DOM/Chrome
+ * coupling so it tests as a plain object.
+ */
+export class SegmentStatsTracker {
+  private positiveSpeechThreshold: number;
+  private speaking = false;
+  private lastFrameProb = 0;
+  private peak = 0;
+  private sum = 0;
+  private frames = 0;
+  private speechFrames = 0;
+
+  constructor(positiveSpeechThreshold: number = SILERO_V5_DEFAULT_POSITIVE_THRESHOLD) {
+    this.positiveSpeechThreshold = positiveSpeechThreshold;
+  }
+
+  /** Re-point at the active preset's threshold (the preset is chosen after construction). */
+  setPositiveSpeechThreshold(threshold: number): void {
+    if (Number.isFinite(threshold)) {
+      this.positiveSpeechThreshold = threshold;
+    }
+  }
+
+  /** Open a segment, seeding it with the most-recently-observed (triggering) frame. */
+  beginSegment(): void {
+    this.peak = 0;
+    this.sum = 0;
+    this.frames = 0;
+    this.speechFrames = 0;
+    this.speaking = true;
+    this.accumulate(this.lastFrameProb);
+  }
+
+  /** Record one frame. Always tracked for seeding; only accumulated while in a segment. */
+  observe(speechProb: number): void {
+    const prob = toFiniteProb(speechProb);
+    this.lastFrameProb = prob;
+    if (this.speaking) {
+      this.accumulate(prob);
+    }
+  }
+
+  /** Close the segment and return its summary. */
+  endSegment(): SegmentSpeechStats {
+    const stats: SegmentSpeechStats = {
+      peakSpeechProb: this.peak,
+      meanSpeechProb: this.frames > 0 ? this.sum / this.frames : 0,
+      speechFrameCount: this.speechFrames,
+      frameCount: this.frames,
+      positiveSpeechThreshold: this.positiveSpeechThreshold,
+    };
+    this.speaking = false;
+    return stats;
+  }
+
+  /** Drop the in-progress segment (a library misfire, or a stop/destroy) without emitting stats. */
+  reset(): void {
+    this.speaking = false;
+    this.peak = 0;
+    this.sum = 0;
+    this.frames = 0;
+    this.speechFrames = 0;
+  }
+
+  private accumulate(prob: number): void {
+    this.peak = Math.max(this.peak, prob);
+    this.sum += prob;
+    this.frames += 1;
+    if (prob >= this.positiveSpeechThreshold) {
+      this.speechFrames += 1;
+    }
+  }
+}

--- a/test/offscreen/vad_handler-admission.spec.ts
+++ b/test/offscreen/vad_handler-admission.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #420 — The offscreen VAD handler now runs the admission gate at the cheapest
+ * possible point: BEFORE serialising the audio across the offscreen→content IPC.
+ *
+ *  - A confident segment is forwarded as VAD_SPEECH_END carrying the new per-segment
+ *    stats (peakSpeechProb / meanSpeechProb / speechFrameCount), so downstream
+ *    observers and future calibration can see them.
+ *  - A low-confidence segment (one that opened on a permissive preset but never
+ *    cleared the 0.5 speech bar) is dropped as VAD_MISFIRE — the audio array is never
+ *    even sent, which is the whole point of gating here rather than server-side.
+ */
+
+const { fakeVad, sendMessage, micVadNew } = vi.hoisted(() => {
+  const sendMessage = vi.fn();
+  (globalThis as any).chrome = {
+    runtime: {
+      getURL: (p: string) => `chrome-extension://test/${p}`,
+      sendMessage,
+    },
+  };
+  const fakeVad = { start: vi.fn(), pause: vi.fn(), destroy: vi.fn() };
+  return {
+    fakeVad,
+    sendMessage,
+    micVadNew: vi.fn(async (_opts?: any) => fakeVad),
+  };
+});
+
+vi.mock("@ricky0123/vad-web", () => ({ MicVAD: { new: micVadNew } }));
+vi.mock("onnxruntime-web", () => ({ env: { logLevel: "error", wasm: {} } }));
+vi.mock("../../src/LoggingModule.js", () => ({
+  logger: { log: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), reportError: vi.fn() },
+}));
+vi.mock("../../src/offscreen/media_coordinator", () => ({
+  incrementUsage: vi.fn(),
+  decrementUsage: vi.fn(),
+  resetUsageCounter: vi.fn(),
+  registerMessageHandler: vi.fn(),
+}));
+
+import { startVAD, destroyVAD } from "../../src/offscreen/vad_handler";
+
+/** Capture the callbacks vad_handler handed to MicVAD.new for the current instance. */
+function activeCallbacks(): {
+  onSpeechStart: () => void;
+  onSpeechEnd: (audio: Float32Array) => void;
+  onVADMisfire: () => void;
+  onFrameProcessed: (p: { isSpeech: number; notSpeech: number }) => void;
+} {
+  const opts = micVadNew.mock.calls.at(-1)![0] as any;
+  return opts;
+}
+
+const frame = (isSpeech: number) => ({ isSpeech, notSpeech: 1 - isSpeech });
+
+function messagesOfType(type: string) {
+  return sendMessage.mock.calls.map((c) => c[0]).filter((m) => m.type === type);
+}
+
+describe("#420 vad_handler admission gate", () => {
+  beforeEach(async () => {
+    destroyVAD(); // clear any instance from a prior test
+    sendMessage.mockClear();
+    micVadNew.mockClear();
+    await startVAD(1);
+    sendMessage.mockClear(); // drop start-time chatter; keep only the segment events
+  });
+
+  it("forwards a confident segment as VAD_SPEECH_END with per-segment stats", () => {
+    const cb = activeCallbacks();
+    cb.onFrameProcessed(frame(0.8)); // triggering frame
+    cb.onSpeechStart();
+    cb.onFrameProcessed(frame(0.95));
+    cb.onFrameProcessed(frame(0.2)); // redemption-tail frame
+    cb.onSpeechEnd(new Float32Array([0.1, -0.1, 0.2]));
+
+    const speechEnds = messagesOfType("VAD_SPEECH_END");
+    expect(speechEnds).toHaveLength(1);
+    const msg = speechEnds[0];
+    expect(msg.peakSpeechProb).toBeCloseTo(0.95, 5);
+    expect(msg.speechFrameCount).toBe(2); // 0.8 + 0.95 clear 0.5; 0.2 does not
+    expect(msg.meanSpeechProb).toBeCloseTo((0.8 + 0.95 + 0.2) / 3, 5);
+    // No misfire for a real utterance.
+    expect(messagesOfType("VAD_MISFIRE")).toHaveLength(0);
+  });
+
+  it("drops a low-confidence segment as VAD_MISFIRE without ever sending the audio", () => {
+    const cb = activeCallbacks();
+    // A segment that opened on a permissive preset but only ever reached 0.45.
+    cb.onFrameProcessed(frame(0.42));
+    cb.onSpeechStart();
+    cb.onFrameProcessed(frame(0.45));
+    cb.onFrameProcessed(frame(0.1));
+    cb.onSpeechEnd(new Float32Array([0.1, -0.1, 0.2]));
+
+    expect(messagesOfType("VAD_SPEECH_END")).toHaveLength(0); // audio never serialised
+    const misfires = messagesOfType("VAD_MISFIRE");
+    expect(misfires).toHaveLength(1);
+    expect(misfires[0].reason).toMatch(/admission-gate/);
+  });
+});

--- a/test/vad/OffscreenVADClient-admission.spec.ts
+++ b/test/vad/OffscreenVADClient-admission.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * #420 — The offscreen handler now attaches per-segment speech-probability stats to
+ * VAD_SPEECH_END. The client must FORWARD them through its onSpeechEnd callback (they
+ * were computed, put on the wire, then dropped at this boundary — the gap the issue
+ * calls out). Verified here against a fake port.
+ */
+
+vi.mock("../../src/LoggingModule", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
+vi.mock("../../src/offscreen/media_coordinator", () => ({
+  sanitizeMessageForLogs: (m: any) => m,
+}));
+vi.mock("../../src/ui/VADStatusIndicator", () => ({
+  VADStatusIndicator: class {
+    updateStatus = vi.fn();
+    hide = vi.fn();
+    show = vi.fn();
+    destroy = vi.fn();
+  },
+}));
+
+import { OffscreenVADClient } from "../../src/vad/OffscreenVADClient";
+
+describe("#420 OffscreenVADClient forwards admission stats", () => {
+  let ports: any[];
+
+  beforeEach(() => {
+    ports = [];
+    (global as any).chrome = {
+      runtime: {
+        connect: vi.fn(() => {
+          const port = {
+            onMessage: { addListener: vi.fn() },
+            onDisconnect: { addListener: vi.fn() },
+            postMessage: vi.fn(),
+            disconnect: vi.fn(),
+          };
+          ports.push(port);
+          return port;
+        }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete (global as any).chrome;
+  });
+
+  const deliver = (message: any, portIndex = 0) => {
+    const listener = ports[portIndex].onMessage.addListener.mock.calls[0][0];
+    listener(message);
+  };
+
+  it("passes peakSpeechProb / meanSpeechProb / speechFrameCount to onSpeechEnd", () => {
+    const client = new OffscreenVADClient();
+    const onSpeechEnd = vi.fn();
+    client.on("onSpeechEnd", onSpeechEnd);
+
+    deliver({
+      origin: "offscreen-document",
+      type: "VAD_SPEECH_END",
+      duration: 800,
+      audioData: [0.1, -0.1, 0.2],
+      frameCount: 3,
+      captureTimestamp: 1000,
+      confidence: 0.6,
+      peakSpeechProb: 0.93,
+      meanSpeechProb: 0.71,
+      speechFrameCount: 12,
+    });
+
+    expect(onSpeechEnd).toHaveBeenCalledTimes(1);
+    const data = onSpeechEnd.mock.calls[0][0];
+    expect(data.peakSpeechProb).toBeCloseTo(0.93, 5);
+    expect(data.meanSpeechProb).toBeCloseTo(0.71, 5);
+    expect(data.speechFrameCount).toBe(12);
+    // Existing fields still forwarded.
+    expect(data.duration).toBe(800);
+    expect(data.captureTimestamp).toBe(1000);
+  });
+
+  it("forwards admission-gate-drop detail through onVADMisfire (distinguishable from a library misfire)", () => {
+    const client = new OffscreenVADClient();
+    const onVADMisfire = vi.fn();
+    client.on("onVADMisfire", onVADMisfire);
+
+    deliver({
+      origin: "offscreen-document",
+      type: "VAD_MISFIRE",
+      reason: "admission-gate:low-peak-confidence",
+      peakSpeechProb: 0.41,
+      meanSpeechProb: 0.39,
+      speechFrameCount: 2,
+    });
+
+    expect(onVADMisfire).toHaveBeenCalledTimes(1);
+    const info = onVADMisfire.mock.calls[0][0];
+    expect(info.reason).toBe("admission-gate:low-peak-confidence");
+    expect(info.peakSpeechProb).toBeCloseTo(0.41, 5);
+    expect(info.speechFrameCount).toBe(2);
+  });
+
+  it("a plain library misfire forwards undefined gate detail", () => {
+    const client = new OffscreenVADClient();
+    const onVADMisfire = vi.fn();
+    client.on("onVADMisfire", onVADMisfire);
+
+    deliver({ origin: "offscreen-document", type: "VAD_MISFIRE" });
+
+    expect(onVADMisfire).toHaveBeenCalledTimes(1);
+    const info = onVADMisfire.mock.calls[0][0];
+    expect(info.reason).toBeUndefined();
+  });
+});

--- a/test/vad/OnscreenVADClient-admission.spec.ts
+++ b/test/vad/OnscreenVADClient-admission.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * #420 — The in-page VAD client (Firefox / mobile, no offscreen document) runs the
+ * same admission gate as the offscreen handler, via the shared SegmentStatsTracker +
+ * admitSegment. Confident segments forward their stats through onSpeechEnd; segments
+ * that never clear the speech bar are dropped as a misfire (never uploaded).
+ *
+ * This is also the first unit coverage of OnscreenVADClient — it drives the callbacks
+ * OnscreenVADClient hands to MicVAD.new directly.
+ */
+
+const { fakeVad, micVadNew } = vi.hoisted(() => {
+  const fakeVad = { start: vi.fn(), pause: vi.fn(), destroy: vi.fn() };
+  return { fakeVad, micVadNew: vi.fn(async (_opts?: any) => fakeVad) };
+});
+
+vi.mock("@ricky0123/vad-web", () => ({ MicVAD: { new: micVadNew } }));
+vi.mock("../../src/LoggingModule", () => ({
+  logger: { log: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), reportError: vi.fn() },
+}));
+vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
+vi.mock("../../src/ui/VADStatusIndicator", () => ({
+  VADStatusIndicator: class {
+    updateStatus = vi.fn();
+    hide = vi.fn();
+    show = vi.fn();
+    destroy = vi.fn();
+  },
+}));
+vi.mock("../../src/UserAgentModule", () => ({
+  getBrowserInfo: () => ({ name: "Chrome", isMobile: false }),
+}));
+vi.mock("../../src/chatbots/ChatbotIdentifier", () => ({
+  ChatbotIdentifier: { identifyChatbot: () => "pi", isInDictationMode: () => false },
+}));
+
+import { OnscreenVADClient } from "../../src/vad/OnscreenVADClient";
+
+const lastOptions = () => micVadNew.mock.calls.at(-1)![0] as any;
+const frame = (isSpeech: number) => ({ isSpeech, notSpeech: 1 - isSpeech });
+
+describe("#420 OnscreenVADClient admission gate + stat forwarding", () => {
+  beforeEach(() => {
+    (global as any).chrome = {
+      runtime: { getURL: (p: string) => `chrome-extension://test/${p}` },
+    };
+    micVadNew.mockClear();
+    fakeVad.start.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete (global as any).chrome;
+  });
+
+  it("forwards peak/mean/speechFrameCount on a confident segment", async () => {
+    const client = new OnscreenVADClient();
+    await client.initialize({ preset: "balanced" });
+    const opts = lastOptions();
+    const onSpeechEnd = vi.fn();
+    const onVADMisfire = vi.fn();
+    client.on("onSpeechEnd", onSpeechEnd);
+    client.on("onVADMisfire", onVADMisfire);
+
+    opts.onFrameProcessed(frame(0.8)); // triggering frame
+    opts.onSpeechStart();
+    opts.onFrameProcessed(frame(0.95));
+    opts.onFrameProcessed(frame(0.2)); // redemption tail
+    opts.onSpeechEnd(new Float32Array([0.1, -0.1, 0.2]));
+
+    expect(onVADMisfire).not.toHaveBeenCalled();
+    expect(onSpeechEnd).toHaveBeenCalledTimes(1);
+    const data = onSpeechEnd.mock.calls[0][0];
+    expect(data.peakSpeechProb).toBeCloseTo(0.95, 5);
+    expect(data.speechFrameCount).toBe(2); // 0.8 + 0.95 clear 0.4; 0.2 does not
+    expect(data.meanSpeechProb).toBeCloseTo((0.8 + 0.95 + 0.2) / 3, 5);
+  });
+
+  it("drops a low-confidence segment as a misfire (no onSpeechEnd, no upload)", async () => {
+    const client = new OnscreenVADClient();
+    await client.initialize({ preset: "balanced" });
+    const opts = lastOptions();
+    const onSpeechEnd = vi.fn();
+    const onVADMisfire = vi.fn();
+    client.on("onSpeechEnd", onSpeechEnd);
+    client.on("onVADMisfire", onVADMisfire);
+
+    // balanced opens at 0.4; floor = 0.4 + 0.05 = 0.45. This blip peaks 0.42 — below it.
+    opts.onFrameProcessed(frame(0.41));
+    opts.onSpeechStart();
+    opts.onFrameProcessed(frame(0.42));
+    opts.onSpeechEnd(new Float32Array([0.1, -0.1]));
+
+    expect(onSpeechEnd).not.toHaveBeenCalled();
+    expect(onVADMisfire).toHaveBeenCalledTimes(1);
+    // The misfire carries gate-drop detail so it's distinguishable from a library misfire.
+    const info = onVADMisfire.mock.calls[0][0];
+    expect(info.reason).toMatch(/admission-gate/);
+    expect(info.peakSpeechProb).toBeCloseTo(0.42, 5);
+  });
+});

--- a/test/vad/VADConfigs.spec.ts
+++ b/test/vad/VADConfigs.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { VAD_CONFIGS, type VADPreset } from "../../src/vad/VADConfigs";
+
+/**
+ * #420 item 2 — Lock the VAD preset values. They were hand-tuned in one commit (PR
+ * #158, "detect shorter phrases") with no benchmark and no test, so they could
+ * silently drift. This pins the exact numbers so any change to them is a DELIBERATE,
+ * reviewed decision — and documents the invariant ordering between presets. (The
+ * numbers themselves stay as-is; re-tuning waits on the VAD-quality benchmark, item 3.)
+ */
+
+describe("#420 VAD_CONFIGS preset values are locked", () => {
+  it("highSensitivity matches the committed tuning", () => {
+    expect(VAD_CONFIGS.highSensitivity).toEqual({
+      model: "v5",
+      positiveSpeechThreshold: 0.35,
+      negativeSpeechThreshold: 0.2,
+      redemptionFrames: 12,
+      minSpeechFrames: 2,
+      preSpeechPadFrames: 3,
+      submitUserSpeechOnPause: false,
+    });
+  });
+
+  it("balanced matches the committed tuning", () => {
+    expect(VAD_CONFIGS.balanced).toEqual({
+      model: "v5",
+      positiveSpeechThreshold: 0.4,
+      negativeSpeechThreshold: 0.25,
+      redemptionFrames: 10,
+      minSpeechFrames: 3,
+      preSpeechPadFrames: 2,
+      submitUserSpeechOnPause: false,
+    });
+  });
+
+  it("conservative matches the committed tuning", () => {
+    expect(VAD_CONFIGS.conservative).toEqual({
+      model: "v5",
+      positiveSpeechThreshold: 0.6,
+      negativeSpeechThreshold: 0.45,
+      redemptionFrames: 8,
+      minSpeechFrames: 4,
+      preSpeechPadFrames: 1,
+      submitUserSpeechOnPause: false,
+    });
+  });
+
+  it("'none' inherits all library defaults (empty override)", () => {
+    expect(VAD_CONFIGS.none).toEqual({});
+  });
+});
+
+describe("#420 VAD_CONFIGS preset ordering invariants", () => {
+  const tuned: VADPreset[] = ["highSensitivity", "balanced", "conservative"];
+
+  it("positive speech threshold rises from highSensitivity → balanced → conservative", () => {
+    expect(VAD_CONFIGS.highSensitivity.positiveSpeechThreshold!).toBeLessThan(
+      VAD_CONFIGS.balanced.positiveSpeechThreshold!
+    );
+    expect(VAD_CONFIGS.balanced.positiveSpeechThreshold!).toBeLessThan(
+      VAD_CONFIGS.conservative.positiveSpeechThreshold!
+    );
+  });
+
+  it("negativeSpeechThreshold stays below positiveSpeechThreshold (Silero validity rule)", () => {
+    tuned.forEach((preset) => {
+      expect(VAD_CONFIGS[preset].negativeSpeechThreshold!).toBeLessThan(
+        VAD_CONFIGS[preset].positiveSpeechThreshold!
+      );
+    });
+  });
+
+  it("every tuned preset pins the v5 model and disables submitUserSpeechOnPause", () => {
+    tuned.forEach((preset) => {
+      expect(VAD_CONFIGS[preset].model).toBe("v5");
+      expect(VAD_CONFIGS[preset].submitUserSpeechOnPause).toBe(false);
+    });
+  });
+
+  it("more sensitive presets allow a longer redemption tail and fewer min speech frames", () => {
+    // The aggressive presets deliberately favour NOT clipping short/quiet phrases:
+    // a longer redemption window and a lower minimum-speech-frames bar.
+    expect(VAD_CONFIGS.highSensitivity.redemptionFrames!).toBeGreaterThan(
+      VAD_CONFIGS.conservative.redemptionFrames!
+    );
+    expect(VAD_CONFIGS.highSensitivity.minSpeechFrames!).toBeLessThan(
+      VAD_CONFIGS.conservative.minSpeechFrames!
+    );
+  });
+});

--- a/test/vad/segmentAdmission.spec.ts
+++ b/test/vad/segmentAdmission.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  SegmentStatsTracker,
+  admitSegment,
+  admissionPeakFloor,
+  DEFAULT_ADMISSION_CONFIG,
+  type SegmentSpeechStats,
+} from "../../src/vad/segmentAdmission";
+
+/**
+ * #420 — The Silero VAD computes a per-frame speech probability that, until now, we
+ * put on the wire and then dropped before any gate could see it. This pins two pure
+ * pieces that put that signal to work:
+ *
+ *  - SegmentStatsTracker: accumulates a segment's peak / mean speech probability and
+ *    its speech-frame count (frames clearing the active positiveSpeechThreshold), so a
+ *    near-threshold non-speech blip can be told apart from a confident utterance.
+ *  - admitSegment: the conservative admission gate. Its floor is anchored to the active
+ *    preset's OWN opening threshold plus a small margin — NOT a fixed absolute value —
+ *    so it can never reject far above the bar the VAD itself used to admit the segment.
+ *    That keeps a quiet utterance on the trigger-happy `highSensitivity` preset from
+ *    being clipped, while still dropping the barely-opened blips that hallucinate.
+ */
+
+describe("#420 SegmentStatsTracker (per-segment speech-probability accumulation)", () => {
+  it("captures peak, mean, speech-frame count, total frame count and the active threshold", () => {
+    const tracker = new SegmentStatsTracker(0.4); // positiveSpeechThreshold
+    // Triggering frame arrives BEFORE onSpeechStart in the real pipeline.
+    tracker.observe(0.6);
+    tracker.beginSegment(); // seeds the segment with the triggering frame (0.6)
+    tracker.observe(0.9);
+    tracker.observe(0.2); // redemption-tail frame, below the threshold
+    const stats = tracker.endSegment();
+
+    expect(stats.peakSpeechProb).toBeCloseTo(0.9, 5);
+    expect(stats.frameCount).toBe(3); // 0.6 (seed) + 0.9 + 0.2
+    expect(stats.meanSpeechProb).toBeCloseTo((0.6 + 0.9 + 0.2) / 3, 5);
+    expect(stats.speechFrameCount).toBe(2); // 0.6 and 0.9 clear 0.4; 0.2 does not
+    expect(stats.positiveSpeechThreshold).toBe(0.4); // the bar it was scored against
+  });
+
+  it("ignores frames observed while NOT in a segment (between utterances)", () => {
+    const tracker = new SegmentStatsTracker(0.4);
+    tracker.observe(0.95); // stray frame before any segment opens
+    tracker.observe(0.1);
+    tracker.beginSegment(); // seeds with the most recent frame (0.1)
+    tracker.observe(0.8);
+    const stats = tracker.endSegment();
+
+    expect(stats.frameCount).toBe(2); // 0.1 (seed) + 0.8 — NOT the stray 0.95
+    expect(stats.peakSpeechProb).toBeCloseTo(0.8, 5);
+  });
+
+  it("reports zeroed stats for an empty/never-started segment", () => {
+    const tracker = new SegmentStatsTracker(0.5);
+    const stats = tracker.endSegment();
+    expect(stats).toEqual<SegmentSpeechStats>({
+      peakSpeechProb: 0,
+      meanSpeechProb: 0,
+      speechFrameCount: 0,
+      frameCount: 0,
+      positiveSpeechThreshold: 0.5,
+    });
+  });
+
+  it("counts speech frames against the configured positiveSpeechThreshold (inclusive at the bar)", () => {
+    const tracker = new SegmentStatsTracker(0.5);
+    tracker.beginSegment();
+    tracker.observe(0.5); // exactly at the bar counts as speech (>=)
+    tracker.observe(0.49); // just under does not
+    const stats = tracker.endSegment();
+    // frame 0 is the seed (lastFrameProb defaults to 0, below 0.5)
+    expect(stats.speechFrameCount).toBe(1);
+  });
+
+  it("resets cleanly so a misfire (or a stop) does not bleed into the next segment", () => {
+    const tracker = new SegmentStatsTracker(0.4);
+    tracker.observe(0.9);
+    tracker.beginSegment();
+    tracker.observe(0.9);
+    tracker.reset(); // e.g. a library misfire, or a mid-utterance stop
+
+    tracker.observe(0.2);
+    tracker.beginSegment();
+    tracker.observe(0.3);
+    const stats = tracker.endSegment();
+    expect(stats.peakSpeechProb).toBeCloseTo(0.3, 5); // not the prior 0.9
+    expect(stats.frameCount).toBe(2);
+  });
+
+  it("can be re-pointed at a new positiveSpeechThreshold (preset chosen after construction)", () => {
+    const tracker = new SegmentStatsTracker();
+    tracker.setPositiveSpeechThreshold(0.6);
+    tracker.beginSegment();
+    tracker.observe(0.55); // below the new bar
+    tracker.observe(0.7); // above it
+    const stats = tracker.endSegment();
+    expect(stats.speechFrameCount).toBe(1);
+    expect(stats.positiveSpeechThreshold).toBe(0.6);
+  });
+
+  it("treats non-finite probabilities as 0 (robustness against bad frames)", () => {
+    const tracker = new SegmentStatsTracker(0.4);
+    tracker.beginSegment();
+    tracker.observe(Number.NaN);
+    tracker.observe(0.8);
+    const stats = tracker.endSegment();
+    expect(stats.peakSpeechProb).toBeCloseTo(0.8, 5);
+    expect(Number.isFinite(stats.meanSpeechProb)).toBe(true);
+  });
+});
+
+describe("#420 admitSegment (preset-relative admission gate)", () => {
+  const stats = (overrides: Partial<SegmentSpeechStats>): SegmentSpeechStats => ({
+    peakSpeechProb: 0.9,
+    meanSpeechProb: 0.6,
+    speechFrameCount: 5,
+    frameCount: 8,
+    positiveSpeechThreshold: 0.4, // balanced preset
+    ...overrides,
+  });
+
+  it("defaults to a small margin over the preset threshold and no duration floor", () => {
+    expect(DEFAULT_ADMISSION_CONFIG.minPeakMarginOverThreshold).toBe(0.05);
+    expect(DEFAULT_ADMISSION_CONFIG.minSpeechFrames).toBe(0);
+  });
+
+  it("computes the peak floor as preset threshold + margin", () => {
+    expect(admissionPeakFloor(stats({ positiveSpeechThreshold: 0.35 }))).toBeCloseTo(0.4, 5);
+    expect(admissionPeakFloor(stats({ positiveSpeechThreshold: 0.4 }))).toBeCloseTo(0.45, 5);
+  });
+
+  it("admits a confident segment", () => {
+    expect(admitSegment(stats({ peakSpeechProb: 0.92 }))).toEqual({
+      admit: true,
+      reason: "admitted",
+    });
+  });
+
+  it("admits a short-but-loud utterance (peak high, very few frames) — the safety guarantee", () => {
+    expect(
+      admitSegment(stats({ peakSpeechProb: 0.95, speechFrameCount: 2, frameCount: 3 }))
+    ).toEqual({ admit: true, reason: "admitted" });
+  });
+
+  it("admits a QUIET sustained utterance on highSensitivity (peak above its own 0.35 bar)", () => {
+    // The reviewer's case: highSensitivity opens at 0.35; a quiet word peaks ~0.45,
+    // which the VAD admits. Floor = 0.35 + 0.05 = 0.40, so the gate must NOT clip it.
+    expect(
+      admitSegment(stats({ positiveSpeechThreshold: 0.35, peakSpeechProb: 0.45 })).admit
+    ).toBe(true);
+  });
+
+  it("rejects a barely-opened blip that never climbed past its own threshold + margin", () => {
+    // Opened at 0.35 but peaked only 0.38 — below the 0.40 floor. Prime non-speech.
+    expect(
+      admitSegment(stats({ positiveSpeechThreshold: 0.35, peakSpeechProb: 0.38 }))
+    ).toEqual({ admit: false, reason: "low-peak-confidence" });
+  });
+
+  it("admits a segment peaking exactly at the floor (inclusive)", () => {
+    // balanced floor = 0.45; a peak of exactly 0.45 is admitted.
+    expect(admitSegment(stats({ positiveSpeechThreshold: 0.4, peakSpeechProb: 0.45 })).admit).toBe(true);
+  });
+
+  it("applies the duration floor only when configured (>0)", () => {
+    const cfg = { minPeakMarginOverThreshold: 0.05, minSpeechFrames: 4 };
+    expect(admitSegment(stats({ peakSpeechProb: 0.9, speechFrameCount: 3 }), cfg)).toEqual({
+      admit: false,
+      reason: "too-few-speech-frames",
+    });
+    expect(admitSegment(stats({ peakSpeechProb: 0.9, speechFrameCount: 4 }), cfg).admit).toBe(true);
+  });
+
+  it("never clips on duration alone under the default config (duration floor disabled)", () => {
+    expect(admitSegment(stats({ peakSpeechProb: 0.9, speechFrameCount: 1 })).admit).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

The SayPi ASR backend hallucinates "Thank you"/"you" on silent or non-speech clips that reach it, and the server-side defenses are weak (most providers don't expose a usable `no_speech_prob`). The cheapest, highest-leverage place to stop non-speech from reaching the model is the **client VAD we already run** — and a review (#420) found we were computing the Silero VAD's per-frame speech probability, putting it on the wire, and then **dropping it before any gate could use it**.

This PR closes the low-effort cluster of #420 — items **1** (forward the signal + add an admission gate), **2** (lock the preset values), and **5** (resolve the dead config). Items **3** (a VAD-quality benchmark) and **4** (re-map host→preset) are deliberately deferred — see *Deferred* below.

## What

**1 — Forward the speech-probability signal and gate on it (the core fix).**
- New pure module `src/vad/segmentAdmission.ts`:
  - `SegmentStatsTracker` accumulates a segment's **peak** / **mean** speech probability and its **speech-frame count** (frames clearing the active `positiveSpeechThreshold` — the same definition vad-web uses internally), correctly handling the library's *frame-processed-before-speech-start* ordering by seeding the segment with the triggering frame.
  - `admitSegment(stats, config)` — the conservative gate. The peak floor is **anchored to the active preset's own opening threshold** plus a small margin (`positiveSpeechThreshold + 0.05`), *not* a fixed absolute value. The VAD admits a segment as soon as enough frames clear the preset threshold, so anchoring there guarantees the gate never rejects a segment far above the bar the VAD itself used — a *quiet* utterance on `highSensitivity` (opens at 0.35, floor 0.40) is kept, while a barely-opened blip that never climbed past 0.40 is dropped. The duration floor is **off by default**, so a short-but-loud "yes"/"no"/"stop" is never clipped either.
- Wired into **both** VAD clients:
  - Offscreen (`vad_handler.ts`): gate runs at the cheapest point — a rejected segment is sent as `VAD_MISFIRE`, so the audio array is **never serialised across the offscreen→content IPC**. Admitted segments carry `peakSpeechProb`/`meanSpeechProb`/`speechFrameCount`.
  - Onscreen (`OnscreenVADClient.ts`, Firefox/mobile): same gate via the shared module; a rejected segment fires `onVADMisfire` instead of `onSpeechEnd`. As a side effect this **collapses the three near-identical callback builders** (primary/fallback/minimal) into one shared `buildSegmentCallbacks()` — they were a standing drift hazard and now differ only in asset-path options. This also adds the first unit coverage of `OnscreenVADClient`.
- The stats are forwarded end-to-end through `VADClientInterface.onSpeechEnd` → `AudioInputMachine` (which logs them for observability). **Gate drops are observable and distinguishable** from genuine non-speech: the reject path carries a `reason: "admission-gate:…"` + the stats through `onVADMisfire`, logged distinctly on both the offscreen and content-script sides (a future telemetry counter can read these fields).

Where the gate bites: active for every preset (it drops the barely-opened band just above each opening threshold), and never rejects a segment that confidently cleared its own preset.

### Review

A multi-lens adversarial subagent review (correctness / regression / edge-failure) found and I fixed: **(a)** the original fixed-0.5 floor could clip *quiet* speech on `highSensitivity`/`balanced` (their openings are below 0.5) → made the floor **preset-relative** (above); **(b)** gate drops were indistinguishable from library misfires → threaded `reason`+stats through `onVADMisfire` and log them distinctly; **(c)** a mid-utterance stop could strand the tracker `speaking=true` (harmless in practice, but now made explicit) → defensive `reset()` on stop/destroy. A follow-up verification pass confirmed all three resolved with no new defects.

**2 — Lock the preset values.** `test/vad/VADConfigs.spec.ts` pins the exact preset numbers and the ordering invariants so the hand-tuned values (PR #158, never benchmarked) can't silently drift. `VADConfigs.ts` now annotates every frame count with its ms equivalent (32 ms/frame) and the Silero v5 baseline each value departs from.

**5 — Resolve the dead config.** `none` is documented as the no-override init fallback (it *is* used). `conservative` is documented as a valid noisy-environment preset that no code path selects *yet* — kept rather than deleted because item 4 plans to wire it to a noise estimate, and now locked by test so it can't rot.

## Trade-off (explicit)

The VAD config is a dial between **false-reject** (clipping real short/quiet speech) and **false-accept** (uploading non-speech → a server hallucination). This gate moves the dial toward fewer hallucinations at some false-reject risk. It is tuned conservatively — the floor is only 0.05 above each preset's own opening bar and the duration floor is off — so the residual risk is confined to a genuinely marginal utterance that never climbs even 0.05 past the threshold the VAD used to admit it. Calibrating the exact margin is precisely what item 3 (the benchmark) is for.

## Deferred (still open under #420)

- **Item 3 (VAD-quality benchmark):** the ASR WER/RTF harness it should mirror lives in the **separate `saypi-benchmarks` repo** (Python) and already has a `vad/` corpus — so the benchmark belongs there, not here, and needs a labelled non-speech/short-confirmation corpus that doesn't exist yet. The offline path is feasible (`@ricky0123/vad-web` exposes `NonRealTimeVAD`).
- **Item 4 (host→preset remap, incl. a mobile/desktop axis):** explicitly gated on item 3 — should be a measured swap, not a blind one.

## Verification

- `npm test` green locally: type-check + Jest (2) + **Vitest (1433 passed, 1 skipped, 0 failed)**.
- New tests (fail-first TDD): `segmentAdmission.spec.ts` (accumulator + gate), `vad_handler-admission.spec.ts` (offscreen gate → misfire-vs-speech-end), `OffscreenVADClient-admission.spec.ts` + `OnscreenVADClient-admission.spec.ts` (stat forwarding + gate on both clients), `VADConfigs.spec.ts` (locked presets).
- Multi-lens adversarial subagent review (correctness / regression / edge-failure) — verdicts posted as a PR comment.

Addresses #420 (items 1, 2, 5). Related: #414 (upload compression), saypi-api#261 (server NoSpeechFilter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
