### PR TITLE
feat(permissions): detect mic permission loss after update (#437)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1282,6 +1282,20 @@
       }
     }
   },
+  "permissions_revokedHeading": {
+    "message": "🎙️ Let's reconnect your microphone",
+    "description": "Heading shown when microphone access was previously granted but has since been revoked."
+  },
+  "permissions_revokedInfo": {
+    "message": "Your microphone access was turned off — this often happens after a browser or system update. Re-allow it below and $productName$ will be back to listening when you're in a call.",
+    "description": "Informational text shown when microphone access was revoked after being granted.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
+  },
   "permissions_promptAction": {
     "message": "You'll see a browser prompt at the top of this window. Just hit <strong>\"Allow while visiting the site\"</strong> so we can start talking.",
     "description": "Instructional text on what action the user should take in the browser prompt."

--- a/src/permissions/permissionLossDetection.ts
+++ b/src/permissions/permissionLossDetection.ts
@@ -1,0 +1,40 @@
+/**
+ * Microphone permission-loss detection (#437 slice 4c).
+ *
+ * Distinguishes a mic that was *previously granted but is now revoked* (e.g.
+ * macOS turning it off after an OS update) from a normal first-time prompt, so
+ * the permissions page can show tailored "your access was turned off" recovery
+ * copy instead of the generic first-run prompt. Pure + unit-tested; the
+ * background service worker persists the flag and drives the routing.
+ */
+
+/** Storage key recording that the mic was granted at least once. */
+export const MIC_GRANTED_FLAG = "saypi_mic_granted";
+
+/** Query-param value flagging the permissions page as a revoked-access recovery. */
+export const REVOKED_REASON = "revoked";
+
+/** True when the mic was granted before but the current state is no longer granted. */
+export function detectPermissionLoss(
+  previouslyGranted: boolean,
+  currentState: string
+): boolean {
+  return previouslyGranted && currentState !== "granted";
+}
+
+/** Adds the revoked-reason marker to the permissions page URL on a loss. */
+export function buildPermissionsUrl(baseUrl: string, isLoss: boolean): string {
+  if (!isLoss) return baseUrl;
+  const sep = baseUrl.includes("?") ? "&" : "?";
+  return `${baseUrl}${sep}reason=${REVOKED_REASON}`;
+}
+
+/** Reads the revoked reason from a URL query string, or null. */
+export function parsePermissionReason(search: string): typeof REVOKED_REASON | null {
+  try {
+    const params = new URLSearchParams(search);
+    return params.get("reason") === REVOKED_REASON ? REVOKED_REASON : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/permissions/permissions-prompt.ts
+++ b/src/permissions/permissions-prompt.ts
@@ -2,18 +2,28 @@
 import getMessage from '../i18n';
 import { classifyMicError } from './micPermissionRecovery';
 import { renderMicRecovery } from './micRecoveryView';
+import { parsePermissionReason } from './permissionLossDetection';
 
 document.addEventListener('DOMContentLoaded', async () => {
+  // When the background flags this as a revoked-access recovery (mic was granted
+  // before, e.g. turned off after an OS/browser update), show tailored copy
+  // instead of the first-run prompt wording (#437).
+  const isRevoked = parsePermissionReason(window.location.search) !== null;
+
   // Localize static HTML content
   document.title = getMessage('permissions_promptTitle');
   const headingElement = document.getElementById('prompt-heading');
   if (headingElement) {
-    headingElement.textContent = getMessage('permissions_promptHeading');
+    headingElement.textContent = getMessage(
+      isRevoked ? 'permissions_revokedHeading' : 'permissions_promptHeading'
+    );
   }
   const infoElement = document.getElementById('prompt-info');
   if (infoElement) {
     // The productName placeholder will be $1, which is "Say, Pi" from the appName key
-    infoElement.innerHTML = getMessage('permissions_promptInfo', getMessage('appName'));
+    infoElement.innerHTML = isRevoked
+      ? getMessage('permissions_revokedInfo', getMessage('appName'))
+      : getMessage('permissions_promptInfo', getMessage('appName'));
   }
   const actionElement = document.getElementById('prompt-action');
   if (actionElement) {

--- a/src/svc/background.ts
+++ b/src/svc/background.ts
@@ -5,6 +5,7 @@ import { authenticate, isPKCESupported } from "../auth/OAuthService";
 import { registerDevReloadHandler, DEV_FEED_SPEECH_MESSAGE } from "../dev/devReload";
 import { pickSyntheticSpeechClip } from "../offscreen/syntheticSpeechPool";
 import { maybeOpenFirstRunTab } from "../onboarding/firstRun";
+import { detectPermissionLoss, buildPermissionsUrl, MIC_GRANTED_FLAG } from "../permissions/permissionLossDetection";
 
 // Track when PKCE authentication is in progress to prevent cookie listener interference
 let isPKCEAuthInProgress = false;
@@ -736,6 +737,9 @@ async function handleCheckAndRequestMicPermission(originalRequestId: string, ori
     logger.debug(`[Background] Microphone permission state for extension origin: ${permissionStatus.state}`);
 
     if (permissionStatus.state === 'granted') {
+      // Remember the mic was granted, so a later revocation (e.g. after an OS
+      // update) can be recognised as a loss rather than a first-time prompt (#437).
+      try { await browser.storage.local.set({ [MIC_GRANTED_FLAG]: true }); } catch { /* non-fatal */ }
       replyToRequester(originalSender, {
         type: 'MICROPHONE_PERMISSION_RESPONSE',
         requestId: originalRequestId,
@@ -744,8 +748,15 @@ async function handleCheckAndRequestMicPermission(originalRequestId: string, ori
       return;
     }
 
-    // If 'denied' or 'prompt', proceed to open the permissions tab.
-    const permissionsPageUrl = getExtensionURL(PERMISSIONS_PROMPT_PATH_HTML);
+    // If 'denied' or 'prompt', proceed to open the permissions tab. If the mic
+    // was previously granted, this is a revocation — flag the page so it shows
+    // tailored "your access was turned off" recovery copy (#437).
+    let micPreviouslyGranted = false;
+    try {
+      micPreviouslyGranted = !!(await browser.storage.local.get(MIC_GRANTED_FLAG))[MIC_GRANTED_FLAG];
+    } catch { /* default false */ }
+    const isPermissionLoss = detectPermissionLoss(micPreviouslyGranted, permissionStatus.state);
+    const permissionsPageUrl = buildPermissionsUrl(getExtensionURL(PERMISSIONS_PROMPT_PATH_HTML), isPermissionLoss);
     let newTabId: number | undefined;
     let handlingPrompt = true; // Flag to manage listeners correctly
 
@@ -765,13 +776,17 @@ async function handleCheckAndRequestMicPermission(originalRequestId: string, ori
         return;
       }
       logger.debug(`[Background] Sending final MICROPHONE_PERMISSION_RESPONSE for ${originalRequestId}: granted=${granted}, error=${error}`);
+      // Record a (re)grant so a future revocation is detected as a loss (#437).
+      if (granted) {
+        browser.storage.local.set({ [MIC_GRANTED_FLAG]: true }).catch(() => undefined);
+      }
       replyToRequester(originalSender, {
         type: 'MICROPHONE_PERMISSION_RESPONSE',
         requestId: originalRequestId,
         granted: granted,
         error: error
       });
-      cleanupPromptListeners(); 
+      cleanupPromptListeners();
     };
 
     const messageListenerFromPromptTab = (msg: any, senderFromPrompt: any) => {

--- a/test/permissions/permissionLossDetection.spec.ts
+++ b/test/permissions/permissionLossDetection.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectPermissionLoss,
+  buildPermissionsUrl,
+  parsePermissionReason,
+  REVOKED_REASON,
+} from "../../src/permissions/permissionLossDetection";
+
+describe("detectPermissionLoss (#437)", () => {
+  it("is a loss when previously granted but now not granted", () => {
+    expect(detectPermissionLoss(true, "denied")).toBe(true);
+    expect(detectPermissionLoss(true, "prompt")).toBe(true);
+  });
+
+  it("is not a loss when still granted", () => {
+    expect(detectPermissionLoss(true, "granted")).toBe(false);
+  });
+
+  it("is not a loss when never previously granted (first-time prompt)", () => {
+    expect(detectPermissionLoss(false, "prompt")).toBe(false);
+    expect(detectPermissionLoss(false, "denied")).toBe(false);
+  });
+});
+
+describe("buildPermissionsUrl (#437)", () => {
+  it("appends the revoked reason on a loss", () => {
+    expect(buildPermissionsUrl("chrome-extension://x/permissions.html", true)).toBe(
+      `chrome-extension://x/permissions.html?reason=${REVOKED_REASON}`
+    );
+  });
+
+  it("leaves the url untouched for a first-time prompt", () => {
+    expect(buildPermissionsUrl("chrome-extension://x/permissions.html", false)).toBe(
+      "chrome-extension://x/permissions.html"
+    );
+  });
+});
+
+describe("parsePermissionReason (#437)", () => {
+  it("extracts the revoked reason", () => {
+    expect(parsePermissionReason("?reason=revoked")).toBe(REVOKED_REASON);
+  });
+
+  it("returns null when absent or unknown", () => {
+    expect(parsePermissionReason("")).toBeNull();
+    expect(parsePermissionReason("?reason=something-else")).toBeNull();
+    expect(parsePermissionReason("?foo=bar")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

Slice **4c** of #437 — greenlit by the saypi-saas agent. Completes the other half of the acceptance criterion *"permission loss after a browser/OS update is detected and recoverable."* A previously-granted mic that gets silently revoked (most often when macOS / the browser resets it after an update) is now **detected** on call-start and routed to **tailored recovery**, instead of being indistinguishable from a first-time prompt.

## Changes

- **`src/permissions/permissionLossDetection.ts`** — pure helpers: `detectPermissionLoss` (previously-granted ∧ now-not-granted), `buildPermissionsUrl` (adds `?reason=revoked` on a loss), `parsePermissionReason`, `MIC_GRANTED_FLAG`.
- **`src/svc/background.ts`** — the mic-permission handler records a granted flag whenever access is observed/regained, and on a not-granted check reads it to decide if this is a revocation; if so it opens the permissions page with `reason=revoked`.
- **`permissions-prompt.ts`** — reads the reason and swaps in "your access was turned off (often after an update) — re-allow it below" heading + copy, then the existing **3a recovery panel** handles the retry.
- `permissions_revoked*` i18n.

## Tests (fail-first TDD)

- `permissionLossDetection.spec.ts` — detection truth table (loss only when previously-granted & now-not-granted), URL building (reason appended only on loss), reason parsing (revoked / absent / unknown).
- Full suite green: Vitest **1549 passed** (1 skipped, no unhandled errors), Jest passed, `tsc --noEmit` clean, `i18n-validate` clean.

## Scope / verification

The pure detection + routing + copy-selection are covered hermetically; the real revoke → reconnect round-trip (OS toggling the mic, the live `navigator.permissions` state) is Layer-4 territory. Reuses slice 3a's recovery panel for the actual retry UX.

**This is the last greenlit residual of #437** (with 4d, merged). The post-win survey stays deferred to saypi-saas's P4 `/api/feedback` sink.

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)