### PR TITLE
feat(e2e): add e2e-dictation-sweep harness for universal dictation

### DIFF
--- a/doc/e2e-dictation-sweep.md
+++ b/doc/e2e-dictation-sweep.md
@@ -1,0 +1,124 @@
+# E2E dictation sweep — real-host defect hunt for universal dictation
+
+A repeatable, agent-launched sweep that drives a synthetic **dictation** turn into
+each configured field (the local test fixture + real, login-free sites) and surfaces
+SayPi-attributable defects. This is the universal-dictation counterpart to
+`doc/e2e-host-sweep.md` — that sweep covers the three chat hosts'
+voice-conversation feature; this one covers `UniversalDictationModule.ts`, the
+separate code path that injects a floating per-field button into arbitrary
+non-chat-host input fields.
+
+> **Layer:** this is **Layer 4 (CDP)** for real-site targets — real DOM, real
+> network, the only layer that can find real-host DOM drift. The local fixture
+> target runs through the same harness for convenience (one CDP session, one
+> profile) even though it's not subject to drift. Not CI; needs the founder's
+> machine unlocked (a visible window opens) for the real-site target.
+
+## What this does NOT cover
+
+Universal dictation has no chat concepts — no model/voice selection, no TTS, no
+conversation thread, no assistant reply. Success is just **"spoken text landed in
+the focused field."** Activation is the floating `.saypi-dictation-button` injected
+per focused field, NOT `#saypi-callButton` (the chat-host mechanism
+`e2e-host-sweep.mjs` drives) — confirmed by two live spikes before this harness was
+built (see `doc/specs/2026-06-30-e2e-dictation-sweep-design.md`).
+
+Not in v1, by design (see the spec's Non-goals): the right-click "Start Dictation
+with Say, Pi" context-menu activation path, cross-field auto-switch, and the
+Lexical/Slate/Quill editor strategies (no login-free site using those frameworks was
+found — `TextInsertionManager.ts` has dedicated strategies for them, untested here).
+
+## Targets (v1)
+
+Defined in `scripts/e2e-dictation-sweep-lib.mjs`'s `TARGETS` — the extension point
+for adding more. See GH issue #163 ("Universal Dictation Platform Support Roadmap")
+for what's confirmed-working vs. known-broken before adding a site; a finding that
+matches an already-logged known-broken site/behavior there is not novel.
+
+| target | fields | why |
+|---|---|---|
+| `fixture` (`test/fixtures/test-dictation.html`, served locally) | plain `<input>`, `<textarea>`, plain `<div contenteditable>` | zero-login, zero-drift baseline covering 3 field types in one page |
+| `mistral` (`chat.mistral.ai`, branded "Vibe" in-product) | `ProseMirror` contenteditable composer | real, **login-free** (one-time ToS dialog, no sign-in), confirmed-working per issue #163, adds rich-editor-strategy + live-DOM-drift coverage |
+
+Candidates ruled out for v1 (see the design spec for detail): Character.AI
+(hard signup wall before any composer is reachable), GitHub (anonymous users can't
+reach an actual comment textarea), Gemini (only reachable because the shared seeded
+CDP profile happens to carry a logged-in Google session — not a reproducible
+login-free path).
+
+## Preconditions
+
+1. **Google Chrome** installed (set `CHROME_PATH` if not at the default).
+2. **Seeded CDP profile** at `~/.config/saypi-cdp-profile` (`SAYPI_CDP_PROFILE_DIR`
+   to override), with the dev extension profile-installed (Developer mode + Load
+   unpacked). See `doc/layer4-cdp-real-host-loop.md` for the one-time setup. No
+   SayPi account sign-in is needed (dictation doesn't need auth) — same profile the
+   host sweep uses is fine, no extra seeding step.
+3. **Dev build at HEAD:** `npm run e2e:build` (the profile-installed unpacked
+   extension re-reads `.output/chrome-mv3-dev` from disk on each launch, so
+   rebuilding at HEAD = the sweep tests current `main`; confirm via the
+   `data-saypi-build` stamp the sweep logs).
+4. **`cf_clearance` fresh** (only matters if a future target is Cloudflare-gated):
+   `npm run layer4cdp:diagnose` should say **VERDICT: usable**.
+
+## Run it
+
+```bash
+npm run e2e:build              # 1. build current HEAD into .output/chrome-mv3-dev
+npm run e2e-dictation-sweep    # 2. sweep all v1 targets (headed)
+
+# variants
+node scripts/e2e-dictation-sweep.mjs fixture     # local fixture only (fast, no network)
+node scripts/e2e-dictation-sweep.mjs mistral     # real-site only
+node scripts/e2e-dictation-sweep.mjs --headless  # re-test headless (real-site target may wall this)
+```
+
+Per field the harness writes to
+`.output/e2e-dictation-sweep/<run>/<target>__<index>/`: `evidence.json`
+(console / pageErrors / requestFailed / decorated / buttonAppeared /
+transcriptLanded / transcriptText) and screenshots (`01-focused`, `99-final` or
+`99-no-button` on failure). A run-level `summary.json` holds the per-field
+`summarizeField()` rollup.
+
+## Analysis discipline (don't skip — this is where false findings come from)
+
+1. **Corroborate every finding with a screenshot AND the console trace before
+   concluding.** A `transcriptLanded=false` could mean a real regression, a button
+   that never appeared, or a harness timing issue (slow real-site content-script
+   injection) — open the screenshot before deciding which.
+2. **Attribute to SayPi only.** `summarizeField()` splits `saypiErrors`/
+   `saypiWarnings` from `hostErrors` (reusing `e2e-host-sweep-lib.mjs`'s
+   `classifyConsoleLine` — Mistral's composer is also ProseMirror, so the same
+   host-noise patterns apply).
+3. **Dedup against GH issue #163 first**, then open/closed issues generally
+   (`gh issue list --state all`). #163 is the existing roadmap/known-broken-sites
+   list for this feature — a finding matching its known-broken entries isn't novel;
+   comment on/update #163 instead of filing a duplicate `bug` issue. Only genuine
+   regressions on already-confirmed-working sites/fields, or new findings on the v1
+   fixture (no prior failure history), get a fresh issue.
+4. **Honest per-target reporting.** A clean sweep — both targets, all fields,
+   transcript landed — is reported clean-with-evidence, not padded with a low-value
+   finding to manufacture a defect count.
+
+## Filing
+
+File SayPi-attributable, novel, verified defects per the **Issue Authoring
+Standard** (`AGENTS.md`): Problem / Scope / Reproduction-verification (expected vs
+actual) / Acceptance criteria / Notes-Hypotheses (non-binding). Note in the body
+that it was found via this Layer-4 CDP dictation sweep on the current commit.
+Labels: `bug` (no host-specific labels exist for dictation targets the way the chat
+sweep has `claude`/`chatgpt`/`pi ai` — use the target name in the body instead).
+
+## Boundaries
+
+- **Headed** for the real-site target (Mistral isn't currently known to wall
+  headless, but the harness defaults headed for parity with the host sweep and to
+  catch a future change). The local fixture target works headless too if ever
+  needed, since it has no Cloudflare/bot-detection surface.
+- Single dictation turn per field (`loop:false`) — same synthetic-speech limitation
+  as the host sweep (issue #364); no multi-utterance or field-switching scenarios.
+- Built on `scripts/layer4cdp-lib.mjs` (launch/Cloudflare/profile helpers, shared
+  with the host sweep) + `scripts/e2e-dictation-sweep-lib.mjs` (pure: target
+  registry, arg parse, transcript-landed check, summary — reuses
+  `e2e-host-sweep-lib.mjs`'s `classifyConsoleLine` for console attribution —
+  unit-tested in `test/scripts/e2e-dictation-sweep-lib.spec.ts`).

--- a/doc/specs/2026-06-30-e2e-dictation-sweep-design.md
+++ b/doc/specs/2026-06-30-e2e-dictation-sweep-design.md
@@ -1,0 +1,155 @@
+# e2e-dictation-sweep design
+
+## Problem
+
+`e2e-host-sweep` (doc/e2e-host-sweep.md) drives a real voice-conversation turn on
+pi.ai/claude.ai/chatgpt.com to catch real-host DOM drift in SayPi's chat integration.
+It has no counterpart for **universal dictation** — `UniversalDictationModule.ts`,
+the separate code path that injects a floating per-field button into arbitrary
+non-chat-host input fields and drives speech-to-text into them. There is no Layer-3
+(hermetic) coverage for it either (`e2e/specs/dictation-stt.e2e.ts` and
+`synthetic-audio-stt.e2e.ts` both exercise dictation through the pi.ai chat composer,
+not `UniversalDictationModule`). The only existing artifact is a manual test fixture,
+`test/fixtures/test-dictation.html`, never wired into any automated runner.
+
+## Empirical validation (done before this spec)
+
+Two live Layer-4 (CDP) spikes against the current dev build confirmed the
+synthetic-speech primitive (`saypi:dev-feed-speech`) works for universal dictation,
+which is NOT activated via `#saypi-callButton` (the chat-host mechanism) but via a
+floating `.saypi-dictation-button` injected per focused field:
+
+1. **Local fixture** (`test/fixtures/test-dictation.html`, served over a local static
+   HTTP server): focused `#message` textarea → `.saypi-dictation-button:visible`
+   appeared → armed synthetic speech → clicked the button → `Dictation Machine
+   [TEXTAREA]` ran through VAD → STT (`api.saypi.ai/transcribe`) → the synthetic
+   sentence landed in the field. Confirmed visually via screenshot.
+2. **Mistral's Le Chat** (`https://chat.mistral.ai/chat`, branded "Vibe" in-product) —
+   real, public, reachable with **no login** (one-time "Accept and continue" ToS
+   dialog, no sign-in/sign-up required to use the composer). Its composer is a real
+   `ProseMirror` contenteditable (`class="ProseMirror"`). Same flow confirmed
+   end-to-end: button appeared, transcript landed correctly, screenshot shows
+   "Sign in"/"Sign up" still present (never authenticated).
+
+Candidates ruled out for v1: **Character.AI** hard-gates behind a signup wall before
+any composer is reachable. **GitHub** issue/PR comment boxes require sign-in for
+anonymous users (no usable textarea without auth). **Gemini** only "worked" because
+the shared seeded CDP profile already carries a logged-in Google session from prior
+unrelated browsing — not a reproducible login-free path, so excluded to avoid an
+undocumented auth dependency.
+
+## Non-goals (v1)
+
+- The right-click "Start Dictation with Say, Pi" context-menu activation path (a
+  second documented way to start dictation, per the test fixture's instructions) —
+  not exercised; native context menus aren't practically driveable over CDP/Playwright
+  without an extension-side test hook, and the button-click path already proves the
+  underlying mechanism.
+- Cross-field auto-switch (focusing a different field while dictation is active).
+- Lexical/Slate/Quill editor-strategy coverage — no login-free site using those
+  frameworks was found in this pass. Documented as a follow-up target, not built now.
+- Model/voice selection, TTS, "assistant replied" detection — none of these exist in
+  dictation; the verification model is intentionally much simpler than the chat sweep.
+
+## Architecture
+
+A sibling to `e2e-host-sweep`, not an extension of it — the two have incompatible
+success models (multi-turn conversation + TTS vs. single-field-value landed) and
+sharing one script would mean threading chat-only branches through dictation runs.
+
+```
+scripts/
+  layer4cdp-lib.mjs              (existing, reused as-is: CDP launch, profile,
+                                   Cloudflare detection, clean shutdown)
+  e2e-dictation-sweep-lib.mjs    (new: pure helpers — TARGETS table, evidence
+                                   shaping, transcript-match logic — unit-testable)
+  e2e-dictation-sweep.mjs        (new: orchestration — mirrors e2e-host-sweep.mjs's
+                                   shape: spawn Chrome, iterate targets, write
+                                   evidence.json + summary.json, screenshots)
+
+doc/
+  e2e-dictation-sweep.md          (new: tracked runbook, mirrors
+                                    doc/e2e-host-sweep.md's structure)
+
+.claude/skills/e2e-dictation-sweep/SKILL.md   (new: LOCAL ONLY, gitignored — per the
+                                                repo's existing skill-authoring
+                                                convention; machinery/docs are
+                                                tracked, the skill pointer is not)
+
+package.json: add "e2e-dictation-sweep": "node scripts/e2e-dictation-sweep.mjs"
+```
+
+## Targets (v1)
+
+An explicit, documented array in `e2e-dictation-sweep-lib.mjs` — the extension point
+for adding sites later (comment points at GH issue #163, "Universal Dictation
+Platform Support Roadmap", as the source of truth for what's confirmed-working vs.
+known-broken):
+
+```js
+export const TARGETS = [
+  {
+    key: "fixture",
+    label: "local test fixture",
+    url: null, // served locally by the harness itself
+    dismissModal: null,
+    fields: [
+      { selector: "#name", type: "input", label: "Name (plain input)" },
+      { selector: "#message", type: "textarea", label: "Message (textarea)" },
+      { selector: ".contenteditable-field", type: "contenteditable", label: "Rich Text Editor (plain contenteditable)" },
+    ],
+  },
+  {
+    key: "mistral",
+    label: "Mistral Le Chat",
+    url: "https://chat.mistral.ai/chat",
+    dismissModal: { role: "button", name: /accept and continue/i },
+    fields: [
+      { selector: "[contenteditable='true'].ProseMirror, [contenteditable='true']", type: "contenteditable", label: "Composer (ProseMirror)" },
+    ],
+  },
+];
+```
+
+## Per-field flow
+
+No chat concepts (no model/voice select, no TTS, no conversation thread). For each
+target, then each field on that target:
+
+1. Navigate to the target's URL (skip for the fixture — harness serves it). Dismiss
+   `dismissModal` if configured and present.
+2. Click/focus the field selector.
+3. Wait for `.saypi-dictation-button:visible` (timeout → recorded failure: "no
+   dictation button appeared for this field" — this is itself evidence, not a skip).
+4. Screenshot (`NN-focused.png`).
+5. Arm `saypi:dev-feed-speech` (`{loop:false}`), click the visible dictation button.
+6. Poll the field's `.value` (input/textarea) or `.textContent` (contenteditable)
+   for the known synthetic-speech transcript text, up to 30s.
+7. Screenshot (`NN-final.png`). Capture console messages (split SayPi vs. host, same
+   `saypiErrors`/`hostErrors` distinction as the host sweep) and failed network
+   requests matching the same filter as `e2e-host-sweep.mjs`.
+8. Write per-field evidence: `{target, field, decorated, buttonAppeared,
+   transcriptLanded, transcriptText, saypiErrors, consoleErrors, netFailures}`.
+
+A run-level `summary.json` aggregates all target/field results, mirroring
+`e2e-host-sweep.mjs`'s `summary.json` shape (one entry per field, not per host).
+
+## Analysis & filing discipline
+
+Same discipline as `doc/e2e-host-sweep.md`: corroborate with screenshots, attribute
+failures to SayPi only, no padding to hit a target finding count — a clean sweep is
+reported clean-with-evidence, not stretched into manufactured findings. One addition
+specific to dictation: GH issue #163 is the existing roadmap/known-broken-sites
+list — a finding that matches an already-logged known-broken site/behavior there is
+not novel; comment on/update #163 instead of filing a duplicate `bug` issue. Only
+genuine regressions on already-confirmed-working sites/fields, or new findings on the
+v1 fixture (which has no prior failure history), get a fresh issue.
+
+## Testing
+
+- `e2e-dictation-sweep-lib.mjs`'s pure helpers (target table shape validation,
+  transcript-match logic, evidence shaping) get Vitest unit tests, same pattern as
+  `layer4cdp-lib.mjs`'s existing unit tests.
+- The orchestration script itself (`e2e-dictation-sweep.mjs`) is validated by actually
+  running it against the live Chrome/CDP harness — same as `e2e-host-sweep.mjs`, this
+  is Layer-4 only, not unit-testable in isolation, and not part of CI.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "layer4cdp:verify": "node scripts/layer4cdp.mjs verify",
     "layer4cdp:self-test": "node scripts/layer4cdp.mjs self-test",
     "e2e-host-sweep": "node scripts/e2e-host-sweep.mjs",
+    "e2e-dictation-sweep": "node scripts/e2e-dictation-sweep.mjs",
     "release:preflight": "node scripts/release.mjs preflight",
     "release:plan": "node scripts/release.mjs plan",
     "release:packet": "node scripts/release.mjs packet",

--- a/scripts/e2e-dictation-sweep-lib.mjs
+++ b/scripts/e2e-dictation-sweep-lib.mjs
@@ -1,0 +1,122 @@
+// Pure helpers for the E2E dictation-sweep harness (scripts/e2e-dictation-sweep.mjs) —
+// the universal-dictation counterpart to e2e-host-sweep.mjs/e2e-host-sweep-lib.mjs.
+// Kept dependency-free so they unit-test like layer4cdp-lib.mjs.
+// Universal dictation (UniversalDictationModule.ts) activates via a floating
+// per-field `.saypi-dictation-button`, NOT #saypi-callButton, and has no chat
+// concepts (no model/voice select, no TTS, no conversation thread) — success here
+// is just "spoken text landed in the focused field."
+// Design: doc/specs/2026-06-30-e2e-dictation-sweep-design.md
+// Runbook: doc/e2e-dictation-sweep.md
+import { classifyConsoleLine } from "./e2e-host-sweep-lib.mjs";
+
+/**
+ * @typedef {{selector: string, type: "input"|"textarea"|"contenteditable", label: string}} DictationField
+ * @typedef {{key: string, label: string, url: string|null, dismissModal: {role: string, name: RegExp}|null, fields: DictationField[]}} DictationTarget
+ */
+
+/**
+ * v1 sweep targets. Each is a site (or the local fixture, url: null — the harness
+ * serves it) with one or more focusable fields to dictate into. Extension point for
+ * new sites: see GH issue #163 ("Universal Dictation Platform Support Roadmap") for
+ * what's confirmed-working vs. known-broken before adding one — a finding that
+ * matches an already-logged known-broken site there isn't novel.
+ * @type {DictationTarget[]}
+ */
+export const TARGETS = [
+  {
+    key: "fixture",
+    label: "local test fixture",
+    url: null,
+    dismissModal: null,
+    fields: [
+      { selector: "#name", type: "input", label: "Name (plain input)" },
+      { selector: "#message", type: "textarea", label: "Message (textarea)" },
+      { selector: "#rich-text-editor", type: "contenteditable", label: "Rich Text Editor (plain contenteditable)" },
+    ],
+  },
+  {
+    key: "mistral",
+    label: "Mistral Le Chat",
+    url: "https://chat.mistral.ai/chat",
+    dismissModal: { role: "button", name: /accept and continue/i },
+    fields: [
+      { selector: "[contenteditable='true'].ProseMirror, [contenteditable='true']", type: "contenteditable", label: "Composer (ProseMirror)" },
+    ],
+  },
+];
+
+export const DEFAULT_BUTTON_TIMEOUT_MS = 10_000;
+export const DEFAULT_TRANSCRIPT_TIMEOUT_MS = 30_000;
+
+/**
+ * Flatten the target/field tree into one entry per field — the unit both the
+ * orchestrator's loop and the unit tests work with. Pure; never mutates `targets`.
+ * @param {DictationTarget[]} [targets]
+ */
+export function flattenFields(targets = TARGETS) {
+  return targets.flatMap((t) =>
+    t.fields.map((f) => ({
+      targetKey: t.key,
+      targetLabel: t.label,
+      url: t.url,
+      dismissModal: t.dismissModal ?? null,
+      fieldSelector: f.selector,
+      fieldType: f.type,
+      fieldLabel: f.label,
+    })),
+  );
+}
+
+/**
+ * Parse argv (without node/script) into a sweep descriptor.
+ *   [target ...]   one or more target keys (default: all)
+ *   --headless     opt-in headless (for re-testing only; real-host targets may wall this)
+ */
+export function parseSweepArgs(argv = []) {
+  const positional = argv.filter((a) => !a.startsWith("--"));
+  const flags = argv.filter((a) => a.startsWith("--"));
+  const known = TARGETS.map((t) => t.key);
+  const requested = positional.filter((p) => known.includes(p));
+  const unknown = positional.filter((p) => !known.includes(p));
+  return {
+    targets: requested.length ? requested : known,
+    unknownTargets: unknown,
+    headed: !flags.includes("--headless"),
+  };
+}
+
+/**
+ * Has dictation landed plausible text in a field? Synthetic-speech clips vary per
+ * turn (src/offscreen/syntheticSpeechPool.ts picks one of several at random), so
+ * this deliberately does NOT match exact content — same approach as
+ * e2e-host-sweep.mjs's transcript check: any non-empty value means it landed.
+ */
+export function transcriptLanded(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Reduce a captured per-field evidence object to a flat, comparable summary. Pure —
+ * mirrors e2e-host-sweep-lib.mjs's summarize(), but keyed on field-landed rather than
+ * conversation-reply state.
+ */
+export function summarizeField(evidence = {}) {
+  const cons = Array.isArray(evidence.console) ? evidence.console : [];
+  const byOrigin = (origin, type) =>
+    cons.filter((c) => classifyConsoleLine(c.text) === origin && (!type || c.t === type)).length;
+  return {
+    target: evidence.target ?? null,
+    field: evidence.field ?? null,
+    decorated: !!evidence.decorated,
+    cloudflareBlocked: !!evidence.cloudflareBlocked,
+    buttonAppeared: !!evidence.buttonAppeared,
+    transcriptLanded: !!evidence.transcriptLanded,
+    consoleErrors: cons.filter((c) => c.t === "error").length,
+    consoleWarnings: cons.filter((c) => c.t === "warning").length,
+    saypiErrors: byOrigin("saypi", "error"),
+    saypiWarnings: byOrigin("saypi", "warning"),
+    hostErrors: byOrigin("host", "error"),
+    pageErrors: Array.isArray(evidence.pageErrors) ? evidence.pageErrors.length : 0,
+    netFailures: Array.isArray(evidence.requestFailed) ? evidence.requestFailed.length : 0,
+  };
+}

--- a/scripts/e2e-dictation-sweep.mjs
+++ b/scripts/e2e-dictation-sweep.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * E2E dictation sweep — agent-launched, real-host(+local-fixture) E2E for universal
+ * dictation (UniversalDictationModule.ts), the per-field-button counterpart to
+ * e2e-host-sweep.mjs's chat-host conversation sweep. Drives a synthetic dictation
+ * turn into each configured field (TARGETS in e2e-dictation-sweep-lib.mjs) and
+ * checks the transcript landed.
+ *
+ * No chat concepts here — no model/voice selection, no TTS, no conversation thread,
+ * no assistant reply. Success is just "spoken text appeared in the focused field."
+ * Activation is the floating `.saypi-dictation-button` injected per focused field,
+ * NOT #saypi-callButton (that's the chat-host mechanism e2e-host-sweep.mjs drives).
+ *
+ *   node scripts/e2e-dictation-sweep.mjs [target ...] [--headless]
+ *   npm run e2e-dictation-sweep            # all v1 targets, headed
+ *
+ * Real Chrome over CDP on the SEEDED profile (extension profile-installed) — same
+ * harness as e2e-host-sweep.mjs. NOT CI. See doc/e2e-dictation-sweep.md for the full
+ * runbook (preconditions, target list, analysis discipline, how to file findings).
+ * Design: doc/specs/2026-06-30-e2e-dictation-sweep-design.md
+ */
+import { chromium } from "playwright";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { createServer as createNetServer } from "node:net";
+import http from "node:http";
+import { dirname, join, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveCdpProfileDir, buildCdpChromeArgs, isCloudflareChallenge } from "./layer4cdp-lib.mjs";
+import { TARGETS, parseSweepArgs, flattenFields, summarizeField, transcriptLanded } from "./e2e-dictation-sweep-lib.mjs";
+
+const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
+const EXT_DIR = join(repoRoot, ".output", "chrome-mv3-dev");
+const FIXTURE_PATH = join(repoRoot, "test", "fixtures", "test-dictation.html");
+const log = (m) => console.log(`[e2e-dictation-sweep] ${m}`);
+
+// Mirrors e2e-host-sweep.mjs's chromePath() (own copy, not shared — see design doc).
+function chromePath() {
+  const c = [
+    process.env.CHROME_PATH,
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+  ].filter(Boolean);
+  const found = c.find((p) => existsSync(p));
+  if (!found) { log("could not find Google Chrome — set CHROME_PATH"); process.exit(1); }
+  return found;
+}
+
+const freePort = () =>
+  new Promise((res, rej) => {
+    const s = createNetServer();
+    s.unref();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => { const { port } = s.address(); s.close(() => res(port)); });
+  });
+const portDead = async (p) => { try { await fetch(`http://127.0.0.1:${p}/json/version`); return false; } catch { return true; } };
+
+/** Same gotcha + fix as scripts/layer4cdp.mjs / e2e-host-sweep.mjs: Chrome's
+ * exit_type bookkeeping is unreliable on a synced, many-extension profile — mark
+ * the shared seeded profile's NEXT launch as a clean exit so it skips "Restore
+ * pages?". Call only after Chrome is gone. */
+function markCleanExit(profileDir) {
+  try {
+    const pref = join(profileDir, "Default", "Preferences");
+    if (!existsSync(pref)) return;
+    const p = JSON.parse(readFileSync(pref, "utf8"));
+    p.profile = p.profile || {};
+    p.profile.exit_type = "Normal";
+    p.profile.exited_cleanly = true;
+    writeFileSync(pref, JSON.stringify(p));
+  } catch (err) {
+    log(`note: could not mark clean exit (${err.message})`);
+  }
+}
+
+/** Serve the local test fixture over plain HTTP — extensions can't reliably reach
+ * file:// URLs without an explicit "allow access to file URLs" permission, which
+ * the dev profile doesn't grant. Started once, reused for every fixture field. */
+function startFixtureServer() {
+  const html = readFileSync(FIXTURE_PATH);
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(html);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, url: `http://127.0.0.1:${port}/` });
+    });
+  });
+}
+
+/** Dismiss a one-time site modal (e.g. Mistral's ToS dialog) if present.
+ * Best-effort — absence isn't an error, most targets don't have one. */
+async function dismissModalIfPresent(page, dismissModal) {
+  if (!dismissModal) return false;
+  const btn = page.getByRole(dismissModal.role, { name: dismissModal.name });
+  if ((await btn.count().catch(() => 0)) === 0) return false;
+  await btn.click().catch(() => {});
+  await page.waitForTimeout(800);
+  return true;
+}
+
+async function sweepField(ctx, item, outDir, index) {
+  const ev = {
+    target: item.targetKey, targetLabel: item.targetLabel, field: item.fieldLabel,
+    selector: item.fieldSelector, build: null, decorated: false, cloudflareBlocked: false,
+    buttonAppeared: false, transcriptLanded: false, transcriptText: null,
+    console: [], pageErrors: [], requestFailed: [], notes: [],
+  };
+  const dir = join(outDir, `${item.targetKey}__${index}`);
+  mkdirSync(dir, { recursive: true });
+  const page = await ctx.newPage();
+  page.on("console", (m) => ev.console.push({ t: m.type(), text: m.text().slice(0, 600) }));
+  page.on("pageerror", (e) => ev.pageErrors.push({ message: e.message, stack: (e.stack || "").slice(0, 800) }));
+  page.on("requestfailed", (r) => {
+    const u = r.url();
+    if (/saypi|api\.saypi|transcribe|\/merge|auth/.test(u)) ev.requestFailed.push({ url: u.slice(0, 200), failure: r.failure()?.errorText });
+  });
+
+  try {
+    await page.goto(item.url, { waitUntil: "domcontentloaded", timeout: 25_000 }).catch((e) => ev.notes.push(`goto: ${e.message}`));
+    const sig = { title: await page.title().catch(() => ""), url: page.url(), html: (await page.content().catch(() => "")).slice(0, 4000) };
+    if (isCloudflareChallenge(sig)) { ev.cloudflareBlocked = true; log(`${item.targetKey}: BLOCKED by Cloudflare`); return ev; }
+
+    await dismissModalIfPresent(page, item.dismissModal);
+
+    ev.build = await page.evaluate(() => document.documentElement.dataset.saypiBuild ?? null).catch(() => null);
+    if (!ev.build) {
+      // give the content script a moment on slower real sites, then re-check
+      await page.waitForTimeout(2000);
+      ev.build = await page.evaluate(() => document.documentElement.dataset.saypiBuild ?? null).catch(() => null);
+    }
+    ev.decorated = !!ev.build;
+
+    await page.click(item.fieldSelector).catch((e) => ev.notes.push(`focus: ${e.message}`));
+    await page.screenshot({ path: join(dir, "01-focused.png") }).catch(() => {});
+
+    ev.buttonAppeared = await page
+      .waitForSelector(".saypi-dictation-button:visible", { timeout: 10_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!ev.buttonAppeared) {
+      ev.notes.push("no .saypi-dictation-button appeared for this field");
+      await page.screenshot({ path: join(dir, "99-no-button.png") }).catch(() => {});
+      return ev;
+    }
+
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent("saypi:dev-feed-speech", { detail: { loop: false } })));
+    await page.click(".saypi-dictation-button:visible").catch((e) => ev.notes.push(`button click: ${e.message}`));
+
+    const fieldValue = await page
+      .waitForFunction((sel) => {
+        const el = document.querySelector(sel);
+        if (!el) return false;
+        const v = (el.value ?? el.textContent ?? "").trim();
+        return v.length > 0 ? v : false;
+      }, item.fieldSelector, { timeout: 30_000 })
+      .then((h) => h.jsonValue())
+      .catch(() => null);
+
+    ev.transcriptText = fieldValue;
+    ev.transcriptLanded = transcriptLanded(fieldValue);
+    await page.screenshot({ path: join(dir, "99-final.png") }).catch(() => {});
+  } catch (err) {
+    ev.notes.push(`error: ${err.message}`);
+  } finally {
+    writeFileSync(join(dir, "evidence.json"), JSON.stringify(ev, null, 2));
+    await page.close().catch(() => {});
+  }
+  return ev;
+}
+
+async function main() {
+  if (!existsSync(EXT_DIR)) { log(`missing dev build at ${EXT_DIR} — run: npm run e2e:build`); process.exit(1); }
+  const opts = parseSweepArgs(process.argv.slice(2));
+  if (opts.unknownTargets.length) log(`ignoring unknown target(s): ${opts.unknownTargets.join(", ")} (known: ${TARGETS.map((t) => t.key).join(", ")})`);
+  const profileDir = resolveCdpProfileDir(process.env, homedir());
+  if (!existsSync(profileDir)) { log(`no seeded profile at ${profileDir} — run: npm run layer4cdp:seed first`); process.exit(1); }
+
+  const runStamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const outDir = join(repoRoot, ".output", "e2e-dictation-sweep", runStamp);
+  mkdirSync(outDir, { recursive: true });
+
+  const selectedTargets = TARGETS.filter((t) => opts.targets.includes(t.key));
+  let items = flattenFields(selectedTargets);
+  log(`sweeping ${selectedTargets.map((t) => t.key).join(", ")} (${items.length} field(s), ${opts.headed ? "headed" : "headless"}) → ${outDir}`);
+
+  let fixtureServer = null;
+  if (items.some((i) => i.targetKey === "fixture")) {
+    const { server, url } = await startFixtureServer();
+    fixtureServer = server;
+    items = items.map((i) => (i.targetKey === "fixture" ? { ...i, url } : i));
+  }
+
+  const port = await freePort();
+  const child = spawn(
+    chromePath(),
+    buildCdpChromeArgs({ extensionDir: EXT_DIR, port, profileDir, headless: !opts.headed, loadExtension: false }),
+    { stdio: "ignore" },
+  );
+  let browser;
+  const shutdown = async () => {
+    try { const s = await browser.newBrowserCDPSession(); s.send("Browser.close").catch(() => {}); } catch { try { child.kill("SIGTERM"); } catch {} }
+    const dl = Date.now() + 6000;
+    while (Date.now() < dl) { if (await portDead(port)) { markCleanExit(profileDir); return; } await new Promise((r) => setTimeout(r, 200)); }
+    try { child.kill("SIGTERM"); } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+    if (!(await portDead(port))) { try { child.kill("SIGKILL"); } catch {} }
+    await new Promise((r) => setTimeout(r, 500));
+    markCleanExit(profileDir);
+  };
+
+  const summaries = [];
+  try {
+    const dl0 = Date.now() + 15000;
+    while (Date.now() < dl0) { try { if ((await fetch(`http://127.0.0.1:${port}/json/version`)).ok) break; } catch {} await new Promise((r) => setTimeout(r, 200)); }
+    browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+    const ctx = browser.contexts()[0];
+    for (let i = 0; i < 24 && ctx.serviceWorkers().length === 0 && ctx.backgroundPages().length === 0; i++) await new Promise((r) => setTimeout(r, 500));
+    log(`extension SW count: ${ctx.serviceWorkers().length}`);
+
+    let idx = 0;
+    for (const item of items) {
+      log(`--- ${item.targetKey} / ${item.fieldLabel} ---`);
+      const ev = await sweepField(ctx, item, outDir, idx++);
+      const s = summarizeField(ev);
+      summaries.push(s);
+      log(`${item.targetKey}/${item.fieldLabel}: decorated=${s.decorated} cf=${s.cloudflareBlocked} button=${s.buttonAppeared} transcriptLanded=${s.transcriptLanded} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures}`);
+    }
+  } finally {
+    writeFileSync(join(outDir, "summary.json"), JSON.stringify(summaries, null, 2));
+    log(`wrote ${join(outDir, "summary.json")}`);
+    await shutdown();
+    if (fixtureServer) fixtureServer.close();
+  }
+
+  const failed = summaries.filter((s) => !s.transcriptLanded);
+  if (failed.length) {
+    log(`⚠️  ${failed.length}/${summaries.length} field(s) did NOT get a landed transcript — see evidence under ${outDir}.`);
+  }
+  log(`SWEEP DONE — evidence under ${outDir}`);
+  process.exit(0);
+}
+main().catch((e) => { log(`fatal: ${e.message}`); process.exit(1); });

