### PR TITLE
feat(vad): make admission-gate drops observable — per-session counter + honest status (#420)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -994,6 +994,10 @@
     "message": "Non-speech audio detected",
     "description": "VAD detail for non-speech audio detection."
   },
+  "vadDetailAudioTooFaint": {
+    "message": "Audio too faint to transcribe",
+    "description": "VAD detail when speech-like audio was detected but was too faint / low-confidence to transcribe (client-side admission-gate drop)."
+  },
   "vadStatusError": {
     "message": "Error",
     "description": "Generic VAD error status."

--- a/src/events/EventModule.js
+++ b/src/events/EventModule.js
@@ -108,6 +108,11 @@ export default class EventModule {
     EventBus.on("session:transcribing", (detail) => {
       actor.send({ type: "transcribing", ...detail });
     });
+    // #420 — count client-side VAD admission-gate drops per session so a regression
+    // that clips real (quiet) speech is visible in analytics rather than silent.
+    EventBus.on("session:vad-gate-drop", () => {
+      actor.send({ type: "vad_gate_drop" });
+    });
   }
 
   static registerNotifications() {

--- a/src/state-machines/AudioInputMachine.ts
+++ b/src/state-machines/AudioInputMachine.ts
@@ -115,6 +115,14 @@ function setupVADEventListeners() {
         `[AudioInputMachine] Admission gate dropped a segment (${info.reason}): ` +
         `peak=${info.peakSpeechProb}, speechFrames=${info.speechFrameCount}.`
       );
+      // #420 — feed the per-session analytics counter so a regression that clips real
+      // (quiet) speech surfaces in session_ended rather than going silent.
+      EventBus.emit("session:vad-gate-drop", {
+        reason: info.reason,
+        peakSpeechProb: info.peakSpeechProb,
+        meanSpeechProb: info.meanSpeechProb,
+        speechFrameCount: info.speechFrameCount,
+      });
     } else {
       logger.debug("[AudioInputMachine] VAD misfire detected.");
     }

--- a/src/state-machines/SessionAnalyticsMachine.ts
+++ b/src/state-machines/SessionAnalyticsMachine.ts
@@ -61,6 +61,10 @@ interface SessionContext {
   message_count: number;
   audio_duration_seconds: number;
   talk_time_seconds: number;
+  // #420 — count of segments the client-side VAD admission gate dropped this session.
+  // Reported at session end so a regression where the gate clips real (quiet) speech
+  // is visible in analytics rather than silent.
+  vad_gate_drop_count: number;
   last_message: {
     speech_start_time: number;
     speech_end_time: number;
@@ -81,11 +85,13 @@ type SendMessageEvent = {
   wait_time_ms: number;
 };
 type EndSessionEvent = { type: "end_session" };
+type GateDropEvent = { type: "vad_gate_drop" };
 type SessionEvent =
   | EndSessionEvent
   | SendMessageEvent
   | TranscriptionEvent
-  | StartSessionEvent;
+  | StartSessionEvent
+  | GateDropEvent;
 
 const machine = setup({
   types: {
@@ -109,6 +115,7 @@ const machine = setup({
         duration_mins: durationInMinutes,
         audio_duration_seconds: context.audio_duration_seconds,
         talk_time_seconds: context.talk_time_seconds,
+        vad_gate_drop_count: context.vad_gate_drop_count,
       });
     },
     notifySendMessage: async ({ context, event }) => {
@@ -156,6 +163,7 @@ const machine = setup({
       message_count: 0,
       audio_duration_seconds: 0,
       talk_time_seconds: 0,
+      vad_gate_drop_count: 0,
       last_message: {
         speech_start_time: 0,
         speech_end_time: 0,
@@ -167,6 +175,9 @@ const machine = setup({
       message_count: ({ context }) => context.message_count + 1,
       talk_time_seconds: ({ context }) =>
         context.talk_time_seconds + context.last_message.talk_time_seconds,
+    }),
+    incrementGateDropCount: assign({
+      vad_gate_drop_count: ({ context }) => context.vad_gate_drop_count + 1,
     }),
     clearLastMessage: assign({
       last_message: () => {
@@ -216,6 +227,7 @@ const machine = setup({
     message_count: 0,
     audio_duration_seconds: 0,
     talk_time_seconds: 0,
+    vad_gate_drop_count: 0,
     last_message: {
       speech_start_time: 0,
       speech_end_time: 0,
@@ -249,6 +261,11 @@ const machine = setup({
       on: {
         transcribing: {
           actions: "rollupTranscription",
+        },
+        vad_gate_drop: {
+          // #420 — count an admission-gate drop against this session. NOT re-entrant:
+          // a dropped non-speech blip must not reset the 30-min auto-end timer.
+          actions: "incrementGateDropCount",
         },
         send_message: {
           actions: [

--- a/src/vad/OffscreenVADClient.ts
+++ b/src/vad/OffscreenVADClient.ts
@@ -97,13 +97,18 @@ export class OffscreenVADClient implements VADClientInterface {
             speechFrameCount: message.speechFrameCount,
           });
           break;
-        case "VAD_MISFIRE":
-          this.statusIndicator.updateStatus(getMessage('vadStatusMisfire'), getMessage('vadDetailNonSpeechAudioDetected'));
+        case "VAD_MISFIRE": {
+          // #420 — an admission-gate drop heard speech-like audio that was just too
+          // faint to transcribe; "Non-speech audio detected" would be self-contradictory,
+          // so show a distinct detail and surface the drop in the content-script log.
+          const isGateDrop =
+            typeof message.reason === "string" && message.reason.startsWith("admission-gate");
+          const misfireDetail = isGateDrop
+            ? getMessage('vadDetailAudioTooFaint')
+            : getMessage('vadDetailNonSpeechAudioDetected');
+          this.statusIndicator.updateStatus(getMessage('vadStatusMisfire'), misfireDetail);
           setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
-          // #420 — surface an admission-gate drop in the content-script log too (not just
-          // the offscreen one) and forward its reason/stats so it stays distinguishable
-          // from a genuine non-speech misfire for any downstream counter.
-          if (typeof message.reason === "string" && message.reason.startsWith("admission-gate")) {
+          if (isGateDrop) {
             logger.info(
               `[SayPi OffscreenVADClient] Admission gate dropped a segment (${message.reason}): ` +
               `peak=${message.peakSpeechProb}, speechFrames=${message.speechFrameCount}.`
@@ -116,6 +121,7 @@ export class OffscreenVADClient implements VADClientInterface {
             speechFrameCount: message.speechFrameCount,
           });
           break;
+        }
         case "VAD_FRAME_PROCESSED":
           this.callbacks.onFrameProcessed?.(message.probabilities);
           break;

--- a/src/vad/OnscreenVADClient.ts
+++ b/src/vad/OnscreenVADClient.ts
@@ -141,7 +141,9 @@ export class OnscreenVADClient implements VADClientInterface {
             `peak=${stats.peakSpeechProb.toFixed(3)}, mean=${stats.meanSpeechProb.toFixed(3)}, ` +
             `speechFrames=${stats.speechFrameCount}. Not uploading.`
           );
-          this.statusIndicator.updateStatus(getMessage('vadStatusMisfire'), getMessage('vadDetailNonSpeechAudioDetected'));
+          // #420 — the audio WAS speech-like, just too faint to transcribe; show a
+          // distinct detail rather than the self-contradictory "Non-speech audio detected".
+          this.statusIndicator.updateStatus(getMessage('vadStatusMisfire'), getMessage('vadDetailAudioTooFaint'));
           setTimeout(() => this.statusIndicator.updateStatus(getMessage('vadStatusReady'), getMessage('vadDetailWaitingForSpeech')), 1500);
           this.callbacks.onVADMisfire?.({
             reason: `admission-gate:${decision.reason}`,

--- a/test/state-machines/AudioInputMachine-gateDropWiring.spec.ts
+++ b/test/state-machines/AudioInputMachine-gateDropWiring.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * #420 wiring guard. An admission-gate drop must feed the per-session analytics
+ * counter so a regression that clips real (quiet) speech is visible rather than
+ * silent. The counter lives in SessionAnalyticsMachine (unit-tested) and is reached
+ * via EventBus `session:vad-gate-drop`, emitted from AudioInputMachine's onVADMisfire
+ * handler and bridged to the analytics actor in EventModule. Importing either module
+ * at runtime pulls in the whole content-script bootstrap, so — following the repo's
+ * source-scanning wiring guards (#320) — assert the two load-bearing lines exist.
+ */
+const root = resolve(__dirname, "..", "..");
+const audioInput = readFileSync(
+  resolve(root, "src/state-machines/AudioInputMachine.ts"),
+  "utf8"
+);
+const eventModule = readFileSync(resolve(root, "src/events/EventModule.js"), "utf8");
+
+describe("#420 gate-drop analytics wiring", () => {
+  it("AudioInputMachine emits session:vad-gate-drop only in the admission-gate branch", () => {
+    // The emit must sit inside the `info?.reason?.startsWith("admission-gate")` block,
+    // not on the generic library-misfire path (which would over-count).
+    const branch = audioInput.match(
+      /startsWith\(\s*["']admission-gate["']\s*\)\s*\)\s*\{([\s\S]*?)\}\s*else\s*\{/
+    );
+    expect(branch).toBeTruthy();
+    expect(branch![1]).toMatch(/EventBus\.emit\(\s*["']session:vad-gate-drop["']/);
+  });
+
+  it("EventModule bridges session:vad-gate-drop to the analytics actor's vad_gate_drop event", () => {
+    expect(eventModule).toMatch(
+      /EventBus\.on\(\s*["']session:vad-gate-drop["'][\s\S]*?actor\.send\(\s*\{\s*type:\s*["']vad_gate_drop["']\s*\}/
+    );
+  });
+});

--- a/test/state-machines/SessionAnalyticsMachine-characterization.spec.ts
+++ b/test/state-machines/SessionAnalyticsMachine-characterization.spec.ts
@@ -126,6 +126,7 @@ describe("SessionAnalyticsMachine — initial state & context", () => {
       message_count: 0,
       audio_duration_seconds: 0,
       talk_time_seconds: 0,
+      vad_gate_drop_count: 0,
       last_message: {
         speech_start_time: 0,
         speech_end_time: 0,
@@ -506,6 +507,7 @@ describe("SessionAnalyticsMachine — Active: end_session", () => {
       duration_mins: (endTime - startTime) / 1000 / 60,
       audio_duration_seconds: 4,
       talk_time_seconds: 4,
+      vad_gate_drop_count: 0,
     });
 
     dateSpy.mockRestore();
@@ -529,6 +531,62 @@ describe("SessionAnalyticsMachine — Active: end_session", () => {
     expect(ctx.message_count).toBe(0);
     expect(ctx.audio_duration_seconds).toBe(0);
     expect(ctx.talk_time_seconds).toBe(0);
+  });
+});
+
+describe("#420 SessionAnalyticsMachine — Active: vad_gate_drop counter", () => {
+  it("increments vad_gate_drop_count per event while Active, without ending the session", () => {
+    startActive();
+    service.send({ type: "vad_gate_drop" });
+    service.send({ type: "vad_gate_drop" });
+    expect(service.state.matches("Active")).toBe(true);
+    expect(service.state.context.vad_gate_drop_count).toBe(2);
+  });
+
+  it("a gate drop does not call analytics on its own (only counted, flushed at session end)", () => {
+    startActive();
+    getAnalytics().sendEvent.mockClear();
+    service.send({ type: "vad_gate_drop" });
+    expect(getAnalytics().sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("reports the per-session vad_gate_drop_count in session_ended", () => {
+    const startTime = 1_700_000_000_000;
+    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(startTime);
+    service = createTestActor(machine);
+    service.start();
+    service.send("start_session");
+    const sessionId = service.state.context.session_id;
+
+    service.send({ type: "vad_gate_drop" });
+    service.send({ type: "vad_gate_drop" });
+    service.send({ type: "vad_gate_drop" });
+
+    getAnalytics().sendEvent.mockClear();
+    service.send("end_session");
+
+    const call = getAnalytics().sendEvent.mock.calls.find((c) => c[0] === "session_ended");
+    expect(call).toBeTruthy();
+    expect((call![1] as Record<string, unknown>).session_id).toBe(sessionId);
+    expect((call![1] as Record<string, unknown>).vad_gate_drop_count).toBe(3);
+
+    dateSpy.mockRestore();
+  });
+
+  it("resets vad_gate_drop_count on a fresh session", () => {
+    startActive();
+    service.send({ type: "vad_gate_drop" });
+    service.send("end_session");
+    service.send("start_session");
+    expect(service.state.context.vad_gate_drop_count).toBe(0);
+  });
+
+  it("ignores vad_gate_drop while Idle (no session to attribute it to)", () => {
+    service = createTestActor(machine);
+    service.start();
+    service.send({ type: "vad_gate_drop" });
+    expect(service.state.matches("Idle")).toBe(true);
+    expect(service.state.context.vad_gate_drop_count).toBe(0);
   });
 });
 

--- a/test/vad/OffscreenVADClient-admission.spec.ts
+++ b/test/vad/OffscreenVADClient-admission.spec.ts
@@ -14,12 +14,16 @@ vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
 vi.mock("../../src/offscreen/media_coordinator", () => ({
   sanitizeMessageForLogs: (m: any) => m,
 }));
+const { indicatorInstances } = vi.hoisted(() => ({ indicatorInstances: [] as any[] }));
 vi.mock("../../src/ui/VADStatusIndicator", () => ({
   VADStatusIndicator: class {
     updateStatus = vi.fn();
     hide = vi.fn();
     show = vi.fn();
     destroy = vi.fn();
+    constructor() {
+      indicatorInstances.push(this);
+    }
   },
 }));
 
@@ -30,6 +34,7 @@ describe("#420 OffscreenVADClient forwards admission stats", () => {
 
   beforeEach(() => {
     ports = [];
+    indicatorInstances.length = 0;
     (global as any).chrome = {
       runtime: {
         connect: vi.fn(() => {
@@ -103,9 +108,21 @@ describe("#420 OffscreenVADClient forwards admission stats", () => {
     expect(info.reason).toBe("admission-gate:low-peak-confidence");
     expect(info.peakSpeechProb).toBeCloseTo(0.41, 5);
     expect(info.speechFrameCount).toBe(2);
+
+    // A gate drop shows a distinct, non-self-contradictory status detail — the audio
+    // WAS speech-like, just too faint to transcribe — NOT "Non-speech audio detected".
+    const indicator = indicatorInstances[0];
+    expect(indicator.updateStatus).toHaveBeenCalledWith(
+      "vadStatusMisfire",
+      "vadDetailAudioTooFaint"
+    );
+    expect(indicator.updateStatus).not.toHaveBeenCalledWith(
+      "vadStatusMisfire",
+      "vadDetailNonSpeechAudioDetected"
+    );
   });
 
-  it("a plain library misfire forwards undefined gate detail", () => {
+  it("a plain library misfire forwards undefined gate detail and keeps the non-speech status", () => {
     const client = new OffscreenVADClient();
     const onVADMisfire = vi.fn();
     client.on("onVADMisfire", onVADMisfire);
@@ -115,5 +132,12 @@ describe("#420 OffscreenVADClient forwards admission stats", () => {
     expect(onVADMisfire).toHaveBeenCalledTimes(1);
     const info = onVADMisfire.mock.calls[0][0];
     expect(info.reason).toBeUndefined();
+
+    // A genuine library misfire (non-speech blip) keeps the original detail.
+    const indicator = indicatorInstances[0];
+    expect(indicator.updateStatus).toHaveBeenCalledWith(
+      "vadStatusMisfire",
+      "vadDetailNonSpeechAudioDetected"
+    );
   });
 });

--- a/test/vad/OnscreenVADClient-admission.spec.ts
+++ b/test/vad/OnscreenVADClient-admission.spec.ts
@@ -20,12 +20,16 @@ vi.mock("../../src/LoggingModule", () => ({
   logger: { log: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), reportError: vi.fn() },
 }));
 vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
+const { indicatorInstances } = vi.hoisted(() => ({ indicatorInstances: [] as any[] }));
 vi.mock("../../src/ui/VADStatusIndicator", () => ({
   VADStatusIndicator: class {
     updateStatus = vi.fn();
     hide = vi.fn();
     show = vi.fn();
     destroy = vi.fn();
+    constructor() {
+      indicatorInstances.push(this);
+    }
   },
 }));
 vi.mock("../../src/UserAgentModule", () => ({
@@ -47,6 +51,7 @@ describe("#420 OnscreenVADClient admission gate + stat forwarding", () => {
     };
     micVadNew.mockClear();
     fakeVad.start.mockClear();
+    indicatorInstances.length = 0;
   });
 
   afterEach(() => {
@@ -98,5 +103,13 @@ describe("#420 OnscreenVADClient admission gate + stat forwarding", () => {
     const info = onVADMisfire.mock.calls[0][0];
     expect(info.reason).toMatch(/admission-gate/);
     expect(info.peakSpeechProb).toBeCloseTo(0.42, 5);
+
+    // And it shows the distinct "too faint" status detail, not the misleading
+    // "Non-speech audio detected" (the audio WAS speech-like, just below the bar).
+    const indicator = indicatorInstances[0];
+    expect(indicator.updateStatus).toHaveBeenCalledWith(
+      "vadStatusMisfire",
+      "vadDetailAudioTooFaint"
+    );
   });
 });


### PR DESCRIPTION
## Why

Two follow-ups from the #420 review (PR #423), both about making admission-gate drops **visible rather than silent** — so a regression where the gate clips real (quiet) speech surfaces instead of quietly losing dictation:

1. The gate's reject path showed the user **"Non-speech audio detected"** even for a borderline drop where there *was* speech-like audio (just too faint) — self-contradictory.
2. Gate drops weren't **counted anywhere**, so a field regression that repeatedly rejects quiet speech would be invisible in analytics.

## What

**1 — Per-session gate-drop counter.** `SessionAnalyticsMachine` gains a `vad_gate_drop_count` (seeded 0, reset per session), incremented on a new `vad_gate_drop` machine event, and reported in the `session_ended` analytics payload (count only — no per-drop stats/PII). The event is handled **only in the `Active` state** (a drop while idle is ignored) and is **non-re-entrant** (a dropped blip must not reset the 30-min session-end timer). Wiring: `AudioInputMachine`'s `onVADMisfire` handler emits EventBus `session:vad-gate-drop` **only** in the `admission-gate` branch (never on a genuine library misfire), and `EventModule` bridges it to the analytics actor — matching the existing `session:*` → actor pattern.

**2 — Distinct, honest status string.** A new i18n key `vadDetailAudioTooFaint` ("Audio too faint to transcribe") is shown on the gate-drop status path in both `OffscreenVADClient` (when the `VAD_MISFIRE` carries an `admission-gate` reason) and `OnscreenVADClient`. A genuine library misfire still shows "Non-speech audio detected". The new key is en-only for now — Chrome falls back to en for the other 31 locales, and the credentialed `npm run translate` (founder-run, per the repo's en-source-first convention) localizes it before the next release.

## Verification

- `npm test` green: type-check + Jest + **Vitest (1454 passed, 1 skipped, 0 failed)**; the prebuild i18n validator passes.
- Fail-first TDD: new gate-drop tests in `SessionAnalyticsMachine-characterization.spec.ts` (count increments in Active, ignored in Idle, reset per session, reported in `session_ended`), a source-scan wiring guard `AudioInputMachine-gateDropWiring.spec.ts`, and status-string assertions added to both clients' admission specs.
- Adversarial subagent review: **approve**, no new defects (block-scoping of the converted `VAD_MISFIRE` case, no library-misfire over-count, count-only analytics payload, en-only safe vs the i18n tests — all confirmed). Verdict posted as a PR comment.

> Note (unrelated to this diff): `npm test` locally needed `webm-muxer` installed into the shared `node_modules` — it landed in `package.json`/lock via #422 but the shared install predated that merge. CI installs fresh, so it's a local-only setup gap, not a code change.

Follow-ups to #420 (which remains open for items 3 & 4). Related: #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
