### PR TITLE
feat(onboarding): first-run welcome tab on fresh install (#437)

### DIFF
--- a/.wxt/types/paths.d.ts
+++ b/.wxt/types/paths.d.ts
@@ -42,6 +42,7 @@ declare module "wxt/browser" {
     | "/icons/sixty-seconds.svg"
     | "/logos/marquee.png"
     | "/offscreen.html"
+    | "/onboarding.html"
     | "/ort-wasm-simd-threaded.mjs"
     | "/permissions.html"
     | "/settings.html"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1158,6 +1158,46 @@
     "message": "Releasing VAD resources...",
     "description": "VAD detail when releasing VAD resources."
   },
+  "onboarding_heading": {
+    "message": "🗣️ Welcome to Say, Pi",
+    "description": "Main heading on the first-run onboarding page."
+  },
+  "onboarding_intro": {
+    "message": "You're two steps away from your first spoken conversation with an AI. Talking is about 3× faster than typing — let's get you set up.",
+    "description": "Intro paragraph on the first-run onboarding page."
+  },
+  "onboarding_step1Title": {
+    "message": "Pin Say, Pi to your toolbar",
+    "description": "Title of the first onboarding step (pin the extension)."
+  },
+  "onboarding_step1Body": {
+    "message": "Click the puzzle-piece 🧩 icon at the top-right of your browser, then the pin 📌 next to Say, Pi. That keeps the call button one click away.",
+    "description": "Body of the first onboarding step explaining how to pin the extension."
+  },
+  "onboarding_step2Title": {
+    "message": "Open an AI chat and start talking",
+    "description": "Title of the second onboarding step (start a conversation)."
+  },
+  "onboarding_step2Body": {
+    "message": "Head to one of the supported assistants below, then tap the Say, Pi call button and say hello. We'll ask for microphone access the first time — that's expected, and we only listen while you're actively in a call.",
+    "description": "Body of the second onboarding step explaining how to start a voice conversation."
+  },
+  "onboarding_ctaPi": {
+    "message": "Open Pi",
+    "description": "Button label that opens Pi.ai."
+  },
+  "onboarding_ctaClaude": {
+    "message": "Open Claude",
+    "description": "Button label that opens Claude.ai."
+  },
+  "onboarding_ctaChatgpt": {
+    "message": "Open ChatGPT",
+    "description": "Button label that opens ChatGPT."
+  },
+  "onboarding_footer": {
+    "message": "You can revisit this any time from Say, Pi's settings. Your privacy matters — audio is only captured during an active call.",
+    "description": "Footer text on the first-run onboarding page."
+  },
   "permissions_promptTitle": {
     "message": "Microphone Permission",
     "description": "Title of the permissions prompt page."

--- a/entrypoints/onboarding/index.html
+++ b/entrypoints/onboarding/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Welcome to Say, Pi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <script type="module" src="./index.ts"></script>
+  </head>
+  <body>
+    <main class="card">
+      <h1 id="onboarding-heading">🗣️ Welcome to Say, Pi</h1>
+      <p id="onboarding-intro" class="lead">
+        You're two steps away from your first spoken conversation with an AI. Talking is
+        about 3× faster than typing — let's get you set up.
+      </p>
+
+      <ol class="steps">
+        <li>
+          <h2 id="onboarding-step1-title">Pin Say, Pi to your toolbar</h2>
+          <p id="onboarding-step1-body">
+            Click the puzzle-piece <span aria-hidden="true">🧩</span> icon at the top-right
+            of your browser, then the pin <span aria-hidden="true">📌</span> next to
+            Say, Pi. That keeps the call button one click away.
+          </p>
+        </li>
+        <li>
+          <h2 id="onboarding-step2-title">Open an AI chat and start talking</h2>
+          <p id="onboarding-step2-body">
+            Head to one of the supported assistants below, then tap the Say, Pi call
+            button and say hello. We'll ask for microphone access the first time — that's
+            expected, and we only listen while you're actively in a call.
+          </p>
+          <div class="cta-row">
+            <a class="cta" id="onboarding-cta-pi" href="https://pi.ai/talk" target="_blank" rel="noopener noreferrer">Open Pi</a>
+            <a class="cta" id="onboarding-cta-claude" href="https://claude.ai/new" target="_blank" rel="noopener noreferrer">Open Claude</a>
+            <a class="cta" id="onboarding-cta-chatgpt" href="https://chatgpt.com/" target="_blank" rel="noopener noreferrer">Open ChatGPT</a>
+          </div>
+        </li>
+      </ol>
+
+      <p class="footer-text" id="onboarding-footer">
+        You can revisit this any time from Say, Pi's settings. Your privacy matters — audio
+        is only captured during an active call.
+      </p>
+    </main>
+  </body>
+</html>

--- a/entrypoints/onboarding/index.ts
+++ b/entrypoints/onboarding/index.ts
@@ -1,0 +1,2 @@
+import "./style.css";
+import "../../src/onboarding/onboarding-page.ts";

--- a/entrypoints/onboarding/style.css
+++ b/entrypoints/onboarding/style.css
@@ -1,0 +1,112 @@
+:root {
+  --saypi-ink: #2c3e50;
+  --saypi-body: #3a3f47;
+  --saypi-accent: #6c5ce7;
+  --saypi-accent-ink: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Roboto", system-ui, sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  color: var(--saypi-body);
+  background: linear-gradient(135deg, #f5f3ff 0%, #eef2ff 100%);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 48px 20px;
+}
+
+.card {
+  background: #fff;
+  max-width: 560px;
+  width: 100%;
+  padding: 40px 40px 32px;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(44, 62, 80, 0.12);
+}
+
+h1 {
+  color: var(--saypi-ink);
+  margin: 0 0 12px;
+  font-size: 1.8rem;
+}
+
+.lead {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin: 0 0 28px;
+}
+
+.steps {
+  list-style: none;
+  counter-reset: step;
+  margin: 0;
+  padding: 0;
+}
+
+.steps > li {
+  counter-increment: step;
+  position: relative;
+  padding: 0 0 24px 52px;
+}
+
+.steps > li::before {
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--saypi-accent);
+  color: var(--saypi-accent-ink);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.steps h2 {
+  font-size: 1.1rem;
+  color: var(--saypi-ink);
+  margin: 4px 0 6px;
+}
+
+.steps p {
+  margin: 0 0 12px;
+  line-height: 1.6;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.cta {
+  display: inline-block;
+  background: var(--saypi-accent);
+  color: var(--saypi-accent-ink);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 10px 18px;
+  border-radius: 8px;
+  transition: filter 0.15s ease;
+}
+
+.cta:hover,
+.cta:focus {
+  filter: brightness(1.08);
+}
+
+.footer-text {
+  font-size: 0.9rem;
+  color: #7a7f87;
+  margin: 16px 0 0;
+  line-height: 1.5;
+}

--- a/src/onboarding/firstRun.ts
+++ b/src/onboarding/firstRun.ts
@@ -1,0 +1,64 @@
+/**
+ * First-run onboarding gating (#437).
+ *
+ * Decides whether to open the post-install onboarding tab and guarantees it
+ * only ever happens once on a fresh install — never on a browser/extension
+ * update, and never repeatedly. The logic is dependency-injected so it can be
+ * unit-tested without a real `browser` environment; the background service
+ * worker wires it to `browser.tabs` / `browser.storage.local` (see
+ * `src/svc/background.ts`).
+ */
+
+/** Extension-root path of the onboarding page (WXT emits `onboarding.html`). */
+export const ONBOARDING_PAGE_PATH = "onboarding.html";
+
+/** Storage key recording that the first-run tab has already been shown. */
+export const ONBOARDING_SHOWN_KEY = "saypi_onboarding_shown";
+
+/** The shape of `runtime.onInstalled` details we care about. */
+export interface InstalledDetailsLike {
+  reason?: string;
+}
+
+export interface FirstRunDeps {
+  /** Opens a new tab at the given URL. */
+  openTab: (url: string) => Promise<unknown>;
+  /** Resolves an extension-relative path to a full extension URL. */
+  getUrl: (path: string) => string;
+  /** Minimal async key/value storage (e.g. browser.storage.local). */
+  storage: {
+    get: (key: string) => Promise<unknown>;
+    set: (key: string, value: unknown) => Promise<void>;
+  };
+}
+
+/** True only for a brand-new install (not an update or browser update). */
+export function isFreshInstall(reason: string | undefined): boolean {
+  return reason === "install";
+}
+
+/**
+ * Opens the onboarding tab exactly once on a fresh install. Returns whether a
+ * tab was opened. Swallows all errors — a failure here must never break
+ * extension installation.
+ */
+export async function maybeOpenFirstRunTab(
+  details: InstalledDetailsLike | undefined,
+  deps: FirstRunDeps
+): Promise<boolean> {
+  try {
+    if (!isFreshInstall(details?.reason)) return false;
+
+    // Guard against re-showing (e.g. uninstall/reinstall loops, or an install
+    // event arriving more than once).
+    const alreadyShown = await deps.storage.get(ONBOARDING_SHOWN_KEY);
+    if (alreadyShown) return false;
+
+    await deps.openTab(deps.getUrl(ONBOARDING_PAGE_PATH));
+    await deps.storage.set(ONBOARDING_SHOWN_KEY, true);
+    return true;
+  } catch (e) {
+    console.debug("[Onboarding] Failed to open first-run tab:", e);
+    return false;
+  }
+}

--- a/src/onboarding/onboarding-page.ts
+++ b/src/onboarding/onboarding-page.ts
@@ -1,0 +1,56 @@
+/**
+ * First-run onboarding page logic (#437).
+ *
+ * The page ships with English text inline in the HTML; this localizes it for
+ * other locales by id. The mapping + apply step are extracted as a pure
+ * function so they can be unit-tested in JSDOM without the extension runtime.
+ */
+import getMessage from "../i18n";
+
+/** Maps element ids in onboarding/index.html to their i18n message keys. */
+export const ONBOARDING_I18N_KEYS: Record<string, string> = {
+  "onboarding-heading": "onboarding_heading",
+  "onboarding-intro": "onboarding_intro",
+  "onboarding-step1-title": "onboarding_step1Title",
+  "onboarding-step1-body": "onboarding_step1Body",
+  "onboarding-step2-title": "onboarding_step2Title",
+  "onboarding-step2-body": "onboarding_step2Body",
+  "onboarding-cta-pi": "onboarding_ctaPi",
+  "onboarding-cta-claude": "onboarding_ctaClaude",
+  "onboarding-cta-chatgpt": "onboarding_ctaChatgpt",
+  "onboarding-footer": "onboarding_footer",
+};
+
+/**
+ * Replaces each known element's text with its localized message when one
+ * exists. Missing/empty translations are skipped so the inline English text
+ * remains as the fallback.
+ */
+export function applyOnboardingI18n(
+  root: ParentNode,
+  translate: (key: string) => string
+): void {
+  for (const [id, key] of Object.entries(ONBOARDING_I18N_KEYS)) {
+    const el = root.querySelector(`#${id}`);
+    if (!el) continue;
+    let msg = "";
+    try {
+      msg = translate(key) ?? "";
+    } catch {
+      msg = "";
+    }
+    if (msg) el.textContent = msg;
+  }
+}
+
+function init(): void {
+  applyOnboardingI18n(document, (key) => getMessage(key));
+}
+
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+}

--- a/src/svc/background.ts
+++ b/src/svc/background.ts
@@ -4,6 +4,7 @@ import { deserializeApiRequest, type SerializedApiRequest } from "../utils/ApiRe
 import { authenticate, isPKCESupported } from "../auth/OAuthService";
 import { registerDevReloadHandler, DEV_FEED_SPEECH_MESSAGE } from "../dev/devReload";
 import { pickSyntheticSpeechClip } from "../offscreen/syntheticSpeechPool";
+import { maybeOpenFirstRunTab } from "../onboarding/firstRun";
 
 // Track when PKCE authentication is in progress to prevent cookie listener interference
 let isPKCEAuthInProgress = false;
@@ -414,8 +415,8 @@ function updateContextMenuTitle(tabId: number, isDictationActive: boolean) {
   } catch {}
 }
 
-// Context menu setup for dictation
-browser.runtime.onInstalled.addListener(() => {
+// Context menu setup for dictation + first-run onboarding tab
+browser.runtime.onInstalled.addListener((details) => {
   try {
     if (!browser.contextMenus || typeof browser.contextMenus.create !== 'function') return;
     const appName = getMessage("appName");
@@ -430,6 +431,18 @@ browser.runtime.onInstalled.addListener(() => {
       ]
     });
   } catch {}
+
+  // On a fresh install, open the onboarding tab once to guide the user to
+  // their first spoken exchange (#437). Never fires on update; never re-nags.
+  void maybeOpenFirstRunTab(details, {
+    openTab: (url: string) => browser.tabs.create({ url, active: true }),
+    getUrl: getExtensionURL,
+    storage: {
+      get: async (key: string) => (await browser.storage.local.get(key))[key],
+      set: async (key: string, value: unknown) =>
+        browser.storage.local.set({ [key]: value }),
+    },
+  });
 });
 
 // Handle context menu clicks

--- a/test/onboarding/firstRun.spec.ts
+++ b/test/onboarding/firstRun.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  isFreshInstall,
+  maybeOpenFirstRunTab,
+  ONBOARDING_PAGE_PATH,
+  ONBOARDING_SHOWN_KEY,
+} from "../../src/onboarding/firstRun";
+
+describe("isFreshInstall (#437)", () => {
+  it("is true only for a fresh install", () => {
+    expect(isFreshInstall("install")).toBe(true);
+  });
+  it("is false for browser/extension updates", () => {
+    expect(isFreshInstall("update")).toBe(false);
+    expect(isFreshInstall("chrome_update")).toBe(false);
+    expect(isFreshInstall("browser_update")).toBe(false);
+    expect(isFreshInstall("shared_module_update")).toBe(false);
+    expect(isFreshInstall(undefined)).toBe(false);
+  });
+});
+
+describe("maybeOpenFirstRunTab (#437)", () => {
+  let store: Record<string, unknown>;
+  let openTab: ReturnType<typeof vi.fn>;
+  let getUrl: ReturnType<typeof vi.fn>;
+  let deps: any;
+
+  beforeEach(() => {
+    store = {};
+    openTab = vi.fn().mockResolvedValue(undefined);
+    getUrl = vi.fn((p: string) => `chrome-extension://abc/${p}`);
+    deps = {
+      openTab,
+      getUrl,
+      storage: {
+        get: vi.fn(async (k: string) => store[k]),
+        set: vi.fn(async (k: string, v: unknown) => {
+          store[k] = v;
+        }),
+      },
+    };
+  });
+
+  it("opens the onboarding tab once on fresh install and records that it was shown", async () => {
+    const opened = await maybeOpenFirstRunTab({ reason: "install" }, deps);
+
+    expect(opened).toBe(true);
+    expect(openTab).toHaveBeenCalledWith(`chrome-extension://abc/${ONBOARDING_PAGE_PATH}`);
+    expect(store[ONBOARDING_SHOWN_KEY]).toBe(true);
+  });
+
+  it("does not open on update", async () => {
+    const opened = await maybeOpenFirstRunTab({ reason: "update" }, deps);
+
+    expect(opened).toBe(false);
+    expect(openTab).not.toHaveBeenCalled();
+  });
+
+  it("does not reopen if already shown (no nag on reinstall loops)", async () => {
+    store[ONBOARDING_SHOWN_KEY] = true;
+
+    const opened = await maybeOpenFirstRunTab({ reason: "install" }, deps);
+
+    expect(opened).toBe(false);
+    expect(openTab).not.toHaveBeenCalled();
+  });
+
+  it("never lets a tab-open failure escape (install must not break)", async () => {
+    openTab.mockRejectedValueOnce(new Error("no tabs api"));
+
+    await expect(maybeOpenFirstRunTab({ reason: "install" }, deps)).resolves.toBe(false);
+  });
+});

--- a/test/onboarding/onboarding-page.spec.ts
+++ b/test/onboarding/onboarding-page.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { applyOnboardingI18n, ONBOARDING_I18N_KEYS } from "../../src/onboarding/onboarding-page";
+
+function makeRoot(): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML = `
+    <h1 id="onboarding-heading">English heading</h1>
+    <p id="onboarding-intro">English intro</p>
+    <a id="onboarding-cta-pi">Open Pi</a>
+  `;
+  return root;
+}
+
+describe("applyOnboardingI18n (#437)", () => {
+  it("replaces element text with the localized message when one exists", () => {
+    const root = makeRoot();
+    const dict: Record<string, string> = {
+      onboarding_heading: "Bienvenue",
+      onboarding_intro: "Intro localisée",
+      onboarding_ctaPi: "Ouvrir Pi",
+    };
+
+    applyOnboardingI18n(root, (k) => dict[k] ?? "");
+
+    expect(root.querySelector("#onboarding-heading")!.textContent).toBe("Bienvenue");
+    expect(root.querySelector("#onboarding-intro")!.textContent).toBe("Intro localisée");
+    expect(root.querySelector("#onboarding-cta-pi")!.textContent).toBe("Ouvrir Pi");
+  });
+
+  it("keeps the inline English fallback when the translation is empty/missing", () => {
+    const root = makeRoot();
+
+    applyOnboardingI18n(root, () => "");
+
+    expect(root.querySelector("#onboarding-heading")!.textContent).toBe("English heading");
+    expect(root.querySelector("#onboarding-intro")!.textContent).toBe("English intro");
+  });
+
+  it("does not throw when the translate function throws", () => {
+    const root = makeRoot();
+
+    expect(() =>
+      applyOnboardingI18n(root, () => {
+        throw new Error("i18n unavailable");
+      })
+    ).not.toThrow();
+    // fallback text preserved
+    expect(root.querySelector("#onboarding-heading")!.textContent).toBe("English heading");
+  });
+
+  it("ignores ids that are not present in the document", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `<h1 id="onboarding-heading">Hi</h1>`;
+    // every mapped key resolves, but only the heading exists
+    expect(() => applyOnboardingI18n(root, (k) => k)).not.toThrow();
+    expect(root.querySelector("#onboarding-heading")!.textContent).toBe("onboarding_heading");
+  });
+
+  it("maps every onboarding element id to a namespaced onboarding_ key", () => {
+    for (const key of Object.values(ONBOARDING_I18N_KEYS)) {
+      expect(key).toMatch(/^onboarding_/);
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Extension-side **first-run surface slice** of #437 (week-1 onboarding program, Phase 5).

A new user had **no in-extension first-run guidance** — after install they had to find the extension, pin it, grant the mic, and start talking with no help. For a voice + browser-extension product that's the highest-friction path there is. This adds a guided welcome that opens once on install.

## Changes

- **`src/onboarding/firstRun.ts`** — dependency-injected gating: opens the onboarding tab **exactly once on a fresh install** (`reason === 'install'`), **never on update**, and **never re-nags** (guarded by a `saypi_onboarding_shown` storage flag). All errors are swallowed so a failure here can't break installation.
- **`src/svc/background.ts`** — wire it into the existing `runtime.onInstalled` listener (previously context-menu-only) with real `browser.tabs.create` / `browser.storage.local`.
- **`entrypoints/onboarding/`** — new WXT HTML entrypoint (emits `onboarding.html`): an on-brand welcome page with **pin-to-toolbar guidance**, **"start talking" CTAs** to Pi/Claude/ChatGPT, and a mic-permission expectation note. Self-contained CSS, no new binary assets.
- **`src/onboarding/onboarding-page.ts`** — localizes the page by element id (pure `applyOnboardingI18n` + DOM bootstrap).
- **`_locales/en/messages.json`** — English copy under the `onboarding_*` namespace. Other locales fall back to en until translated (`i18n-validate` passes).
- `.wxt/types/paths.d.ts` — regenerated to include `/onboarding.html` (`.wxt` is tracked in this repo).

## Tests (fail-first TDD)

- `test/onboarding/firstRun.spec.ts` — install-vs-update, open-once / no-renag, and tab-open failure is swallowed.
- `test/onboarding/onboarding-page.spec.ts` — localized-override-when-present, English-fallback-when-missing, throw-safety, absent-id tolerance, namespace check.
- Full suite green: Vitest **1481 passed** (1 skipped), Jest passed, `tsc --noEmit` clean, `wxt prepare` emits `/onboarding.html`, `i18n-validate` clean.

## Design notes / follow-ups

The page copy and visual design are intentionally simple and easy to iterate — happy to adjust tone/branding. The pin instructions are Chromium-flavoured (puzzle-piece icon); Firefox users still get the welcome + CTAs. Deliberately **not** in this PR (subsequent slices of #437): upboarding page on permission-change after an update, mic-permission denial/recovery + live mic test, quiet/whisper mode, and the post-exchange speed-payoff reveal.

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)