### PR TITLE
fix(release): make headless `release:submit` usable — npm hints, .env.publish auto-load, real OAuth errors

### DIFF
--- a/doc/release/publishing-credentials.md
+++ b/doc/release/publishing-credentials.md
@@ -9,9 +9,11 @@ requires `--yes`; `--dry-run` only auth-checks (no upload/publish).
 > everywhere — the API is the only real automation path. See `chrome-web-store.md`.
 
 Credentials are **never** stored in the repo. Provide them as **environment variables** at submit
-time (e.g. a local, gitignored `.env.publish` you `set -a; source .env.publish; set +a`, or your
-shell/CI secret store). The tool only *reads* `process.env`; it never reads `.env.production` or
-echoes secret values.
+time. The easiest way: drop them in a local, gitignored **`.env.publish`** at the repo root
+(`KEY=value` per line) — `submit` **auto-loads that file** into `process.env`, so no manual
+`source` is needed. Already-exported shell vars (or your CI secret store) take precedence over the
+file. The tool reads only `process.env` and `.env.publish`; it **never** reads `.env.production`,
+and it logs only the *names* of the keys it loaded — never their values.
 
 ## Usage
 

--- a/doc/release/publishing-credentials.md
+++ b/doc/release/publishing-credentials.md
@@ -43,10 +43,35 @@ Requires the built artifacts (`release:build` first): `dist/saypi.chrome.zip`,
 | `CWS_REFRESH_TOKEN` | long-lived refresh token (one-time, below) |
 
 **One-time setup:** Google Cloud Console → new project → **enable the Chrome Web Store API** →
