### PR TITLE
fix(auth): route settings sign-out through background SIGN_OUT handler (#454)

### DIFF
--- a/src/popup/auth.js
+++ b/src/popup/auth.js
@@ -28,23 +28,14 @@ function parseJwt(token) {
 // Event handlers
 // The updateAuthUI function is now in auth-shared.js
 
-// Sign out functionality - used by the shared handleSignOut function
-async function signOut() {
-  // Clear stored token
-  await browserAPI.storage.local.remove([
-    'token',
-    'jwtToken',
-    'tokenExpiresAt',
-    'authCookieValue',
-    'authReturnUrl',
-  ]);
-  
-  // Update UI using the shared function
-  updateAuthUI(false);
-}
-
-// Make signOut available to the shared module
-window.signOut = signOut;
+// Sign-out is handled by auth-shared.js's performLocalSignOut(), which sends
+// SIGN_OUT to the background script — the single source of truth for the
+// credential wipe (jwtManager.clear(): in-memory state, refresh alarm, and
+// ALL storage keys incl. oauthRefreshToken) plus auth-cookie removal and
+// auth-status broadcast to content scripts. Do not reintroduce a local
+// window.signOut here: a popup-side storage wipe leaves the background's
+// in-memory session (and its refresh alarm) alive, silently re-signing the
+// user in — see issue #454.
 
 const initializeAuth = async () => {
   // Check current auth state

--- a/test/settings/shared/auth-signout.spec.ts
+++ b/test/settings/shared/auth-signout.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { SettingsHeader } from '../../../entrypoints/settings/components/header';
+import {
+  createTestContainer,
+  cleanupTestContainer,
+  setupChromeMock,
+} from '../setup';
+
+/**
+ * Issue #454: settings/popup sign-out must not orphan `oauthRefreshToken`.
+ *
+ * The settings page loads auth-shared.js and then auth.js (see
+ * entrypoints/settings/index.ts). Sign-out must route through the background
+ * SIGN_OUT handler (src/svc/background.ts), whose `jwtManager.clear()` is the
+ * single source of truth for the credential wipe — including
+ * `oauthRefreshToken`, which otherwise silently re-authenticates the user on
+ * the next service-worker start (JwtManager.loadFromStorage → refreshWithOAuth).
+ */
+
+// The storage keys `JwtManager.clear()` wipes (src/JwtManager.ts) — the
+// contract implemented by the background SIGN_OUT handler.
+const JWT_MANAGER_CLEARED_KEYS = [
+  'jwtToken',
+  'tokenExpiresAt',
+  'authCookieValue',
+  'oauthRefreshToken',
+];
+
+// A well-formed (unsigned) JWT so auth.js's initializeAuth() can parse claims.
+const fakeJwt = [
+  'header',
+  Buffer.from(JSON.stringify({ name: 'Ada Lovelace' })).toString('base64'),
+  'signature',
+].join('.');
+
+describe('settings sign-out (issue #454)', () => {
+  let container: HTMLElement;
+  let headerRoot: HTMLElement | null;
+  let chromeMocks: ReturnType<typeof setupChromeMock>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    container = createTestContainer('<header class="settings-header"></header>');
+    headerRoot = container.querySelector('.settings-header');
+    if (!headerRoot) {
+      throw new Error('Failed to find header root for auth sign-out test');
+    }
+
+    const header = new SettingsHeader(headerRoot);
+    header.render();
+
+    chromeMocks = setupChromeMock();
+    chromeMocks.i18n.getMessage.mockImplementation((key: string, substitutions?: string[]) => {
+      switch (key) {
+        case 'signIn':
+          return 'Sign In';
+        case 'signOut':
+          return 'Sign Out';
+        case 'greeting':
+          return substitutions && substitutions.length > 0
+            ? `Hello, ${substitutions[0]}`
+            : 'Hello';
+        default:
+          return key;
+      }
+    });
+
+    // Seed a signed-in OAuth/PKCE session: JWT + refresh token in storage.
+    (chromeMocks.storage as any)._setState({
+      jwtToken: fakeJwt,
+      tokenExpiresAt: Date.now() + 15 * 60 * 1000,
+      oauthRefreshToken: 'refresh-token-454',
+    });
+
+    // Stand-in for the background SIGN_OUT handler (src/svc/background.ts):
+    // it awaits jwtManager.clear(), which removes JWT_MANAGER_CLEARED_KEYS.
+    chromeMocks.runtime.sendMessage.mockImplementation(
+      (message: any, callback?: (response: any) => void) => {
+        if (message && message.type === 'SIGN_OUT') {
+          chromeMocks.storage.remove(JWT_MANAGER_CLEARED_KEYS, () => {
+            if (callback) callback({ success: true });
+          });
+        } else if (callback) {
+          callback(undefined);
+        }
+      }
+    );
+
+    // Match the real settings-page load order (entrypoints/settings/index.ts):
+    // auth-shared.js first, then auth.js.
+    await import('../../../src/popup/auth-shared.js');
+    // In a real page window === globalThis, so auth.js's bare `updateAuthUI`
+    // references resolve to the global exported by auth-shared.js. Mirror that
+    // here (the Vitest Node env keeps window and globalThis distinct).
+    (globalThis as any).updateAuthUI = (window as any).updateAuthUI;
+    await import('../../../src/popup/auth.js');
+  });
+
+  afterEach(() => {
+    cleanupTestContainer(container);
+    chromeMocks.cleanup();
+    delete (globalThis as any).updateAuthUI;
+    delete (window as any).updateAuthUI;
+    delete (window as any).handleSignIn;
+    delete (window as any).handleSignOut;
+    delete (window as any).refreshAuthUI;
+    delete (window as any).logoutFromSaas;
+    delete (window as any).updateUIAfterSignOut;
+    delete (window as any).performLocalSignOut;
+    delete (window as any).setAuthButtonLoading;
+    delete (window as any).showAuthSuccess;
+    delete (window as any).fallbackToTabAuth;
+    delete (window as any).signOut;
+  });
+
+  it('leaves no stored credential that can re-authenticate the user', async () => {
+    await (window as any).performLocalSignOut();
+
+    const storedState = (chromeMocks.storage as any)._getState();
+    // oauthRefreshToken is the re-auth credential: if it survives sign-out,
+    // JwtManager.loadFromStorage() silently signs the user back in on the
+    // next service-worker start.
+    expect(storedState.oauthRefreshToken).toBeUndefined();
+    expect(storedState.jwtToken).toBeUndefined();
+    expect(storedState.tokenExpiresAt).toBeUndefined();
+    expect(storedState.authCookieValue).toBeUndefined();
+  });
+
+  it('routes sign-out through the background SIGN_OUT handler', async () => {
+    await (window as any).performLocalSignOut();
+
+    // The background handler is the single source of truth: it clears the
+    // in-memory jwtManager singleton, cancels the refresh alarm, removes the
+    // auth cookie, and broadcasts the signed-out status to content scripts.
+    expect(chromeMocks.runtime.sendMessage).toHaveBeenCalledWith(
+      { type: 'SIGN_OUT' },
+      expect.any(Function)
+    );
+  });
+});


### PR DESCRIPTION
**Auth-gated per AGENTS.md: multi-lens review required; do not merge without founder sign-off.**

## Why

Signing out from the settings page didn't stick. The page's local `signOut()` (`src/popup/auth.js`) removed a hardcoded storage-key list — `token`, `jwtToken`, `tokenExpiresAt`, `authCookieValue`, `authReturnUrl` — that predates the PKCE feature and was never updated when `oauthRefreshToken` was introduced. On the next MV3 service-worker start, `JwtManager.loadFromStorage()` finds the orphaned refresh token with no JWT, calls `refreshWithOAuth()`, and silently signs the user back in. On a shared machine, "signed out" doesn't mean signed out.

It's actually worse than a restart-time bug: the local wipe never touches the background's in-memory `jwtManager` singleton, so its scheduled refresh alarm stays alive and re-persists `jwtToken` + `oauthRefreshToken` to storage within one token lifetime — no SW restart needed. And because the background's `storage.onChanged` handler broadcasts auth status from that untouched singleton, content scripts are told `isAuthenticated: true` immediately after the "sign-out".

## What

Delete the local `signOut()` and its `window.signOut` export from `src/popup/auth.js`. `performLocalSignOut()` in `auth-shared.js` prefers `window.signOut` when present; with it gone, it falls through to its existing fallback — `chrome.runtime.sendMessage({ type: "SIGN_OUT" })` — whose background handler (`src/svc/background.ts`) is the single source of truth for sign-out:

- `await jwtManager.clear()` — clears the in-memory session, cancels the refresh alarm, and removes **all** credential keys from storage including `oauthRefreshToken`
- removes the `auth_session` cookie (guarded by `config.authServerUrl`)
- `broadcastAuthStatus()` — content scripts get `isAuthenticated: false` immediately

Local UI feedback is unchanged: `performLocalSignOut()` still calls `updateUIAfterSignOut()` after the message round-trip.

Deliberately **not** the alternative of adding `oauthRefreshToken` to the local remove-list: that would still leave the in-memory background session authenticated, the refresh alarm alive (which rewrites the tokens to storage), and the wrong `isAuthenticated: true` broadcast — failing the issue's acceptance criteria.

Two keys the old local list removed are no longer removed on sign-out, and both are safe to drop: legacy `token` has no remaining writer in the codebase (it's only ever read as a fallback), and `authReturnUrl` is a login-flow-scoped return URL the background already removes after use (`handleAuthReturn`) — it carries no credential.

## Blast radius

The sign-out flow on the settings page for **all** users — Chrome/Edge (OAuth/PKCE and cookie paths) and Firefox MV2. Firefox's settings page loads the same `auth.js` today, so it reroutes through SIGN_OUT too; the handler's `cookies.remove` is `config.authServerUrl`-guarded and `browser.cookies` exists in the MV2 background, and `jwtManager.clear()` is a strict superset of the old local wipe for credential keys. No changes to `src/JwtManager.ts`, `src/auth/`, or the background handler itself — the fix reuses the already-correct path. Sign-**in** is untouched.

## How verified

Fail-first TDD (new Vitest spec `test/settings/shared/auth-signout.spec.ts`, JSDOM, mirrors the real settings-page load order `auth-shared.js` → `auth.js`, background SIGN_OUT handler mocked to mirror `jwtManager.clear()`'s key list):

1. Wrote the test against unfixed `main`-based code → failed for the bug's reason (below).
2. Applied the fix → both tests pass.
3. Full suite `npm test` (tsc `--noEmit` + Jest + Vitest): exit 0 — Jest 1 suite / 2 tests passed; Vitest 181 files, 1584 passed / 1 skipped.

## Fail-first proof

```
 FAIL  test/settings/shared/auth-signout.spec.ts > settings sign-out (issue #454) > leaves no stored credential that can re-authenticate the user
AssertionError: expected 'refresh-token-454' to be undefined

- Expected:
undefined

+ Received:
"refresh-token-454"

 ❯ test/settings/shared/auth-signout.spec.ts:123:43
    121|     // JwtManager.loadFromStorage() silently signs the user back in on…
    122|     // next service-worker start.
    123|     expect(storedState.oauthRefreshToken).toBeUndefined();

 FAIL  test/settings/shared/auth-signout.spec.ts > settings sign-out (issue #454) > routes sign-out through the background SIGN_OUT handler
AssertionError: expected "spy" to be called with arguments: [ { type: 'SIGN_OUT' }, Any<Function> ]

Number of calls: 0

 ❯ test/settings/shared/auth-signout.spec.ts:135:45
    133|     // in-memory jwtManager singleton, cancels the refresh alarm, remo…
    134|     // auth cookie, and broadcasts the signed-out status to content sc…
    135|     expect(chromeMocks.runtime.sendMessage).toHaveBeenCalledWith(

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

Fixes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
