### PR TITLE
feat(permissions): first-class mic-permission denial recovery (#437)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1228,6 +1228,42 @@
     "message": "This tab will close automatically once you've responded.",
     "description": "Footer text indicating the tab will auto-close."
   },
+  "permissions_recoveryDeniedTitle": {
+    "message": "Microphone access is blocked",
+    "description": "Title of the recovery panel when mic permission was denied/blocked."
+  },
+  "permissions_recoveryDeniedBody": {
+    "message": "Your browser is blocking the microphone. Click the camera or lock icon in the address bar, set Microphone to \"Allow\", then try again. On macOS, also check System Settings → Privacy & Security → Microphone.",
+    "description": "Recovery guidance when mic permission is blocked."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "message": "No microphone found",
+    "description": "Title of the recovery panel when no microphone device is available."
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "message": "We couldn't find a microphone. Plug one in (or connect your headset), make sure it's selected as your input device, then try again.",
+    "description": "Recovery guidance when no microphone device is available."
+  },
+  "permissions_recoveryInUseTitle": {
+    "message": "Your microphone is busy",
+    "description": "Title of the recovery panel when the mic is in use by another app."
+  },
+  "permissions_recoveryInUseBody": {
+    "message": "Another app or tab may be using your microphone. Close anything else that might be recording (video calls, voice memos), then try again.",
+    "description": "Recovery guidance when the microphone is in use elsewhere."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "message": "We couldn't access your microphone",
+    "description": "Title of the recovery panel for an unknown mic error."
+  },
+  "permissions_recoveryUnknownBody": {
+    "message": "Something went wrong reaching your microphone. Check that it's connected and allowed in your browser settings, then try again.",
+    "description": "Recovery guidance for an unknown microphone error."
+  },
+  "permissions_retryButton": {
+    "message": "Try again",
+    "description": "Label for the button that re-requests microphone permission."
+  },
   "permissions_errorDomLoadFailure": {
     "message": "Permissions prompt page DOM failed to load correctly.",
     "description": "Error message sent via runtime message if the DOM fails to load."

--- a/entrypoints/permissions/index.html
+++ b/entrypoints/permissions/index.html
@@ -24,6 +24,7 @@
         <strong>"Allow while visiting the site"</strong> so we can start talking.
       </p>
       <p id="status"><em>Waiting for your go-ahead…</em></p>
+      <div id="recovery" class="recovery" hidden></div>
       <p class="footer-text" id="prompt-footer">
         This tab will close automatically once you've responded.
       </p>

--- a/entrypoints/permissions/style.css
+++ b/entrypoints/permissions/style.css
@@ -45,3 +45,40 @@ p {
   color: #777;
   margin-top: 20px;
 }
+
+.recovery {
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 10px;
+  background-color: rgba(108, 92, 231, 0.08);
+  text-align: left;
+}
+
+.recovery h2 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  color: #2c3e50;
+}
+
+.recovery p {
+  margin: 0 0 14px;
+  font-size: 0.95rem;
+}
+
+.retry-button {
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #fff;
+  background-color: #6c5ce7;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+
+.retry-button:hover,
+.retry-button:focus {
+  filter: brightness(1.08);
+}

--- a/src/permissions/micPermissionRecovery.ts
+++ b/src/permissions/micPermissionRecovery.ts
@@ -1,0 +1,82 @@
+/**
+ * Mic-permission recovery classification (#437).
+ *
+ * Turns a `getUserMedia` failure into a first-class, recoverable state with
+ * user-facing guidance, so microphone denial is never a dead end. Pure and
+ * i18n-key-based so it's unit-testable and reusable both on the permissions
+ * page and in the in-call denial path.
+ */
+
+export type MicPermissionOutcome =
+  | "granted"
+  | "denied" // user or policy blocked access (NotAllowedError, SecurityError…)
+  | "no-device" // no microphone available (NotFoundError, OverconstrainedError…)
+  | "in-use" // device exists but couldn't be opened (NotReadableError, busy…)
+  | "unknown";
+
+export interface MicRecovery {
+  outcome: MicPermissionOutcome;
+  /** i18n key for a short title describing the state. */
+  titleKey: string;
+  /** i18n key for the body explaining how to recover. */
+  bodyKey: string;
+  /** Whether re-requesting (a "Try again" button) can help. */
+  canRetry: boolean;
+}
+
+/** Maps a DOMException name from getUserMedia to a recovery outcome (never "granted"). */
+export function classifyMicError(
+  errorName: string | undefined
+): Exclude<MicPermissionOutcome, "granted"> {
+  switch (errorName) {
+    case "NotAllowedError":
+    case "PermissionDeniedError":
+    case "SecurityError":
+      return "denied";
+    case "NotFoundError":
+    case "DevicesNotFoundError":
+    case "OverconstrainedError":
+    case "ConstraintNotSatisfiedError":
+      return "no-device";
+    case "NotReadableError":
+    case "TrackStartError":
+    case "AbortError":
+      return "in-use";
+    default:
+      return "unknown";
+  }
+}
+
+const RECOVERY: Record<Exclude<MicPermissionOutcome, "granted">, MicRecovery> = {
+  denied: {
+    outcome: "denied",
+    titleKey: "permissions_recoveryDeniedTitle",
+    bodyKey: "permissions_recoveryDeniedBody",
+    canRetry: true,
+  },
+  "no-device": {
+    outcome: "no-device",
+    titleKey: "permissions_recoveryNoDeviceTitle",
+    bodyKey: "permissions_recoveryNoDeviceBody",
+    canRetry: true,
+  },
+  "in-use": {
+    outcome: "in-use",
+    titleKey: "permissions_recoveryInUseTitle",
+    bodyKey: "permissions_recoveryInUseBody",
+    canRetry: true,
+  },
+  unknown: {
+    outcome: "unknown",
+    titleKey: "permissions_recoveryUnknownTitle",
+    bodyKey: "permissions_recoveryUnknownBody",
+    canRetry: true,
+  },
+};
+
+/** Describes how to recover from a non-granted outcome. */
+export function describeMicRecovery(
+  outcome: Exclude<MicPermissionOutcome, "granted">
+): MicRecovery {
+  return RECOVERY[outcome] ?? RECOVERY.unknown;
+}

--- a/src/permissions/micRecoveryView.ts
+++ b/src/permissions/micRecoveryView.ts
@@ -1,0 +1,53 @@
+/**
+ * Renders the first-class mic-permission recovery panel (#437).
+ *
+ * Separated from the side-effectful permissions page script so it can be
+ * unit-tested in JSDOM. Pure DOM construction from a recovery descriptor.
+ */
+import {
+  describeMicRecovery,
+  type MicPermissionOutcome,
+} from "./micPermissionRecovery";
+
+export interface RecoveryViewOptions {
+  translate: (key: string, substitutions?: string) => string;
+  onRetry: () => void;
+  retryLabelKey?: string;
+}
+
+/**
+ * Replaces the contents of `container` with a recovery panel (title, body, and
+ * — when retrying can help — a "Try again" button) and makes it visible.
+ * Returns the container.
+ */
+export function renderMicRecovery(
+  container: HTMLElement,
+  outcome: Exclude<MicPermissionOutcome, "granted">,
+  opts: RecoveryViewOptions
+): HTMLElement {
+  const rec = describeMicRecovery(outcome);
+  container.innerHTML = "";
+
+  const title = document.createElement("h2");
+  title.id = "recovery-title";
+  title.textContent = opts.translate(rec.titleKey);
+
+  const body = document.createElement("p");
+  body.id = "recovery-body";
+  body.textContent = opts.translate(rec.bodyKey);
+
+  container.append(title, body);
+
+  if (rec.canRetry) {
+    const btn = document.createElement("button");
+    btn.id = "recovery-retry";
+    btn.type = "button";
+    btn.className = "retry-button";
+    btn.textContent = opts.translate(opts.retryLabelKey ?? "permissions_retryButton");
+    btn.addEventListener("click", () => opts.onRetry());
+    container.append(btn);
+  }
+
+  container.hidden = false;
+  return container;
+}

--- a/src/permissions/permissions-prompt.ts
+++ b/src/permissions/permissions-prompt.ts
@@ -1,5 +1,7 @@
 // src/permissions/permissions-prompt.ts
 import getMessage from '../i18n';
+import { classifyMicError } from './micPermissionRecovery';
+import { renderMicRecovery } from './micRecoveryView';
 
 document.addEventListener('DOMContentLoaded', async () => {
   // Localize static HTML content
@@ -37,41 +39,65 @@ document.addEventListener('DOMContentLoaded', async () => {
     return;
   }
 
-  console.log("[PermissionsPrompt] Requesting microphone permission...");
-  // Set initial status message using the key from HTML part, as it's the same
-  statusElement.innerHTML = `<em>${getMessage('permissions_promptStatusWaiting')}</em>`; 
+  const recoveryElement = document.getElementById('recovery');
 
-  try {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    console.log("[PermissionsPrompt] Microphone permission GRANTED.");
-    statusElement.textContent = getMessage('permissions_statusPermissionGranted');
+  async function attemptMicPermission(): Promise<void> {
+    // Reset to the waiting state and hide any prior recovery panel so a retry
+    // starts clean.
+    statusElement!.innerHTML = `<em>${getMessage('permissions_promptStatusWaiting')}</em>`;
+    if (recoveryElement) {
+      recoveryElement.hidden = true;
+      recoveryElement.innerHTML = '';
+    }
 
-    stream.getTracks().forEach(track => track.stop());
+    console.log("[PermissionsPrompt] Requesting microphone permission...");
 
-    chrome.runtime.sendMessage({
-      type: 'PERMISSION_PROMPT_RESULT',
-      granted: true
-    }, () => {
-      if (chrome.runtime.lastError) {
-        console.error("[PermissionsPrompt] Error sending GRANT message:", chrome.runtime.lastError.message);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      console.log("[PermissionsPrompt] Microphone permission GRANTED.");
+      statusElement!.textContent = getMessage('permissions_statusPermissionGranted');
+
+      stream.getTracks().forEach(track => track.stop());
+
+      chrome.runtime.sendMessage({
+        type: 'PERMISSION_PROMPT_RESULT',
+        granted: true
+      }, () => {
+        if (chrome.runtime.lastError) {
+          console.error("[PermissionsPrompt] Error sending GRANT message:", chrome.runtime.lastError.message);
+        }
+        setTimeout(() => window.close(), 1500);
+      });
+
+    } catch (err: any) {
+      console.error("[PermissionsPrompt] Microphone permission DENIED or error:", err?.name, err?.message);
+      const errorName = err?.name || getMessage('permissions_textUnknownError');
+      statusElement!.textContent = getMessage('permissions_statusPermissionDenied', errorName);
+
+      // Notify the requester so it isn't left hanging, but keep this tab open
+      // and present a first-class recovery panel instead of dead-ending (#437).
+      chrome.runtime.sendMessage({
+        type: 'PERMISSION_PROMPT_RESULT',
+        granted: false,
+        error: err?.message || err?.name || getMessage('permissions_errorUnknownDuringRequest')
+      }, () => {
+        if (chrome.runtime.lastError) {
+          console.error("[PermissionsPrompt] Error sending DENY/ERROR message:", chrome.runtime.lastError.message);
+        }
+      });
+
+      if (recoveryElement) {
+        renderMicRecovery(recoveryElement, classifyMicError(err?.name), {
+          translate: (key, sub) => getMessage(key, sub),
+          onRetry: () => { void attemptMicPermission(); },
+        });
+      } else {
+        // No recovery container (older markup) — fall back to the previous
+        // auto-close behaviour so we never strand the tab.
+        setTimeout(() => window.close(), 2500);
       }
-      setTimeout(() => window.close(), 1500);
-    });
-
-  } catch (err: any) {
-    console.error("[PermissionsPrompt] Microphone permission DENIED or error:", err.name, err.message);
-    const errorName = err.name || getMessage('permissions_textUnknownError');
-    statusElement.textContent = getMessage('permissions_statusPermissionDenied', errorName);
-    
-    chrome.runtime.sendMessage({
-      type: 'PERMISSION_PROMPT_RESULT',
-      granted: false,
-      error: err.message || err.name || getMessage('permissions_errorUnknownDuringRequest')
-    }, () => {
-      if (chrome.runtime.lastError) {
-        console.error("[PermissionsPrompt] Error sending DENY/ERROR message:", chrome.runtime.lastError.message);
-      }
-      setTimeout(() => window.close(), 2500);
-    });
+    }
   }
-}); 
+
+  await attemptMicPermission();
+});

--- a/test/permissions/micPermissionRecovery.spec.ts
+++ b/test/permissions/micPermissionRecovery.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyMicError,
+  describeMicRecovery,
+  type MicPermissionOutcome,
+} from "../../src/permissions/micPermissionRecovery";
+
+describe("classifyMicError (#437)", () => {
+  const cases: Array<[string, MicPermissionOutcome]> = [
+    ["NotAllowedError", "denied"],
+    ["SecurityError", "denied"],
+    ["PermissionDeniedError", "denied"],
+    ["NotFoundError", "no-device"],
+    ["DevicesNotFoundError", "no-device"],
+    ["OverconstrainedError", "no-device"],
+    ["NotReadableError", "in-use"],
+    ["TrackStartError", "in-use"],
+    ["AbortError", "in-use"],
+    ["SomethingWeird", "unknown"],
+    ["", "unknown"],
+  ];
+  it.each(cases)("maps %s -> %s", (name, expected) => {
+    expect(classifyMicError(name)).toBe(expected);
+  });
+
+  it("treats undefined as unknown", () => {
+    expect(classifyMicError(undefined)).toBe("unknown");
+  });
+});
+
+describe("describeMicRecovery (#437)", () => {
+  it("returns a title/body i18n key and retry flag for every outcome", () => {
+    const outcomes: Array<Exclude<MicPermissionOutcome, "granted">> = [
+      "denied",
+      "no-device",
+      "in-use",
+      "unknown",
+    ];
+    for (const outcome of outcomes) {
+      const r = describeMicRecovery(outcome);
+      expect(r.outcome).toBe(outcome);
+      expect(r.titleKey).toMatch(/^permissions_recovery/);
+      expect(r.bodyKey).toMatch(/^permissions_recovery/);
+      expect(typeof r.canRetry).toBe("boolean");
+    }
+  });
+
+  it("offers a retry for every recoverable outcome", () => {
+    const outcomes: Array<Exclude<MicPermissionOutcome, "granted">> = [
+      "denied",
+      "no-device",
+      "in-use",
+      "unknown",
+    ];
+    for (const outcome of outcomes) {
+      expect(describeMicRecovery(outcome).canRetry).toBe(true);
+    }
+  });
+
+  it("distinguishes the denied case from the no-device case in copy keys", () => {
+    expect(describeMicRecovery("denied").titleKey).not.toBe(
+      describeMicRecovery("no-device").titleKey
+    );
+  });
+});