--- a/scripts/e2e-dictation-sweep.mjs
+++ b/scripts/e2e-dictation-sweep.mjs
@@ -28,7 +28,15 @@ import http from "node:http";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveCdpProfileDir, buildCdpChromeArgs, isCloudflareChallenge } from "./layer4cdp-lib.mjs";
-import { TARGETS, parseSweepArgs, flattenFields, summarizeField, transcriptLanded } from "./e2e-dictation-sweep-lib.mjs";
+import {
+  TARGETS,
+  parseSweepArgs,
+  flattenFields,
+  summarizeField,
+  transcriptLanded,
+  DEFAULT_BUTTON_TIMEOUT_MS,
+  DEFAULT_TRANSCRIPT_TIMEOUT_MS,
+} from "./e2e-dictation-sweep-lib.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
 const EXT_DIR = join(repoRoot, ".output", "chrome-mv3-dev");
@@ -93,12 +101,17 @@ function startFixtureServer() {
 }
 
 /** Dismiss a one-time site modal (e.g. Mistral's ToS dialog) if present.
- * Best-effort — absence isn't an error, most targets don't have one. */
+ * Best-effort — absence isn't an error, most targets don't have one. Waits for the
+ * button to become visible rather than a one-shot `count()` check: `count()` doesn't
+ * auto-wait, so on a client-rendered SPA a modal that mounts even slightly after
+ * domcontentloaded would be missed and never dismissed (same waiting idiom as
+ * waitForSelector elsewhere in this codebase, e.g. e2e-host-sweep.mjs/layer4cdp.mjs). */
 async function dismissModalIfPresent(page, dismissModal) {
   if (!dismissModal) return false;
   const btn = page.getByRole(dismissModal.role, { name: dismissModal.name });
-  if ((await btn.count().catch(() => 0)) === 0) return false;
-  await btn.click().catch(() => {});
+  const appeared = await btn.first().waitFor({ state: "visible", timeout: 5_000 }).then(() => true).catch(() => false);
+  if (!appeared) return false;
+  await btn.first().click().catch(() => {});
   await page.waitForTimeout(800);
   return true;
 }
