### PR TITLE
feat(telemetry): attribute usage to teamId once authorized (#437)

### DIFF
--- a/src/TranscriptionForm.ts
+++ b/src/TranscriptionForm.ts
@@ -52,6 +52,7 @@ export async function constructTranscriptionFormData(
     if (usageMeta.version) formData.append("version", usageMeta.version);
     if (usageMeta.app) formData.append("app", usageMeta.app);
     if (usageMeta.language) formData.append("language", usageMeta.language);
+    if (usageMeta.teamId) formData.append("teamId", usageMeta.teamId);
   } catch (error) {
     logger.warn("[TranscriptionForm] Failed to add usage analytics metadata:", error);
   }

--- a/src/TranscriptionModule.ts
+++ b/src/TranscriptionModule.ts
@@ -473,6 +473,7 @@ async function uploadAudioForRefinementInternal(
       if (usageMeta.version) formData.append("version", usageMeta.version);
       if (usageMeta.app) formData.append("app", usageMeta.app);
       if (usageMeta.language) formData.append("language", usageMeta.language);
+      if (usageMeta.teamId) formData.append("teamId", usageMeta.teamId);
     } catch (error) {
       logger.warn(`[Refinement ${requestId}] Failed to add usage metadata:`, error);
     }

--- a/src/tts/TextToSpeechService.ts
+++ b/src/tts/TextToSpeechService.ts
@@ -24,6 +24,7 @@ interface TTSRequestData {
   clientId?: string;
   version?: string;
   app?: string;
+  teamId?: string;
 }
 
 /**
@@ -106,6 +107,7 @@ export class TextToSpeechService {
       if (usageMeta.clientId) data.clientId = usageMeta.clientId;
       if (usageMeta.version) data.version = usageMeta.version;
       if (usageMeta.app) data.app = usageMeta.app;
+      if (usageMeta.teamId) data.teamId = usageMeta.teamId;
     } catch (error) {
       console.warn("[TextToSpeechService] Failed to add usage analytics metadata:", error);
       // Continue without analytics metadata if there's an error

--- a/src/usage/UsageMetadata.ts
+++ b/src/usage/UsageMetadata.ts
@@ -8,6 +8,13 @@ export interface UsageMetadata {
   version?: string;
   app?: string;
   language?: string;
+  /**
+   * The authenticated user's team id (from the JWT claims). Present only once
+   * the user is signed in; absent for anonymous traffic. Sending it attributes
+   * first-conversation usage to the user's team so the onboarding funnel can
+   * tell "installed but never succeeded" apart from "never installed" (#437).
+   */
+  teamId?: string;
 }
 
 /**
@@ -44,6 +51,19 @@ export async function buildUsageMetadata(chatbot?: Chatbot): Promise<UsageMetada
     if (language) result.language = language;
   } catch (e) {
     console.warn("[UsageMetadata] Failed to resolve language", e);
+  }
+
+  try {
+    const { getJwtManagerSync } = await import("../JwtManager");
+    const jwt = getJwtManagerSync();
+    // Only attribute to a team once the user is actually signed in; anonymous
+    // traffic stays keyed on clientId alone.
+    if (jwt.isAuthenticated()) {
+      const teamId = jwt.getClaims()?.teamId;
+      if (teamId) result.teamId = teamId;
+    }
+  } catch (e) {
+    console.warn("[UsageMetadata] Failed to resolve teamId", e);
   }
 
   return result;

--- a/test/TranscriptionModule.formdata.spec.ts
+++ b/test/TranscriptionModule.formdata.spec.ts
@@ -19,6 +19,13 @@ vi.mock("../src/usage/ClientIdManager", () => ({
 vi.mock("../src/usage/VersionManager", () => ({
   getExtensionVersion: vi.fn().mockReturnValue("1.2.3-test"),
 }));
+// Authenticated user with a team — teamId should be forwarded (#437)
+vi.mock("../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({
+    isAuthenticated: () => true,
+    getClaims: () => ({ teamId: "team-99" }),
+  }),
+}));
 
 // Mock preferences to control language and flags
 vi.mock("../src/prefs/PreferenceModule", () => ({
@@ -95,6 +102,7 @@ describe("TranscriptionModule form data analytics fields", () => {
     expect(asMap.get("version")).toBe("1.2.3-test");
     expect(asMap.get("app")).toBe("mockbot");
     expect(asMap.get("language")).toBe("en-US");
+    expect(asMap.get("teamId")).toBe("team-99");
     // Restore append
     (FormData.prototype as any).append = originalAppend;
   });

--- a/test/usage/UsageMetadata.teamId.spec.ts
+++ b/test/usage/UsageMetadata.teamId.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, beforeEach, expect, vi } from "vitest";
+
+// Stable stubs for the always-present fields so the test focuses on teamId.
+vi.mock("../../src/usage/ClientIdManager", () => ({
+  getClientId: vi.fn().mockResolvedValue("client-uuid"),
+}));
+vi.mock("../../src/usage/VersionManager", () => ({
+  getExtensionVersion: vi.fn().mockReturnValue("9.9.9"),
+}));
+vi.mock("../../src/chatbots/ChatbotIdentifier", () => ({
+  ChatbotIdentifier: { getAppId: () => "pi" },
+}));
+vi.mock("../../src/prefs/PreferenceModule", () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({ getCachedLanguage: () => "en-US" }),
+  },
+}));
+
+// The JWT manager is the source of teamId. We swap its claims/auth state per test.
+const getClaims = vi.fn();
+const isAuthenticated = vi.fn();
+vi.mock("../../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({ getClaims, isAuthenticated }),
+}));
+
+import { buildUsageMetadata } from "../../src/usage/UsageMetadata";
+
+describe("buildUsageMetadata — teamId attribution (#437)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes teamId when the user is authenticated", async () => {
+    isAuthenticated.mockReturnValue(true);
+    getClaims.mockReturnValue({ userId: "u1", teamId: "team-42" });
+
+    const meta = await buildUsageMetadata();
+
+    expect(meta.teamId).toBe("team-42");
+    // existing fields still populated
+    expect(meta.clientId).toBe("client-uuid");
+  });
+
+  it("omits teamId when the user is not authenticated (stays anonymous)", async () => {
+    isAuthenticated.mockReturnValue(false);
+    getClaims.mockReturnValue(null);
+
+    const meta = await buildUsageMetadata();
+
+    expect(meta.teamId).toBeUndefined();
+    // anonymous device id is still sent
+    expect(meta.clientId).toBe("client-uuid");
+  });
+
+  it("omits teamId when authenticated but the claim is missing/empty", async () => {
+    isAuthenticated.mockReturnValue(true);
+    getClaims.mockReturnValue({ userId: "u1", teamId: "" });
+
+    const meta = await buildUsageMetadata();
+
+    expect(meta.teamId).toBeUndefined();
+  });
+
+  it("does not throw if reading claims fails — usage metadata still builds", async () => {
+    isAuthenticated.mockImplementation(() => {
+      throw new Error("jwt unavailable");
+    });
+
+    const meta = await buildUsageMetadata();
+
+    expect(meta.teamId).toBeUndefined();
+    expect(meta.clientId).toBe("client-uuid");
+  });
+});


### PR DESCRIPTION
## What & why

Extension-side **funnel-telemetry slice** of #437 (week-1 onboarding program, Phase 5).

Today the extension's STT/TTS usage traffic carries only an anonymous `clientId`, never the signed-in user's team. As the issue notes, that makes "installed but never had a successful conversation" **indistinguishable from "never installed"** — the measurement blind spot the onboarding funnel needs closed.

This PR adds `teamId` (from the JWT claims) to `UsageMetadata` and forwards it on every usage send site, so `saypi-saas` can attribute the **first conversation** to the user's team.

## Changes

- `src/usage/UsageMetadata.ts` — add `teamId?` to the `UsageMetadata` interface; populate it from `getJwtManagerSync().getClaims()?.teamId`, **gated on `isAuthenticated()`** so anonymous traffic stays keyed on `clientId` alone. Failure to read claims is swallowed (usage metadata still builds), matching the other fields.
- Forward `teamId` from all three send sites:
  - `src/TranscriptionForm.ts` — main STT conversation transcription (FormData)
  - `src/TranscriptionModule.ts` — dictation-refinement transcription (FormData)
  - `src/tts/TextToSpeechService.ts` — TTS request body (`TTSRequestData` gains `teamId?`)

The field is backward-compatible: the backend already receives these requests and can start keying on `teamId` when present.

## Tests (fail-first TDD)

- New `test/usage/UsageMetadata.teamId.spec.ts` — teamId included when authenticated; omitted when unauthenticated / claim empty / claims read throws. (Confirmed failing before the implementation.)
- Extended `test/TranscriptionModule.formdata.spec.ts` — asserts `teamId` is forwarded end-to-end on the refinement send path.
- Full suite green: Vitest 1470 passed (1 skipped), Jest passed, `tsc --noEmit` clean.

## Scope / follow-ups

This is **one slice** of epic #437. Deliberately **not** in this PR:
- The explicit **"connected" signal** — needs a new `saypi-saas` backend endpoint; raising as a cross-repo coordination question rather than inventing a contract.
- First-run onboarding surface, mic-permission recovery + live mic test, quiet/whisper mode, speed-payoff reveal — tracked as subsequent slices.

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)