### PR TITLE
fix(dictation): set input/textarea values via the native prototype setter so React registers dictated text (#453)

### DIFF
--- a/src/text-insertion/TextInsertionStrategy.ts
+++ b/src/text-insertion/TextInsertionStrategy.ts
@@ -65,15 +65,42 @@ export class InputTextareaStrategy implements TextInsertionStrategy {
 
   insertText(target: HTMLElement, text: string, replaceAll: boolean, caretOffset?: number): void {
     const inputTarget = target as HTMLInputElement | HTMLTextAreaElement;
+    const newValue = replaceAll ? text : inputTarget.value + text;
 
-    if (replaceAll) {
-      inputTarget.value = text;
+    // Set the value through the native prototype setter so framework value
+    // trackers register the mutation (#453). React installs an instance-level
+    // `value` descriptor (inputValueTracking) that records direct `.value =`
+    // assignments; the subsequent input event is then deduped as "no change"
+    // and the dictated text is dropped/reverted on controlled inputs. Calling
+    // the prototype setter bypasses the instance tracker, so the framework
+    // sees the delta — just like real typing.
+    const prototype =
+      inputTarget instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    const nativeValueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+    if (nativeValueSetter) {
+      nativeValueSetter.call(inputTarget, newValue);
     } else {
-      inputTarget.value = inputTarget.value + text;
+      // Defensive fallback for environments without a prototype descriptor
+      inputTarget.value = newValue;
     }
 
-    // Dispatch input event for framework compatibility
-    inputTarget.dispatchEvent(new Event("input", { bubbles: true }));
+    // Dispatch an InputEvent (not a bare Event) for framework compatibility —
+    // listeners inspect inputType/data, and real typing produces InputEvents.
+    try {
+      inputTarget.dispatchEvent(
+        new InputEvent("input", {
+          bubbles: true,
+          composed: true,
+          inputType: "insertText",
+          data: text,
+        })
+      );
+    } catch {
+      // InputEvent unavailable (exotic/legacy environment) — plain Event
+      inputTarget.dispatchEvent(new Event("input", { bubbles: true }));
+    }
 
     // Position the caret at the requested offset (#178 insert-at-caret). Done after
     // dispatching the input event so our position is the final state even if a

--- a/test/state-machines/TextInsertionStrategies.spec.ts
+++ b/test/state-machines/TextInsertionStrategies.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 
 // Import the actual strategy classes from the shared module
 import {
+  InputTextareaStrategy,
   SlateEditorStrategy,
   QuillEditorStrategy,
   ProseMirrorEditorStrategy,
@@ -10,16 +11,141 @@ import {
 import { TextInsertionManager } from '../../src/text-insertion/TextInsertionManager';
 
 describe('TextInsertionStrategies', () => {
+  let inputTextareaStrategy: InputTextareaStrategy;
   let slateStrategy: SlateEditorStrategy;
   let quillStrategy: QuillEditorStrategy;
   let proseMirrorStrategy: ProseMirrorEditorStrategy;
   let textInsertionManager: TextInsertionManager;
 
   beforeEach(() => {
+    inputTextareaStrategy = new InputTextareaStrategy();
     slateStrategy = new SlateEditorStrategy();
     quillStrategy = new QuillEditorStrategy();
     proseMirrorStrategy = new ProseMirrorEditorStrategy();
     textInsertionManager = TextInsertionManager.getInstance();
+  });
+
+  describe('InputTextareaStrategy', () => {
+    /**
+     * Installs a React-style value tracker on the element (#453).
+     *
+     * This mirrors React's `inputValueTracking` byte-for-byte: `track()`
+     * defines an INSTANCE-level `value` descriptor whose setter records the
+     * assigned value before delegating to the native prototype setter, and
+     * `updateValueIfChanged()` (run on every `input` event) only registers a
+     * change when the DOM value differs from the tracked value.
+     *
+     * Direct `.value =` assignment runs the instance setter, so the tracker
+     * is updated in lockstep and React dedupes the subsequent input event as
+     * "no change" — dictation silently no-ops on controlled inputs. Setting
+     * the value through the native prototype setter bypasses the instance
+     * descriptor, leaving the tracker stale so the framework sees the delta.
+     */
+    function installReactValueTracker(
+      element: HTMLInputElement | HTMLTextAreaElement
+    ): { changes: string[] } {
+      const proto =
+        element instanceof HTMLTextAreaElement
+          ? HTMLTextAreaElement.prototype
+          : HTMLInputElement.prototype;
+      const nativeDesc = Object.getOwnPropertyDescriptor(proto, 'value')!;
+      let trackedValue = String(element.value);
+
+      // React's track(): instance-level descriptor shadowing the prototype's
+      Object.defineProperty(element, 'value', {
+        configurable: true,
+        get() {
+          return nativeDesc.get!.call(this);
+        },
+        set(value: string) {
+          trackedValue = String(value);
+          nativeDesc.set!.call(this, value);
+        },
+      });
+
+      // React's updateValueIfChanged(): dedupe input events by tracked value
+      const changes: string[] = [];
+      element.addEventListener('input', () => {
+        const currentValue = nativeDesc.get!.call(element) as string;
+        if (currentValue !== trackedValue) {
+          trackedValue = currentValue;
+          changes.push(currentValue);
+        }
+      });
+
+      return { changes };
+    }
+
+    it('should handle input and textarea elements only', () => {
+      expect(inputTextareaStrategy.canHandle(document.createElement('input'))).toBe(true);
+      expect(inputTextareaStrategy.canHandle(document.createElement('textarea'))).toBe(true);
+
+      const contentEditableDiv = document.createElement('div');
+      contentEditableDiv.contentEditable = 'true';
+      expect(inputTextareaStrategy.canHandle(contentEditableDiv)).toBe(false);
+    });
+
+    it('registers the mutation with a React-style value tracker on an input (replaceAll)', () => {
+      const input = document.createElement('input');
+      const { changes } = installReactValueTracker(input);
+
+      inputTextareaStrategy.insertText(input, 'hello', true);
+
+      expect(input.value).toBe('hello');
+      // React only commits the change when the tracker sees a delta at
+      // input-event time; direct `.value =` assignment updates the tracker
+      // first, so the event is deduped and dictation silently no-ops.
+      expect(changes).toEqual(['hello']);
+    });
+
+    it('registers the mutation with a React-style value tracker on a textarea', () => {
+      const textarea = document.createElement('textarea');
+      const { changes } = installReactValueTracker(textarea);
+
+      inputTextareaStrategy.insertText(textarea, 'dictated text', true);
+
+      expect(textarea.value).toBe('dictated text');
+      expect(changes).toEqual(['dictated text']);
+    });
+
+    it('registers appended text with a React-style value tracker (replaceAll=false)', () => {
+      const input = document.createElement('input');
+      input.value = 'hello';
+      const { changes } = installReactValueTracker(input);
+
+      inputTextareaStrategy.insertText(input, ' world', false);
+
+      expect(input.value).toBe('hello world');
+      expect(changes).toEqual(['hello world']);
+    });
+
+    it('dispatches a bubbling InputEvent describing the insertion', () => {
+      const input = document.createElement('input');
+      const events: Event[] = [];
+      input.addEventListener('input', (event) => events.push(event));
+
+      inputTextareaStrategy.insertText(input, 'abc', true);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toBeInstanceOf(InputEvent);
+      expect((events[0] as InputEvent).inputType).toBe('insertText');
+      expect((events[0] as InputEvent).data).toBe('abc');
+      expect(events[0].bubbles).toBe(true);
+    });
+
+    it('positions the caret at the requested offset after insertion (#178)', () => {
+      const input = document.createElement('input');
+      input.value = 'hello';
+      installReactValueTracker(input);
+
+      // Simulate inserting " there" at the caret (after "hello") within a
+      // longer value, leaving the caret right after the inserted text.
+      inputTextareaStrategy.insertText(input, 'hello there world', true, 11);
+
+      expect(input.value).toBe('hello there world');
+      expect(input.selectionStart).toBe(11);
+      expect(input.selectionEnd).toBe(11);
+    });
   });
 
   describe('QuillEditorStrategy', () => {

--- a/test/vitest.setup.js
+++ b/test/vitest.setup.js
@@ -38,6 +38,7 @@ Object.defineProperties(global, {
   DOMParser: { value: dom.window.DOMParser },
   SVGElement: { value: dom.window.SVGElement },
   Event: { value: dom.window.Event },
+  InputEvent: { value: dom.window.InputEvent },
   Blob: { value: dom.window.Blob },
   Audio: { value: dom.window.Audio || vi.fn() },
   FormData: { value: dom.window.FormData, writable: true, configurable: true },


### PR DESCRIPTION
## Why

Universal dictation silently no-ops on React-controlled `<input>`/`<textarea>` fields — most modern web apps. `InputTextareaStrategy` (the strategy every plain input/textarea routes through via `TextInsertionManager` → `DictationMachine.insertText`) assigned `inputTarget.value` directly and dispatched a bare `Event("input")`.

React installs an **instance-level** `value` descriptor on each controlled element (`inputValueTracking`): its setter records every assignment before delegating to the native setter, and React's `updateValueIfChanged` only commits a change when the DOM value differs from that tracked value at input-event time. Direct `.value =` assignment runs the instance setter, so the tracker updates in lockstep, the input event is deduped as "no change", and the dictated text is dropped/reverted — dictation appears to do nothing. The codebase already knew this hazard: `PiPrompt.setNativeValue` (src/chatbots/Pi.ts) works around the same tracker for Pi.ai's prompt, but the dictation strategies never got the treatment (noted as the "Framework Support" post-MVP gap in `doc/UNIVERSAL_DICTATION_SUMMARY.md`, tracked broadly by #163).

## What

Single-function change in `src/text-insertion/TextInsertionStrategy.ts` (`InputTextareaStrategy.insertText`):

- Compute the new value (`replaceAll ? text : value + text`), then set it through the **native prototype setter** — `Object.getOwnPropertyDescriptor(HTMLInputElement.prototype | HTMLTextAreaElement.prototype, "value").set.call(...)` — which bypasses the instance tracker so the framework sees the delta, exactly like real typing. Falls back to plain assignment if the descriptor is missing (defensive; behaviorally identical on non-framework pages).
- Upgrade the dispatched event from a bare `Event("input")` to a bubbling, composed `InputEvent` with `inputType: "insertText"` and `data`, matching the sibling strategies (Lexical/Slate/ProseMirror) and real keyboard input, with a plain-`Event` fallback guarded by try/catch.
- The #178 insert-at-caret behavior (`setSelectionRange` after the event) is untouched and now regression-guarded by a test.

Test-side, the fix exposed a latent environment gap: `test/vitest.setup.js` builds its own JSDOM globals list and defined `Event` but not `InputEvent`, which had been silently masking every strategy's `InputEvent` path under Vitest (their try/catch fell back). Exposed `InputEvent: dom.window.InputEvent` — a one-line fidelity fix to the shared setup.

## How verified

Fail-first TDD per the repo protocol. New `describe("InputTextareaStrategy")` block in `test/state-machines/TextInsertionStrategies.spec.ts` installs a byte-for-byte replica of React's tracker (instance-level `value` descriptor recording assignments + an `input` listener that dedupes against the tracked value) and asserts the change registers for: input replace-all, textarea, and append mode; plus an `InputEvent` shape assertion and a #178 caret-offset regression guard.

- Before the fix: 4 of the new tests fail for the bug's reason (tracker sees no delta / bare Event) — output below.
- After the fix: the spec file passes 27/27.
- Full suite (`npm test`): typecheck clean, Jest 2/2, Vitest **1588 passed | 1 skipped (180 files)** — no other test needed changes.

## Fail-first proof

Captured from `npx vitest run test/state-machines/TextInsertionStrategies.spec.ts` on the branch before the fix was applied:

```
 FAIL  test/state-machines/TextInsertionStrategies.spec.ts > TextInsertionStrategies > InputTextareaStrategy > registers the mutation with a React-style value tracker on an input (replaceAll)
AssertionError: expected [] to deeply equal [ 'hello' ]

- Expected
+ Received

- [
-   "hello",
- ]
+ []

 ❯ test/state-machines/TextInsertionStrategies.spec.ts:98:23
     96|       // input-event time; direct `.value =` assignment updates the tr…
     97|       // first, so the event is deduped and dictation silently no-ops.
     98|       expect(changes).toEqual(['hello']);

 FAIL  test/state-machines/TextInsertionStrategies.spec.ts > TextInsertionStrategies > InputTextareaStrategy > registers the mutation with a React-style value tracker on a textarea
AssertionError: expected [] to deeply equal [ 'dictated text' ]

 FAIL  test/state-machines/TextInsertionStrategies.spec.ts > TextInsertionStrategies > InputTextareaStrategy > registers appended text with a React-style value tracker (replaceAll=false)
AssertionError: expected [] to deeply equal [ 'hello world' ]

 FAIL  test/state-machines/TextInsertionStrategies.spec.ts > TextInsertionStrategies > InputTextareaStrategy > dispatches a bubbling InputEvent describing the insertion
AssertionError: expected Event{ isTrusted: false, …(1) } to be an instance of InputEvent

 Test Files  1 failed (1)
      Tests  4 failed | 23 passed (27)
```

## Blast radius

Every dictation insertion into `<input>`/`<textarea>` on all sites (universal dictation is the primary consumer; the chat hosts' composers are contenteditable/ProseMirror, so this strategy isn't selected there in practice). On framework pages the behavior change is the intended fix — the app's onChange now fires, as it does for real typing. On non-framework pages the native prototype setter is semantically identical to direct assignment, and Vue's `v-model` (which reads `e.target.value` from a native listener) continues to work. Watch item: pages that "worked" by reading the DOM value directly will now also receive framework onChange — strictly more faithful to real typing.

The `vitest.setup.js` change adds a previously-missing global; the full Vitest suite (1588 tests) confirms nothing depended on its absence.

Fixes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
