### PR TITLE
feat(onboarding): in-extension post-win micro-survey (#437)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -724,6 +724,24 @@
       }
     }
   },
+  "surveyQuestion": {
+    "message": "How's voice working out for you so far?",
+    "description": "The single question of the one-time post-win micro-survey."
+  },
+  "surveyRatingLabel": {
+    "message": "Rate $rating$ out of 5",
+    "description": "Accessible label for a survey rating button.",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "message": "Thanks — that helps us make Say, Pi better. 🙏",
+    "description": "Acknowledgement shown after the user answers the post-win survey."
+  },
   "nicknameLabel": {
     "message": "Assistant nickname",
     "description": "Label for the input field to set a custom nickname for the AI assistant."

--- a/src/auth/UsageTracker.ts
+++ b/src/auth/UsageTracker.ts
@@ -42,6 +42,8 @@ export interface UsageStats {
   sttSeconds: number;
   /** Whether the one-time post-win speed-payoff notice has been shown — #437 */
   postWinShown: boolean;
+  /** Whether the one-time post-win micro-survey has been shown — #437 */
+  surveyShown: boolean;
 }
 
 /**
@@ -56,6 +58,7 @@ const DEFAULT_STATS: UsageStats = {
   lastPromptLevel: undefined,
   sttSeconds: 0,
   postWinShown: false,
+  surveyShown: false,
 };
 
 const STORAGE_KEY = "saypi-usage-stats";
@@ -243,6 +246,17 @@ export class UsageTracker {
     this.stats.postWinShown = true;
     await this.saveStats();
     logger.debug("[UsageTracker] Recorded post-win notice shown");
+  }
+
+  /**
+   * Record that the one-time post-win micro-survey has been shown (#437), so it
+   * never appears again.
+   */
+  public async markSurveyShown(): Promise<void> {
+    if (this.stats.surveyShown) return;
+    this.stats.surveyShown = true;
+    await this.saveStats();
+    logger.debug("[UsageTracker] Recorded post-win survey shown");
   }
 
   /**

--- a/src/onboarding/SurveyNoticeModule.ts
+++ b/src/onboarding/SurveyNoticeModule.ts
@@ -1,0 +1,141 @@
+/**
+ * Post-win micro-survey notice (#437).
+ *
+ * After a few successful spoken exchanges (a "clearly good conversation"), shows
+ * a one-time below-composer micro-survey for signed-in users. A rating posts to
+ * the saypi-saas feedback sink (Bearer-JWT authed via callApi); the result is
+ * never surfaced as an error. Mirrors the injected-notice lifecycle of
+ * SpeedPayoffNoticeModule; the gate is the pure `decideSurvey`.
+ */
+import EventBus from "../events/EventBus";
+import getMessage from "../i18n";
+import { findNoticeInjectionPoint } from "../ui/notice/findNoticeInjectionPoint";
+import { getUsageTracker } from "../auth/UsageTracker";
+import { ChatbotIdentifier } from "../chatbots/ChatbotIdentifier";
+import { getJwtManagerSync } from "../JwtManager";
+import { getClientId } from "../usage/ClientIdManager";
+import { getExtensionVersion } from "../usage/VersionManager";
+import { callApi } from "../ApiClient";
+import { decideSurvey } from "./postWinSurvey";
+import { renderSurvey, renderSurveyThanks } from "./surveyView";
+import { submitPostWinFeedback } from "./feedbackClient";
+
+const THANKS_HIDE_MS = 3000;
+
+export class SurveyNoticeModule {
+  private static instance: SurveyNoticeModule;
+  private currentNotice: HTMLElement | null = null;
+  private handled = false;
+
+  private constructor() {}
+
+  public static getInstance(): SurveyNoticeModule {
+    if (!SurveyNoticeModule.instance) {
+      SurveyNoticeModule.instance = new SurveyNoticeModule();
+    }
+    return SurveyNoticeModule.instance;
+  }
+
+  public initialize(): void {
+    EventBus.on("saypi:usage:updated", this.handleUsageUpdated);
+  }
+
+  private isAuthenticated(): boolean {
+    try {
+      return getJwtManagerSync().isAuthenticated();
+    } catch {
+      return false;
+    }
+  }
+
+  private handleUsageUpdated = async (): Promise<void> => {
+    if (this.handled || this.currentNotice) return;
+
+    const stats = getUsageTracker().getStats();
+    if (!decideSurvey({ ...stats, authenticated: this.isAuthenticated() })) return;
+
+    // Mark handled + persisted before rendering so it can never show twice.
+    this.handled = true;
+    try {
+      await getUsageTracker().markSurveyShown();
+    } catch (error) {
+      console.debug("[PostWinSurvey] Failed to persist survey-shown flag:", error);
+    }
+    this.showSurvey(stats.interactionCount);
+  };
+
+  private showSurvey(interactionCount: number): void {
+    let chatbotId: string;
+    try {
+      chatbotId = String(ChatbotIdentifier.getAppId() ?? "").toLowerCase();
+    } catch {
+      chatbotId = "";
+    }
+
+    const root = document.createElement("div");
+    root.className = "saypi-survey-notice";
+    if (chatbotId) root.setAttribute("data-chatbot", chatbotId);
+
+    renderSurvey(root, {
+      translate: (key, sub) => getMessage(key, sub),
+      onRate: (rating) => void this.submit(rating, chatbotId, interactionCount),
+      onDismiss: () => this.dismiss(),
+    });
+
+    const injectionPoint = findNoticeInjectionPoint(chatbotId);
+    if (!injectionPoint) {
+      console.debug("[PostWinSurvey] No injection point; skipping survey");
+      return;
+    }
+    injectionPoint.insertAdjacentElement("afterend", root);
+    this.currentNotice = root;
+    setTimeout(() => root.classList.add("visible"), 50);
+  }
+
+  private async submit(rating: number, chatbotId: string, interactionCount: number): Promise<void> {
+    const notice = this.currentNotice;
+    if (notice) renderSurveyThanks(notice, (key) => getMessage(key));
+
+    let clientId: string | undefined;
+    try {
+      clientId = await getClientId();
+    } catch {
+      clientId = undefined;
+    }
+
+    await submitPostWinFeedback(
+      {
+        rating,
+        app: chatbotId || undefined,
+        version: getExtensionVersion() || undefined,
+        clientId,
+        metadata: { conversations: interactionCount },
+      },
+      { callApi },
+    );
+
+    setTimeout(() => this.dismiss(), THANKS_HIDE_MS);
+  }
+
+  private dismiss(): void {
+    if (!this.currentNotice) return;
+    const notice = this.currentNotice;
+    notice.classList.remove("visible");
+    setTimeout(() => {
+      notice.parentNode?.removeChild(notice);
+      if (this.currentNotice === notice) this.currentNotice = null;
+    }, 300);
+  }
+
+  /** Test/teardown helper. */
+  public cleanup(): void {
+    EventBus.off("saypi:usage:updated", this.handleUsageUpdated);
+    if (this.currentNotice) {
+      this.currentNotice.parentNode?.removeChild(this.currentNotice);
+      this.currentNotice = null;
+    }
+    this.handled = false;
+  }
+}
+
+export const getSurveyNoticeModule = (): SurveyNoticeModule => SurveyNoticeModule.getInstance();

--- a/src/onboarding/feedbackClient.ts
+++ b/src/onboarding/feedbackClient.ts
@@ -1,0 +1,53 @@
+/**
+ * Submits post-win survey feedback to the saypi-saas sink (#437).
+ *
+ * Auth is the user's Bearer JWT, attached by `callApi` (which also handles the
+ * 401-refresh-and-retry for SayPi hosts). `callApi` is injected so the
+ * request/response handling is unit-testable; failures are swallowed so a
+ * feedback error never disrupts the conversation.
+ */
+import {
+  buildPostWinFeedback,
+  FEEDBACK_URL,
+  type PostWinFeedbackInput,
+} from "./feedbackPayload";
+
+export interface SubmitResult {
+  ok: boolean;
+  status?: number;
+  /** Present on a 429, in ms, from the Retry-After header. */
+  retryAfterMs?: number;
+}
+
+export interface FeedbackDeps {
+  callApi: (url: string, options: RequestInit) => Promise<Response>;
+}
+
+/** Parses an HTTP Retry-After (delta-seconds) header into milliseconds. */
+export function parseRetryAfter(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  return undefined;
+}
+
+export async function submitPostWinFeedback(
+  input: PostWinFeedbackInput,
+  deps: FeedbackDeps
+): Promise<SubmitResult> {
+  const body = buildPostWinFeedback(input);
+  try {
+    const res = await deps.callApi(FEEDBACK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (res.status === 429) {
+      return { ok: false, status: 429, retryAfterMs: parseRetryAfter(res.headers.get("Retry-After")) };
+    }
+    return { ok: res.ok, status: res.status };
+  } catch (error) {
+    console.debug("[PostWinSurvey] Feedback submission failed:", error);
+    return { ok: false };
+  }
+}

--- a/src/onboarding/feedbackPayload.ts
+++ b/src/onboarding/feedbackPayload.ts
@@ -1,0 +1,50 @@
+/**
+ * Post-win survey feedback payload (#437).
+ *
+ * Builds the JSON body for the saypi-saas feedback sink. The contract is fixed
+ * (saypi-saas#202/#214): Bearer-JWT authed; teamId/userId are derived from the
+ * verified token server-side, so the client never sends teamId. Pure + tested.
+ */
+
+export const FEEDBACK_URL = "https://www.saypi.ai/api/feedback";
+export const POST_WIN_SOURCE = "extension_post_win";
+
+export interface PostWinFeedbackInput {
+  /** CSAT/NPS-style score; clamped to the 0-10 contract range. */
+  rating?: number;
+  message?: string;
+  app?: string;
+  version?: string;
+  clientId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FeedbackBody {
+  source: string;
+  rating?: number;
+  message?: string;
+  app?: string;
+  version?: string;
+  clientId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function buildPostWinFeedback(input: PostWinFeedbackInput): FeedbackBody {
+  const body: FeedbackBody = { source: POST_WIN_SOURCE };
+
+  if (typeof input.rating === "number" && isFinite(input.rating)) {
+    body.rating = Math.min(10, Math.max(0, Math.round(input.rating)));
+  }
+
+  const message = input.message?.trim();
+  if (message) body.message = message.slice(0, 4000);
+
+  if (input.app) body.app = String(input.app).toLowerCase();
+  if (input.version) body.version = input.version;
+  if (input.clientId) body.clientId = input.clientId;
+  if (input.metadata && Object.keys(input.metadata).length > 0) {
+    body.metadata = input.metadata;
+  }
+
+  return body;
+}

--- a/src/onboarding/postWinSurvey.ts
+++ b/src/onboarding/postWinSurvey.ts
@@ -1,0 +1,25 @@
+/**
+ * Gate for the one-time post-win micro-survey (#437).
+ *
+ * Shown once, after the user has had a few successful spoken exchanges (a
+ * "clearly good conversation", per the week-1 design) — deliberately later than
+ * the first-exchange speed-payoff notice so the two don't stack. Only for
+ * authenticated users, since the feedback sink derives identity from the JWT.
+ */
+
+/** Successful exchanges before the survey is offered. */
+export const SURVEY_MIN_INTERACTIONS = 3;
+
+export interface SurveyInputs {
+  surveyShown: boolean;
+  interactionCount: number;
+  authenticated: boolean;
+}
+
+export function decideSurvey(s: SurveyInputs): boolean {
+  return (
+    !s.surveyShown &&
+    s.authenticated &&
+    s.interactionCount >= SURVEY_MIN_INTERACTIONS
+  );
+}

--- a/src/onboarding/surveyView.ts
+++ b/src/onboarding/surveyView.ts
@@ -1,0 +1,71 @@
+/**
+ * DOM for the post-win micro-survey notice (#437).
+ *
+ * Separated from the side-effectful module so the markup + interactions are
+ * unit-testable in JSDOM. One question, a 1–5 rating row, and a dismiss; a
+ * separate thank-you state after submission.
+ */
+
+export const SURVEY_RATINGS = [1, 2, 3, 4, 5] as const;
+
+export interface SurveyViewOptions {
+  translate: (key: string, substitutions?: string) => string;
+  onRate: (rating: number) => void;
+  onDismiss: () => void;
+}
+
+/** Builds the survey prompt (question + rating buttons + dismiss) into `root`. */
+export function renderSurvey(root: HTMLElement, opts: SurveyViewOptions): void {
+  root.innerHTML = "";
+  const t = opts.translate;
+
+  const content = document.createElement("div");
+  content.className = "saypi-survey-notice-content";
+
+  const question = document.createElement("p");
+  question.id = "saypi-survey-question";
+  question.className = "saypi-survey-notice-question";
+  question.textContent = t("surveyQuestion");
+
+  const ratings = document.createElement("div");
+  ratings.className = "saypi-survey-notice-ratings";
+  ratings.setAttribute("role", "group");
+  ratings.setAttribute("aria-label", t("surveyQuestion"));
+
+  for (const n of SURVEY_RATINGS) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "saypi-survey-notice-rating";
+    btn.dataset.rating = String(n);
+    btn.textContent = String(n);
+    btn.setAttribute("aria-label", t("surveyRatingLabel", String(n)));
+    btn.addEventListener("click", () => opts.onRate(n));
+    ratings.append(btn);
+  }
+
+  const close = document.createElement("button");
+  close.type = "button";
+  close.className = "saypi-survey-notice-close";
+  close.setAttribute("aria-label", t("dismissNotice"));
+  close.textContent = "×";
+  close.addEventListener("click", () => opts.onDismiss());
+
+  content.append(question, ratings, close);
+  root.append(content);
+}
+
+/** Replaces the survey with a brief thank-you acknowledgement. */
+export function renderSurveyThanks(
+  root: HTMLElement,
+  translate: (key: string) => string
+): void {
+  root.innerHTML = "";
+  const content = document.createElement("div");
+  content.className = "saypi-survey-notice-content";
+  const thanks = document.createElement("p");
+  thanks.id = "saypi-survey-thanks";
+  thanks.className = "saypi-survey-notice-question";
+  thanks.textContent = translate("surveyThanks");
+  content.append(thanks);
+  root.append(content);
+}

--- a/src/saypi.index.js
+++ b/src/saypi.index.js
@@ -17,6 +17,7 @@ import "./styles/agent-notice.scss";
 import "./styles/compat-notice.scss";
 import "./styles/auth-prompt.scss";
 import "./styles/speed-notice.scss";
+import "./styles/survey-notice.scss";
 
 import { ChatbotService } from "./chatbots/ChatbotService.ts";
 import { ChatbotIdentifier } from "./chatbots/ChatbotIdentifier.ts";
@@ -97,6 +98,14 @@ import "./styles/pi.scss"; // scoped by chatbot flags, i.e. <body class="pi">
     getSpeedPayoffNoticeModule().initialize();
   } catch (error) {
     logger.error("Speed-payoff notice failed to initialize (non-fatal):", error);
+  }
+
+  // Initialize the one-time post-win micro-survey (#437)
+  try {
+    const { getSurveyNoticeModule } = await import(/* webpackMode: "eager" */ "./onboarding/SurveyNoticeModule.ts");
+    getSurveyNoticeModule().initialize();
+  } catch (error) {
+    logger.error("Post-win survey failed to initialize (non-fatal):", error);
   }
 
   // Initialize telemetry module

--- a/src/styles/survey-notice.scss
+++ b/src/styles/survey-notice.scss
@@ -1,0 +1,106 @@
+// Post-win micro-survey notice styling (#437).
+.saypi-survey-notice {
+  display: block;
+  margin: 0.75rem 0;
+  padding: 0;
+  border-radius: 0.5rem;
+  background: linear-gradient(135deg, rgba(108, 92, 231, 0.07) 0%, rgba(59, 130, 246, 0.07) 100%);
+  border: 1px solid rgba(108, 92, 231, 0.22);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: inherit;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: all 0.3s ease-in-out;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+
+  &.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .saypi-survey-notice-content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+    padding: 0.875rem 1rem;
+    position: relative;
+  }
+
+  .saypi-survey-notice-question {
+    flex: 1 1 auto;
+    margin: 0;
+    color: inherit;
+    font-weight: 500;
+  }
+
+  .saypi-survey-notice-ratings {
+    display: flex;
+    gap: 0.375rem;
+  }
+
+  .saypi-survey-notice-rating {
+    width: 2rem;
+    height: 2rem;
+    border: 1.5px solid rgba(108, 92, 231, 0.35);
+    border-radius: 0.5rem;
+    background: transparent;
+    color: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+
+    &:hover,
+    &:focus {
+      background: rgba(108, 92, 231, 0.12);
+      border-color: rgba(108, 92, 231, 0.7);
+    }
+  }
+
+  .saypi-survey-notice-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    border: none;
+    background: rgba(107, 114, 128, 0.1);
+    border-radius: 50%;
+    color: rgba(107, 114, 128, 0.6);
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(107, 114, 128, 0.2);
+      color: rgba(107, 114, 128, 0.8);
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    background: linear-gradient(135deg, rgba(108, 92, 231, 0.12) 0%, rgba(59, 130, 246, 0.12) 100%);
+    border-color: rgba(108, 92, 231, 0.32);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+
+  [data-chatbot="claude"] & {
+    margin: 0.75rem auto;
+    max-width: 48rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: opacity 0.2s ease;
+    transform: none;
+
+    &.visible {
+      transform: none;
+    }
+  }
+}

--- a/test/onboarding/feedbackClientAndGate.spec.ts
+++ b/test/onboarding/feedbackClientAndGate.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { submitPostWinFeedback, parseRetryAfter } from "../../src/onboarding/feedbackClient";
+import { decideSurvey, SURVEY_MIN_INTERACTIONS } from "../../src/onboarding/postWinSurvey";
+import { FEEDBACK_URL } from "../../src/onboarding/feedbackPayload";
+
+function res(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(status === 204 ? null : JSON.stringify({ success: status < 400 }), {
+    status,
+    headers,
+  });
+}
+
+describe("submitPostWinFeedback (#437)", () => {
+  it("POSTs the built body to the feedback endpoint and reports success", async () => {
+    const callApi = vi.fn().mockResolvedValue(res(200));
+    const r = await submitPostWinFeedback({ rating: 5, app: "pi" }, { callApi });
+
+    expect(r.ok).toBe(true);
+    const [url, opts] = callApi.mock.calls[0];
+    expect(url).toBe(FEEDBACK_URL);
+    expect(opts.method).toBe("POST");
+    const sent = JSON.parse(opts.body);
+    expect(sent.source).toBe("extension_post_win");
+    expect(sent.rating).toBe(5);
+    expect("teamId" in sent).toBe(false);
+  });
+
+  it("surfaces a 429 with the parsed Retry-After", async () => {
+    const callApi = vi.fn().mockResolvedValue(res(429, { "Retry-After": "30" }));
+    const r = await submitPostWinFeedback({ rating: 4 }, { callApi });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(429);
+    expect(r.retryAfterMs).toBe(30000);
+  });
+
+  it("swallows network errors (never throws, never disrupts the call)", async () => {
+    const callApi = vi.fn().mockRejectedValue(new Error("offline"));
+    await expect(submitPostWinFeedback({ rating: 1 }, { callApi })).resolves.toEqual({ ok: false });
+  });
+
+  it("reports a non-ok status without throwing", async () => {
+    const callApi = vi.fn().mockResolvedValue(res(401));
+    const r = await submitPostWinFeedback({ rating: 2 }, { callApi });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(401);
+  });
+});
+
+describe("parseRetryAfter (#437)", () => {
+  it("converts delta-seconds to ms; null/garbage -> undefined", () => {
+    expect(parseRetryAfter("15")).toBe(15000);
+    expect(parseRetryAfter(null)).toBeUndefined();
+    expect(parseRetryAfter("soon")).toBeUndefined();
+  });
+});
+
+describe("decideSurvey (#437)", () => {
+  it("shows once, only when authenticated and engaged", () => {
+    expect(decideSurvey({ surveyShown: false, authenticated: true, interactionCount: SURVEY_MIN_INTERACTIONS })).toBe(true);
+  });
+  it("does not show before the interaction threshold", () => {
+    expect(decideSurvey({ surveyShown: false, authenticated: true, interactionCount: SURVEY_MIN_INTERACTIONS - 1 })).toBe(false);
+  });
+  it("does not show when unauthenticated (sink needs the JWT identity)", () => {
+    expect(decideSurvey({ surveyShown: false, authenticated: false, interactionCount: 10 })).toBe(false);
+  });
+  it("does not show again once shown", () => {
+    expect(decideSurvey({ surveyShown: true, authenticated: true, interactionCount: 10 })).toBe(false);
+  });
+});

--- a/test/onboarding/feedbackPayload.spec.ts
+++ b/test/onboarding/feedbackPayload.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPostWinFeedback,
+  FEEDBACK_URL,
+  POST_WIN_SOURCE,
+} from "../../src/onboarding/feedbackPayload";
+
+// Contract: POST https://www.saypi.ai/api/feedback (saypi-saas#202/#214)
+describe("buildPostWinFeedback (#437)", () => {
+  it("always tags the source and posts to the agreed endpoint", () => {
+    expect(FEEDBACK_URL).toBe("https://www.saypi.ai/api/feedback");
+    expect(buildPostWinFeedback({}).source).toBe(POST_WIN_SOURCE);
+  });
+
+  it("clamps + rounds rating into the 0-10 range and omits a non-numeric rating", () => {
+    expect(buildPostWinFeedback({ rating: 4 }).rating).toBe(4);
+    expect(buildPostWinFeedback({ rating: 11 }).rating).toBe(10);
+    expect(buildPostWinFeedback({ rating: -2 }).rating).toBe(0);
+    expect(buildPostWinFeedback({ rating: 3.6 }).rating).toBe(4);
+    expect(buildPostWinFeedback({}).rating).toBeUndefined();
+    expect(buildPostWinFeedback({ rating: NaN }).rating).toBeUndefined();
+  });
+
+  it("trims + caps a message and omits an empty one", () => {
+    expect(buildPostWinFeedback({ message: "  hi  " }).message).toBe("hi");
+    expect(buildPostWinFeedback({ message: "   " }).message).toBeUndefined();
+    expect(buildPostWinFeedback({ message: "x".repeat(5000) }).message!.length).toBe(4000);
+  });
+
+  it("lowercases app and forwards optional ids, omitting empties", () => {
+    const body = buildPostWinFeedback({ app: "Pi", version: "1.2.3", clientId: "abc" });
+    expect(body.app).toBe("pi");
+    expect(body.version).toBe("1.2.3");
+    expect(body.clientId).toBe("abc");
+    expect(buildPostWinFeedback({}).app).toBeUndefined();
+  });
+
+  it("does NOT include teamId (derived server-side from the token)", () => {
+    const body = buildPostWinFeedback({ app: "claude" }) as unknown as Record<string, unknown>;
+    expect("teamId" in body).toBe(false);
+  });
+});

