### PR TITLE
fix(e2e): reset mock /transcribe state per test so no spec's assertion can pass off another's traffic

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -114,6 +114,10 @@ panel left empty by a chunk/import break.
      dictation-stt.e2e.ts fake mic (WAV) -> getUserMedia -> offscreen Silero-v5 VAD
                           -> onSpeechEnd -> SW POSTs /transcribe (mock echoes a
                           transcript) -> draft written into #saypi-prompt.value
+     mock-isolation.e2e.ts a fresh test observes ZERO mock /transcribe state —
+                          guards the per-test reset the context fixture performs,
+                          so no spec's hits/content-type assertion can be
+                          satisfied by another spec's traffic (#462)
      tooltip-contrast.e2e.ts page.goto(https://claude.ai/new) -> body.claude ->
                           the real built CSS renders .saypi-tooltip as an opaque
                           dark pill (guards the host-CSS-var contrast bug)
@@ -143,12 +147,12 @@ instead of silently calling the real internet.
 | Path | Role |
 | --- | --- |
 | `playwright.config.ts` | serial runner, global setup/teardown, CI retries/trace |
-| `fixtures/extension.ts` | `test`/`expect` fixture: launches the context, exposes `serviceWorker`/`extensionId` |
+| `fixtures/extension.ts` | `test`/`expect` fixture: resets the mock API's transcribe state (per-test isolation, #462), launches the context, exposes `serviceWorker`/`extensionId` |
 | `fixtures/launch-args.ts` | pure builder for the Chrome launch args (unit-testable) |
 | `fixtures/audio/` | the fake-mic WAV clip + its [README](fixtures/audio/README.md) |
 | `support/global-setup.ts` | build guard + start mock servers + export ports |
 | `support/global-teardown.ts` | close mock servers |
-| `support/mock-servers.ts` | self-signed HTTPS page server (Host-routed Pi/Claude pages) + saypi-api (`/transcribe`, GA catch-all) |
+| `support/mock-servers.ts` | self-signed HTTPS page server (Host-routed Pi/Claude pages) + saypi-api (`/transcribe`, hit/content-type diagnostics + per-test reset route, GA catch-all) |
 | `support/mock-pi-page.html` | minimal Pi.ai-shaped DOM the content script decorates |
 | `support/mock-claude-page.html` | minimal claude.ai stand-in (defines no `--black`) for the host-CSS contrast spec |
 | `support/transcribe-response.ts` | the STT contract: shape of the `/transcribe` response |

--- a/e2e/fixtures/extension.ts
+++ b/e2e/fixtures/extension.ts
@@ -13,6 +13,14 @@ export const test = base.extend<{
   context: async ({}, use) => {
     const piPort = Number(process.env.SAYPI_E2E_PI_PORT);
     const apiPort = Number(process.env.SAYPI_E2E_API_PORT);
+    // Isolation by construction (#462): zero the mock API's transcribe state
+    // (hits + lastAudioContentType) BEFORE this test's browser exists. Every
+    // spec obtains its browser through this fixture, and the previous test's
+    // context is fully closed by the time this runs (workers=1), so no
+    // mock-server assertion can be satisfied by another test's — or an earlier
+    // CI retry's — traffic. Node-side fetch accepts the self-signed cert via
+    // NODE_TLS_REJECT_UNAUTHORIZED=0 (set in global-setup).
+    await fetch(`https://127.0.0.1:${apiPort}/__transcribe-hits/reset`, { method: "POST" });
     const context = await chromium.launchPersistentContext("", {
       channel: "chromium",
       args: buildLaunchArgs({ extensionDir: EXT_DIR, piPort, apiPort, wavPath: WAV }),

--- a/e2e/specs/mock-isolation.e2e.ts
+++ b/e2e/specs/mock-isolation.e2e.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "../fixtures/extension";
+import { getTranscribeHits, getLastAudioContentType } from "../support/dictation";
+
+/**
+ * #462 isolation guard: the mock API's transcribe state (`hits`,
+ * `lastAudioContentType`) is a single per-run instance shared by every spec, so
+ * without a per-test reset a bare `getTranscribeHits() > 0` assertion could be
+ * satisfied by an EARLIER spec's traffic — and `getLastAudioContentType()` could
+ * report an earlier spec's upload. The `context` fixture therefore resets the
+ * mock's transcribe state before launching each test's browser (isolation by
+ * construction: no context, no extension traffic).
+ *
+ * This spec proves that wiring stays in place: it generates no voice traffic of
+ * its own and asserts it observes ZERO prior state. It is only a meaningful
+ * guard when it runs after a traffic-generating spec — Playwright runs spec
+ * files alphabetically with workers=1, so `dictation-stt.e2e.ts` (and
+ * `decoration.e2e.ts`) precede it in a full-suite run. If the fixture reset is
+ * ever removed, this fails loudly with the leaked hit count.
+ */
+test("a fresh test observes zero mock /transcribe state (per-test reset holds)", async ({
+  serviceWorker,
+}) => {
+  const hits = await getTranscribeHits(serviceWorker);
+  const lastContentType = await getLastAudioContentType(serviceWorker);
+
+  expect(hits, "mock /transcribe hits leaked in from a previous test").toBe(0);
+  expect(
+    lastContentType,
+    "mock lastAudioContentType leaked in from a previous test",
+  ).toBeNull();
+});

--- a/e2e/specs/offscreen-shutdown.e2e.ts
+++ b/e2e/specs/offscreen-shutdown.e2e.ts
@@ -35,9 +35,9 @@ test("offscreen auto-shutdown closes the document but keeps the live content-scr
   const page = await openDecoratedPiPage(context);
 
   // Baseline: an active call registers a real CS<->SW port and creates the offscreen
-  // doc. Wait for a real transcribe hit so the call is genuinely live. The mock's hit
-  // counter is a shared, never-reset global, so assert a NEW hit (delta) rather than
-  // hits > 0, which earlier specs already satisfy in a full-suite run.
+  // doc. Wait for a real transcribe hit so the call is genuinely live. Cross-test
+  // isolation is by construction (per-test mock reset in the context fixture — #462);
+  // the delta form is within-test hygiene: only a hit AFTER the click counts.
   const hitsBefore = await getTranscribeHits(serviceWorker);
   await page.click("#saypi-callButton");
   await expect

--- a/e2e/specs/sw-recycle.e2e.ts
+++ b/e2e/specs/sw-recycle.e2e.ts
@@ -41,11 +41,11 @@ test("idle SW recycle is quiet and self-heals on next use", async ({ context, se
     if (/OffscreenVADClient].*[Pp]ort disconnected/.test(m.text())) disconnectLogs.push(m.text());
   });
 
-  // Snapshot the mock's transcribe-hit counter while the SW is still alive. It is a
-  // shared, never-reset global in the mock server (one instance across the whole
-  // suite), so the self-heal assertion below checks a NEW transcribe occurs (delta):
-  // a bare hits > 0 is already satisfied by earlier specs in a full-suite run, which
-  // would make the positive control vacuous.
+  // Snapshot the mock's transcribe-hit counter while the SW is still alive. Cross-
+  // test isolation is now by construction (the context fixture resets the mock's
+  // transcribe state before every test — #462), so this baseline is 0 in practice;
+  // the delta form is kept as within-test hygiene so the self-heal assertion below
+  // can only be satisfied by a transcribe that happens AFTER the recycle.
   const hitsBeforeRecycle = await getTranscribeHits(serviceWorker);
 
   // Force the idle recycle. Returns the closed targetId, proving an SW existed.

--- a/e2e/support/check-servers.mjs
+++ b/e2e/support/check-servers.mjs
@@ -46,6 +46,23 @@ try {
   assert(typeof json.sequenceNumber === "number", "/transcribe response missing numeric 'sequenceNumber'");
   assert(json.sequenceNumber === 7, `/transcribe should echo sequenceNumber 7, got ${json.sequenceNumber}`);
   assert(servers.transcribeHits() === 1, `expected 1 transcribe hit, got ${servers.transcribeHits()}`);
+  assert(
+    servers.lastAudioContentType() === "audio/wav",
+    `expected audio/wav content-type, got ${servers.lastAudioContentType()}`,
+  );
+
+  // 3) The reset route zeroes the transcribe diagnostics (per-test isolation, #462).
+  const resetRes = await fetch(`https://127.0.0.1:${servers.apiPort}/__transcribe-hits/reset`, {
+    method: "POST",
+  });
+  assert(resetRes.status === 200, `reset status was ${resetRes.status}`);
+  const afterReset = await (await fetch(`https://127.0.0.1:${servers.apiPort}/__transcribe-hits`)).json();
+  assert(afterReset.hits === 0, `expected 0 hits after reset, got ${afterReset.hits}`);
+  assert(
+    afterReset.lastAudioContentType === null,
+    `expected null content-type after reset, got ${afterReset.lastAudioContentType}`,
+  );
+  assert(servers.transcribeHits() === 0, `expected in-process hit counter 0 after reset, got ${servers.transcribeHits()}`);
 
   console.log("servers OK");
 } finally {

--- a/e2e/support/dictation.ts
+++ b/e2e/support/dictation.ts
@@ -32,6 +32,9 @@ export async function openDecoratedPiPage(context: BrowserContext): Promise<Page
  * Read the mock /transcribe hit counter from the SW context. The upload is issued
  * from the extension SW/offscreen context, so it is invisible to page.on("response")
  * and must be read via the service worker.
+ *
+ * The counter is reset before every test by the context fixture (#462), so a bare
+ * `> 0` assertion in a spec can only be satisfied by that test's own traffic.
  */
 export async function getTranscribeHits(serviceWorker: Worker): Promise<number> {
   return serviceWorker.evaluate(async (url) => {
@@ -45,6 +48,10 @@ export async function getTranscribeHits(serviceWorker: Worker): Promise<number> 
  * — `audio/webm` (WebM/Opus) or `audio/wav` (PCM fallback). Proves which encoder
  * path the content script actually took (#414). Read via the SW for the same
  * reason as the hit counter.
+ *
+ * Reset to null before every test by the context fixture (#462), so it provably
+ * reflects an upload made by the current test, never a previous spec's (or an
+ * earlier CI retry's).
  */
 export async function getLastAudioContentType(
   serviceWorker: Worker

--- a/e2e/support/mock-servers.ts
+++ b/e2e/support/mock-servers.ts
@@ -60,6 +60,20 @@ export async function startMockServers(): Promise<MockServers> {
       res.end(JSON.stringify({ hits, lastAudioContentType }));
       return;
     }
+    // Reset route: zero the transcribe diagnostics. The Playwright context
+    // fixture POSTs here BEFORE launching each test's browser, so no spec's
+    // hits/content-type assertion can be satisfied by another test's (or an
+    // earlier CI retry's) traffic — isolation by construction (#462).
+    if (req.method === "POST" && req.url && req.url.startsWith("/__transcribe-hits/reset")) {
+      hits = 0;
+      lastAudioContentType = null;
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "access-control-allow-origin": "*",
+      });
+      res.end(JSON.stringify({ hits, lastAudioContentType }));
+      return;
+    }
     if (req.method === "POST" && req.url && req.url.startsWith("/transcribe")) {
       const chunks: Buffer[] = [];
       req.on("data", (c) => chunks.push(c));


### PR DESCRIPTION
## Why

The Layer-3 mock API's `hits` counter and `lastAudioContentType` live in closures created by the single `startMockServers()` call in global-setup — one instance for the whole serial run, never reset. Three specs (`dictation-stt`, `synthetic-audio-stt`, `opus-upload`) assert a bare `getTranscribeHits() > 0` as their "the upload happened" localizer stage. In a full-suite run, an earlier spec's traffic already satisfies that, so a later spec whose own upload silently never happens sails through the localizer and only dies at the prompt-text stage — mislocalizing the diagnosis. Worse, `opus-upload`'s `getLastAudioContentType()` correctness check could report the Content-Type of a *previous* spec's upload. The same staleness applies across CI **retries** of a single spec, not just across specs. `sw-recycle.e2e.ts` had already worked around this with a baseline/delta and a comment naming the hazard.

## What

Isolation is now enforced **by construction**, not by convention each new spec must remember:

- **`e2e/support/mock-servers.ts`**: new `POST /__transcribe-hits/reset` route that zeroes `hits` and nulls `lastAudioContentType`.
- **`e2e/fixtures/extension.ts`**: the `context` fixture — the only way any spec obtains a browser — POSTs that reset **before launching each test's context**. No context ⇒ no extension traffic, so every test (and every CI retry) provably starts from `hits=0` / `contentType=null`. The previous test's context is fully closed before the next fixture runs (`workers: 1`), so no in-flight upload can straddle the reset.
- **`e2e/specs/mock-isolation.e2e.ts`** (new guard): generates no voice traffic and asserts a fresh test observes zero mock state. It sorts after the traffic-generating `dictation-stt.e2e.ts`, so if the fixture reset is ever removed it fails loudly with the leaked hit count.
- **`e2e/support/check-servers.mjs`**: the standalone smoke check now covers the reset route (1 hit → reset → 0/null) and the audio content-type extraction.
- Comment hygiene: the now-stale "shared, never-reset global" comments in `sw-recycle.e2e.ts` / `offscreen-shutdown.e2e.ts` are updated (their delta pattern is kept as within-test hygiene — only a hit *after* the recycle/click counts); `dictation.ts` helper docs and the README's spec diagram + files table now state the per-test reset semantics.

The bare `> 0` assertions in the three affected specs are left as-is — with per-test reset they are now sound by construction, and they read exactly as intended ("this test's upload happened").

## Verification (fail-first)

1. **Fail-first**: with the guard spec added but no fix, `dictation-stt` + `mock-isolation` run back to back:
   ```
   ✓ dictation-stt.e2e.ts › fake audio -> VAD -> mock STT -> transcript in prompt (8.8s)
   ✘ mock-isolation.e2e.ts › a fresh test observes zero mock /transcribe state
     Error: mock /transcribe hits leaked in from a previous test
     Expected: 0   Received: 1
   ```
   — the probe made zero requests yet saw the previous spec's hit: the exact vacuous-`> 0` hazard.
2. **After the fix**: same pair green; the probe sees `0`/`null`, and `dictation-stt` still passes its bare `> 0` off its own traffic.
3. **Full e2e suite**: `npm run e2e:build && npm run test:e2e` → **13 passed (53.1s)** locally, including `opus-upload` logging `uploaded audio Content-Type: audio/webm` — now provably from its own upload since its test starts from `contentType=null`.
4. **`npm test`**: typecheck + Jest + Vitest all green (181 files / 1599 tests).
5. **`node e2e/support/check-servers.mjs`** → `servers OK` with the new reset assertions.

Serial-run cost: one localhost HTTP roundtrip (~1ms) per test plus one extra ~0.5s spec — no material regression.

Fixes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)