--- a/test/permissions/micRecoveryView.spec.ts
+++ b/test/permissions/micRecoveryView.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderMicRecovery } from "../../src/permissions/micRecoveryView";
+
+const translate = (k: string) => `t:${k}`;
+
+describe("renderMicRecovery (#437)", () => {
+  it("renders a localized title and body for the denied outcome and reveals the panel", () => {
+    const container = document.createElement("div");
+    container.hidden = true;
+
+    renderMicRecovery(container, "denied", { translate, onRetry: () => {} });
+
+    expect(container.hidden).toBe(false);
+    expect(container.querySelector("#recovery-title")!.textContent).toBe(
+      "t:permissions_recoveryDeniedTitle"
+    );
+    expect(container.querySelector("#recovery-body")!.textContent).toBe(
+      "t:permissions_recoveryDeniedBody"
+    );
+  });
+
+  it("includes a retry button that invokes onRetry when clicked", () => {
+    const container = document.createElement("div");
+    const onRetry = vi.fn();
+
+    renderMicRecovery(container, "no-device", { translate, onRetry });
+    const btn = container.querySelector<HTMLButtonElement>("#recovery-retry")!;
+    expect(btn).not.toBeNull();
+    expect(btn.textContent).toBe("t:permissions_retryButton");
+
+    btn.click();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces previous content on re-render (no stale panels stack up)", () => {
+    const container = document.createElement("div");
+    renderMicRecovery(container, "denied", { translate, onRetry: () => {} });
+    renderMicRecovery(container, "in-use", { translate, onRetry: () => {} });
+
+    expect(container.querySelectorAll("#recovery-title").length).toBe(1);
+    expect(container.querySelector("#recovery-title")!.textContent).toBe(
+      "t:permissions_recoveryInUseTitle"
+    );
+  });
+});