--- a/test/onboarding/surveyView.spec.ts
+++ b/test/onboarding/surveyView.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderSurvey, renderSurveyThanks, SURVEY_RATINGS } from "../../src/onboarding/surveyView";
+
+const translate = (k: string, sub?: string) => (sub ? `t:${k}:${sub}` : `t:${k}`);
+
+describe("renderSurvey (#437)", () => {
+  it("renders the question and a button per rating", () => {
+    const root = document.createElement("div");
+    renderSurvey(root, { translate, onRate: () => {}, onDismiss: () => {} });
+
+    expect(root.querySelector("#saypi-survey-question")!.textContent).toBe("t:surveyQuestion");
+    expect(root.querySelectorAll(".saypi-survey-notice-rating").length).toBe(SURVEY_RATINGS.length);
+  });
+
+  it("invokes onRate with the chosen rating", () => {
+    const root = document.createElement("div");
+    const onRate = vi.fn();
+    renderSurvey(root, { translate, onRate, onDismiss: () => {} });
+
+    root.querySelector<HTMLButtonElement>('[data-rating="4"]')!.click();
+    expect(onRate).toHaveBeenCalledWith(4);
+  });
+
+  it("invokes onDismiss from the close button", () => {
+    const root = document.createElement("div");
+    const onDismiss = vi.fn();
+    renderSurvey(root, { translate, onRate: () => {}, onDismiss });
+
+    root.querySelector<HTMLButtonElement>(".saypi-survey-notice-close")!.click();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("renderSurveyThanks (#437)", () => {
+  it("replaces the survey with a thank-you", () => {
+    const root = document.createElement("div");
+    renderSurvey(root, { translate, onRate: () => {}, onDismiss: () => {} });
+    renderSurveyThanks(root, translate);
+
+    expect(root.querySelector(".saypi-survey-notice-rating")).toBeNull();
+    expect(root.querySelector("#saypi-survey-thanks")!.textContent).toBe("t:surveyThanks");
+  });
+});


### PR DESCRIPTION
## What & why

**The final slice of #437.** After a few successful spoken exchanges (a "clearly good conversation"), signed-in users see a one-time below-composer **micro-survey** — one question, a 1–5 rating — whose answer posts to the saypi-saas feedback sink. This is the higher-fidelity in-the-moment counterpart to the web-app dashboard approximation (design §5.3).

**Auth = the user's Bearer JWT**, per the contract agreed and built on **saypi-saas#202 / #214** (Option 1): `POST https://www.saypi.ai/api/feedback` with `Authorization: Bearer <jwt>`. `teamId`/`userId` are derived server-side from the verified token, so the client sends **no `teamId`** and ships **no shared secret** — the originally-proposed `x-api-key` would have been extractable from the extension bundle (the security issue I flagged).

## Changes

- **`feedbackPayload.ts`** — pure body builder (source-tagged `extension_post_win`, rating clamped 0-10, message trimmed/capped, app lowercased, never sends `teamId`).
- **`feedbackClient.ts`** — POST via injected `callApi` (attaches the JWT + 401-refresh for SayPi hosts; `www.saypi.ai` is already in the background-routing allowlist + CORS allow-list); parses 429 `Retry-After`; **swallows all failures** so feedback never disrupts a conversation.
- **`postWinSurvey.ts`** — pure `decideSurvey` gate (after N exchanges, once, authenticated-only).
- **`surveyView.ts`** — JSDOM-testable question + 1–5 rating row + thank-you state.
- **`SurveyNoticeModule.ts`** — injected-notice lifecycle (mirrors the 4b speed-payoff module); subscribes to `saypi:usage:updated`, gates, renders, submits, persists shown-once via `UsageTracker.surveyShown` / `markSurveyShown()`.
- New `survey-notice.scss`; `survey*` i18n; bootstrap init in `saypi.index.js` (non-fatal try/catch).

## Tests (fail-first TDD)

- `feedbackPayload.spec` — source/rating-clamp/message-cap/app-lowercase, **no teamId**.
- `feedbackClientAndGate.spec` — success, **429 + Retry-After**, network-swallow, non-ok status, `parseRetryAfter`, and the gate (threshold / authed-only / once).
- `surveyView.spec` — question + per-rating buttons, `onRate`/`onDismiss`, thank-you.
- Full suite green: Vitest **1567 passed** (1 skipped, no unhandled errors), Jest passed, `tsc --noEmit` clean, `i18n-validate` clean.

## Deploy note

The **live round-trip waits on saypi-saas#214 reaching prod** (the agent will ping saypi-saas#202 when it deploys). Because all failures are swallowed (no broken UX) and the survey only reaches real users via a separate founder-gated store release, shipping ahead of the deploy is safe; I'll do a live `www.saypi.ai/api/feedback` check once it's up.

**This closes the extension side of #437** — all of it (9 PRs: #438–#445 + this).

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)