### PR TITLE
fix(offscreen): owner-guard audio routing so a 2nd tab can't hijack the 1st tab's playback (#452)

### DIFF
--- a/src/offscreen/audio_handler.ts
+++ b/src/offscreen/audio_handler.ts
@@ -124,6 +124,42 @@ function registerLifecycleDebug(audio: HTMLAudioElement) {
   });
 }
 
+/**
+ * Decide whether loading audio for `newTabId` should preempt a different tab that
+ * currently owns the single shared <audio> element. Returns the tab to notify, or
+ * null. Pure (no side effects) so the routing-overwrite contract is unit-testable —
+ * the audio-side mirror of vad_handler's computePreemption (#320). (#452)
+ */
+export function computeAudioPreemption(
+  previousTabId: number | null,
+  newTabId: number,
+  playbackActive: boolean
+): { targetTabId: number } | null {
+  if (previousTabId !== null && previousTabId !== newTabId && playbackActive) {
+    return { targetTabId: previousTabId };
+  }
+  return null;
+}
+
+/**
+ * A control request (pause/resume/stop/URL-less play) against the single shared
+ * <audio> element should be honored only when it comes from the tab that currently
+ * owns playback. A displaced (non-owner) tab must NOT control the audio the new
+ * owner is using — nor decrement the shared usage counter via stop. When there is
+ * no current owner (or no source tab id) there is no ambiguity, so honor it
+ * (legacy behavior) — the audio-side mirror of vad_handler's isTeardownFromOwner
+ * (#320). (#452)
+ */
+export function isAudioRequestFromOwner(
+  sourceTabId: number | undefined,
+  currentOwner: number | null
+): boolean {
+  if (sourceTabId === undefined || currentOwner === null) {
+    return true;
+  }
+  return sourceTabId === currentOwner;
+}
+
 function loadAudio(url: string, tabId: number, playImmediately: boolean = true, volume?: number) {
   if (!audioElement) {
     initializeAudio();
@@ -140,7 +176,37 @@ function loadAudio(url: string, tabId: number, playImmediately: boolean = true, 
   }
   
   logger.debug(`[SayPi Audio Handler] Loading audio from URL: ${url} for tab ${tabId}`);
-  
+
+  // Last-tab-wins: if a DIFFERENT tab currently owns actively-loaded audio, it is
+  // being displaced (there is only one shared <audio> element, so its playback
+  // physically stops when the src is replaced below). Send it a terminal
+  // AUDIO_ENDED so its AudioOutputMachine exits the playing state instead of
+  // hanging — without this, the teardown events fired by the src replacement are
+  // stamped with the NEW owner's tab id and the displaced tab never hears
+  // anything. AUDIO_ENDED (rather than a new message type) rides the existing
+  // bridge → EventBus → AudioOutputMachine path, so no client changes are needed.
+  // (#452, mirrors the #320 VAD preemption notice)
+  //
+  // Usage-counting note: this takeover still increments below, while the displaced
+  // tab's owner-guarded stop no-ops (no matching decrement) — a deliberate
+  // asymmetry shared with the VAD side. It is safe: the count can only stay too
+  // HIGH, which never triggers auto-shutdown early.
+  // playbackActive checks the src ATTRIBUTE (the property getter resolves '' to
+  // the document URL after stopAudio clears it, so it can't be used here).
+  const playbackActive = !!audioElement.getAttribute("src") && !audioElement.ended;
+  const preemption = computeAudioPreemption(currentAudioTabId, tabId, playbackActive);
+  if (preemption) {
+    logger.log(
+      `[SayPi Audio Handler] Tab ${tabId} is taking over audio playback from tab ${preemption.targetTabId}; notifying the displaced tab.`
+    );
+    chrome.runtime.sendMessage({
+      type: "AUDIO_ENDED",
+      detail: { timestamp: Date.now() },
+      targetTabId: preemption.targetTabId,
+      origin: "offscreen-document",
+    });
+  }
+
   currentAudioTabId = tabId;
   incrementUsage('audio');
   
@@ -402,17 +468,29 @@ if (!audioHandlerGlobal.__saypiAudioHandlerRegistered) {
 
   registerMessageHandler("AUDIO_PLAY_REQUEST", (message, sourceTabId) => {
     if (message.url) {
-      // Legacy support - if URL is provided, call loadAudio
+      // Legacy support - if URL is provided, call loadAudio. A load is a
+      // legitimate last-tab-wins takeover, so it is NOT owner-guarded —
+      // loadAudio notifies the displaced owner instead. (#452)
       logger.debug(`[SayPi Audio Handler] Processing AUDIO_PLAY_REQUEST with URL: ${message.url}`);
       return loadAudio(message.url, sourceTabId, true);
     } else {
-      // Standard usage - no URL means play current audio
+      // Standard usage - no URL means play current audio; only the owner may
+      // resume the shared element. (#452)
+      if (!isAudioRequestFromOwner(sourceTabId, currentAudioTabId)) {
+        logger.debug(`[SayPi Audio Handler] Ignoring AUDIO_PLAY_REQUEST (resume) from non-owner tab ${sourceTabId} (current owner: ${currentAudioTabId}).`);
+        return { success: true, ignored: true };
+      }
       logger.debug(`[SayPi Audio Handler] Processing AUDIO_PLAY_REQUEST (resume playback)`);
       return playAudio();
     }
   });
 
   registerMessageHandler("AUDIO_PAUSE_REQUEST", (message, sourceTabId) => {
+    // A displaced (non-owner) tab must not pause the audio the new owner is using. (#452)
+    if (!isAudioRequestFromOwner(sourceTabId, currentAudioTabId)) {
+      logger.debug(`[SayPi Audio Handler] Ignoring AUDIO_PAUSE_REQUEST from non-owner tab ${sourceTabId} (current owner: ${currentAudioTabId}).`);
+      return { success: true, ignored: true };
+    }
     const result = pauseAudio();
     if (result.success) {
       logger.debug(`[SayPi Audio Handler] AUDIO_PAUSE_REQUEST successful at ${new Date().toISOString()}`);
@@ -423,6 +501,11 @@ if (!audioHandlerGlobal.__saypiAudioHandlerRegistered) {
   });
 
   registerMessageHandler("AUDIO_RESUME_REQUEST", (message, sourceTabId) => {
+    // A displaced (non-owner) tab must not resume the audio the new owner is using. (#452)
+    if (!isAudioRequestFromOwner(sourceTabId, currentAudioTabId)) {
+      logger.debug(`[SayPi Audio Handler] Ignoring AUDIO_RESUME_REQUEST from non-owner tab ${sourceTabId} (current owner: ${currentAudioTabId}).`);
+      return { success: true, ignored: true };
+    }
     const result = playAudio();
     if (result.success) {
       logger.debug(`[SayPi Audio Handler] AUDIO_RESUME_REQUEST successful at ${new Date().toISOString()}`);
@@ -433,6 +516,13 @@ if (!audioHandlerGlobal.__saypiAudioHandlerRegistered) {
   });
 
   registerMessageHandler("AUDIO_STOP_REQUEST", (message, sourceTabId) => {
+    // A displaced (non-owner) tab must not stop the audio the new owner is using —
+    // and must not decrement the shared usage counter for a stop that did not
+    // happen (stopAudio decrements unconditionally). (#452)
+    if (!isAudioRequestFromOwner(sourceTabId, currentAudioTabId)) {
+      logger.debug(`[SayPi Audio Handler] Ignoring AUDIO_STOP_REQUEST from non-owner tab ${sourceTabId} (current owner: ${currentAudioTabId}).`);
+      return { success: true, ignored: true };
+    }
     return stopAudio();
   });
 

--- a/test/offscreen/audio_handler-preemption.spec.ts
+++ b/test/offscreen/audio_handler-preemption.spec.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #452 — audio-side mirror of #320 (last-tab-wins + clean handoff). The single
+ * offscreen document holds ONE shared <audio> element and a single
+ * `currentAudioTabId`. When a second tab loads audio while a first tab's playback
+ * is active, the second tab wins the (one) element and the first tab must be
+ * NOTIFIED with a terminal AUDIO_ENDED so its AudioOutputMachine exits the
+ * playing state instead of hanging. Critically, the displaced tab's own
+ * pause/resume/stop requests must NOT control the audio the new owner is using,
+ * nor decrement the shared usage counter (owner-guarded control requests).
+ *
+ * These tests pin the two pure decisions at L1 (the routing-overwrite contract
+ * and the owner-guard safety contract) and verify they are actually wired into
+ * the registered AUDIO_* message handlers end-to-end.
+ */
+
+const { sendMessage, handlers, audioEl, playSpy, pauseSpy } = vi.hoisted(() => {
+  const sendMessage = vi.fn();
+  (globalThis as any).chrome = {
+    runtime: {
+      getURL: (p: string) => `chrome-extension://test/${p}`,
+      sendMessage,
+    },
+  };
+
+  // audio_handler self-initializes at import time and looks this element up by
+  // id, so it must exist in the JSDOM before the module is imported.
+  const audioEl = document.createElement("audio");
+  audioEl.id = "saypi-audio-offscreen";
+  document.body.appendChild(audioEl);
+
+  // JSDOM does not implement HTMLMediaElement playback — stub the methods the
+  // handler calls (and spy on them so ownership guards are observable).
+  const playSpy = vi.fn().mockResolvedValue(undefined);
+  const pauseSpy = vi.fn();
+  Object.defineProperty(audioEl, "play", { value: playSpy });
+  Object.defineProperty(audioEl, "pause", { value: pauseSpy });
+  Object.defineProperty(audioEl, "load", { value: vi.fn() });
+  Object.defineProperty(audioEl, "currentTime", { value: 0, writable: true });
+  Object.defineProperty(audioEl, "ended", { value: false, writable: true });
+
+  const handlers = new Map<string, (message: any, sourceTabId: number) => any>();
+  return { sendMessage, handlers, audioEl, playSpy, pauseSpy };
+});
+
+vi.mock("../../src/LoggingModule.js", () => ({
+  logger: { log: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), reportError: vi.fn() },
+}));
+vi.mock("../../src/offscreen/media_coordinator", () => ({
+  incrementUsage: vi.fn(),
+  decrementUsage: vi.fn(),
+  resetUsageCounter: vi.fn(),
+  registerMessageHandler: vi.fn((type: string, handler: any) => handlers.set(type, handler)),
+}));
+
+import { decrementUsage } from "../../src/offscreen/media_coordinator";
+import {
+  computeAudioPreemption,
+  isAudioRequestFromOwner,
+} from "../../src/offscreen/audio_handler";
+
+describe("#452 computeAudioPreemption (routing-overwrite contract)", () => {
+  it("flags the PREVIOUS tab for preemption when a different tab takes over active playback", () => {
+    expect(computeAudioPreemption(1, 2, true)).toEqual({ targetTabId: 1 });
+  });
+
+  it("does NOT preempt when the same tab re-loads audio (next utterance)", () => {
+    expect(computeAudioPreemption(1, 1, true)).toBeNull();
+  });
+
+  it("does NOT preempt when there was no previous owner", () => {
+    expect(computeAudioPreemption(null, 2, true)).toBeNull();
+  });
+
+  it("does NOT preempt when no playback is active (nothing to take over)", () => {
+    expect(computeAudioPreemption(1, 2, false)).toBeNull();
+  });
+});
+
+describe("#452 isAudioRequestFromOwner (owner-guard safety contract)", () => {
+  it("honors a control request from the current owner", () => {
+    expect(isAudioRequestFromOwner(2, 2)).toBe(true);
+  });
+
+  it("REJECTS a control request from a non-owner (a displaced tab must not control the new owner's audio)", () => {
+    expect(isAudioRequestFromOwner(1, 2)).toBe(false);
+  });
+
+  it("honors a control request when there is no current owner (no ambiguity — preserves legacy behavior)", () => {
+    expect(isAudioRequestFromOwner(1, null)).toBe(true);
+  });
+
+  it("honors a control request with no source tab id (legacy callers)", () => {
+    expect(isAudioRequestFromOwner(undefined, 2)).toBe(true);
+  });
+});
+
+describe("#452 audio_handler wiring: preemption notice + owner-guarded control", () => {
+  const invoke = (type: string, message: any, sourceTabId: number) => {
+    const handler = handlers.get(type);
+    expect(handler, `handler registered for ${type}`).toBeDefined();
+    return handler!(message, sourceTabId);
+  };
+
+  beforeEach(() => {
+    sendMessage.mockClear();
+    playSpy.mockClear();
+    pauseSpy.mockClear();
+    vi.mocked(decrementUsage).mockClear();
+  });
+
+  it("notifies the displaced tab with a terminal AUDIO_ENDED when another tab takes over", () => {
+    // Tab 1 starts playback — no previous owner, so nobody to notify.
+    invoke("AUDIO_LOAD_REQUEST", { url: "https://example.com/tab1.mp3" }, 1);
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    // Tab 2 loads audio while tab 1's playback is active → last-tab-wins on the
+    // single shared element; tab 1 must receive a terminal AUDIO_ENDED so its
+    // output state machine exits the playing state instead of hanging.
+    invoke("AUDIO_LOAD_REQUEST", { url: "https://example.com/tab2.mp3" }, 2);
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: "AUDIO_ENDED",
+      detail: { timestamp: expect.any(Number) },
+      targetTabId: 1,
+      origin: "offscreen-document",
+    });
+  });
+
+  it("a non-owner's pause/resume/stop does NOT control the owner's audio or corrupt the usage counter", () => {
+    // State carried from the previous test: tab 2 owns active playback.
+    // Tab 1 (displaced) issues every control request — none may touch the shared
+    // element the new owner is using, and stop must not decrement usage.
+    invoke("AUDIO_PAUSE_REQUEST", {}, 1);
+    expect(pauseSpy).not.toHaveBeenCalled();
+
+    invoke("AUDIO_RESUME_REQUEST", {}, 1);
+    invoke("AUDIO_PLAY_REQUEST", {}, 1); // URL-less play == resume
+    expect(playSpy).not.toHaveBeenCalled();
+
+    invoke("AUDIO_STOP_REQUEST", {}, 1);
+    expect(pauseSpy).not.toHaveBeenCalled();
+    expect(decrementUsage).not.toHaveBeenCalled();
+    expect(audioEl.getAttribute("src")).toBe("https://example.com/tab2.mp3");
+
+    // The current owner (tab 2) can still control its own audio.
+    invoke("AUDIO_PAUSE_REQUEST", {}, 2);
+    expect(pauseSpy).toHaveBeenCalledTimes(1);
+    invoke("AUDIO_RESUME_REQUEST", {}, 2);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    invoke("AUDIO_STOP_REQUEST", {}, 2);
+    expect(decrementUsage).toHaveBeenCalledWith("audio");
+    expect(audioEl.getAttribute("src")).toBe("");
+  });
+
+  it("does NOT notify on a same-tab reload or when no playback is active", () => {
+    // State carried from the previous test: tab 2 owns, playback stopped (src cleared).
+    // Same tab loading the next utterance is the normal single-tab flow — silent.
+    invoke("AUDIO_LOAD_REQUEST", { url: "https://example.com/tab2-next.mp3" }, 2);
+    invoke("AUDIO_LOAD_REQUEST", { url: "https://example.com/tab2-again.mp3" }, 2);
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    // Owner stops cleanly, then a new tab takes over idle audio — nothing to preempt.
+    invoke("AUDIO_STOP_REQUEST", {}, 2);
+    invoke("AUDIO_LOAD_REQUEST", { url: "https://example.com/tab3.mp3" }, 3);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

In the shared offscreen document there is exactly one `<audio>` element and one module-global `currentAudioTabId`. `loadAudio()` overwrote that owner unconditionally, and the `AUDIO_PAUSE/RESUME/STOP` (and URL-less `AUDIO_PLAY`) handlers ignored `sourceTabId` entirely. With SayPi active in two Chrome/Edge tabs on TTS-capable hosts, a second tab starting playback produced two real defects:

1. **The displaced tab's state machine hangs.** Because the owner overwrite happens *before* the `src` replacement, the teardown events (`pause`/`emptied`) fired by killing tab A's playback are stamped with tab B's id. Tab A never receives any terminal event, so its `AudioOutputMachine` stays stuck in the playing/speaking state.
2. **A displaced tab can still control the new owner's audio.** Its pause/stop requests hit the shared element (silently killing tab B's playback), and its stop decrements the shared usage counter for a stop that shouldn't count — corrupting the auto-shutdown accounting.

This is the audio-side analogue of #320, which was fixed only on the VAD side (`computePreemption` / `isTeardownFromOwner` in `vad_handler.ts`).

## What

All inside `src/offscreen/audio_handler.ts`, mirroring the #320 model:

- **`computeAudioPreemption` (exported, pure):** in `loadAudio()`, before the owner overwrite, if a *different* tab owns actively-loaded audio (non-empty `src` attribute and not `ended`), the displaced tab is sent a terminal `AUDIO_ENDED`. That message type deliberately reuses the existing delivery path — `OffscreenAudioBridge` → `audio:offscreen:ended` → `AudioModule` → `outputActor.send({ type: "ended" })` — so the displaced tab's `AudioOutputMachine` exits the playing state with **zero client-side changes** (a new `AUDIO_PREEMPTED` type would emit an EventBus event nothing consumes).
- **`isAudioRequestFromOwner` (exported, pure):** `AUDIO_PAUSE_REQUEST`, `AUDIO_RESUME_REQUEST`, `AUDIO_STOP_REQUEST`, and the URL-less `AUDIO_PLAY_REQUEST` branch are honored only from the owning tab. Legacy-safe semantics identical to the VAD side: requests with `sourceTabId === undefined` or when there is no current owner are honored. URL-carrying loads are *not* guarded — a load is a legitimate last-tab-wins takeover, which now notifies instead of silently displacing.
- The usage counter keeps the deliberate #320 "too-high-is-safe" asymmetry: the guarded non-owner stop no longer decrements, so the count can only stay too high (which never triggers auto-shutdown early), never too low.

One stated deviation from the triage brief: non-owner requests return `{ success: true, ignored: true }` rather than `{ success: false, error: "not audio owner" }` — exact parity with the #320 VAD guard's response shape, and it avoids the handlers' error-logging path firing for a benign ignored request during displaced-tab teardown.

## How verified

Fail-first TDD (protocol per `CLAUDE.md`): `test/offscreen/audio_handler-preemption.spec.ts` was written first, modeled line-for-line on the #320 spec (`test/offscreen/vad_handler-preemption.spec.ts`). It imports the real module (self-initializing against a JSDOM `<audio id="saypi-audio-offscreen">` with stubbed media methods), captures the registered `AUDIO_*` handlers via a mocked `registerMessageHandler`, and pins both the pure contracts and the end-to-end wiring.

## Fail-first proof

Captured on the branch base (main @ 6ba1556) before the fix — 10 of 11 tests failed. The two wiring tests failed for the bug's exact reasons (the pure-contract tests failed because the guard helpers did not exist yet):

```
 FAIL  test/offscreen/audio_handler-preemption.spec.ts > #452 audio_handler wiring: preemption notice + owner-guarded control > notifies the displaced tab with a terminal AUDIO_ENDED when another tab takes over
AssertionError: expected "spy" to be called with arguments: [ { type: 'AUDIO_ENDED', …(3) } ]

Number of calls: 0

 ❯ test/offscreen/audio_handler-preemption.spec.ts:122:25
    120|     // output state machine exits the playing state instead of hanging.
    121|     invoke("AUDIO_LOAD_REQUEST", { url: "https://example.com/tab2.mp3"…
    122|     expect(sendMessage).toHaveBeenCalledWith({
       |                         ^
    123|       type: "AUDIO_ENDED",
    124|       detail: { timestamp: expect.any(Number) },

 FAIL  test/offscreen/audio_handler-preemption.spec.ts > #452 audio_handler wiring: preemption notice + owner-guarded control > a non-owner's pause/resume/stop does NOT control the owner's audio or corrupt the usage counter
AssertionError: expected "spy" to not be called at all, but actually been called 1 times

 ❯ test/offscreen/audio_handler-preemption.spec.ts:135:26
    133|     // element the new owner is using, and stop must not decrement usa…
    134|     invoke("AUDIO_PAUSE_REQUEST", {}, 1);
    135|     expect(pauseSpy).not.toHaveBeenCalled();
       |                          ^

 Test Files  1 failed (1)
      Tests  10 failed | 1 passed (11)
```

After the fix: the new spec passes (11/11), and the full gate is green — `npm test` = `tsc --noEmit` + Jest (2 passed) + Vitest (181 files, 1593 passed, 1 skipped).

## Blast radius

Confined to the offscreen document's audio handler — the Chrome/Edge MV3 TTS playback path for all hosts. No background routing, bridge, or state-machine changes; `AUDIO_ENDED` is an existing, already-consumed message type, so there is no client protocol change. Single-tab behavior is byte-identical (guards honor requests with no source tab or no current owner, same legacy-safe semantics as #320). Multi-tab behavior changes deliberately — that is the fix. Firefox MV2 is untouched (no offscreen document).

Fixes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)
