### PR TITLE
chore(tsconfig): enable noUnusedLocals to guard against dead-code regrowth

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
+    "noUnusedLocals": true,
     "allowJs": true,
     "jsx": "react-jsx",
     "jsxImportSource": "preact",


### PR DESCRIPTION
Capstone to the dead-code sweep (#427 + #428). Those left the codebase **noUnusedLocals-clean** (a transient pass reported zero findings), so enabling the flag now is free — no violations to fix — and it keeps things that way: unused imports/locals/private-members fail the type-check gate (and CI) instead of re-accumulating.

**Scope:** `noUnusedLocals` only, not `noUnusedParameters`. Unused *parameters* are frequently intentional in this codebase (event handlers, interface conformance, leading params before a used one) and would be noisy.

**Dev-friction tradeoff (the reason this was your call):** a temporarily-unused local now errors during iteration. Escape hatch: prefix with `_` (e.g. `_unused`) or just remove it.

**Verification:** `npm test` green — `tsc --noEmit` with the flag active, plus Jest + Vitest, **1450 passed / 1 skipped**. One-line change to `tsconfig.json`.