### PR TITLE
feat(onboarding): environment question pre-sets quiet mode (#437)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1240,6 +1240,30 @@
     "message": "Nice — your microphone works! 🎉",
     "description": "Status shown after the onboarding mic test completes successfully."
   },
+  "onboarding_envTitle": {
+    "message": "Where will you usually talk?",
+    "description": "Heading for the onboarding question about the user's environment."
+  },
+  "onboarding_envPrivate": {
+    "message": "Somewhere private",
+    "description": "Environment option: a private space."
+  },
+  "onboarding_envMixed": {
+    "message": "A mix of places",
+    "description": "Environment option: a mix of private and shared spaces."
+  },
+  "onboarding_envAroundOthers": {
+    "message": "Around other people",
+    "description": "Environment option: around other people."
+  },
+  "onboarding_envQuietOn": {
+    "message": "Quiet mode on — we'll pick up softer speech and reply quietly, so you can talk discreetly.",
+    "description": "Confirmation shown when the environment answer enables quiet mode."
+  },
+  "onboarding_envQuietOff": {
+    "message": "Got it — we'll keep the standard listening and playback settings.",
+    "description": "Confirmation shown when the environment answer leaves quiet mode off."
+  },
   "permissions_promptTitle": {
     "message": "Microphone Permission",
     "description": "Title of the permissions prompt page."

--- a/entrypoints/onboarding/index.html
+++ b/entrypoints/onboarding/index.html
@@ -51,6 +51,25 @@
         </li>
       </ol>
 
+      <section class="env-question">
+        <h2 id="onboarding-env-title">Where will you usually talk?</h2>
+        <div class="env-options" role="radiogroup" aria-labelledby="onboarding-env-title">
+          <label class="env-option">
+            <input type="radio" name="voice-environment" value="private" />
+            <span id="onboarding-env-private-label">Somewhere private</span>
+          </label>
+          <label class="env-option">
+            <input type="radio" name="voice-environment" value="mixed" />
+            <span id="onboarding-env-mixed-label">A mix of places</span>
+          </label>
+          <label class="env-option">
+            <input type="radio" name="voice-environment" value="around-others" />
+            <span id="onboarding-env-around-label">Around other people</span>
+          </label>
+        </div>
+        <p class="env-status" id="onboarding-env-status" role="status" aria-live="polite"></p>
+      </section>
+
       <p class="footer-text" id="onboarding-footer">
         You can revisit this any time from Say, Pi's settings. Your privacy matters — audio
         is only captured during an active call.

--- a/entrypoints/onboarding/style.css
+++ b/entrypoints/onboarding/style.css
@@ -137,6 +137,50 @@ h1 {
   color: var(--saypi-ink);
 }
 
+.env-question {
+  margin: 28px 0 0;
+  padding-top: 24px;
+  border-top: 1px solid #ece9fb;
+}
+
+.env-question h2 {
+  font-size: 1.1rem;
+  color: var(--saypi-ink);
+  margin: 0 0 12px;
+}
+
+.env-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.env-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border: 1.5px solid #ddd6fe;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.env-option:hover {
+  border-color: var(--saypi-accent);
+}
+
+.env-option input {
+  accent-color: var(--saypi-accent);
+}
+
+.env-status {
+  margin: 12px 0 0;
+  min-height: 1.2em;
+  font-size: 0.95rem;
+  color: var(--saypi-accent);
+}
+
 .footer-text {
   font-size: 0.9rem;
   color: #7a7f87;

--- a/src/onboarding/environmentQuestion.ts
+++ b/src/onboarding/environmentQuestion.ts
@@ -1,0 +1,55 @@
+/**
+ * Wires the onboarding "where will you usually talk?" question (#437 slice 4d).
+ *
+ * On selection, maps the environment to the quiet-mode default and persists it.
+ * The storage write is injected so the binding logic is unit-testable; the page
+ * passes a writer that sets the `quietMode` pref (which content scripts pick up
+ * live via storage.onChanged).
+ */
+import {
+  environmentToQuietMode,
+  VOICE_ENVIRONMENTS,
+  type VoiceEnvironment,
+} from "./environmentQuietMode";
+
+export interface EnvironmentQuestionDeps {
+  translate: (key: string) => string;
+  setQuietMode: (on: boolean) => Promise<void>;
+}
+
+/** Binds the environment radios; returns a disposer. */
+export function wireEnvironmentQuestion(
+  root: ParentNode,
+  deps: EnvironmentQuestionDeps
+): () => void {
+  const radios = Array.from(
+    root.querySelectorAll<HTMLInputElement>('input[name="voice-environment"]')
+  );
+  const status = root.querySelector<HTMLElement>("#onboarding-env-status");
+
+  const onChange = async (radio: HTMLInputElement): Promise<void> => {
+    if (!radio.checked) return;
+    const env = radio.value as VoiceEnvironment;
+    if (!(VOICE_ENVIRONMENTS as readonly string[]).includes(env)) return;
+
+    const quiet = environmentToQuietMode(env);
+    try {
+      await deps.setQuietMode(quiet);
+    } catch (e) {
+      console.debug("[Onboarding] Failed to apply quiet mode from environment:", e);
+    }
+    if (status) {
+      status.textContent = deps.translate(
+        quiet ? "onboarding_envQuietOn" : "onboarding_envQuietOff"
+      );
+    }
+  };
+
+  const handlers = radios.map((radio) => {
+    const handler = () => void onChange(radio);
+    radio.addEventListener("change", handler);
+    return { radio, handler };
+  });
+
+  return () => handlers.forEach(({ radio, handler }) => radio.removeEventListener("change", handler));
+}

--- a/src/onboarding/environmentQuietMode.ts
+++ b/src/onboarding/environmentQuietMode.ts
@@ -1,0 +1,16 @@
+/**
+ * Onboarding environment question → quiet mode mapping (#437 slice 4d).
+ *
+ * Asks where the user will usually talk, and pre-sets quiet/whisper mode for the
+ * one case where speaking aloud is most awkward — around others. Pure so it's
+ * unit-tested; the page wiring reads the answer and flips the `quietMode` pref.
+ */
+
+export const VOICE_ENVIRONMENTS = ["private", "mixed", "around-others"] as const;
+
+export type VoiceEnvironment = (typeof VOICE_ENVIRONMENTS)[number];
+
+/** Whether the chosen environment should enable quiet/whisper mode by default. */
+export function environmentToQuietMode(env: VoiceEnvironment): boolean {
+  return env === "around-others";
+}

--- a/src/onboarding/onboarding-page.ts
+++ b/src/onboarding/onboarding-page.ts
@@ -5,8 +5,10 @@
  * other locales by id. The mapping + apply step are extracted as a pure
  * function so they can be unit-tested in JSDOM without the extension runtime.
  */
+import { browser } from "wxt/browser";
 import getMessage from "../i18n";
 import { wireMicTest } from "./micTestWiring";
+import { wireEnvironmentQuestion } from "./environmentQuestion";
 
 /** Maps element ids in onboarding/index.html to their i18n message keys. */
 export const ONBOARDING_I18N_KEYS: Record<string, string> = {
@@ -20,6 +22,10 @@ export const ONBOARDING_I18N_KEYS: Record<string, string> = {
   "onboarding-cta-claude": "onboarding_ctaClaude",
   "onboarding-cta-chatgpt": "onboarding_ctaChatgpt",
   "onboarding-mic-test-btn": "onboarding_micTestButton",
+  "onboarding-env-title": "onboarding_envTitle",
+  "onboarding-env-private-label": "onboarding_envPrivate",
+  "onboarding-env-mixed-label": "onboarding_envMixed",
+  "onboarding-env-around-label": "onboarding_envAroundOthers",
   "onboarding-footer": "onboarding_footer",
 };
 
@@ -58,9 +64,19 @@ export function setupMicTest(root: ParentNode): void {
   );
 }
 
+/** Wires the "where will you usually talk?" question if present (#437). */
+export function setupEnvironmentQuestion(root: ParentNode): void {
+  if (!root.querySelector('input[name="voice-environment"]')) return;
+  wireEnvironmentQuestion(root, {
+    translate: (key) => getMessage(key),
+    setQuietMode: (on) => browser.storage.local.set({ quietMode: on }),
+  });
+}
+
 function init(): void {
   applyOnboardingI18n(document, (key) => getMessage(key));
   setupMicTest(document);
+  setupEnvironmentQuestion(document);
 }
 
 if (typeof document !== "undefined") {

--- a/test/onboarding/environmentQuestion.spec.ts
+++ b/test/onboarding/environmentQuestion.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { wireEnvironmentQuestion } from "../../src/onboarding/environmentQuestion";
+
+const translate = (k: string) => `t:${k}`;
+
+function buildRoot(): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML = `
+    <input type="radio" name="voice-environment" value="private" id="env-private" />
+    <input type="radio" name="voice-environment" value="mixed" id="env-mixed" />
+    <input type="radio" name="voice-environment" value="around-others" id="env-around" />
+    <p id="onboarding-env-status"></p>
+  `;
+  return root;
+}
+
+function pick(root: ParentNode, id: string): HTMLInputElement {
+  const el = root.querySelector<HTMLInputElement>(`#${id}`)!;
+  el.checked = true;
+  el.dispatchEvent(new Event("change"));
+  return el;
+}
+
+describe("wireEnvironmentQuestion (#437)", () => {
+  it("enables quiet mode and confirms when 'around others' is chosen", async () => {
+    const root = buildRoot();
+    const setQuietMode = vi.fn().mockResolvedValue(undefined);
+    wireEnvironmentQuestion(root, { translate, setQuietMode });
+
+    pick(root, "env-around");
+    await Promise.resolve();
+
+    expect(setQuietMode).toHaveBeenCalledWith(true);
+    expect(root.querySelector("#onboarding-env-status")!.textContent).toBe("t:onboarding_envQuietOn");
+  });
+
+  it("leaves quiet mode off for a private space", async () => {
+    const root = buildRoot();
+    const setQuietMode = vi.fn().mockResolvedValue(undefined);
+    wireEnvironmentQuestion(root, { translate, setQuietMode });
+
+    pick(root, "env-private");
+    await Promise.resolve();
+
+    expect(setQuietMode).toHaveBeenCalledWith(false);
+    expect(root.querySelector("#onboarding-env-status")!.textContent).toBe("t:onboarding_envQuietOff");
+  });
+
+  it("does not throw when the storage write rejects", async () => {
+    const root = buildRoot();
+    const setQuietMode = vi.fn().mockRejectedValue(new Error("storage fail"));
+    wireEnvironmentQuestion(root, { translate, setQuietMode });
+
+    expect(() => pick(root, "env-around")).not.toThrow();
+    await Promise.resolve();
+    expect(setQuietMode).toHaveBeenCalledWith(true);
+  });
+
+  it("the disposer detaches the change handlers", async () => {
+    const root = buildRoot();
+    const setQuietMode = vi.fn().mockResolvedValue(undefined);
+    const dispose = wireEnvironmentQuestion(root, { translate, setQuietMode });
+
+    dispose();
+    pick(root, "env-around");
+    await Promise.resolve();
+
+    expect(setQuietMode).not.toHaveBeenCalled();
+  });
+});

--- a/test/onboarding/environmentQuietMode.spec.ts
+++ b/test/onboarding/environmentQuietMode.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import {
+  environmentToQuietMode,
+  VOICE_ENVIRONMENTS,
+} from "../../src/onboarding/environmentQuietMode";
+
+describe("environmentToQuietMode (#437)", () => {
+  it("enables quiet mode only when the user is around others", () => {
+    expect(environmentToQuietMode("around-others")).toBe(true);
+  });
+
+  it("leaves quiet mode off for private and mixed spaces", () => {
+    expect(environmentToQuietMode("private")).toBe(false);
+    expect(environmentToQuietMode("mixed")).toBe(false);
+  });
+
+  it("covers exactly the three offered environments", () => {
+    expect(VOICE_ENVIRONMENTS).toEqual(["private", "mixed", "around-others"]);
+    // every offered environment yields a boolean (no undefined branches)
+    for (const env of VOICE_ENVIRONMENTS) {
+      expect(typeof environmentToQuietMode(env)).toBe("boolean");
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Slice **4d** of #437 — greenlit by the saypi-saas agent on the issue. The design's "defuse the awkwardness of talking aloud" lever: ask, on the onboarding page, **where the user will usually talk**, and pre-set **quiet/whisper mode** (shipped in 4a) for the case where speaking aloud is most awkward — around others — *before* their first call.

## Changes

- **`src/onboarding/environmentQuietMode.ts`** — pure mapping: only `around-others` enables quiet mode (`private` / `mixed` leave it off).
- **`src/onboarding/environmentQuestion.ts`** — binds the radio group; on selection persists the choice through an **injected** storage writer and confirms in an `aria-live` region (so the binding is unit-testable).
- **Onboarding page** — a "Where will you usually talk?" radiogroup + status line. The page writes the `quietMode` pref to `browser.storage.local`; content scripts pick it up **live** via `storage.onChanged` (the slice-4a `quietMode` case), so VAD sensitivity + softer TTS are pre-set before the first conversation. `onboarding_env*` i18n + styles.

## Tests (fail-first TDD)

- `environmentQuietMode.spec.ts` — around-others→on, private/mixed→off, exhaustive coverage.
- `environmentQuestion.spec.ts` — selection applies + confirms, storage-failure swallowed, disposer detaches handlers.
- Full suite green: Vitest **1542 passed** (1 skipped), Jest passed, `tsc --noEmit` clean, `i18n-validate` clean, `wxt prepare` still emits `onboarding.html`.

## Scope

Placement is on the first-run onboarding page (the user's environment is most salient there); it reuses the existing `quietMode` pref so the settings toggle and this question stay in sync. Slice **4c** (permission-loss-after-update detection) is the other greenlit residual, coming as a separate PR. Survey (slice 3) still deferred to saypi-saas's P4 sink.

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)