### PR TITLE
feat(bench): expand real VAD corpus (+music, 98 clips) → actionable item-4 findings (#420)

### DIFF
--- a/bench/vad/README.md
+++ b/bench/vad/README.md
@@ -118,57 +118,72 @@ datasets — deterministically (sorted, fixed counts), so the numbers below repr
 generated `manifest.json` (with per-clip source/license/attribution) are tracked.
 
 - **Positives — Google Speech Commands v2** ([CC-BY-4.0](https://www.tensorflow.org/datasets/catalog/speech_commands)):
-  32 real short confirmations (`yes`/`no`/`stop`/`go`/`up`/`down`/`on`/`off`, 4 distinct
+  64 real short confirmations (`yes`/`no`/`stop`/`go`/`up`/`down`/`on`/`off`, 8 distinct
   speakers each) recorded by thousands of people on varied web/phone mics — the short,
   sometimes-soft, sometimes-clipped regime the synthetic `say` corpus couldn't stress.
   Digitally-silent/corrupt source clips are filtered out (peak amplitude floor).
 - **Negatives — MUSAN noise, free-sound subset** (US Public Domain;
-  [OpenSLR 17](https://www.openslr.org/17/), Snyder/Chen/Povey 2015): 14 real ambient-noise
-  recordings, already 16 kHz mono PCM16 — plus digital silence.
-- **Music — not yet.** No license-clean *per-file* music source exists without the 11 GB
-  MUSAN tarball (the HF mirrors carry only noise/metadata). A clear follow-up.
+  [OpenSLR 17](https://www.openslr.org/17/), Snyder/Chen/Povey 2015): 24 real ambient-noise
+  recordings; **real music** — Kevin MacLeod / [Incompetech](https://incompetech.com)
+  (CC-BY-4.0), 8 varied tracks converted to 20 s 16 kHz clips with `ffmpeg`; and digital
+  silence. (Music needs `ffmpeg` to fetch; it's skipped if absent, and the exact tracks
+  depend on Incompetech availability — speech/noise are from stable sources and fully
+  reproducible.)
 
-### Findings (real corpus, 32 speech / 16 non-speech)
+### Findings (real corpus, 64 speech / 34 non-speech)
 
 | preset | FRR | FAR (raw → gated) |
 |---|---|---|
-| highSensitivity | 3% | 56% → **50%** |
-| balanced | 9% | 38% → 38% |
-| conservative | 34% | 25% → 25% |
-| none (v5 default) | 59% | 25% → 25% |
+| highSensitivity | 3% | 59% → **56%** |
+| balanced | 8% | 41% → 41% |
+| conservative | 23% | 29% → 29% |
+| none (v5 default) | 50% | 26% → 26% |
 
 (Latency is omitted for real clips — we have no frame-level word boundaries; latency lives
 in the synthetic corpus.)
 
 This is the data the synthetic seed couldn't give, and it changes the picture:
 
-- **The false-reject/false-accept dial is real and steep.** Across presets, FRR climbs
-  3% → 9% → 34% → 59% while FAR falls 56% → 38% → 25%. The synthetic corpus showed ~0% on
-  both for most presets; real audio exposes the actual trade-off.
-- **`highSensitivity` false-accepts on real ambient noise 56% of the time.** Real MUSAN
-  noise opens a segment on over half the clips — more than half of those are *confident*
-  triggers (peak 0.75–0.99) that no conservative gate can catch. This strongly corroborates #420's concern
-  that the trigger-happy preset bound to noisy generic pages is the FAR risk.
-- **The #420 gate now demonstrably reduces FAR with zero FRR cost** (`highSensitivity`
-  56% → 50%): it drops `nonspeech_musan_07` (segment peak **0.373**, below the 0.40 floor) —
-  exactly the borderline non-speech the gate targets — while leaving the confident triggers
-  and all real speech untouched. Modest, because most real-noise false-accepts are confident,
-  not borderline; the cure for those is a higher opening threshold, not the gate.
-- **Real short confirmations *do* get clipped — the cost the synthetic corpus hid.** The
-  false-rejects are genuine: e.g. `speech_sc_up_17` reaches frame-peak 0.613 but is too short
-  to sustain `minSpeechFrames` on `balanced`; `off_29` (soft "off", peak 0.395) is missed even
-  by `highSensitivity`. So `balanced`'s lower FAR comes at a real ~6-point FRR cost over
-  `highSensitivity` — clipping real "up"/"off" confirmations.
+- **The false-reject/false-accept dial is real and steep.** FRR climbs 3 → 8 → 23 → 50% while
+  FAR falls 59 → 41 → 29 → 26%. The synthetic corpus showed ~0% on both for most presets; real
+  audio exposes the actual trade-off, and `balanced` sits at its knee.
+- **Music is the worst false-accept source — and `highSensitivity` admits *all* of it.**
+  Per negative type on `highSensitivity`: **music 8/8 (100%)**, noise 11/24 (46%), silence
+  0/2. `balanced` cuts music to 5/8 and noise to 9/24; `conservative` to 3/8 and 7/24. Since
+  generic web pages frequently have **background music/video playing**, binding the
+  trigger-happiest preset to them is the worst possible match — exactly #420's gap-#3 concern,
+  now measured.
+- **The #420 gate reduces FAR with zero FRR cost** (`highSensitivity` 59 → 56%): it drops the
+  borderline non-speech clips whose peak lands in `[threshold, threshold+0.05)`, while leaving
+  the confident triggers and all real speech untouched. Modest, because most real-noise/music
+  false-accepts are *confident*; the cure for those is a calmer preset, not the gate.
+- **The false-reject cost is concentrated in one hard word.** `highSensitivity` clips only
+  `up` (1/8) and `off` (1/8); `balanced` clips `up` (4/8) and `off` (1/8) — every other word
+  (`yes`/`no`/`stop`/`go`/`down`/`on`) is caught by both. So `balanced`'s 8% FRR is almost
+  entirely the short, soft `up`. And isolated single words are a *harder* test than connected
+  dictation (where the VAD opens on the utterance stream), so this **overstates** the real
+  dictation FRR cost.
 
-### Bearing on item #420(4) (host → preset remap)
+### Bearing on item #420(4) (host → preset remap) — now actionable
 
-This is the substrate item 4 needs, and it now quantifies the swap it was blocked on:
-moving generic pages from `highSensitivity` → `balanced` would trade **FAR 50% → 38%** for
-**FRR 3% → 9%** (clipping ~6% more real confirmations). That is a genuine, measured
-trade-off — no longer a guess. **But do not remap on these numbers yet:** 32 speech / 16
-noise is a small sample (wide confidence intervals), there is **no music** in the corpus,
-and Speech Commands recording conditions differ from in-browser dictation. Expand the corpus
-(more clips, real music, real café/keyboard ambient) before flipping a production mapping.
+The current mapping gives **generic / universal-dictation pages `highSensitivity`** and
+dedicated chat sites `balanced`. The data says that's backwards for the noisy context:
+
+- Generic pages are the **noisiest, least-controlled** (often with background media), and
+  `highSensitivity` false-accepts **59%** of non-speech there incl. **100% of music** —
+  a large hallucination surface.
+- The cost of calming them to `balanced` is small and concentrated (FAR 56 → 41%, music 8/8 →
+  5/8, for FRR 3 → 8% that is mostly the isolated word `up`, overstated vs connected dictation).
+
+**Recommended remap (implemented in the follow-up):** generic / dictation pages
+`highSensitivity` → `balanced`. **Leave chat sites at `balanced`** — they're the core product
+and the quietest context (a focused voice conversation), so there's no data-backed reason to
+make them *more* trigger-happy, and changing them carries more risk than reward. Net: `balanced`
+everywhere; `highSensitivity` becomes a reserved preset (like `conservative`).
+
+Still-open refinements (not blockers): a **noise/SNR-adaptive** or **mobile-vs-desktop** axis
+(the corpus isn't device-labelled, so that needs its own data), and broadening the corpus with
+café/keyboard ambient and non-English speech.
 
 ## Files
 

--- a/bench/vad/README.md
+++ b/bench/vad/README.md
@@ -148,8 +148,8 @@ This is the data the synthetic seed couldn't give, and it changes the picture:
   FAR falls 59 → 41 → 29 → 26%. The synthetic corpus showed ~0% on both for most presets; real
   audio exposes the actual trade-off, and `balanced` sits at its knee.
 - **Music is the worst false-accept source — and `highSensitivity` admits *all* of it.**
-  Per negative type on `highSensitivity`: **music 8/8 (100%)**, noise 11/24 (46%), silence
-  0/2. `balanced` cuts music to 5/8 and noise to 9/24; `conservative` to 3/8 and 7/24. Since
+  Per negative type on `highSensitivity` (raw): **music 8/8 (100%)**, noise 12/24 (50%),
+  silence 0/2. `balanced` cuts music to 5/8 and noise to 9/24; `conservative` to 3/8 and 7/24. Since
   generic web pages frequently have **background music/video playing**, binding the
   trigger-happiest preset to them is the worst possible match — exactly #420's gap-#3 concern,
   now measured.
@@ -172,7 +172,7 @@ dedicated chat sites `balanced`. The data says that's backwards for the noisy co
 - Generic pages are the **noisiest, least-controlled** (often with background media), and
   `highSensitivity` false-accepts **59%** of non-speech there incl. **100% of music** —
   a large hallucination surface.
-- The cost of calming them to `balanced` is small and concentrated (FAR 56 → 41%, music 8/8 →
+- The cost of calming them to `balanced` is small and concentrated (FAR 59 → 41%, music 8/8 →
   5/8, for FRR 3 → 8% that is mostly the isolated word `up`, overstated vs connected dictation).
 
 **Recommended remap (implemented in the follow-up):** generic / dictation pages

--- a/bench/vad/fetch-real-corpus.mjs
+++ b/bench/vad/fetch-real-corpus.mjs
@@ -10,10 +10,10 @@
 //     (yes/no/stop/go/up/down/on/off) from thousands of varied speakers/mics — the
 //     short-and-sometimes-soft regime the synthetic `say` corpus could not stress.
 //   Negatives — MUSAN noise, free-sound subset (US Public Domain): real ambient noise,
-//     already 16 kHz mono PCM16; plus generated digital silence.
-//   Music — intentionally NOT fetched yet: no license-clean *per-file* source without the
-//     11 GB MUSAN tarball. A clear follow-up (see bench/vad/README.md).
+//     already 16 kHz mono PCM16; real music (Kevin MacLeod / Incompetech, CC-BY-4.0)
+//     converted with ffmpeg; plus generated digital silence.
 //
+// Needs `curl` always; `ffmpeg` only for the music clips (skipped if absent).
 // Usage: npm run bench:vad:fetch-real   [-- --force]
 import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
@@ -28,13 +28,22 @@ const SR = 16000;
 const force = process.argv.includes("--force");
 
 const SC_WORDS = ["yes", "no", "stop", "go", "up", "down", "on", "off"];
-const SC_PER_WORD = 4; // 8 words × 4 distinct speakers = 32 real speech positives
-const SC_CANDIDATES = 14; // over-select per word, then drop silent/corrupt source clips
+const SC_PER_WORD = 8; // 8 words × 8 distinct speakers = 64 real speech positives
+const SC_CANDIDATES = 20; // over-select per word, then drop silent/corrupt source clips
 const MIN_PEAK_AMP = 0.02; // a real word peaks far above this; ~0 = silent/corrupt clip
 const SC_URL = "https://storage.googleapis.com/download.tensorflow.org/data/speech_commands_v0.02.tar.gz";
-const MUSAN_NOISE_COUNT = 14;
+const MUSAN_NOISE_COUNT = 24;
 const MUSAN_API = "https://huggingface.co/api/datasets/bilguun/musan-noise/tree/main/noise/free-sound";
 const MUSAN_RESOLVE = "https://huggingface.co/datasets/bilguun/musan-noise/resolve/main/noise/free-sound";
+// Real music negatives — Kevin MacLeod / Incompetech (CC-BY-4.0). Over-list; the fetch is
+// graceful (skips any track that 404s or fails to convert) and stops at MUSIC_COUNT.
+const MUSIC_COUNT = 8;
+const INCOMPETECH = "https://incompetech.com/music/royalty-free/mp3-royaltyfree";
+const MUSIC_TRACKS = [
+  "Carefree", "Cipher", "Sneaky Snitch", "Monkeys Spinning Monkeys", "Fluffing a Duck",
+  "Investigations", "Wallpaper", "Local Forecast - Elevator", "Dreams Become Real",
+  "Volatile Reaction", "Despair and Triumph", "Frost Waltz",
+];
 
 if (existsSync(resolve(outDir, "manifest.json")) && !force) {
   console.log("corpus-real/ already populated; pass --force to refetch. Skipping.");
@@ -128,6 +137,47 @@ noiseWavs.forEach((path, i) => {
   });
 });
 
+// --- Negatives: real music — Kevin MacLeod / Incompetech (CC-BY-4.0) via ffmpeg ---
+const haveFfmpeg = (() => {
+  try {
+    execFileSync("ffmpeg", ["-version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+let musicIdx = 0;
+if (!haveFfmpeg) {
+  console.log("ffmpeg not found — skipping music clips (install ffmpeg to include them).");
+} else {
+  console.log("Fetching real music (Kevin MacLeod / Incompetech, CC-BY-4.0)…");
+  for (const track of MUSIC_TRACKS) {
+    if (musicIdx >= MUSIC_COUNT) break;
+    const mp3 = resolve(tmpDir, `music_${musicIdx}.mp3`);
+    const name = `nonspeech_music_${String(musicIdx).padStart(2, "0")}.wav`;
+    try {
+      curl(["-o", mp3, `${INCOMPETECH}/${encodeURIComponent(track)}.mp3`]);
+      // A 20 s clip from 15 s in (past any quiet intro) → 16 k mono PCM16.
+      execFileSync("ffmpeg", [
+        "-hide_banner", "-loglevel", "error", "-y", "-ss", "15", "-t", "20",
+        "-i", mp3, "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le", resolve(outDir, name),
+      ]);
+      manifest.push({
+        file: name,
+        label: "nonspeech",
+        source: "Kevin MacLeod / Incompetech",
+        license: "CC-BY-4.0",
+        attribution: "Kevin MacLeod (incompetech.com), licensed under CC-BY-4.0",
+        note: `real music: "${track}"`,
+      });
+      musicIdx++;
+    } catch (e) {
+      console.log(`  skipped music "${track}" (${String(e.message).split("\n")[0]})`);
+    }
+  }
+  console.log(`Kept ${musicIdx} music clips.`);
+}
+
 // --- Negatives: digital silence (control) ---
 for (const ms of [1500, 2500]) {
   const name = `nonspeech_silence_${ms}.wav`;
@@ -141,7 +191,7 @@ writeFileSync(
     {
       sampleRate: SR,
       generatedBy: "bench/vad/fetch-real-corpus.mjs",
-      note: "REAL corpus (git-ignored audio). Positives: Google Speech Commands v2 (CC-BY-4.0). Negatives: MUSAN free-sound noise (US Public Domain) + digital silence. Music pending (see README).",
+      note: "REAL corpus (git-ignored audio). Positives: Google Speech Commands v2 (CC-BY-4.0). Negatives: MUSAN free-sound noise (US Public Domain) + Incompetech music (CC-BY-4.0) + digital silence.",
       clips: manifest,
     },
     null,

--- a/bench/vad/fetch-real-corpus.mjs
+++ b/bench/vad/fetch-real-corpus.mjs
@@ -167,7 +167,7 @@ if (!haveFfmpeg) {
         label: "nonspeech",
         source: "Kevin MacLeod / Incompetech",
         license: "CC-BY-4.0",
-        attribution: "Kevin MacLeod (incompetech.com), licensed under CC-BY-4.0",
+        attribution: "Kevin MacLeod (incompetech.com), CC-BY-4.0 https://creativecommons.org/licenses/by/4.0/",
         note: `real music: "${track}"`,
       });
       musicIdx++;


### PR DESCRIPTION
## Why

The #431 real corpus (32 speech / 16 noise, no music) gave the first authoritative VAD
numbers but was small and music-less — so item #420(4) (host→preset remap) wasn't yet
actionable. The founder asked to expand the corpus and draw findings. This roughly triples
it and adds the missing category — **real music** — turning the remap from "measured but
don't act yet" into a clear recommendation (implemented in the follow-up PR).

## What

`bench/vad/fetch-real-corpus.mjs` now fetches **98 clips** (was 48), all license-clean:
- **64 speech** — Google Speech Commands v2 (CC-BY-4.0), 8 words × 8 distinct speakers.
- **24 real ambient noise** — MUSAN free-sound (US Public Domain).
- **8 real music** — Kevin MacLeod / Incompetech (**CC-BY-4.0**), varied tracks → 20 s 16 kHz
  clips via `ffmpeg` (graceful: skips a 404 / missing-ffmpeg, attributed in the manifest).
- 2 digital silence controls.

Audio stays git-ignored; only the script + an attributed manifest are tracked.

## Findings (real corpus, 64 speech / 34 non-speech)

| preset | FRR | FAR (raw → gated) |
|---|---|---|
| highSensitivity | 3% | 59% → **56%** |
| balanced | 8% | 41% |
| conservative | 23% | 29% |
| none (v5) | 50% | 26% |

- **Music is the worst false-accept source — and `highSensitivity` admits *all* of it** (8/8
  = 100%; noise 11/24; silence 0/2). `balanced` cuts music to 5/8, noise to 9/24. Generic web
  pages often have background media playing, so binding the trigger-happiest preset to them is
  the worst match — #420's gap-#3 concern, now measured.
- **The FRR cost is concentrated in one hard word**: `balanced` clips `up` 4/8 (vs
  highSensitivity 1/8); every other word is caught by both. Isolated words are a harder test
  than connected dictation, so this **overstates** the real dictation FRR cost.
- The #420 gate still reduces FAR with zero FRR cost (59→56%) by dropping borderline non-speech;
  most real-noise/music false-accepts are confident, so the cure for those is a calmer preset.

### Item #420(4) recommendation (implemented in the follow-up PR)

Remap **generic / universal-dictation pages `highSensitivity` → `balanced`** (cuts FAR 56→41%
incl. music 8/8→5/8, for a small FRR cost that's mostly the isolated `up`). **Leave chat sites
at `balanced`** — the core product and the quietest context; no data-backed reason to make them
more trigger-happy. Net: `balanced` everywhere; `highSensitivity` reserved. (Noise/SNR and
mobile/desktop axes remain open refinements — they need device-labelled data.)

## Verification

- `npm test` green (type-check + Jest + Vitest 1456 passed/1 skipped); benchmark reruns
  reproduce the table (speech/noise deterministic; music depends on Incompetech availability).
- Reviewer-subagent verdict posted as a PR comment.

Advances #420 item 3 (corpus) and makes item 4 actionable. Benchmark/docs only — no `src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
