### PR TITLE
chore: sweep the deferred dead code (follow-up to #427)

### DIFF
--- a/src/TelemetryModule.ts
+++ b/src/TelemetryModule.ts
@@ -98,7 +98,6 @@ export class TelemetryModule {
   private speechStartTime: number = 0;
   private speechEndTime: number = 0;
   private transcriptionStartTime: number = 0;
-  private transcriptionEndTime: number = 0;
   private lastTranscriptionTime: number = 0;
   private promptSubmissionTime: number = 0;
   private completionStartTime: number = 0;
@@ -164,7 +163,6 @@ export class TelemetryModule {
         this.currentTelemetry.timestamps.transcriptionEnd = event.timestamp;
         // Save the last transcription time for grace period calculation
         this.lastTranscriptionTime = event.timestamp;
-        this.transcriptionEndTime = event.timestamp;
         logger.debug(`Transcription received and lastTranscriptionTime updated: ${this.lastTranscriptionTime}`);
         this.emitUpdate();
       }
@@ -255,7 +253,6 @@ export class TelemetryModule {
     this.speechStartTime = 0;
     this.speechEndTime = 0;
     this.transcriptionStartTime = 0;
-    this.transcriptionEndTime = 0;
     this.promptSubmissionTime = 0;
     this.completionStartTime = 0;
     this.completionEndTime = 0;

--- a/src/chatbots/chatgpt/ChatGPTResponse.ts
+++ b/src/chatbots/chatgpt/ChatGPTResponse.ts
@@ -513,13 +513,6 @@ export class ChatGPTMessageControls extends MessageControls {
       inner?.setAttribute('data-saypi-shielded', 'true');
     } catch {}
     try { this.repositionMenuToBottomRight(wrapper); } catch {}
-    this.outsideShieldCleanup = () => {
-      try { wrapper.removeAttribute('data-saypi-shielded'); } catch {}
-      try {
-        const inner = wrapper.querySelector('[data-radix-menu-content],[data-radix-dropdown-menu-content],[role="menu"]') as HTMLElement | null;
-        inner?.removeAttribute('data-saypi-shielded');
-      } catch {}
-    };
   }
 
   private scheduleLazyAttach(): void {
@@ -531,34 +524,11 @@ export class ChatGPTMessageControls extends MessageControls {
     }, 200);
   }
 
-  // The shielding / positioning helpers are kept in case of dropdown interference
-  private outsideShieldEventHandlers: Array<{event: string, handler: (...args: any[]) => void}> = [];
-  private outsideShieldCleanup: (() => void) | null = null;
-  private outsideShieldWatch: any = null;
-  private outsideShieldTrigger: HTMLElement | null = null;
-  private outsideShieldWrapper: HTMLElement | null = null;
-
   private sweepShieldAttributes(ancestor: HTMLElement | null): void {
     const sel = '[data-saypi-shielded]';
     const nodes = Array.from((ancestor || document).querySelectorAll(sel));
     for (const n of nodes) { try { n.removeAttribute('data-saypi-shielded'); } catch {} }
   }
-
-  private gentlyCloseMenu(wrapper: HTMLElement, trigger?: HTMLElement | null): void {
-    try {
-      const menu = wrapper.querySelector('[data-radix-menu-content],[data-radix-dropdown-menu-content],[role="menu"]') as HTMLElement | null;
-      const isOpen = !!menu && (menu.getAttribute('data-state') === 'open' || wrapper.getAttribute('data-state') === 'open');
-      if (!isOpen) return;
-      if (menu) { try { menu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' })); } catch {} }
-      setTimeout(() => {
-        const stillOpen = menu && (menu.getAttribute('data-state') === 'open' || wrapper.getAttribute('data-state') === 'open');
-        if (stillOpen && trigger) { try { this.synthesizeUserClick(trigger); } catch {} }
-        try { this.blurTrigger(trigger || undefined); } catch {}
-      }, 40);
-    } catch {}
-  }
-
-  private blurTrigger(trigger?: HTMLElement | null): void { try { trigger && trigger.blur?.(); } catch {} }
 
   private repositionMenuToBottomRight(wrapper: HTMLElement): void {
     const menu = wrapper.querySelector('[data-radix-menu-content],[data-radix-dropdown-menu-content],[role="menu"]') as HTMLElement | null;
@@ -571,12 +541,6 @@ export class ChatGPTMessageControls extends MessageControls {
     wrapper.style.transform = `translate(${x}px, ${y}px) scale(0.965)`;
   }
 
-  private restoreMenuPosition(wrapper: HTMLElement): void {
-    const prev = (wrapper as any)._saypiPrevTransform;
-    if (typeof prev === 'string') { wrapper.style.transform = prev; }
-    else { try { wrapper.style.removeProperty('transform'); } catch {} }
-    try { delete (wrapper as any)._saypiPrevTransform; } catch {}
-  }
 }
 
 export class ChatGPTTextBlockCapture extends ElementTextStream {

--- a/src/dom/MessageElements.ts
+++ b/src/dom/MessageElements.ts
@@ -8,10 +8,8 @@ import {
 import { TTSControlsModule } from "../tts/TTSControlsModule";
 import { SpeechSynthesisModule } from "../tts/SpeechSynthesisModule";
 import { BillingModule, UtteranceCharge } from "../billing/BillingModule";
-import { Observation } from "./Observation";
 import { Chatbot } from "../chatbots/Chatbot";
 import EventBus from "../events/EventBus";
-import { isMobileDevice } from "../UserAgentModule";
 import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { SpeechHistoryModule } from "../tts/SpeechHistoryModule";
 import { regenerateSpeech } from "./regenerateSpeech";
@@ -64,46 +62,6 @@ declare global {
         getMessageTelemetry: (messageId: string) => Record<string, number> | null;
       };
     };
-  }
-}
-
-class PopupMenu {
-  private _element: HTMLElement;
-
-  constructor(
-    private message: AssistantResponse,
-    element: HTMLElement,
-    private speech: SpeechUtterance | null,
-    private ttsControls: TTSControlsModule
-  ) {
-    this._element = element;
-  }
-
-  get element(): HTMLElement {
-    return this._element;
-  }
-
-  decorate(): void {
-    this._element.classList.add("popup-menu");
-    this.ttsControls.addCopyButton(this.message, this._element, true);
-    if (this.speech) {
-      this.decorateSpeech(this.speech);
-    }
-  }
-  decorateSpeech(speech: SpeechUtterance) {
-    this.ttsControls.addSpeechButton(speech, this._element, null, true);
-  }
-
-  static find(chatbot: Chatbot, searchRoot: HTMLElement): Observation {
-    let popupMenu = searchRoot.querySelector(".popup-menu");
-    if (popupMenu) {
-      return Observation.foundAlreadyDecorated(".popup-menu", popupMenu);
-    }
-    popupMenu = searchRoot.querySelector(".shadow-input") as HTMLElement | null; // TODO: generalize with Chatbot parameter
-    if (popupMenu) {
-      return Observation.foundUndecorated(".popup-menu", popupMenu);
-    }
-    return Observation.notFound(".popup-menu");
   }
 }
 
@@ -831,30 +789,6 @@ abstract class MessageControls {
       messageContentElement.id = `saypi-message-content-${this.message.utteranceId}`;
     }
 
-    if (isMobileDevice()) {
-      // TODO: we need a way to deregister this listener when the message is removed - perhaps a teardown method?
-      EventBus.on(
-        "saypi:tts:menuPop",
-        (event: { utteranceId: string; menu: PopupMenu }) => {
-    const id = this.message.element.dataset.utteranceId;
-    if (
-      !id ||
-      id !== event.utteranceId ||
-            id !== charge.utteranceId ||
-            !charge.cost
-    ) {
-      return;
-    }
-    const menuElement = event.menu.element;
-    const menuCostElement = menuElement.querySelector(".saypi-cost");
-      if (menuCostElement) {
-        this.ttsControls.updateCostBasis(menuElement, charge);
-      } else {
-        this.ttsControls.addCostBasis(menuElement, charge, true);
-      }
-    }
-      );
-    }
   }
 
   /**
@@ -2188,7 +2122,7 @@ abstract class MessageControls {
   }
 }
 
-export { AssistantResponse, MessageControls, PopupMenu };
+export { AssistantResponse, MessageControls };
 
 /**
  * Represents a user message in the chat history


### PR DESCRIPTION
Follow-up to #427 — removes the three items that PR deliberately left for your call. You said sweep them, so here they are. All confirmed dead and **behaviorally inert** (adversarially reviewed — no blockers).

## Removed

- **ChatGPT `outsideShield*` cluster** — the 5 write-only properties, the never-invoked `outsideShieldCleanup` assignment, and the uncalled `gentlyCloseMenu`/`blurTrigger`/`restoreMenuPosition`. The *live* shield path (`enableOutsideDismissShield` + `sweepShieldAttributes` + `repositionMenuToBottomRight`) is **kept intact** — only the `// kept in case of dropdown interference` cleanup/close helpers (which had zero callers and whose cleanup closure was never run) are gone.
- **`saypi:tts:menuPop` / `PopupMenu` machinery** — the dead `PopupMenu` class and the now-emitterless listener block inside `decorateCost` (its only emitter, `watchForPopupMenu`, was removed in #427). The **main cost-display path in `decorateCost` is unchanged**. Cascade: dropped the orphaned `isMobileDevice` + `Observation` imports and `PopupMenu` from the export.
- **`TelemetryModule.transcriptionEndTime`** — turned out *not* to be an unfinished metric: the reported value `currentTelemetry.timestamps.transcriptionEnd` is a **distinct, still-recorded field** (read in 18 places). `transcriptionEndTime` was just a redundant write-only copy.

## Result

After this, **`noUnusedLocals` reports zero unused symbols** across the entire codebase — the sweep (this + #427) is complete.

## Verification

`npm test` green — tsc + Jest + Vitest, **1450 passed / 1 skipped**. Diff is **+1 / −106** across 3 files. Both touched-but-partially-live methods (`decorateCost`, `enableOutsideDismissShield`) were adversarially confirmed unchanged in their live paths.