### PR TITLE
fix(pi): rescue undecorated composer + restore removed call button (#460)

### DIFF
--- a/src/buttons/CallButton.ts
+++ b/src/buttons/CallButton.ts
@@ -248,7 +248,10 @@ export class CallButton {
         const svg = callButton.querySelector("svg");
 
         if (!svg) {
-            console.error("SVG element not found within the call button.");
+            // Normal transient during (re)creation: createButton assigns this.element
+            // before the async callInactive/callActive render mounts the SVG, and it
+            // redraws the segments itself once the SVG is in place (#460).
+            logger.debug("Call button SVG not mounted yet; skipping segment redraw.");
             return;
         }
 

--- a/src/chatbots/bootstrap.ts
+++ b/src/chatbots/bootstrap.ts
@@ -22,6 +22,9 @@ export class DOMObserver {
   agentNoticeModule: AgentModeNoticeModule;
   private domObserver: MutationObserver | null = null;
   private isObservingDom: boolean = false;
+  // Ancestors already being watched for submit-button re-renders; guards against
+  // stacking a new MutationObserver each time decoratePromptControls re-runs.
+  private submitButtonMonitoredAncestors = new WeakSet<HTMLElement>();
   private domMutationCallback = (mutations: MutationRecord[]) => {
     // Skip decoration work entirely on non-chatable pages
     if (!this.shouldDecorateUI()) {
@@ -86,6 +89,15 @@ export class DOMObserver {
           const chatHistoryObs = this.findChatHistory(removedElement);
           if (chatHistoryObs.found) {
             this.findAndDecorateChatHistory(document.body);
+          }
+          // A host re-render can remove the injected call button while keeping the
+          // decorated prompt element — no finder notices, because the prompt still
+          // reports "already decorated" (#460). Restore the button in place.
+          const callButtonRemoved =
+            removedElement.id === "saypi-callButton" ||
+            removedElement.querySelector?.("#saypi-callButton");
+          if (callButtonRemoved) {
+            this.ensureCallButtonPresent();
           }
         });
     });
@@ -169,6 +181,14 @@ export class DOMObserver {
       if (!this.shouldDecorateUI()) {
         return;
       }
+      // Rescue an undecorated (or de-buttoned) composer. The prompt was the only
+      // decoration target WITHOUT a document-wide re-scan here, so a composer that
+      // mounted while observation was stopped (e.g. the route monitor's 300ms poll
+      // caught a transient non-chatable path during Pi's boot) stayed bare forever —
+      // no call button until a full reload (#460). Does not re-emit content-loaded:
+      // we are already inside that event.
+      this.findAndDecoratePrompt(document.body);
+      this.ensureCallButtonPresent();
       const audioControlsObs = this.findAndDecorateAudioControls(document.body);
       if (audioControlsObs.isReady()) {
         this.voiceMenuUiMgr.findAndDecorateVoiceMenu(
@@ -211,19 +231,24 @@ export class DOMObserver {
    * bootstrap chain. Mirrors startChatHistoryProgressiveSearch's backoff so a
    * composer that hydrates slightly after document_idle is still caught even if
    * its insertion doesn't surface to the MutationObserver as an added node.
+   *
+   * The retry window covers ~30s: a live cold-cache probe of pi.ai/talk measured
+   * the composer mounting at t≈25s (#460), so the old ~7.5s window left the tail
+   * of real first loads with no recovery path. A transiently non-chatable path
+   * skips the scan but keeps the loop alive — Pi's boot can blip through one, and
+   * ending the loop there made the miss permanent.
    */
-  private bootstrapInitialDecoration(attempt = 1, maxAttempts = 10): void {
-    if (!this.shouldDecorateUI()) {
-      return;
-    }
-    const promptObs = this.findAndDecoratePrompt(document.body);
-    if (promptObs.isReady()) {
-      EventBus.emit("saypi:ui:content-loaded");
-      return;
-    }
-    // Already decorated by another path → the chain has already started; stop.
-    if (promptObs.found) {
-      return;
+  private bootstrapInitialDecoration(attempt = 1, maxAttempts = 18): void {
+    if (this.shouldDecorateUI()) {
+      const promptObs = this.findAndDecoratePrompt(document.body);
+      if (promptObs.isReady()) {
+        EventBus.emit("saypi:ui:content-loaded");
+        return;
+      }
+      // Already decorated by another path → the chain has already started; stop.
+      if (promptObs.found) {
+        return;
+      }
     }
     if (attempt < maxAttempts) {
       const delay = Math.min(100 * Math.pow(1.5, attempt - 1), 3000);
@@ -274,6 +299,23 @@ export class DOMObserver {
   // Function to decorate the prompt input element, and other elements that depend on it
   decoratePrompt(prompt: HTMLElement): void {
     prompt.id = "saypi-prompt";
+    this.decoratePromptControls(prompt);
+
+    // Trigger agent mode notice if needed (async call, no need to await)
+    this.agentNoticeModule.showNoticeIfNeeded().catch(error => {
+      console.debug('Failed to show agent notice:', error);
+    });
+  }
+
+  /**
+   * Decorates the containers around an (already id'd) prompt and inserts the call
+   * button. Split out from decoratePrompt so the call button can be restored when
+   * the host re-renders the composer row: a React commit can destroy the injected
+   * button while REUSING the same prompt element — which keeps id=saypi-prompt, so
+   * every finder reports "already decorated" and no other path re-creates it (#460).
+   * Idempotent: safe to re-run against a decorated-but-buttonless composer.
+   */
+  private decoratePromptControls(prompt: HTMLElement): void {
     const promptContainer = this.chatbot.getPromptContainer(prompt);
     if (promptContainer) {
       // Ensure ChatGPT does not get the SayPi control panel decorations (Phase 1)
@@ -292,17 +334,39 @@ export class DOMObserver {
       if (controlsContainer) {
         controlsContainer.id = "saypi-prompt-controls-container";
         const ancestor = this.addIdPromptAncestor(controlsContainer);
-        if (ancestor) this.monitorForSubmitButton(ancestor);
+        if (ancestor && !this.submitButtonMonitoredAncestors.has(ancestor)) {
+          this.submitButtonMonitoredAncestors.add(ancestor);
+          this.monitorForSubmitButton(ancestor);
+        }
         const submitButtonSearch = this.findSubmitButton(controlsContainer);
         const insertionPosition = submitButtonSearch.found ? -1 : 0;
-        buttonModule.createCallButton(controlsContainer, insertionPosition);
+        if (!document.getElementById("saypi-callButton")) {
+          buttonModule.createCallButton(controlsContainer, insertionPosition);
+        }
       }
     }
-    
-    // Trigger agent mode notice if needed (async call, no need to await)
-    this.agentNoticeModule.showNoticeIfNeeded().catch(error => {
-      console.debug('Failed to show agent notice:', error);
-    });
+  }
+
+  /**
+   * Restores the call button if it has been removed from the document while the
+   * decorated prompt is still present (#460). If the prompt itself is gone, the
+   * prompt-removal path in domMutationCallback handles full re-decoration instead.
+   */
+  private ensureCallButtonPresent(): void {
+    if (!this.shouldDecorateUI()) {
+      return;
+    }
+    if (document.getElementById("saypi-callButton")) {
+      return;
+    }
+    const prompt = document.getElementById("saypi-prompt");
+    if (!prompt) {
+      return;
+    }
+    logger.debug(
+      "Call button missing while the prompt persists — restoring it (#460)"
+    );
+    this.decoratePromptControls(prompt);
   }
 
   /**

--- a/test/buttons/CallButton-svg-mount-gap.spec.ts
+++ b/test/buttons/CallButton-svg-mount-gap.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the heavy module-level dependencies so CallButton imports cleanly in jsdom
+// (mirrors CallButton-arc-rebuild.spec.ts).
+vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
+vi.mock("../../src/AnimationModule", () => ({
+  default: { startAnimation: vi.fn(), stopAnimation: vi.fn() },
+}));
+vi.mock("../../src/StateMachineService", () => ({ default: { actor: null } }));
+vi.mock("../../src/buttons/GlowColorUpdater", () => ({
+  GlowColorUpdater: class {
+    updateGlowColor() {}
+  },
+}));
+
+import { CallButton } from "../../src/buttons/CallButton";
+
+/**
+ * #460 — createButton assigns `this.element` before the (async) callInactive/
+ * callActive render mounts the SVG. When the call button is (re)created during an
+ * active flow — e.g. the bootstrap restore path re-inserting a button the host
+ * re-render destroyed — state-machine transitions can invoke updateButtonSegments
+ * inside that gap. That is a normal transient (createButton redraws the segments
+ * right after the SVG mounts), not an error condition.
+ */
+describe("CallButton — updateButtonSegments before the SVG mounts (#460)", () => {
+  let btn: HTMLButtonElement;
+  let cb: any;
+
+  beforeEach(() => {
+    btn = document.createElement("button"); // no SVG inside yet
+    document.body.appendChild(btn);
+    cb = Object.create(CallButton.prototype);
+    cb.element = btn;
+    cb.sayPiActor = { send: vi.fn() };
+    cb.segments = [];
+    cb.currentSegment = null;
+    cb.callIsActive = false;
+    cb.glowColorUpdater = { updateGlowColor: vi.fn() };
+    cb.chatbot = { getNickname: async () => "Pi", getID: () => "pi" };
+  });
+
+  it("returns quietly without logging a console error", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    cb.updateButtonSegments();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/test/chatbots/PiBootstrapInitialLoad.spec.ts
+++ b/test/chatbots/PiBootstrapInitialLoad.spec.ts
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mirror the mock set used by Pi-onboarding.spec.ts / ClaudeBootstrapReload.spec.ts:
+// stub the modules bootstrap.ts pulls in that carry heavy transitive imports or
+// fire async side effects during decoration.
+vi.mock("../../src/prefs/PreferenceModule", () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({
+      reloadCache: vi.fn(),
+      getLanguage: vi.fn().mockResolvedValue("en-US"),
+    }),
+  },
+}));
+
+vi.mock("../../src/tts/VoiceMenuUIManager", () => ({
+  VoiceMenuUIManager: class {
+    constructor() {}
+    findAndDecorateVoiceMenu() {}
+  },
+}));
+
+// decoratePrompt fires AgentModeNoticeModule.showNoticeIfNeeded() (async, fire-and-forget)
+vi.mock("../../src/ui/AgentModeNoticeModule", () => ({
+  AgentModeNoticeModule: {
+    getInstance: () => ({ showNoticeIfNeeded: vi.fn().mockResolvedValue(undefined) }),
+  },
+}));
+
+// createCallButton inserts a REAL button element so the call-button-removal
+// scenario (host re-render destroys the injected button) can be exercised.
+const { createCallButtonMock } = vi.hoisted(() => ({
+  createCallButtonMock: vi.fn((container: HTMLElement) => {
+    const button = document.createElement("button");
+    button.id = "saypi-callButton";
+    container.appendChild(button);
+    return button;
+  }),
+}));
+
+vi.mock("../../src/ButtonModule.js", () => ({
+  buttonModule: {
+    createCallButton: createCallButtonMock,
+    createEnterButton: vi.fn(),
+    createExitButton: vi.fn(),
+    createMiniSettingsButton: vi.fn(),
+    createImmersiveModeButton: vi.fn(),
+    createSettingsButton: vi.fn(),
+    createImmersiveModeMenuButton: vi.fn(),
+    createSettingsMenuButton: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/themes/ThemeManagerModule", () => ({
+  ThemeManager: {
+    getInstance: () => ({ createThemeToggleButton: vi.fn() }),
+  },
+}));
+
+let DOMObserver: typeof import("../../src/chatbots/bootstrap").DOMObserver;
+let PiAIChatbot: typeof import("../../src/chatbots/Pi").PiAIChatbot;
+let EventBus: typeof import("../../src/events/EventBus.js").default;
+
+beforeAll(async () => {
+  DOMObserver = (await import("../../src/chatbots/bootstrap")).DOMObserver;
+  PiAIChatbot = (await import("../../src/chatbots/Pi")).PiAIChatbot;
+  EventBus = (await import("../../src/events/EventBus.js")).default;
+});
+
+/**
+ * Build Pi's /talk composer as observed live (2026-07, issue #460):
+ *   div.w-full                                  ← addIdPromptAncestor target
+ *     └── div (controls row)                    ← getPromptControlsContainer (textarea case)
+ *           ├── div (prompt container)          ← getPromptContainer (textarea parent)
+ *           │     └── textarea[enterkeyhint]    ← getPromptInput → #saypi-prompt
+ *           └── button.rounded-full.transition-colors.duration-300  ← submit
+ */
+function buildPiComposer(): HTMLElement {
+  const wrapper = document.createElement("div");
+  wrapper.className = "w-full";
+  wrapper.innerHTML = `
+    <div class="composer-row">
+      <div class="prompt-holder">
+        <textarea enterkeyhint="enter" placeholder="What's on your mind?"></textarea>
+      </div>
+      <button class="rounded-full transition-colors duration-300">submit</button>
+    </div>`;
+  return wrapper;
+}
+
+function setPath(path: string): void {
+  window.history.replaceState(null, "", path);
+}
+
+describe("Pi bootstrap on initial /talk load (#460: call button missing)", () => {
+  let observer: InstanceType<typeof DOMObserver>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    EventBus.removeAllListeners("saypi:ui:content-loaded");
+    document.body.innerHTML = "";
+    setPath("/talk");
+  });
+
+  afterEach(() => {
+    EventBus.removeAllListeners("saypi:ui:content-loaded");
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    setPath("/");
+  });
+
+  it("decorates a composer that mounted while route observation was stopped (non-chatable interlude)", () => {
+    // Reported repro shape: on the first /talk load of a session, Pi's boot can pass
+    // through a non-chatable path. The route monitor (300ms poll) stops the
+    // MutationObserver on the non-chatable tick; if the composer mounts inside that
+    // window, nothing ever decorates it — reload or SPA-nav-away-and-back "fixes" it.
+    observer = new DOMObserver(new PiAIChatbot());
+    observer.observeDOM(); // empty DOM at start — nothing to decorate yet
+
+    // Route blips to a non-chatable Pi path, caught by the 300ms poll
+    setPath("/onboarding");
+    vi.advanceTimersByTime(300);
+
+    // Pi mounts the composer while observation is stopped
+    document.body.appendChild(buildPiComposer());
+
+    // Route lands back on /talk; poll notices and handleRouteChange emits
+    // content-loaded 300ms later
+    setPath("/talk");
+    vi.advanceTimersByTime(700);
+
+    expect(createCallButtonMock).toHaveBeenCalled();
+    expect(document.getElementById("saypi-prompt")).not.toBeNull();
+    expect(document.getElementById("saypi-callButton")).not.toBeNull();
+  });
+
+  it("emitting saypi:ui:content-loaded rescues an undecorated, already-present composer", () => {
+    // The content-loaded handler re-scans document.body for audio controls, the
+    // sidebar, and chat history — the prompt must get the same document-wide rescue.
+    observer = new DOMObserver(new PiAIChatbot());
+    // Neutralize the MutationObserver and the initial bootstrap scan so the rescue
+    // path is the only thing that can decorate.
+    vi.spyOn(observer as any, "startObservingDom").mockImplementation(() => {});
+    vi.spyOn(observer as any, "bootstrapInitialDecoration").mockImplementation(() => {});
+    observer.observeDOM();
+
+    document.body.appendChild(buildPiComposer());
+    EventBus.emit("saypi:ui:content-loaded");
+
+    expect(createCallButtonMock).toHaveBeenCalled();
+    expect(document.getElementById("saypi-callButton")).not.toBeNull();
+  });
+
+  it("catches a composer that mounts ~20s after load via the initial-decoration retry loop", () => {
+    // Live probe evidence (issue #460): on a cold cache, Pi's composer mounted at
+    // t≈25s — far beyond the old ~7.5s retry window. If the MutationObserver misses
+    // the mount for any reason, the retry loop is the only recovery, so it must
+    // cover the observed cold-load tail.
+    observer = new DOMObserver(new PiAIChatbot());
+    vi.spyOn(observer as any, "startObservingDom").mockImplementation(() => {});
+    observer.observeDOM(); // empty DOM — retry loop starts
+
+    vi.advanceTimersByTime(10_000); // old window (~7.5s) exhausted
+    document.body.appendChild(buildPiComposer());
+    vi.advanceTimersByTime(25_000); // within the extended window
+
+    expect(createCallButtonMock).toHaveBeenCalled();
+    expect(document.getElementById("saypi-callButton")).not.toBeNull();
+  });
+
+  it("re-creates the call button when the host re-render removes it but keeps the decorated prompt", async () => {
+    // Pi (React) can rebuild the composer row, destroying the injected button while
+    // reusing the same <textarea> node — which keeps id=saypi-prompt, so every finder
+    // reports "already decorated" and the button never comes back.
+    document.body.appendChild(buildPiComposer());
+    observer = new DOMObserver(new PiAIChatbot());
+    observer.observeDOM(); // decorates immediately (composer already present)
+
+    const button = document.getElementById("saypi-callButton");
+    expect(button).not.toBeNull();
+    expect(document.getElementById("saypi-prompt")).not.toBeNull();
+
+    button!.remove();
+    await vi.advanceTimersByTimeAsync(0); // flush MutationObserver microtask
+
+    expect(document.getElementById("saypi-callButton")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

On the initial load of https://pi.ai/talk the SayPi call button could be missing from the composer until a page reload or an SPA navigation away and back (#460). Everything else (sidebar buttons, audio controls) decorated normally.

## Root cause

The prompt was the only decoration target with **no document-wide rescue path**, so any missed mount was permanent:

1. **`content-loaded` never decorated the prompt.** The handler re-scans `document.body` for audio controls, the sidebar, and chat history — but not the composer. If the composer mounted while route observation was stopped (the 300ms route poll calls `stopObservingDom()` on transiently non-chatable paths during Pi's boot), nothing ever decorated it — matching the report exactly: no call button, everything else normal, reload fixes it.
2. **The initial-decoration retry window was ~7.5s**, while a live cold-cache probe measured Pi's composer mounting at **t≈25s**. The loop also self-terminated permanently if a single retry tick landed on a non-chatable path.
3. **A removed call button was undetectable.** A host re-render that destroys the injected button while reusing the same `<textarea>` (which keeps `id=saypi-prompt`) leaves every finder reporting "already decorated" — the button could never come back.

Investigation details (instrumented headed-CDP probes against live pi.ai, mutation/URL timelines) are on the issue.

## Fix

- `content-loaded` now rescues the prompt (`findAndDecoratePrompt(document.body)`) and restores a missing call button (`ensureCallButtonPresent`).
- `bootstrapInitialDecoration` retries for ~30s and survives transiently non-chatable ticks.
- The mutation **removal** branch detects a removed `#saypi-callButton` and re-creates it in place. `decoratePromptControls` extracted from `decoratePrompt` for reuse, guarded against duplicate buttons and stacked submit-button observers.
- `updateButtonSegments` no longer `console.error`s in the (re)creation gap before the async SVG mounts — with the restore path this is a normal transient (it surfaced as flaky page errors in the Layer 3 suite until downgraded).

## Testing

- **Fail-first specs** (all 4 watched failing before the fix): `test/chatbots/PiBootstrapInitialLoad.spec.ts` (route-blip miss, content-loaded rescue, ~20s late mount, button-removal restore) and `test/buttons/CallButton-svg-mount-gap.spec.ts`.
- Full gate green in the worktree: typecheck + Jest + Vitest (182 files / 1590 tests).
- Layer 3 e2e: 12/12, zero console errors.
- Layer 4 (CDP) on live pi.ai/talk with this branch's build: decoration + a full synthetic voice turn verified.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVm2qYNQoMSQMUpnWcriJE