### PR TITLE
feat(audio): quiet/whisper mode — sensitive VAD + softer TTS (#437)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -121,6 +121,14 @@
     "message": "Sound effects",
     "description": "Label for the checkbox to enable/disable sound effects."
   },
+  "quietModeLabel": {
+    "message": "Quiet mode",
+    "description": "Label for the toggle that enables quiet/whisper mode."
+  },
+  "quietModeTooltip": {
+    "message": "Speak softly — picks up quieter speech and lowers the assistant's reply volume, so you can use voice around others.",
+    "description": "Tooltip explaining what quiet/whisper mode does."
+  },
   "preferedLanguage": {
     "message": "Language",
     "description": "Label for a control to select the prefered transcription language."

--- a/entrypoints/settings/tabs/general/GeneralPanel.tsx
+++ b/entrypoints/settings/tabs/general/GeneralPanel.tsx
@@ -37,6 +37,25 @@ export function GeneralPanel() {
 
       <div
         class="user-preference-item w-full max-w-lg"
+        id="quiet-mode-preference"
+      >
+        <label
+          class="wraper"
+          for="quiet-mode"
+          data-i18n-attr="title:quietModeTooltip"
+        >
+          <span class="label-text" data-i18n="quietModeLabel">
+            Quiet mode
+          </span>
+          <div class="switch-wrap control">
+            <input type="checkbox" id="quiet-mode" name="quietMode" />
+            <div class="switch"></div>
+          </div>
+        </label>
+      </div>
+
+      <div
+        class="user-preference-item w-full max-w-lg"
         id="analytics-consent-preference-item"
       >
         <label class="wraper" for="share-data">

--- a/entrypoints/settings/tabs/general/index.ts
+++ b/entrypoints/settings/tabs/general/index.ts
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { TabController } from '../../shared/types';
 import { getStoredValue, setStoredValue } from '../../shared/storage';
+import { sendMessageToActiveTab } from '../../shared/messaging';
 import { mountInto, unmountFrom } from '../../../../src/ui/preact/mount';
 import { GeneralPanel } from './GeneralPanel';
 import dataSharingPortraitUrl from '../../../../src/popup/data-sharing-portrait.jpg';
@@ -19,6 +20,7 @@ export class GeneralTab implements TabController {
 
     // Initialize components
     await this.setupSoundEffects();
+    await this.setupQuietMode();
     await this.setupAnalytics();
     await this.setupConsent();
     this.setupClearPreferences();
@@ -63,6 +65,30 @@ export class GeneralTab implements TabController {
     });
   }
   
+  /**
+   * Quiet/whisper mode (#437): a more sensitive VAD preset plus quieter TTS
+   * playback, so the user can speak softly (e.g. around others). The content
+   * script reacts live via the broadcast preference message.
+   */
+  private async setupQuietMode(): Promise<void> {
+    const input = this.container.querySelector<HTMLInputElement>('#quiet-mode');
+    if (!input) return;
+
+    const value = await getStoredValue('quietMode', false);
+    input.checked = value;
+    if (value) input.parentElement?.classList.add('checked');
+
+    input.addEventListener('change', async () => {
+      try {
+        await setStoredValue('quietMode', input.checked);
+        input.parentElement?.classList.toggle('checked', input.checked);
+        sendMessageToActiveTab({ quietMode: input.checked });
+      } catch (error) {
+        // Error already logged by setStoredValue; prevent unhandled rejection.
+      }
+    });
+  }
+
   private async setupAnalytics(): Promise<void> {
     const input = this.container.querySelector<HTMLInputElement>('#share-data');
     if (!input) return;

--- a/src/audio/AudioModule.js
+++ b/src/audio/AudioModule.js
@@ -10,6 +10,7 @@ import { isSafari } from "../UserAgentModule.ts";
 // SlowResponseHandler and adapter are imported dynamically for Pi.ai only
 import { CacheBuster } from "../CacheBuster.ts";
 import { UserPreferenceModule } from "../prefs/PreferenceModule.ts";
+import { ttsVolumeForQuietMode } from "../tts/quietVolume.ts";
 import { ChatbotService } from "../chatbots/ChatbotService.ts";
 import OffscreenAudioBridge from "./OffscreenAudioBridge.js";
 import { BrowserCompatibilityModule } from "../compat/BrowserCompatibilityModule.ts";
@@ -595,8 +596,11 @@ export default class AudioModule {
         return;
       }
       
-      // Fallback to in-page audio
+      // Fallback to in-page audio. Quiet/whisper mode plays the reply softly (#437).
       audioElement.src = url;
+      audioElement.volume = ttsVolumeForQuietMode(
+        UserPreferenceModule.getInstance().getCachedQuietMode()
+      );
       if (play) {
         const playbackController = new AbortController();
         this.pendingPlaybackController = playbackController;

--- a/src/audio/OffscreenAudioBridge.js
+++ b/src/audio/OffscreenAudioBridge.js
@@ -2,6 +2,8 @@ import { browser } from "wxt/browser";
 import { logger } from "../LoggingModule.js";
 import EventBus from "../events/EventBus.js";
 import { isFirefox, isSafari, isMobileChromium, likelySupportsOffscreen, getBrowserInfo } from "../UserAgentModule.ts";
+import { UserPreferenceModule } from "../prefs/PreferenceModule.ts";
+import { ttsVolumeForQuietMode } from "../tts/quietVolume.ts";
 
 /**
  * Bridge class that connects the content script to the offscreen document for audio playback
@@ -403,7 +405,11 @@ export default class OffscreenAudioBridge {
       return false;
     }
     
-    return await this._sendMessageToOffscreen("AUDIO_LOAD_REQUEST", { url, autoPlay });
+    // Quiet/whisper mode plays the assistant's reply softly (#437).
+    const volume = ttsVolumeForQuietMode(
+      UserPreferenceModule.getInstance().getCachedQuietMode()
+    );
+    return await this._sendMessageToOffscreen("AUDIO_LOAD_REQUEST", { url, autoPlay, volume });
   }
 
   /**

--- a/src/offscreen/audio_handler.ts
+++ b/src/offscreen/audio_handler.ts
@@ -124,7 +124,7 @@ function registerLifecycleDebug(audio: HTMLAudioElement) {
   });
 }
 
-function loadAudio(url: string, tabId: number, playImmediately: boolean = true) {
+function loadAudio(url: string, tabId: number, playImmediately: boolean = true, volume?: number) {
   if (!audioElement) {
     initializeAudio();
   }
@@ -159,7 +159,12 @@ function loadAudio(url: string, tabId: number, playImmediately: boolean = true) 
     
     // Set the source
     audioElement.src = url;
-    
+
+    // Apply quiet-mode playback volume when provided (#437); default stays full.
+    if (typeof volume === "number" && isFinite(volume)) {
+      audioElement.volume = Math.min(1, Math.max(0, volume));
+    }
+
     if (playImmediately) {
       logger.debug(`[SayPi Audio Handler] Attempting to play audio from: ${url}`);
       audioElement.play()
@@ -388,7 +393,7 @@ if (!audioHandlerGlobal.__saypiAudioHandlerRegistered) {
     if (message.url) {
       logger.debug(`[SayPi Audio Handler] Processing AUDIO_LOAD_REQUEST with URL: ${message.url}`);
       const autoPlay = message.autoPlay !== false; // Default to true if not specified
-      return loadAudio(message.url, sourceTabId, autoPlay);
+      return loadAudio(message.url, sourceTabId, autoPlay, message.volume);
     } else {
       logger.warn(`[SayPi Audio Handler] Missing URL in AUDIO_LOAD_REQUEST`);
       return { success: false, error: "No URL provided for loading audio" };

--- a/src/prefs/PreferenceModule.ts
+++ b/src/prefs/PreferenceModule.ts
@@ -28,7 +28,7 @@ const LOCAL_STORAGE_KEYS = [
   "prefer", "language", "discretionaryMode", "nickname",
   "autoSubmit", "allowInterruptions", "soundEffects", "theme",
   "shareData", "voiceId", VOICE_PREFERENCES_KEY, "enableTTS", "vadStatusIndicatorEnabled", "removeFillerWords",
-  "autoReadAloudChatGPT"
+  "autoReadAloudChatGPT", "quietMode"
 ];
 
 // Add a flag to mark that sync-to-local migration has completed
@@ -153,6 +153,10 @@ class UserPreferenceModule {
         voiceId: activeVoiceId ?? null,
         voicePreferences: preferences,
       });
+    }).catch((error) => {
+      // Init side-effects must not surface as unhandled rejections (e.g. if the
+      // chatbot identity isn't resolvable yet); the cache simply stays unprimed.
+      console.debug("[PreferenceModule] Failed to prime voice preferences:", error);
     });
     this.getStoredValue("enableTTS", true, 'local').then((value) => {
       this.cache.setCachedValue("enableTTS", value);
@@ -183,6 +187,12 @@ class UserPreferenceModule {
     this.getStoredValue("removeFillerWords", false, 'local').then((value) => {
       this.cache.setCachedValue("removeFillerWords", value);
       EventBus.emit("userPreferenceChanged", { removeFillerWords: value });
+    });
+
+    // Quiet/whisper mode (default false) — #437
+    this.getStoredValue("quietMode", false, 'local').then((value) => {
+      this.cache.setCachedValue("quietMode", value);
+      EventBus.emit("userPreferenceChanged", { quietMode: value });
     });
 
     // Auto Read Aloud for ChatGPT (default true)
@@ -362,6 +372,12 @@ class UserPreferenceModule {
           EventBus.emit("userPreferenceChanged", { removeFillerWords: request.removeFillerWords });
         }
 
+        if ("quietMode" in request) {
+          this.cache.setCachedValue("quietMode", request.quietMode);
+          actions.push(this.setStoredValue("quietMode", request.quietMode, 'local'));
+          EventBus.emit("userPreferenceChanged", { quietMode: request.quietMode });
+        }
+
         if ("autoReadAloudChatGPT" in request) {
           this.cache.setCachedValue("autoReadAloudChatGPT", request.autoReadAloudChatGPT);
           actions.push(this.setStoredValue("autoReadAloudChatGPT", request.autoReadAloudChatGPT, 'local'));
@@ -447,6 +463,10 @@ class UserPreferenceModule {
                   case "removeFillerWords":
                     this.cache.setCachedValue("removeFillerWords", newValue);
                     eventData = { removeFillerWords: newValue };
+                    break;
+                  case "quietMode":
+                    this.cache.setCachedValue("quietMode", newValue);
+                    eventData = { quietMode: newValue };
                     break;
                   case "autoReadAloudChatGPT":
                     this.cache.setCachedValue("autoReadAloudChatGPT", newValue);
@@ -671,6 +691,27 @@ class UserPreferenceModule {
     this.cache.setCachedValue("removeFillerWords", enabled);
     EventBus.emit("userPreferenceChanged", { removeFillerWords: enabled });
     return this.setStoredValue("removeFillerWords", enabled, 'local');
+  }
+
+  // Quiet/whisper mode (LOCAL) — #437: more sensitive VAD + quieter TTS playback
+  public async getQuietMode(): Promise<boolean> {
+    const cached = this.cache.getCachedValue("quietMode", null);
+    if (cached !== null) {
+      return Promise.resolve(cached as boolean);
+    }
+    const stored = await this.getStoredValue("quietMode", false, 'local') as boolean;
+    this.cache.setCachedValue("quietMode", stored);
+    return stored;
+  }
+
+  public getCachedQuietMode(): boolean {
+    return this.cache.getCachedValue("quietMode", false) as boolean;
+  }
+
+  public setQuietMode(enabled: boolean): Promise<void> {
+    this.cache.setCachedValue("quietMode", enabled);
+    EventBus.emit("userPreferenceChanged", { quietMode: enabled });
+    return this.setStoredValue("quietMode", enabled, 'local');
   }
 
   // keepSegments removed (dev-only via env)

--- a/src/state-machines/AudioInputMachine.ts
+++ b/src/state-machines/AudioInputMachine.ts
@@ -10,6 +10,7 @@ import { logger } from "../LoggingModule";
 import { likelySupportsOffscreen, getBrowserInfo } from "../UserAgentModule";
 import { VADPreset, selectVADPreset } from "../vad/VADConfigs";
 import { ChatbotIdentifier } from "../chatbots/ChatbotIdentifier";
+import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { persistAudioSegment } from "../audio/AudioSegmentPersistence";
 
 setupInterceptors();
@@ -36,13 +37,10 @@ let previousDefaultDevice: MediaDeviceInfo | null = null;
 // VAD client instance - will be either OffscreenVADClient or OnscreenVADClient
 let vadClient: VADClientInterface | null = null;
 
-// Choose the VAD preset once based on chatbot context. #420 item 4: the host→preset
-// mapping is centralised + benchmark-driven in selectVADPreset (see bench/vad/README.md);
-// today every context resolves to `balanced` (generic/dictation pages used to get the
-// trigger-happy `highSensitivity`, which the benchmark showed over-uploads real noise/music).
-const currentVADPreset: VADPreset = selectVADPreset({
-  isDictation: ChatbotIdentifier.isInDictationMode(),
-});
+// The VAD preset is chosen per-recording (see setupRecording) so a runtime change to
+// quiet mode takes effect on the next call without a page reload. #420 item 4: the
+// host→preset mapping is centralised + benchmark-driven in selectVADPreset
+// (see bench/vad/README.md); #437: quiet/whisper mode overrides it to highSensitivity.
 
 // Initialize the appropriate VAD client based on browser support
 function initializeVADClient() {
@@ -336,9 +334,14 @@ async function setupRecording(completion_callback?: (success: boolean, error?: s
       logger.debug("[AudioInputMachine] Using OnscreenVADClient - skipping extension permission check (host site permissions will be requested during VAD initialization)...");
     }
 
-    // Initialize the VAD client (works for both offscreen and onscreen)
+    // Initialize the VAD client (works for both offscreen and onscreen). Choose the
+    // preset now so a runtime quiet-mode toggle is honoured on the next recording (#437).
     logger.debug("[AudioInputMachine] Initializing VAD client...");
-    const initResult = await vadClient.initialize({ preset: currentVADPreset });
+    const preset: VADPreset = selectVADPreset({
+      isDictation: ChatbotIdentifier.isInDictationMode(),
+      quietMode: UserPreferenceModule.getInstance().getCachedQuietMode(),
+    });
+    const initResult = await vadClient.initialize({ preset });
     
     if (!initResult.success) {
       const errorMsg = initResult.error || "Failed to initialize VAD";

--- a/src/tts/quietVolume.ts
+++ b/src/tts/quietVolume.ts
@@ -1,0 +1,15 @@
+/**
+ * TTS playback volume for quiet/whisper mode (#437).
+ *
+ * In quiet mode the assistant should reply softly so the whole exchange stays
+ * discreet (e.g. around others). Single source of truth for the scalar, used by
+ * both the in-page and offscreen playback paths.
+ */
+
+/** Playback volume (0..1) applied to TTS audio when quiet mode is on. */
+export const QUIET_TTS_VOLUME = 0.5;
+
+/** Resolves the TTS playback volume (0..1) for the current quiet-mode state. */
+export function ttsVolumeForQuietMode(quietMode: boolean): number {
+  return quietMode ? QUIET_TTS_VOLUME : 1;
+}

--- a/src/vad/VADConfigs.ts
+++ b/src/vad/VADConfigs.ts
@@ -76,6 +76,12 @@ export const VAD_CONFIGS: Record<VADPreset, Partial<RealTimeVADOptions>> = {
 export interface VADSelectionContext {
   /** True on generic / universal-dictation pages; false on dedicated chat sites. */
   isDictation: boolean;
+  /**
+   * Quiet/whisper mode (#437): the user is speaking quietly (e.g. around others),
+   * so trade the benchmark-tuned defaults for the most sensitive preset to catch
+   * whispered speech. Off/unset preserves the normal mapping.
+   */
+  quietMode?: boolean;
 }
 
 /**
@@ -90,10 +96,12 @@ export interface VADSelectionContext {
  *  - Dedicated chat sites stay `balanced` — the core product and the quietest context, with
  *    no data-backed reason to make them *more* trigger-happy.
  *
- * `context` is unused today but kept as the seam for a future noise/SNR- or device-adaptive
+ * Quiet/whisper mode (#437) overrides the host mapping with `highSensitivity` so
+ * quietly-spoken/whispered speech still opens the gate. Otherwise the host context
+ * is unused today but kept as the seam for a future noise/SNR- or device-adaptive
  * split (item 4's remaining refinement), which would re-diverge the mapping.
  */
 export function selectVADPreset(context: VADSelectionContext): VADPreset {
-  void context;
+  if (context.quietMode) return "highSensitivity";
   return "balanced";
 }

--- a/test/state-machines/AudioInputMachine-presetWiring.spec.ts
+++ b/test/state-machines/AudioInputMachine-presetWiring.spec.ts
@@ -17,14 +17,20 @@ const src = readFileSync(
 );
 
 describe("#420 AudioInputMachine selects the VAD preset via selectVADPreset", () => {
-  it("imports and calls selectVADPreset to choose currentVADPreset", () => {
+  it("imports and calls selectVADPreset to choose the preset", () => {
     expect(src).toMatch(/import\s*\{[^}]*\bselectVADPreset\b[^}]*\}\s*from\s*["']\.\.\/vad\/VADConfigs["']/);
-    expect(src).toMatch(/currentVADPreset[^=]*=\s*selectVADPreset\(/);
+    // Selection is computed per-recording (see #437) rather than a module const, but it
+    // must still go through selectVADPreset(...) — not a hardcoded literal.
+    expect(src).toMatch(/=\s*selectVADPreset\(/);
   });
 
   it("no longer hardcodes the trigger-happy highSensitivity preset for dictation pages", () => {
     // The benchmark retired highSensitivity from active selection; it must not reappear
     // as a literal preset choice in this file.
     expect(src).not.toMatch(/["']highSensitivity["']/);
+  });
+
+  it("#437 passes the quiet-mode preference into the preset selection", () => {
+    expect(src).toMatch(/quietMode:\s*UserPreferenceModule\.getInstance\(\)\.getCachedQuietMode\(\)/);
   });
 });

--- a/test/tts/quietVolume.spec.ts
+++ b/test/tts/quietVolume.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { QUIET_TTS_VOLUME, ttsVolumeForQuietMode } from "../../src/tts/quietVolume";
+
+describe("ttsVolumeForQuietMode (#437)", () => {
+  it("is full volume when quiet mode is off", () => {
+    expect(ttsVolumeForQuietMode(false)).toBe(1);
+  });
+
+  it("is the reduced quiet volume when quiet mode is on", () => {
+    expect(ttsVolumeForQuietMode(true)).toBe(QUIET_TTS_VOLUME);
+  });
+
+  it("the quiet volume is a valid, genuinely quieter scalar", () => {
+    expect(QUIET_TTS_VOLUME).toBeGreaterThan(0);
+    expect(QUIET_TTS_VOLUME).toBeLessThan(1);
+  });
+});

--- a/test/vad/VADConfigs.spec.ts
+++ b/test/vad/VADConfigs.spec.ts
@@ -109,8 +109,20 @@ describe("#420 selectVADPreset (host→preset mapping)", () => {
     expect(selectVADPreset({ isDictation: false })).toBe("balanced");
   });
 
-  it("never selects the trigger-happy highSensitivity preset for any current context", () => {
+  it("never selects the trigger-happy highSensitivity preset for any non-quiet context", () => {
     const chosen: VADPreset[] = [true, false].map((isDictation) => selectVADPreset({ isDictation }));
     expect(chosen).not.toContain("highSensitivity");
+  });
+});
+
+describe("#437 selectVADPreset quiet/whisper mode", () => {
+  it("uses highSensitivity when quiet mode is on (catches whispered speech)", () => {
+    expect(selectVADPreset({ isDictation: false, quietMode: true })).toBe("highSensitivity");
+    expect(selectVADPreset({ isDictation: true, quietMode: true })).toBe("highSensitivity");
+  });
+
+  it("falls back to the normal mapping when quiet mode is off or unset", () => {
+    expect(selectVADPreset({ isDictation: false, quietMode: false })).toBe("balanced");
+    expect(selectVADPreset({ isDictation: true })).toBe("balanced");
   });
 });


### PR DESCRIPTION
## What & why

Slice **4a** of #437. Per your call: quiet/whisper mode = the existing **highSensitivity** VAD preset **+ lowered TTS playback volume**, behind a settings toggle. Lets a user speak quietly (around others) and still be heard, with the assistant replying softly so the whole exchange stays discreet.

## Changes

- **VAD sensitivity** — `selectVADPreset` (the #420 seam) gains a `quietMode` context flag; when on it returns `highSensitivity` (opens on quieter speech) instead of the benchmark default. Preset is now chosen **per-recording** in `AudioInputMachine.setupRecording` (was a module-load const), so toggling quiet mode takes effect on the next call **without a page reload**.
- **TTS volume** — new `ttsVolumeForQuietMode(quietMode)` scalar (single source of truth), applied on **both** playback paths: in-page (`AudioModule.loadAudio`) and offscreen (threaded through `OffscreenAudioBridge.loadAudio` → `AUDIO_LOAD_REQUEST` → `audio_handler.loadAudio`, clamped to 0..1). No GainNode existed; this sets `audioElement.volume`.
- **Preference** — `quietMode` local boolean in `PreferenceModule` (mirrors `removeFillerWords`), read synchronously via `getCachedQuietMode()`; VAD + TTS pick up changes live via the cache update on the broadcast pref message.
- **Settings** — a "Quiet mode" toggle in the General tab + `quietMode*` i18n.

### Incidental hardening
`PreferenceModule`'s voice-preference priming `.then()` had no `.catch()`. Once these new call sites construct the singleton in tests, a partially-mocked `ChatbotIdentifier.getAppId()` surfaced as an **unhandled rejection** (always a function in prod). Added a `.catch()` — init side-effects shouldn't reject. (Confirmed the error is absent on clean `main` and absent again after the fix.)

## Tests (fail-first TDD)

- `VADConfigs.spec` — quiet mode → highSensitivity; off/unset → normal mapping.
- `tts/quietVolume.spec` — full volume off, reduced on, valid scalar.
- `AudioInputMachine-presetWiring.spec` — #420 guard updated for call-time selection + extended to lock the quiet-mode wiring.
- Full suite green: Vitest **1522 passed** (1 skipped, **no unhandled errors**), Jest passed, `tsc --noEmit` clean, `i18n-validate` clean.

## Scope / follow-ups

Surfaced as a settings toggle this PR; the **onboarding environment question** (private/mixed/around-others → quiet mode) can map onto this same pref as a small follow-up. The VAD/TTS real-audio behaviour is best confirmed at Layer 4; the logic is covered hermetically here. Slice **4b** (speed-payoff post-win notice) is parked on saypi-saas#202 (value-mirror data source). Slice 1b (connected ping) closed — derived backend-side from `teamId`.

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)