-create an **OAuth client (Web application)** with redirect `https://developers.google.com/oauthplayground`
-→ OAuth Playground (use your own creds) → authorize scope `https://www.googleapis.com/auth/chromewebstore`
-**signed in as the account that owns the extension** → exchange for a **refresh token**. The owning
-account **must have 2-Step Verification on** or publish returns 403. (Flow: `using-api` guide.)
+create an **OAuth client (Web application)** with redirect `https://developers.google.com/oauthplayground`.
+The owning account **must have 2-Step Verification on** or publish returns 403.
+
+### Minting `CWS_REFRESH_TOKEN` (the part you'll redo)
+
+`CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, and `CWS_REFRESH_TOKEN` must **all come from the same OAuth
+client** — a refresh token presented with a *different* client's id/secret fails the token
+exchange with **`401 unauthorized_client`** (not `invalid_grant`; that one means expired/revoked).
+
+1. Google Cloud Console → the OAuth client → copy the **Client ID** and download the full
+   **Client secret** (the console only shows it masked).
+2. Open **https://developers.google.com/oauthplayground** → top-right **⚙️** → tick
+   **"Use your own OAuth credentials"** → paste that Client ID + secret.
+3. Step 1 → **"Input your own scopes"** → `https://www.googleapis.com/auth/chromewebstore` →
+   **Authorize APIs**.
+4. Sign in **as the account that owns the extension**. ("Google hasn't verified this app" →
+   **Advanced → Go to … (unsafe)** — it's your own client.)
+5. Step 2 → **Exchange authorization code for tokens** → copy the **Refresh token** (`1//…`).
+6. Put all three (id, secret, refresh token) in `.env.publish`.
+
+If the exchange returns **no refresh token** (only an access token), you've authorized this
+client+account before — revoke at https://myaccount.google.com/permissions and redo, or confirm
+"Use your own credentials" is ticked (the Playground forces `prompt=consent`).
+
+> ⚠️ **Refresh-token lifetime hinges on the OAuth app's publishing status** (Google Auth Platform
+> → **Audience** → *Publishing status*): **"Testing" → the refresh token expires in ~7 days**
+> (you'll remint weekly); **"In production" → long-lived** (no inactivity expiry under 6 months).
+> For a publishing client you only use yourself, **publish the app to production** so the token
+> persists. A working `--dry-run` today does **not** tell you which you have — only this field does.
 
 API V2 (`chromewebstore.googleapis.com`) is current; V1 sunsets 2026-10-15. V2 can't create items or
 change visibility (fine — Say, Pi exists).

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -585,11 +585,16 @@ export function interpretCwsPublish(json = {}) {
   const state = json.state;
   return { ok: ["PENDING_REVIEW", "STAGED", "PUBLISHED", "PUBLISHED_TO_TESTERS"].includes(state), state, warnings: json.warningInfo?.warnings || [], raw: json };
 }
-/** V2 surfaces failures as {error:{code,status,message}} — format for a clear CI message. */
+/**
+ * Format a Chrome API failure for a clear CI message. Two shapes occur:
+ *  - V2 store API: {error:{code,status,message}} → "STATUS: message".
+ *  - OAuth token endpoint: {error:"invalid_grant", error_description:"…"} where `error` is
+ *    a STRING. Must NOT be treated as the object shape (that rendered "undefined: undefined").
+ */
 export function cwsErrorMessage(json = {}) {
   const e = json.error;
-  if (e) return `${e.status || e.code}: ${e.message}`;
-  if (json.error_description || json.error) return json.error_description || json.error; // oauth token error shape
+  if (e && typeof e === "object") return `${e.status || e.code}: ${e.message}`;
+  if (json.error_description || e) return json.error_description || e; // oauth token error shape (string `error`)
   return "unknown error";
 }
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -44,6 +44,9 @@ const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
 const STORES_PATH = join(repoRoot, "doc", "release", "stores.json");
 const RELEASE_NOTES_PATH = join(repoRoot, "_locales", "en", "release_notes.txt");
 const DIST = join(repoRoot, "dist");
+// Gitignored, founder-provided publishing credentials (#412). Loaded ONLY for `submit`,
+// and ONLY this file — never .env.production (which carries build secrets, see SAFETY above).
+const ENV_PUBLISH_PATH = join(repoRoot, ".env.publish");
 
 const C = { reset: "\x1b[0m", red: "\x1b[31m", green: "\x1b[32m", yellow: "\x1b[33m", dim: "\x1b[2m", bold: "\x1b[1m" };
 const log = (m) => console.log(m);
@@ -438,11 +441,34 @@ function createGhRelease(v, tag) {
  * command: a real submit publishes to a live store. `--dry-run` only auth-checks (no publish);
  * a real submit requires --yes and is founder-only. Credentials come from env (founder-provided).
  */
+// Load .env.publish into process.env so `submit` works without a manual
+// `set -a; source .env.publish; set +a`. Already-exported shell vars win (we never
+// override), and values are never logged — only the names of keys loaded. Returns the
+// count loaded. A simple KEY=VALUE parser: optional leading `export `, `#` comments and
+// blank lines skipped, surrounding quotes stripped. (Deliberately only .env.publish.)
+function loadPublishEnv() {
+  if (!existsSync(ENV_PUBLISH_PATH)) return 0;
+  const loaded = [];
+  for (const raw of readFileSync(ENV_PUBLISH_PATH, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^(?:export\s+)?([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (!m) continue;
+    const [, key, rawVal] = m;
+    if (key in process.env) continue; // explicit shell env takes precedence
+    process.env[key] = rawVal.replace(/^(['"])(.*)\1$/, "$2");
+    loaded.push(key);
+  }
+  if (loaded.length) log(`${C.dim}Loaded ${loaded.length} credential(s) from .env.publish: ${loaded.join(", ")}${C.reset}`);
+  return loaded.length;
+}
+
 async function cmdSubmit({ store, version, yes, dryRun }) {
   if (!PUBLISH_STORES.includes(store)) {
     bad(`\`submit\` needs a store: ${PUBLISH_STORES.join(" | ")} (e.g. \`npm run release:submit -- chrome --dry-run\`).`);
     process.exit(2);
   }
+  loadPublishEnv();
   if (!dryRun) requireYes(`submit ${store}`, { yes });
   const v = version || pkgVersion();
   log(`${C.bold}${dryRun ? "Dry-run" : "Submitting"} ${store} — v${v}${C.reset}`);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -209,7 +209,13 @@ function cmdPacket({ version }) {
 
 function requireYes(cmd, flags) {
   if (!flags.yes) {
+    // `cmd` is the subcommand plus any positional, e.g. "bump" or "submit chrome".
+    // Show the npm-correct form too: via `npm run`, flags MUST follow a `--` separator,
+    // or npm swallows them and a bare `--yes`/`--dry-run` silently never reaches this script.
+    const [sub, ...rest] = cmd.split(" ");
+    const npmHint = `npm run release:${sub} -- ${[...rest, "--yes"].join(" ")}`;
     bad(`\`${cmd}\` mutates state and is founder-only. Re-run with --yes once you've reviewed the plan.`);
+    warn(`Via npm, flags need a \`--\` separator: ${npmHint}`);
     warn(`Release is irreversible once users auto-update (AGENTS.md). Never run this autonomously.`);
     process.exit(2);
   }
@@ -434,7 +440,7 @@ function createGhRelease(v, tag) {
  */
 async function cmdSubmit({ store, version, yes, dryRun }) {
   if (!PUBLISH_STORES.includes(store)) {
-    bad(`\`submit\` needs a store: ${PUBLISH_STORES.join(" | ")} (e.g. \`submit chrome --dry-run\`).`);
+    bad(`\`submit\` needs a store: ${PUBLISH_STORES.join(" | ")} (e.g. \`npm run release:submit -- chrome --dry-run\`).`);
     process.exit(2);
   }
   if (!dryRun) requireYes(`submit ${store}`, { yes });
@@ -504,6 +510,7 @@ async function main() {
     default:
       log(`Usage: node scripts/release.mjs <preflight|plan|packet|bump|build|verify|tag|finalize|submit> [--save] [--version X] [--dry-run] [--yes]`);
       log(`       submit <chrome|edge|firefox> [--dry-run | --yes]   # ⛔ founder-only API submission (#412)`);
+      log(`Via npm, put flags after \`--\` or npm drops them, e.g. \`npm run release:submit -- chrome --dry-run\`.`);
       process.exit(command ? 1 : 0);
   }
 }

--- a/test/scripts/release-lib.spec.ts
+++ b/test/scripts/release-lib.spec.ts
@@ -430,6 +430,10 @@ describe("Chrome Web Store API helpers", () => {
     expect(interpretCwsPublish({ state: "REJECTED" }).ok).toBe(false);
     expect(cwsErrorMessage({ error: { status: "PERMISSION_DENIED", message: "nope" } })).toBe("PERMISSION_DENIED: nope");
     expect(cwsErrorMessage({ error_description: "bad refresh token" })).toBe("bad refresh token");
+    // OAuth token endpoint shape: `error` is a STRING (not the V2 {code,status,message}
+    // object) with a sibling error_description. Must not render "undefined: undefined".
+    expect(cwsErrorMessage({ error: "unauthorized_client", error_description: "Unauthorized" })).toBe("Unauthorized");
+    expect(cwsErrorMessage({ error: "invalid_grant" })).toBe("invalid_grant");
   });
 });
 


### PR DESCRIPTION
Three fixes to the headless `release:submit` path (#412), all surfaced while wiring up the Chrome Web Store API for the v1.12.0 release.

## 1. npm-correct flag hints

`npm run release:submit chrome --dry-run` exits at the founder-gate with no clue why: `npm` swallows the trailing flag (flags after an `npm run` script need a `--` separator), so the script ran as a real submit and hit the `--yes` gate. The script's own messages compounded it by suggesting bare forms like `submit chrome --dry-run`.

- `requireYes` now prints the `--`-separated npm form for whichever command was gated (`npm run release:submit -- chrome --yes`, `npm run release:bump -- --yes`).
- The submit store-missing example and the usage block use/explain the `--` form.

## 2. Auto-load `.env.publish`

`submit` only read `process.env`, so credentials had to be `set -a; source .env.publish; set +a`'d by hand every run. `cmdSubmit` now auto-loads a gitignored `.env.publish` from the repo root:
- Only `.env.publish` — **never** `.env.production` (build secrets stay out).
- Already-exported shell vars / CI secrets take precedence (the file never overrides them).
- Logs only the **names** of keys loaded, never values.

## 3. Surface real OAuth token errors

`cwsErrorMessage` assumed `json.error` is always the V2 store-API object `{code,status,message}`. Google's **OAuth token endpoint** uses the OAuth shape where `error` is a **string** (`unauthorized_client`, `invalid_grant`) with a sibling `error_description` — so a refresh-token auth failure rendered the useless `Chrome auth failed: undefined: undefined`, hiding the real 401. Now branches on `typeof` and shows the real message (verified end-to-end: `Chrome auth failed: Unauthorized`). Fail-first test added.

## Verification

- `vitest run test/scripts/release-lib.spec.ts test/scripts/release-publish.spec.ts` → 62 passing (incl. new OAuth-shape coverage).
- Exercised every gate/usage path, the `.env.publish` loader (key-name logging, shell precedence, quote-stripping), and the improved error message against live Chrome creds.

Direct `node scripts/release.mjs …` / CI usage is unaffected. Tracked docs (`publishing-credentials.md`) updated for the auto-load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)