@@ -139,7 +152,7 @@ async function sweepField(ctx, item, outDir, index) {
     await page.screenshot({ path: join(dir, "01-focused.png") }).catch(() => {});
 
     ev.buttonAppeared = await page
-      .waitForSelector(".saypi-dictation-button:visible", { timeout: 10_000 })
+      .waitForSelector(".saypi-dictation-button:visible", { timeout: DEFAULT_BUTTON_TIMEOUT_MS })
       .then(() => true)
       .catch(() => false);
 
@@ -158,7 +171,7 @@ async function sweepField(ctx, item, outDir, index) {
         if (!el) return false;
         const v = (el.value ?? el.textContent ?? "").trim();
         return v.length > 0 ? v : false;
-      }, item.fieldSelector, { timeout: 30_000 })
+      }, item.fieldSelector, { timeout: DEFAULT_TRANSCRIPT_TIMEOUT_MS })
       .then((h) => h.jsonValue())
       .catch(() => null);
 

--- a/test/fixtures/test-dictation.html
+++ b/test/fixtures/test-dictation.html
@@ -176,7 +176,7 @@
         <h2>Content Editable (Rich Text)</h2>
         
         <label>Rich Text Editor:</label>
-        <div class="contenteditable-field" contenteditable="true" data-placeholder="Start typing or use dictation...">
+        <div id="rich-text-editor" class="contenteditable-field" contenteditable="true" data-placeholder="Start typing or use dictation...">
         </div>
         
         <label>Notes Field:</label>

