### PR TITLE
fix(e2e): leave diagnosable failure artifacts on first attempt (screenshots + retained trace + CI HTML report)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -47,9 +47,15 @@ npx playwright test --config e2e/playwright.config.ts e2e/specs/dictation-stt.e2
 npx playwright show-trace test-results/**/trace.zip
 ```
 
-Retries are `0` locally and `2` on CI; a Playwright trace is captured
-`on-first-retry`. `workers: 1` / `fullyParallel: false` — the harness binds
-mock servers and a fake-mic device per run, so the specs run serially.
+Retries are `0` locally and `2` on CI. Every failed attempt — including a
+first-attempt failure with zero retries — leaves diagnosable evidence in
+`test-results/` at the repo root: screenshots (`screenshot: "only-on-failure"`)
+and a trace (`trace: "retain-on-failure"`, recorded per attempt and kept only
+when the attempt fails, so green runs pay ~nothing and write nothing). CI adds
+an HTML reporter so the `playwright-report/` upload in the failure-artifact
+step is a browsable report, not an empty directory (#463). `workers: 1` /
+`fullyParallel: false` — the harness binds mock servers and a fake-mic device
+per run, so the specs run serially.
 
 ## Settings page (Preact migration)
 
@@ -267,7 +273,9 @@ tests, but it also carries risk that unit tests don't:
 - **CI risk (now a required check):** headless Chromium + fake-audio + WASM-VAD
   on shared Ubuntu runners is inherently timing-sensitive — the VAD's
   speech-end detection and the SW upload race can flake under load. CI runs with
-  2 retries and uploads the trace on failure. The suite earned promotion to a
+  2 retries and uploads failure artifacts (per-attempt screenshots + traces in
+  `test-results/`, plus the HTML report in `playwright-report/`). The suite
+  earned promotion to a
   **required** check (2026-06-20) after a stable green streak on CI runners; it
   remains a separate workflow rather than part of the `npm test` aggregate. If
   it starts flaking under load, fix the flake — don't silently demote it.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -10,6 +10,19 @@ export default defineConfig({
   timeout: 60_000,
   globalSetup: resolve(import.meta.dirname, "support/global-setup.ts"),
   globalTeardown: resolve(import.meta.dirname, "support/global-teardown.ts"),
-  reporter: process.env.CI ? [["github"], ["list"]] : "list",
-  use: { trace: "on-first-retry" },
+  // CI adds an HTML report (playwright-report/) so the failure-artifact upload
+  // in .github/workflows/e2e.yaml has a browsable report — with github+list
+  // alone that directory was never written and the upload was empty (#463).
+  reporter: process.env.CI
+    ? [["github"], ["list"], ["html", { open: "never" }]]
+    : "list",
+  use: {
+    // Failure evidence must exist on the FIRST attempt: retries are 0 locally,
+    // so the old "on-first-retry" trace never fired and a local failure left
+    // nothing diagnosable (#463). "retain-on-failure" records every attempt and
+    // keeps the trace only when the attempt fails (final failure included);
+    // passing runs discard it, keeping green-run overhead negligible.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
 });


### PR DESCRIPTION
## Why

A failing Layer-3 spec left almost nothing an agent could diagnose from. The config captured a trace `on-first-retry` only — but local retries are 0, so the trace *never* fired locally, and in CI it only covered retried attempts. No screenshots were captured at all. And CI's reporters were `github`+`list` (no HTML reporter), so the `playwright-report/` path in the failure-artifact upload (`.github/workflows/e2e.yaml`) was always empty. Since this repo diagnoses CI failures autonomously from uploaded evidence rather than by a human re-running locally, a red e2e run was disproportionately expensive.

Verified the premise empirically before fixing: breaking `decoration.e2e.ts` (wrong selector) and running the suite left only `error-context.md` — no screenshot, no trace, no report.

## What

`e2e/playwright.config.ts` (Playwright 1.60):

- `trace: "retain-on-failure"` — records per attempt, keeps the trace only when the attempt fails. A first-attempt failure (local, retries=0) and the final CI failure both retain a trace; green runs discard it.
- `screenshot: "only-on-failure"` — failure screenshots on every attempt.
- CI reporter gains `["html", { open: "never" }]` — `playwright-report/` is now a browsable report.

**No workflow change.** The HTML report and `test-results/` both land at the repo root — exactly the paths `e2e.yaml`'s existing upload step already points at — so triggers, required-check names, retries, and test selection are all untouched. `e2e/README.md` updated to describe the new artifact behavior.

The change also flows into the on-demand `playwright.visual.config.ts` (it spreads the base config), which is harmless-to-helpful for local visual runs.

## Verification (break-a-spec, temporary, not committed)

| Scenario | Before | After |
| --- | --- | --- |
| Local failure (retries=0) | `error-context.md` only | `test-failed-{1..3}.png` + `trace.zip` + `error-context.md` |
| CI-mode failure (`CI=true`, 2 retries) | traces on retries only, `playwright-report/` never written | screenshots + `trace.zip` for **every** attempt incl. the final one, plus `playwright-report/index.html` at repo root |
| Full green suite | 43.7s, writes nothing | 45.1s (~3% overhead), writes nothing (traces discarded on pass) |

Gates: `npm test` green (typecheck + Jest + Vitest, 181 files / 1599 tests) and `npm run e2e:build && npm run test:e2e` green (12 passed, 45.1s).

Fixes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)