### PR TITLE
feat(vad): remap generic/dictation pages highSensitivity→balanced per benchmark (#420 item 4)

### DIFF
--- a/src/state-machines/AudioInputMachine.ts
+++ b/src/state-machines/AudioInputMachine.ts
@@ -8,7 +8,7 @@ import { OnscreenVADClient } from '../vad/OnscreenVADClient';
 import { VADClientInterface } from '../vad/VADClientInterface';
 import { logger } from "../LoggingModule";
 import { likelySupportsOffscreen, getBrowserInfo } from "../UserAgentModule";
-import { VADPreset } from "../vad/VADConfigs";
+import { VADPreset, selectVADPreset } from "../vad/VADConfigs";
 import { ChatbotIdentifier } from "../chatbots/ChatbotIdentifier";
 import { persistAudioSegment } from "../audio/AudioSegmentPersistence";
 
@@ -36,10 +36,13 @@ let previousDefaultDevice: MediaDeviceInfo | null = null;
 // VAD client instance - will be either OffscreenVADClient or OnscreenVADClient
 let vadClient: VADClientInterface | null = null;
 
-// Choose preset once based on chatbot context
-const currentVADPreset: VADPreset = ChatbotIdentifier.isInDictationMode()
-  ? "highSensitivity"
-  : "balanced";
+// Choose the VAD preset once based on chatbot context. #420 item 4: the host→preset
+// mapping is centralised + benchmark-driven in selectVADPreset (see bench/vad/README.md);
+// today every context resolves to `balanced` (generic/dictation pages used to get the
+// trigger-happy `highSensitivity`, which the benchmark showed over-uploads real noise/music).
+const currentVADPreset: VADPreset = selectVADPreset({
+  isDictation: ChatbotIdentifier.isInDictationMode(),
+});
 
 // Initialize the appropriate VAD client based on browser support
 function initializeVADClient() {

--- a/src/vad/VADConfigs.ts
+++ b/src/vad/VADConfigs.ts
@@ -13,15 +13,18 @@ import type { RealTimeVADOptions } from "@ricky0123/vad-web";
  * false-accepts. The #420 admission gate (`segmentAdmission.ts`) backstops that
  * false-accept risk; a VAD-quality benchmark to re-tune these numbers is #420 item 3.
  *
- * Wiring status (which presets a code path actually selects):
- *  - `highSensitivity` / `balanced`: selected by AudioInputMachine from the host —
- *    dictation/generic pages get `highSensitivity`, dedicated chat sites get `balanced`
- *    (revisiting that mapping is #420 item 4).
+ * Wiring status (which presets a code path actually selects) — see `selectVADPreset`:
+ *  - `balanced`: the preset every context uses today (#420 item 4). The VAD-quality
+ *    benchmark (bench/vad/README.md) put it at the knee of the false-reject/false-accept
+ *    trade-off, so it is the host-agnostic default.
+ *  - `highSensitivity`: previously bound to dictation/generic pages, but the benchmark
+ *    showed it false-accepts ~59% of real non-speech there (100% of music) for only a
+ *    marginal false-reject edge — so it is now **reserved, unselected** (the gap-#3 fix).
  *  - `conservative`: a valid noisy-environment preset that **no code path selects yet**.
- *    Kept (not deleted) because #420 item 4 plans to wire it to a noise/SNR estimate;
- *    its values are locked by test so it can't rot in the meantime.
+ *    Kept (not deleted) because #420 item 4 plans to wire it to a noise/SNR estimate.
  *  - `none`: the no-override fallback `initializeVAD` resolves to when no (or an
  *    unknown) preset is requested — it inherits the library's v5 defaults verbatim.
+ * (Both `highSensitivity` and `conservative` stay locked by test so they can't rot.)
  */
 export type VADPreset = "highSensitivity" | "balanced" | "conservative" | "none";
 
@@ -68,3 +71,29 @@ export const VAD_CONFIGS: Record<VADPreset, Partial<RealTimeVADOptions>> = {
     // No-override fallback: inherit all base options from Silero VAD v5.
   },
 };
+
+/** The context that drives VAD preset selection. */
+export interface VADSelectionContext {
+  /** True on generic / universal-dictation pages; false on dedicated chat sites. */
+  isDictation: boolean;
+}
+
+/**
+ * Choose the VAD preset for a context — #420 item 4, driven by the VAD-quality benchmark
+ * (`bench/vad/README.md`), not a guess.
+ *
+ * Both contexts map to `balanced` today:
+ *  - Generic / universal-dictation pages were `highSensitivity`, but on the real corpus it
+ *    false-accepts ~59% of non-speech there (100% of music) for only a marginal, mostly
+ *    isolated-"up" false-reject edge — so the noisiest, least-controlled context no longer
+ *    gets the trigger-happiest preset (the issue's gap #3).
+ *  - Dedicated chat sites stay `balanced` — the core product and the quietest context, with
+ *    no data-backed reason to make them *more* trigger-happy.
+ *
+ * `context` is unused today but kept as the seam for a future noise/SNR- or device-adaptive
+ * split (item 4's remaining refinement), which would re-diverge the mapping.
+ */
+export function selectVADPreset(context: VADSelectionContext): VADPreset {
+  void context;
+  return "balanced";
+}

--- a/test/state-machines/AudioInputMachine-presetWiring.spec.ts
+++ b/test/state-machines/AudioInputMachine-presetWiring.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * #420 item 4 wiring guard. The host→preset decision must go through the centralised,
+ * benchmark-driven `selectVADPreset` (which maps every context to `balanced`) — NOT the
+ * old inline `isInDictationMode() ? "highSensitivity" : "balanced"` ternary that bound
+ * the trigger-happiest preset to the noisiest (generic/dictation) context. Importing
+ * AudioInputMachine at runtime pulls in the whole content-script bootstrap, so — per the
+ * repo's source-scanning wiring guards — assert the wiring against the real source: it
+ * catches a revert to `highSensitivity` or a bypass of `selectVADPreset`.
+ */
+const src = readFileSync(
+  resolve(__dirname, "..", "..", "src/state-machines/AudioInputMachine.ts"),
+  "utf8"
+);
+
+describe("#420 AudioInputMachine selects the VAD preset via selectVADPreset", () => {
+  it("imports and calls selectVADPreset to choose currentVADPreset", () => {
+    expect(src).toMatch(/import\s*\{[^}]*\bselectVADPreset\b[^}]*\}\s*from\s*["']\.\.\/vad\/VADConfigs["']/);
+    expect(src).toMatch(/currentVADPreset[^=]*=\s*selectVADPreset\(/);
+  });
+
+  it("no longer hardcodes the trigger-happy highSensitivity preset for dictation pages", () => {
+    // The benchmark retired highSensitivity from active selection; it must not reappear
+    // as a literal preset choice in this file.
+    expect(src).not.toMatch(/["']highSensitivity["']/);
+  });
+});

--- a/test/vad/VADConfigs.spec.ts
+++ b/test/vad/VADConfigs.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { VAD_CONFIGS, type VADPreset } from "../../src/vad/VADConfigs";
+import { VAD_CONFIGS, selectVADPreset, type VADPreset } from "../../src/vad/VADConfigs";
 
 /**
  * #420 item 2 — Lock the VAD preset values. They were hand-tuned in one commit (PR
@@ -87,5 +87,30 @@ describe("#420 VAD_CONFIGS preset ordering invariants", () => {
     expect(VAD_CONFIGS.highSensitivity.minSpeechFrames!).toBeLessThan(
       VAD_CONFIGS.conservative.minSpeechFrames!
     );
+  });
+});
+
+/**
+ * #420 item 4 — host→preset selection. The VAD-quality benchmark (bench/vad/README.md)
+ * showed `highSensitivity` (previously bound to generic / universal-dictation pages, the
+ * noisiest context) false-accepts 59% of real non-speech there — 100% of music — for only
+ * a marginal false-reject edge concentrated in one short word. So the noisiest context no
+ * longer gets the trigger-happiest preset (the issue's gap #3): every context now uses
+ * `balanced` (the measured knee), and `highSensitivity` joins `conservative` as a reserved,
+ * unselected preset. This locks that decision; a future noise/SNR- or device-adaptive split
+ * would re-diverge them.
+ */
+describe("#420 selectVADPreset (host→preset mapping)", () => {
+  it("uses balanced for dictation / generic pages (was highSensitivity — the gap-#3 fix)", () => {
+    expect(selectVADPreset({ isDictation: true })).toBe("balanced");
+  });
+
+  it("uses balanced for dedicated chat sites (unchanged — the core product, quietest context)", () => {
+    expect(selectVADPreset({ isDictation: false })).toBe("balanced");
+  });
+
+  it("never selects the trigger-happy highSensitivity preset for any current context", () => {
+    const chosen: VADPreset[] = [true, false].map((isDictation) => selectVADPreset({ isDictation }));
+    expect(chosen).not.toContain("highSensitivity");
   });
 });


### PR DESCRIPTION
## Why

#420 item 4 — re-map the host→VAD-preset mapping, now that the VAD-quality benchmark
(#430/#431/#432) gives the data the issue required ("only once #3 exists, not a blind
swap"). The benchmark exposed the exact problem the issue's gap-#3 hypothesised: the
**trigger-happiest preset was bound to the noisiest context.**

On the real corpus (64 real confirmations / 34 real noise+music):

| preset | FRR | FAR |
|---|---|---|
| highSensitivity (generic/dictation) | 3% | **59%** (100% of music) |
| balanced (chat) | 8% | 41% |

Generic / universal-dictation pages — the noisiest, least-controlled context, often with
**background music/video playing** — were getting `highSensitivity`, which false-accepts
**59%** of real non-speech there (and **100% of music**), a large hallucination surface.
The cost of calming them is small and concentrated: FRR 3%→8%, almost entirely the short,
soft isolated word "up" — and isolated words overstate the real *connected*-dictation cost.

## What

- **`src/vad/VADConfigs.ts`** — new `selectVADPreset(context)`: the centralised,
  benchmark-driven host→preset decision. Today it returns **`balanced` for every context**
  (the measured knee of the false-reject/false-accept trade-off). `context` is retained as
  the seam for a future noise/SNR- or device-adaptive split.
- **`src/state-machines/AudioInputMachine.ts`** — replaces the inline
  `isDictation ? "highSensitivity" : "balanced"` ternary with `selectVADPreset(...)`.

**Net behavior change:** generic / dictation pages `highSensitivity` → `balanced`. **Chat
sites are unchanged** (`balanced`) — they're the core product and the quietest context, with
no data-backed reason to make them *more* trigger-happy, so the core voice experience is
untouched. `highSensitivity` joins `conservative` as a reserved, unselected preset (still
defined + locked by test, not deleted).

## Verification

- `npm test` green: type-check + Jest + **Vitest (1461 passed, 1 skipped)**.
- Fail-first tests: `VADConfigs.spec.ts` locks the decision (`selectVADPreset` → `balanced`
  for both contexts, never `highSensitivity`); `AudioInputMachine-presetWiring.spec.ts`
  source-scans that the machine calls `selectVADPreset` and no longer hardcodes
  `highSensitivity` (catches a revert).
- Adversarial subagent review: **approve** — the behavior delta is exactly the intended
  remap (nothing else), faithful to the documented data, no collateral damage, the residual
  FRR risk acknowledged. Verdict posted as a PR comment.

## Scope note

This is a UX-tuning change (which preset), explicitly authorised by the founder. Not
manifest/permissions/auth/server-contract. The remaining item-4 *refinements* — a noise/SNR
or mobile/desktop adaptive axis, and a broader corpus — are documented in `bench/vad/README.md`
as future enhancements (they need device-labelled data), not blockers.

Closes #420 (items 1/2/5 in #423, observability in #424, benchmark in #430/#431/#432, this
remap completes item 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
