### PR TITLE
feat(onboarding): live "try it yourself" mic-test meter (#437)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1198,6 +1198,26 @@
     "message": "You can revisit this any time from Say, Pi's settings. Your privacy matters — audio is only captured during an active call.",
     "description": "Footer text on the first-run onboarding page."
   },
+  "onboarding_micTestButton": {
+    "message": "🎤 Test your microphone",
+    "description": "Button that starts the no-stakes onboarding microphone test."
+  },
+  "onboarding_micTestRequesting": {
+    "message": "Requesting microphone…",
+    "description": "Status shown while the onboarding mic test waits for permission."
+  },
+  "onboarding_micTestListening": {
+    "message": "Listening — say something! 🎙️",
+    "description": "Status shown while the onboarding mic test is metering input."
+  },
+  "onboarding_micTestStop": {
+    "message": "Stop test",
+    "description": "Button label to stop the onboarding mic test while it is running."
+  },
+  "onboarding_micTestDone": {
+    "message": "Nice — your microphone works! 🎉",
+    "description": "Status shown after the onboarding mic test completes successfully."
+  },
   "permissions_promptTitle": {
     "message": "Microphone Permission",
     "description": "Title of the permissions prompt page."

--- a/entrypoints/onboarding/index.html
+++ b/entrypoints/onboarding/index.html
@@ -41,6 +41,13 @@
             <a class="cta" id="onboarding-cta-claude" href="https://claude.ai/new" target="_blank" rel="noopener noreferrer">Open Claude</a>
             <a class="cta" id="onboarding-cta-chatgpt" href="https://chatgpt.com/" target="_blank" rel="noopener noreferrer">Open ChatGPT</a>
           </div>
+          <div class="mic-test">
+            <button type="button" id="onboarding-mic-test-btn" class="cta secondary">🎤 Test your microphone</button>
+            <div class="meter" id="onboarding-mic-meter" hidden aria-hidden="true">
+              <div class="meter-fill" id="onboarding-mic-meter-fill" style="width: 0%"></div>
+            </div>
+            <p class="mic-test-status" id="onboarding-mic-test-status" role="status" aria-live="polite"></p>
+          </div>
         </li>
       </ol>
 

--- a/entrypoints/onboarding/style.css
+++ b/entrypoints/onboarding/style.css
@@ -104,6 +104,39 @@ h1 {
   filter: brightness(1.08);
 }
 
+.cta.secondary {
+  background: transparent;
+  color: var(--saypi-accent);
+  border: 1.5px solid var(--saypi-accent);
+}
+
+.mic-test {
+  margin-top: 16px;
+}
+
+.meter {
+  margin-top: 12px;
+  height: 12px;
+  border-radius: 6px;
+  background: #ece9fb;
+  overflow: hidden;
+}
+
+.meter-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #6c5ce7 0%, #a29bfe 100%);
+  border-radius: 6px;
+  transition: width 0.08s linear;
+}
+
+.mic-test-status {
+  margin: 8px 0 0;
+  min-height: 1.2em;
+  font-size: 0.95rem;
+  color: var(--saypi-ink);
+}
+
 .footer-text {
   font-size: 0.9rem;
   color: #7a7f87;

--- a/src/onboarding/audioLevel.ts
+++ b/src/onboarding/audioLevel.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure audio-level math for the onboarding "try it yourself" mic meter (#437).
+ *
+ * Kept free of Web Audio / DOM so it can be unit-tested; the page wires an
+ * AnalyserNode's time-domain samples into `computeRms` and feeds the result
+ * through `rmsToMeterPercent` to drive the meter bar.
+ */
+
+/** Root-mean-square of a block of normalized (-1..1) audio samples; 0 for empty. */
+export function computeRms(samples: ArrayLike<number>): number {
+  const n = samples.length;
+  if (n === 0) return 0;
+  let sumSquares = 0;
+  for (let i = 0; i < n; i++) {
+    const s = samples[i];
+    sumSquares += s * s;
+  }
+  return Math.sqrt(sumSquares / n);
+}
+
+export interface MeterScale {
+  /** RMS at or above which the meter is full (default 0.4 — comfortable speech). */
+  ceil?: number;
+}
+
+/**
+ * Maps an RMS value to a 0..100 meter percentage, clamped. Linear from 0 up to
+ * `ceil`, then pinned at 100.
+ */
+export function rmsToMeterPercent(rms: number, scale: MeterScale = {}): number {
+  const ceil = scale.ceil ?? 0.4;
+  if (!(rms > 0) || ceil <= 0) return 0;
+  const pct = (rms / ceil) * 100;
+  return Math.min(100, Math.max(0, pct));
+}

--- a/src/onboarding/micMeter.ts
+++ b/src/onboarding/micMeter.ts
@@ -1,0 +1,61 @@
+/**
+ * Lifecycle controller for the onboarding "try it yourself" mic meter (#437).
+ *
+ * The scheduler, clock, and level reader are injected so the loop (tick →
+ * report → auto-stop → cleanup) is unit-testable without real Web Audio. The
+ * onboarding page wires `readLevel` to an AnalyserNode and `schedule`/`cancel`
+ * to requestAnimationFrame.
+ */
+import { rmsToMeterPercent } from "./audioLevel";
+
+export interface MicMeterDeps {
+  /** Returns the current RMS level (0..1). */
+  readLevel: () => number;
+  /** Called each frame with the clamped meter percentage (0..100). */
+  onLevel: (percent: number) => void;
+  /** Called once when the meter finishes (duration elapsed or stopped) for cleanup. */
+  onDone?: () => void;
+  /** Schedules the next frame; returns a cancel handle. */
+  schedule: (cb: () => void) => number;
+  /** Cancels a scheduled frame. */
+  cancel: (handle: number) => void;
+  /** Monotonic clock in ms. */
+  now: () => number;
+  /** How long the meter runs before auto-stopping (default 10s). */
+  durationMs?: number;
+}
+
+export interface MicMeterHandle {
+  stop: () => void;
+}
+
+export function startMicMeter(deps: MicMeterDeps): MicMeterHandle {
+  const durationMs = deps.durationMs ?? 10_000;
+  const startedAt = deps.now();
+  let handle: number | null = null;
+  let finished = false;
+
+  function finish(): void {
+    if (finished) return;
+    finished = true;
+    if (handle !== null) {
+      deps.cancel(handle);
+      handle = null;
+    }
+    deps.onDone?.();
+  }
+
+  function frame(): void {
+    if (finished) return;
+    deps.onLevel(rmsToMeterPercent(deps.readLevel()));
+    if (deps.now() - startedAt >= durationMs) {
+      finish();
+      return;
+    }
+    handle = deps.schedule(frame);
+  }
+
+  handle = deps.schedule(frame);
+
+  return { stop: finish };
+}

--- a/src/onboarding/micTestWiring.ts
+++ b/src/onboarding/micTestWiring.ts
@@ -1,0 +1,139 @@
+/**
+ * Wires the onboarding "try it yourself" mic-test (#437).
+ *
+ * Web Audio is hidden behind an injectable `acquire()` that yields a level
+ * reader + release fn, so the start/stop/toggle/error logic here is fully
+ * unit-testable; the default acquire does getUserMedia + AnalyserNode in a real
+ * browser. Reuses the slice-3a mic-error classifier for a friendly denial path.
+ */
+import { computeRms } from "./audioLevel";
+import { startMicMeter, type MicMeterHandle } from "./micMeter";
+import {
+  classifyMicError,
+  describeMicRecovery,
+} from "../permissions/micPermissionRecovery";
+
+export interface MicSource {
+  /** Current RMS level (0..1). */
+  readLevel: () => number;
+  /** Tears down the stream/audio graph. */
+  release: () => void;
+}
+
+export interface MicTestElements {
+  button: HTMLButtonElement;
+  meter: HTMLElement;
+  fill: HTMLElement;
+  status: HTMLElement;
+}
+
+export interface MicTestWiringOptions {
+  translate: (key: string, substitutions?: string) => string;
+  acquire?: () => Promise<MicSource>;
+  schedule?: (cb: () => void) => number;
+  cancel?: (handle: number) => void;
+  now?: () => number;
+  durationMs?: number;
+}
+
+async function defaultAcquire(): Promise<MicSource> {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const Ctx: typeof AudioContext =
+    window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+  const ctx = new Ctx();
+  const source = ctx.createMediaStreamSource(stream);
+  const analyser = ctx.createAnalyser();
+  analyser.fftSize = 1024;
+  source.connect(analyser);
+  const data = new Float32Array(analyser.fftSize);
+  return {
+    readLevel: () => {
+      analyser.getFloatTimeDomainData(data);
+      return computeRms(data);
+    },
+    release: () => {
+      try {
+        source.disconnect();
+      } catch {
+        /* ignore */
+      }
+      stream.getTracks().forEach((t) => t.stop());
+      void ctx.close();
+    },
+  };
+}
+
+/** Attaches click handling to the mic-test button. Returns a disposer. */
+export function wireMicTest(els: MicTestElements, opts: MicTestWiringOptions): () => void {
+  const acquire = opts.acquire ?? defaultAcquire;
+  const schedule = opts.schedule ?? ((cb) => requestAnimationFrame(cb));
+  const cancel = opts.cancel ?? ((h) => cancelAnimationFrame(h));
+  const now = opts.now ?? (() => performance.now());
+  const durationMs = opts.durationMs ?? 10_000;
+  const t = opts.translate;
+
+  let source: MicSource | null = null;
+  let meter: MicMeterHandle | null = null;
+  let running = false;
+
+  function reset(statusKey: string): void {
+    running = false;
+    meter = null;
+    if (source) {
+      source.release();
+      source = null;
+    }
+    els.meter.hidden = true;
+    els.fill.style.width = "0%";
+    els.button.disabled = false;
+    els.button.textContent = t("onboarding_micTestButton");
+    els.status.textContent = statusKey ? t(statusKey) : "";
+  }
+
+  async function start(): Promise<void> {
+    els.button.disabled = true;
+    els.status.textContent = t("onboarding_micTestRequesting");
+    try {
+      source = await acquire();
+    } catch (err) {
+      const recovery = describeMicRecovery(classifyMicError((err as DOMException)?.name));
+      reset("");
+      // Show the recovery guidance instead of a generic failure (#437).
+      els.status.textContent = t(recovery.bodyKey);
+      return;
+    }
+
+    running = true;
+    els.button.disabled = false;
+    els.button.textContent = t("onboarding_micTestStop");
+    els.meter.hidden = false;
+    els.status.textContent = t("onboarding_micTestListening");
+
+    const src = source;
+    meter = startMicMeter({
+      readLevel: () => src.readLevel(),
+      onLevel: (pct) => {
+        els.fill.style.width = `${pct}%`;
+      },
+      onDone: () => reset("onboarding_micTestDone"),
+      schedule,
+      cancel,
+      now,
+      durationMs,
+    });
+  }
+
+  function onClick(): void {
+    if (running) {
+      meter?.stop();
+    } else {
+      void start();
+    }
+  }
+
+  els.button.addEventListener("click", onClick);
+  return () => {
+    els.button.removeEventListener("click", onClick);
+    meter?.stop();
+  };
+}

--- a/src/onboarding/onboarding-page.ts
+++ b/src/onboarding/onboarding-page.ts
@@ -6,6 +6,7 @@
  * function so they can be unit-tested in JSDOM without the extension runtime.
  */
 import getMessage from "../i18n";
+import { wireMicTest } from "./micTestWiring";
 
 /** Maps element ids in onboarding/index.html to their i18n message keys. */
 export const ONBOARDING_I18N_KEYS: Record<string, string> = {
@@ -18,6 +19,7 @@ export const ONBOARDING_I18N_KEYS: Record<string, string> = {
   "onboarding-cta-pi": "onboarding_ctaPi",
   "onboarding-cta-claude": "onboarding_ctaClaude",
   "onboarding-cta-chatgpt": "onboarding_ctaChatgpt",
+  "onboarding-mic-test-btn": "onboarding_micTestButton",
   "onboarding-footer": "onboarding_footer",
 };
 
@@ -43,8 +45,22 @@ export function applyOnboardingI18n(
   }
 }
 
+/** Wires the "try it yourself" mic-test if its elements are present. */
+export function setupMicTest(root: ParentNode): void {
+  const button = root.querySelector<HTMLButtonElement>("#onboarding-mic-test-btn");
+  const meter = root.querySelector<HTMLElement>("#onboarding-mic-meter");
+  const fill = root.querySelector<HTMLElement>("#onboarding-mic-meter-fill");
+  const status = root.querySelector<HTMLElement>("#onboarding-mic-test-status");
+  if (!button || !meter || !fill || !status) return;
+  wireMicTest(
+    { button, meter, fill, status },
+    { translate: (key, sub) => getMessage(key, sub) }
+  );
+}
+
 function init(): void {
   applyOnboardingI18n(document, (key) => getMessage(key));
+  setupMicTest(document);
 }
 
 if (typeof document !== "undefined") {

--- a/test/onboarding/audioLevel.spec.ts
+++ b/test/onboarding/audioLevel.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { computeRms, rmsToMeterPercent } from "../../src/onboarding/audioLevel";
+
+describe("computeRms (#437)", () => {
+  it("is 0 for silence", () => {
+    expect(computeRms([0, 0, 0, 0])).toBe(0);
+    expect(computeRms(new Float32Array(8))).toBe(0);
+  });
+
+  it("is 1 for a full-scale square wave", () => {
+    expect(computeRms([1, -1, 1, -1])).toBeCloseTo(1, 6);
+  });
+
+  it("equals the constant magnitude for a DC signal", () => {
+    expect(computeRms([0.5, 0.5, 0.5, 0.5])).toBeCloseTo(0.5, 6);
+  });
+
+  it("returns 0 for an empty buffer (no NaN)", () => {
+    expect(computeRms([])).toBe(0);
+  });
+
+  it("is non-negative and grows with amplitude", () => {
+    const quiet = computeRms([0.1, -0.1, 0.1, -0.1]);
+    const loud = computeRms([0.8, -0.8, 0.8, -0.8]);
+    expect(quiet).toBeGreaterThanOrEqual(0);
+    expect(loud).toBeGreaterThan(quiet);
+  });
+});
+
+describe("rmsToMeterPercent (#437)", () => {
+  it("maps silence to 0%", () => {
+    expect(rmsToMeterPercent(0)).toBe(0);
+  });
+
+  it("clamps to the 0..100 range", () => {
+    expect(rmsToMeterPercent(-1)).toBe(0);
+    expect(rmsToMeterPercent(99)).toBe(100);
+  });
+
+  it("reaches 100% at or above the ceiling", () => {
+    expect(rmsToMeterPercent(0.5, { ceil: 0.5 })).toBe(100);
+    expect(rmsToMeterPercent(0.6, { ceil: 0.5 })).toBe(100);
+  });
+
+  it("is monotonic between floor and ceiling", () => {
+    const a = rmsToMeterPercent(0.1, { ceil: 0.5 });
+    const b = rmsToMeterPercent(0.2, { ceil: 0.5 });
+    const c = rmsToMeterPercent(0.3, { ceil: 0.5 });
+    expect(a).toBeLessThan(b);
+    expect(b).toBeLessThan(c);
+  });
+});

--- a/test/onboarding/micMeter.spec.ts
+++ b/test/onboarding/micMeter.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import { startMicMeter } from "../../src/onboarding/micMeter";
+
+/**
+ * Drives the meter with a controllable scheduler + clock so we can test the
+ * lifecycle (ticking, auto-stop, cleanup) without real Web Audio.
+ */
+function harness() {
+  let pending: (() => void) | null = null;
+  let nextId = 1;
+  let t = 0;
+  return {
+    schedule: (cb: () => void) => {
+      pending = cb;
+      return nextId++;
+    },
+    cancel: () => {
+      pending = null;
+    },
+    now: () => t,
+    advance(ms: number) {
+      t += ms;
+    },
+    tick() {
+      const cb = pending;
+      pending = null;
+      cb?.();
+    },
+    get hasPending() {
+      return pending !== null;
+    },
+  };
+}
+
+describe("startMicMeter (#437)", () => {
+  it("reports a meter percent on each tick", () => {
+    const h = harness();
+    const onLevel = vi.fn();
+    startMicMeter({
+      readLevel: () => 0.4, // -> 100%
+      onLevel,
+      schedule: h.schedule,
+      cancel: h.cancel,
+      now: h.now,
+      durationMs: 1000,
+    });
+
+    h.tick();
+    h.advance(100);
+    h.tick();
+
+    expect(onLevel).toHaveBeenCalledWith(100);
+    expect(onLevel.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("auto-stops after durationMs and calls onDone exactly once", () => {
+    const h = harness();
+    const onDone = vi.fn();
+    startMicMeter({
+      readLevel: () => 0.2,
+      onLevel: () => {},
+      onDone,
+      schedule: h.schedule,
+      cancel: h.cancel,
+      now: h.now,
+      durationMs: 500,
+    });
+
+    h.tick(); // t=0
+    h.advance(600); // past duration
+    h.tick(); // should detect done
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(h.hasPending).toBe(false);
+
+    // no further scheduling after done
+    h.advance(1000);
+    h.tick();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop() halts ticking and is idempotent", () => {
+    const h = harness();
+    const onLevel = vi.fn();
+    const meter = startMicMeter({
+      readLevel: () => 0.3,
+      onLevel,
+      schedule: h.schedule,
+      cancel: h.cancel,
+      now: h.now,
+      durationMs: 10000,
+    });
+
+    h.tick();
+    const callsBefore = onLevel.mock.calls.length;
+    meter.stop();
+    meter.stop(); // idempotent
+    expect(h.hasPending).toBe(false);
+
+    h.advance(100);
+    h.tick();
+    expect(onLevel.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("invokes onDone when stopped so cleanup always runs", () => {
+    const h = harness();
+    const onDone = vi.fn();
+    const meter = startMicMeter({
+      readLevel: () => 0.1,
+      onLevel: () => {},
+      onDone,
+      schedule: h.schedule,
+      cancel: h.cancel,
+      now: h.now,
+      durationMs: 10000,
+    });
+    meter.stop();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/onboarding/micTestWiring.spec.ts
+++ b/test/onboarding/micTestWiring.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { wireMicTest, type MicTestElements } from "../../src/onboarding/micTestWiring";
+
+const translate = (k: string) => `t:${k}`;
+
+function buildEls(): MicTestElements {
+  const root = document.createElement("div");
+  root.innerHTML = `
+    <button id="b"></button>
+    <div id="m" hidden><div id="f" style="width:0%"></div></div>
+    <p id="s"></p>
+  `;
+  return {
+    button: root.querySelector("#b")!,
+    meter: root.querySelector("#m")!,
+    fill: root.querySelector("#f")!,
+    status: root.querySelector("#s")!,
+  };
+}
+
+// Controllable scheduler/clock so we can step the meter loop deterministically.
+function harness() {
+  let pending: (() => void) | null = null;
+  let t = 0;
+  return {
+    schedule: (cb: () => void) => {
+      pending = cb;
+      return 1;
+    },
+    cancel: () => {
+      pending = null;
+    },
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+    tick: () => {
+      const cb = pending;
+      pending = null;
+      cb?.();
+    },
+    get hasPending() {
+      return pending !== null;
+    },
+  };
+}
+
+describe("wireMicTest (#437)", () => {
+  let els: MicTestElements;
+  beforeEach(() => {
+    els = buildEls();
+  });
+
+  it("starts metering on click: shows the meter and drives the fill width", async () => {
+    const h = harness();
+    const release = vi.fn();
+    const acquire = vi.fn().mockResolvedValue({ readLevel: () => 0.4, release });
+
+    wireMicTest(els, { translate, acquire, schedule: h.schedule, cancel: h.cancel, now: h.now, durationMs: 1000 });
+    els.button.click();
+    await Promise.resolve(); // let acquire resolve
+    await Promise.resolve();
+
+    h.tick();
+    expect(els.meter.hidden).toBe(false);
+    expect(els.fill.style.width).toBe("100%"); // 0.4 rms -> full
+    expect(els.button.textContent).toBe("t:onboarding_micTestStop");
+    expect(els.status.textContent).toBe("t:onboarding_micTestListening");
+  });
+
+  it("auto-stops after the duration and releases the source", async () => {
+    const h = harness();
+    const release = vi.fn();
+    const acquire = vi.fn().mockResolvedValue({ readLevel: () => 0.2, release });
+
+    wireMicTest(els, { translate, acquire, schedule: h.schedule, cancel: h.cancel, now: h.now, durationMs: 500 });
+    els.button.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    h.tick(); // t=0
+    h.advance(600);
+    h.tick(); // detects done
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(els.meter.hidden).toBe(true);
+    expect(els.fill.style.width).toBe("0%");
+    expect(els.button.textContent).toBe("t:onboarding_micTestButton");
+    expect(els.status.textContent).toBe("t:onboarding_micTestDone");
+  });
+
+  it("clicking while running stops early and releases", async () => {
+    const h = harness();
+    const release = vi.fn();
+    const acquire = vi.fn().mockResolvedValue({ readLevel: () => 0.3, release });
+
+    wireMicTest(els, { translate, acquire, schedule: h.schedule, cancel: h.cancel, now: h.now, durationMs: 10000 });
+    els.button.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    h.tick();
+
+    els.button.click(); // stop
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(els.meter.hidden).toBe(true);
+  });
+
+  it("shows recovery guidance and re-enables the button when access is denied", async () => {
+    const acquire = vi.fn().mockRejectedValue(Object.assign(new Error("no"), { name: "NotAllowedError" }));
+
+    wireMicTest(els, { translate, acquire });
+    els.button.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(els.button.disabled).toBe(false);
+    expect(els.meter.hidden).toBe(true);
+    expect(els.status.textContent).toBe("t:permissions_recoveryDeniedBody");
+  });
+});


### PR DESCRIPTION
## What & why

Slice **3b** of #437. Acceptance hypothesis: *a ~10-second live audio-meter "try it yourself" both verifies the mic and gives a safe first utterance.*

Slice 2's onboarding page told users to start talking but gave them no no-stakes way to confirm their microphone works. This adds an inline mic test: click → speak → watch the level bar move → "your microphone works 🎉".

## Changes

- **`src/onboarding/audioLevel.ts`** — pure RMS + meter-scaling math.
- **`src/onboarding/micMeter.ts`** — metering lifecycle (tick → report → auto-stop after 10s → cleanup) with injected scheduler/clock; unit-testable.
- **`src/onboarding/micTestWiring.ts`** — button/meter/status wiring with Web Audio behind an injectable `acquire()` (default: `getUserMedia` + `AnalyserNode`), so start/stop/toggle/error are fully hermetic. **Reuses slice-3a's `classifyMicError`/`describeMicRecovery`** so a denied mic shows real recovery guidance instead of a dead end.
- Onboarding HTML/CSS: a "Test your microphone" button, an animated level bar, and a polite `aria-live` status; `onboarding_micTest*` i18n keys.

## Tests (fail-first TDD)

- `audioLevel.spec.ts` — RMS for silence/full-scale/DC/empty, clamping + monotonicity.
- `micMeter.spec.ts` — ticking, auto-stop-once, idempotent stop, cleanup-always-runs.
- `micTestWiring.spec.ts` — start reveals meter + drives fill width, auto-stop releases the source, click-to-stop, **denied → recovery guidance + button re-enabled**.
- Full suite green: Vitest **1516 passed** (1 skipped), Jest passed, `tsc --noEmit` clean, `i18n-validate` clean.

## Scope / notes

The real `getUserMedia` + `AnalyserNode` path is Layer-3/4 territory (a real mic / fake-audio browser); all control-flow and math are covered hermetically here via the `acquire()` seam. Remaining #437 slices: **4** (quiet/whisper mode + speed-payoff reveal) and **1b** (connected ping — blocked on the `saypi-saas` endpoint contract).

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)