--- a/test/scripts/e2e-dictation-sweep-lib.spec.ts
+++ b/test/scripts/e2e-dictation-sweep-lib.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  TARGETS,
+  flattenFields,
+  parseSweepArgs,
+  transcriptLanded,
+  summarizeField,
+} from "../../scripts/e2e-dictation-sweep-lib.mjs";
+
+describe("TARGETS registry", () => {
+  it("covers the v1 fixture + Mistral targets, each with at least one field", () => {
+    expect(TARGETS.map((t) => t.key)).toEqual(["fixture", "mistral"]);
+    for (const t of TARGETS) {
+      expect(typeof t.label).toBe("string");
+      expect(t.fields.length).toBeGreaterThan(0);
+      for (const f of t.fields) {
+        expect(typeof f.selector).toBe("string");
+        expect(typeof f.label).toBe("string");
+        expect(["input", "textarea", "contenteditable"]).toContain(f.type);
+      }
+    }
+  });
+  it("the fixture target has no URL (the harness serves it) and no modal to dismiss", () => {
+    const fixture = TARGETS.find((t) => t.key === "fixture");
+    expect(fixture?.url).toBeNull();
+    expect(fixture?.dismissModal).toBeNull();
+  });
+  it("the mistral target is a real https URL with a ToS dismiss config", () => {
+    const mistral = TARGETS.find((t) => t.key === "mistral");
+    expect(mistral?.url).toMatch(/^https:\/\//);
+    expect(mistral?.dismissModal).toMatchObject({ role: "button" });
+  });
+});
+
+describe("flattenFields", () => {
+  it("produces one flat entry per field, carrying the parent target's key/label/url/modal", () => {
+    const items = flattenFields(TARGETS);
+    const fixtureFieldCount = TARGETS.find((t) => t.key === "fixture")?.fields.length ?? 0;
+    const mistralFieldCount = TARGETS.find((t) => t.key === "mistral")?.fields.length ?? 0;
+    expect(items.length).toBe(fixtureFieldCount + mistralFieldCount);
+    for (const item of items) {
+      expect(item.targetKey).toBeDefined();
+      expect(item.targetLabel).toBeDefined();
+      expect(item.fieldSelector).toBeDefined();
+      expect(item.fieldType).toBeDefined();
+      expect(item.fieldLabel).toBeDefined();
+    }
+  });
+  it("does not mutate the source TARGETS array", () => {
+    const before = JSON.stringify(TARGETS);
+    flattenFields(TARGETS);
+    expect(JSON.stringify(TARGETS)).toBe(before);
+  });
+  it("is pure over a custom targets array (doesn't reach for the module-level TARGETS)", () => {
+    const custom = [{ key: "x", label: "X", url: "https://x.example", dismissModal: null, fields: [{ selector: "#a", type: "input" as const, label: "A" }] }];
+    expect(flattenFields(custom)).toEqual([
+      { targetKey: "x", targetLabel: "X", url: "https://x.example", dismissModal: null, fieldSelector: "#a", fieldType: "input", fieldLabel: "A" },
+    ]);
+  });
+});
+
+describe("parseSweepArgs", () => {
+  it("defaults to all targets, headed", () => {
+    const a = parseSweepArgs([]);
+    expect(a.targets).toEqual(["fixture", "mistral"]);
+    expect(a.headed).toBe(true);
+    expect(a.unknownTargets).toEqual([]);
+  });
+  it("selects a subset by target key, preserving the requested set", () => {
+    expect(parseSweepArgs(["mistral"]).targets).toEqual(["mistral"]);
+  });
+  it("collects unknown target tokens instead of treating them as targets", () => {
+    const a = parseSweepArgs(["gmail", "fixture"]);
+    expect(a.targets).toEqual(["fixture"]);
+    expect(a.unknownTargets).toEqual(["gmail"]);
+  });
+  it("honors --headless", () => {
+    expect(parseSweepArgs(["--headless"]).headed).toBe(false);
+  });
+});
+
+describe("transcriptLanded", () => {
+  it("is true for any non-empty trimmed string", () => {
+    expect(transcriptLanded("Hello there, this is a test.")).toBe(true);
+    expect(transcriptLanded("  padded  ")).toBe(true);
+  });
+  it("is false for empty, whitespace-only, null, or non-string values", () => {
+    expect(transcriptLanded("")).toBe(false);
+    expect(transcriptLanded("   ")).toBe(false);
+    expect(transcriptLanded(null)).toBe(false);
+    expect(transcriptLanded(undefined)).toBe(false);
+    expect(transcriptLanded(false)).toBe(false);
+  });
+});
+
+describe("summarizeField", () => {
+  it("separates SayPi-attributable errors/warnings from host noise, keyed on field-landed", () => {
+    const s = summarizeField({
+      target: "mistral",
+      field: "Composer (ProseMirror)",
+      decorated: true,
+      buttonAppeared: true,
+      transcriptLanded: true,
+      console: [
+        { t: "error", text: "[SayPi DEBUG] something broke" },
+        { t: "error", text: "ProseMirror expects the CSS white-space property" },
+        { t: "warning", text: "[SayPi] heads up" },
+      ],
+      pageErrors: [{ message: "x" }],
+      requestFailed: [{ url: "https://api.saypi.ai/transcribe" }],
+    });
+    expect(s).toMatchObject({
+      target: "mistral",
+      field: "Composer (ProseMirror)",
+      decorated: true,
+      buttonAppeared: true,
+      transcriptLanded: true,
+      consoleErrors: 2,
+      saypiErrors: 1,
+      hostErrors: 1,
+      saypiWarnings: 1,
+      pageErrors: 1,
+      netFailures: 1,
+    });
+  });
+  it("is robust to an empty / partial evidence object", () => {
+    const s = summarizeField({});
+    expect(s.decorated).toBe(false);
+    expect(s.buttonAppeared).toBe(false);
+    expect(s.transcriptLanded).toBe(false);
+    expect(s.consoleErrors).toBe(0);
+    expect(s.saypiErrors).toBe(0);
+  });
+  it("flags a field whose button never appeared as not landed, regardless of decoration", () => {
+    const s = summarizeField({ decorated: true, buttonAppeared: false, transcriptLanded: false });
+    expect(s.decorated).toBe(true);
+    expect(s.buttonAppeared).toBe(false);
+    expect(s.transcriptLanded).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Layer-4 (CDP) E2E sweep for **universal dictation** (`UniversalDictationModule.ts`) — the per-field-button counterpart to `e2e-host-sweep.mjs`'s chat-host conversation sweep, which has no overlap or coverage for this code path today.
- v1 targets: the local `test/fixtures/test-dictation.html` fixture (plain input/textarea/contenteditable, zero-login baseline) and Mistral's Le Chat (`chat.mistral.ai`, real, login-free, ProseMirror composer, confirmed-working per GH issue #163). Both empirically validated end-to-end via live Layer-4 CDP spikes before any code was written.
- Reuses `layer4cdp-lib.mjs` (CDP launch/profile machinery) and `e2e-host-sweep-lib.mjs`'s `classifyConsoleLine` (SayPi-vs-host console attribution).
- New `npm run e2e-dictation-sweep`; runbook at `doc/e2e-dictation-sweep.md`; design spec at `doc/specs/2026-06-30-e2e-dictation-sweep-design.md`.
- Backed by a local-only `.claude/skills/e2e-dictation-sweep/SKILL.md` (gitignored per this repo's skill-authoring convention — not part of this diff).

## Review
Went through a 4-dimension adversarial multi-agent review (correctness, reuse-vs-`e2e-host-sweep`, repo-convention-fit, robustness) before this PR — 10 candidate findings extracted, 3 survived adversarial verification (2 were duplicate reports of the same issue), both fixed in the second commit:
- `dismissModalIfPresent` used a non-auto-waiting `Locator.count()` right after `domcontentloaded` to detect Mistral's one-time ToS dialog — a real race condition on a client-rendered SPA. Swapped for `waitFor({state:"visible"})`, matching the waiting idiom already used elsewhere (`waitForSelector` in `e2e-host-sweep.mjs`/`layer4cdp.mjs`).
- `DEFAULT_BUTTON_TIMEOUT_MS`/`DEFAULT_TRANSCRIPT_TIMEOUT_MS` were exported but never imported — the orchestrator hardcoded the matching literals instead, so tuning the constants would've silently no-op'd. Wired through.

## Test plan
- [x] `npm test` green (typecheck + jest + vitest, 1584 tests, including 15 new unit tests for the pure lib helpers)
- [x] Live Layer-4 spike confirmed the synthetic-dictation mechanism end-to-end on both v1 targets before this code was written (per the design spec's "Empirical validation" section)
- [ ] Live `npm run e2e-dictation-sweep` run against this branch's build (next step after merge — real-host Chrome session, not CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7ZC1m6vHpFrgU1Y44YqdR