### PR DESCRIPTION
## What & why

Slice **3a** of #437 (week-1 onboarding program). Acceptance criterion: *"Microphone-permission denial is a first-class state with a clear recovery action."*

Today, denial on the permissions page is a **dead end** — a terse error string, then the tab auto-closes after 2.5s, leaving the user stuck with no guidance. This makes denial recoverable: an explanatory panel tailored to *why* it failed, plus a **Try again** button.

## Changes

- **`src/permissions/micPermissionRecovery.ts`** — pure classifier: `getUserMedia` DOMException name → outcome (`denied` / `no-device` / `in-use` / `unknown`) and a localized `{ titleKey, bodyKey, canRetry }` descriptor. Pure + reusable (the in-call denial path can adopt it later).
- **`src/permissions/micRecoveryView.ts`** — renders the recovery panel (title, recovery guidance, "Try again") into a container; JSDOM-testable, no side effects.
- **`permissions-prompt.ts`** — refactored the request into a retryable `attemptMicPermission()`. On failure it renders the recovery panel and **keeps the tab open**; "Try again" re-requests (resolves the transient cases — device busy, just-plugged-in, setting just changed). Still posts `granted:false` so the requester never hangs. Falls back to the prior auto-close only if the container is missing.
- Copy under `permissions_recovery*` + `permissions_retryButton`; panel/button styles added to the permissions stylesheet.

## Tests (fail-first TDD)

- `test/permissions/micPermissionRecovery.spec.ts` — every error-name → outcome mapping, descriptor shape, retry flag, denied≠no-device copy.
- `test/permissions/micRecoveryView.spec.ts` — localized render, retry-button invokes `onRetry`, re-render replaces (no stacked panels).
- Full suite green: Vitest **1499 passed** (1 skipped), Jest passed, `tsc --noEmit` clean, `i18n-validate` clean.

## Scope / follow-ups

- **3b** — the live "try it yourself" mic-test audio meter (separate PR).
- Detecting **permission loss after a browser/OS update** in the in-call path can reuse this same classifier — follow-up.
- The recovery panel renders the real-browser flow; behaviour against a live mic prompt is best confirmed at Layer 4 (out of CI scope). Logic is covered hermetically here.

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)