### PR TITLE
feat(voices): client-side voice preview playback (▶) + gated audition

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1004,6 +1004,16 @@
     "message": "In use",
     "description": "Badge marking the currently selected voice in the settings voice catalog"
   },
+  "voicesPreview": {
+    "message": "Play a sample of $name$",
+    "description": "Accessible label for the play (▶) button that auditions a voice's free sample clip on a voice row; $name$ is the voice's name.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
   "voicesNoneAvailable": {
     "message": "Voices couldn't be loaded right now. Please try again later.",
     "description": "Shown in the settings voice catalog when the voice list is empty for a signed-in user (e.g. a network problem)"

--- a/doc/plans/2026-07-03-voice-preview-playback-impl.md
+++ b/doc/plans/2026-07-03-voice-preview-playback-impl.md
@@ -1,0 +1,100 @@
+# Client-side voice preview playback — implementation record
+
+> The build note for the **"Client preview playback"** phase of the voices
+> rollout ([2026-07-03-voices-rollout-handoff.md](2026-07-03-voices-rollout-handoff.md)),
+> implementing design §4 of [2026-07-02-voice-selection-ux.md](2026-07-02-voice-selection-ux.md).
+> Companion to those docs — they carry the *why*; this carries *what shipped and
+> the decisions taken*.
+
+## What this is
+
+Choice by ear: a free ▶ preview affordance on voice rows that auditions a
+canned ~2s sample clip, plus the plumbing to play it **without ever talking over
+live TTS or an active call**. The whole feature ships **dormant** — the ▶ renders
+on zero voices until saypi-api serves a `sample_url` field, exactly the #284
+pattern (additive, optional, hidden-when-absent).
+
+## Scope decision (founder, 2026-07-03)
+
+Asked whether to keep this strictly dormant or also fix the pre-existing
+select-time double-talk, the founder chose **"Also fix the double-talk now."**
+So this change also reroutes the existing `introduceVoice()` audition through
+the new gated path: selecting a voice mid-TTS/mid-call is now **suppressed**
+rather than talking over live speech. (Accepted trade: select-mid-turn changes
+from interrupt to suppress.)
+
+## How it works
+
+**Playback channel.** A preview reuses the existing `audio:load` → `AudioModule`
+→ shared `<audio>` element path (the same channel conversation TTS uses — no new
+offscreen plumbing, the three hand-synced audio-event lists are untouched). The
+new `audio:preview` EventBus signal is content-script-internal.
+
+**The gate (`AudioOutputMachine`, XState v5).** "Never double-talk" is enforced
+structurally:
+
+- A `preview` event is handled only in the machine's **resting** states —
+  `idle` and `loaded.ended` — so it is silently dropped while `loading` /
+  `loaded.ready` / `loaded.playing` (i.e. while audio is loading or playing).
+  *(Handling `loaded.ended` too is load-bearing: a finished clip parks the
+  machine there, so an idle-only gate would drop the second ▶ tap and the first
+  tap after a TTS reply ends — the menu would look broken.)*
+- A `callActive` context flag (set/cleared by `callStarted`/`callEnded`, bridged
+  from `ConversationMachine`'s `session:started`/`session:ended` — the canonical
+  call boundary, **not** the call-button DOM) closes the idle-but-in-a-call gap.
+- A permitted preview sets the existing `replaying` flag so its deliberately
+  source-mismatched clip is not killed by `shouldSkip`, then emits `audio:load`.
+
+**Surfaces.** The ▶ is its own target, separate from row-select, rendered only
+when `voice.sample_url` is present:
+
+- **claude.ai / chatgpt.com** (`ClaudeVoiceMenu.createMenuItem`): the trailing
+  checkmark column is wrapped in `.saypi-voice-trailing`; the ▶ (`.saypi-voice-preview`)
+  sits beside the checkmark. `e.stopPropagation()` keeps play ≠ select. Styled by
+  SayPi-owned SCSS (`voices.scss`) — **no new arbitrary Tailwind** the host might
+  not compile (cluster-J trap avoided; the grid template is unchanged).
+- **settings Voices tab** (`voices-controller.renderRow`): its own document has
+  no machine/call/TTS, so it previews via a single reused `Audio()` element
+  (injected as `playPreview` for testability). ▶ appears on current rows too
+  (the "Your voice" card previews).
+- **pi.ai — DEFERRED** (see below).
+
+**Metered audition (`introduceVoice`).** Kept synthesizing (still metered) but
+its *playback* is now gated (`speak(..., preview=true)` / `audio:preview`). The
+metered *synthesis* itself is retired later — Phase 2, server-gated on clips
+actually existing.
+
+## Deferred
+
+- **Pi menu ▶.** The Pi custom-voice row *is* a `<button>` that gets
+  `disabled` on selection, so a ▶ cannot nest — it needs the row restructured
+  into a wrapper + sibling button, which touches several fragile Pi-menu
+  assumptions (`removeCustomVoiceRows`, `insertBefore`, the pin logic, the
+  `nodeName === "BUTTON"` mutation observer — the same area that spawned Patch
+  A's Pi7/8 bugs). Since the ▶ is dormant and Pi already gets the gated
+  audition-on-select via the reroute, this ships **last** with real-host (Layer
+  4 CDP) verification once clips exist. Tracked in a follow-up issue.
+- **Retiring the metered `introduceVoice` synthesis** — Phase 2, when
+  GET /voices serves `sample_url`.
+- **Keyboard reachability of the in-host ▶** — the Claude menu has no roving
+  tabindex model today; v1 is mouse + `aria-label`. Its own backlog item.
+
+## Tests (all unit/contract — the dormant affordance can't be real-host-verified yet)
+
+- `AudioOutputMachine-preview.spec.ts` — the interrupt-safety proof (plays from
+  idle/ended + sets replaying; suppressed while loading/playing; dropped during a
+  call, allowed after; second-preview-after-ended).
+- `AudioModulePreviewWiring.spec.ts` — source-scan guard that the EventBus→actor
+  bridge exists with object-form sends (cluster-E, untyped JS seam).
+- `voices-controller.spec.tsx`, `ClaudeVoiceMenu-preview.spec.ts` — ▶ gated on
+  `sample_url`, separate from select, absent on non-voice rows.
+- `VoiceIntroduction.spec.ts`, `SpeechSynthesisModule.spec.ts` — the reroute +
+  the `speak` preview flag.
+
+## Pending / coordination
+
+- One new i18n key `voicesPreview` (English only) — a founder `npm run translate`
+  run is pending (adds to the ~16 keys already awaiting).
+- **saypi-api**: serve `sample_url` as a static, free, `api.saypi.ai`-hosted
+  clip (so provider-match + offscreen CSP + zero billing all hold). Client is
+  dormant until then — same handoff shape as the manifest work.

--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -17,6 +17,22 @@ export interface VoiceCatalogDeps {
   getVoice(host: VoiceHostId): Promise<SpeechSynthesisVoiceRemote | null>;
   setVoice(voice: SpeechSynthesisVoiceRemote, host: VoiceHostId): Promise<void>;
   isAuthenticated(): boolean;
+  /** Play the voice's free canned sample clip (design §4). No-op without one. */
+  playPreview(voice: SpeechSynthesisVoiceRemote): void;
+}
+
+// The settings page is its own document — no content-script audio-output
+// machine, no live TTS, no active call to collide with — so a preview here
+// plays straight through a single reused <audio> element. Reusing one element
+// gives single-preview semantics for free: starting a new sample stops any
+// in-flight one.
+let previewAudio: HTMLAudioElement | null = null;
+function playPreviewClip(url: string): void {
+  if (!previewAudio) previewAudio = new Audio();
+  previewAudio.pause();
+  previewAudio.src = url;
+  // A blocked/failed preview is a non-event, not an error the user must see.
+  void previewAudio.play().catch(() => {});
 }
 
 // The settings page runs outside any host tab, so every preference call MUST
@@ -29,6 +45,9 @@ function defaultDeps(): VoiceCatalogDeps {
     getVoice: (host) => prefs.getVoice(host) as Promise<SpeechSynthesisVoiceRemote | null>,
     setVoice: (voice, host) => prefs.setVoice(voice, host).then(() => {}),
     isAuthenticated: () => getJwtManagerSync().isAuthenticated(),
+    playPreview: (voice) => {
+      if (voice.sample_url) playPreviewClip(voice.sample_url);
+    },
   };
 }
 
@@ -197,6 +216,23 @@ export class VoicesController {
       main.appendChild(description);
     }
     row.appendChild(main);
+
+    // Choice by ear (design §4): a free ▶ preview, its own target separate from
+    // "Use this voice", rendered only when the server serves a sample clip. It
+    // rides on both current and selectable rows so the "Your voice" card can be
+    // auditioned too.
+    if (voice.sample_url) {
+      const preview = document.createElement("button");
+      preview.type = "button";
+      preview.classList.add("voice-preview");
+      preview.setAttribute("aria-label", getMessage("voicesPreview", [voice.name]));
+      preview.innerHTML =
+        '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 5v14l11-7z"></path></svg>';
+      preview.addEventListener("click", () => {
+        this.deps.playPreview(voice);
+      });
+      row.appendChild(preview);
+    }
 
     if (isCurrent) {
       row.classList.add("current");

--- a/entrypoints/settings/tabs/voices/voices.css
+++ b/entrypoints/settings/tabs/voices/voices.css
@@ -74,6 +74,25 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
+  /* Push the trailing controls (▶ preview + Use/badge) together to the right,
+     regardless of how many there are. */
+  margin-right: auto;
+}
+.voice-preview {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 9999px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.voice-preview:hover {
+  background: #f3f4f6;
 }
 .voice-row-name {
   font-weight: 500;

--- a/src/audio/AudioModule.js
+++ b/src/audio/AudioModule.js
@@ -526,6 +526,28 @@ export default class AudioModule {
         outputActor.send({ type: "skipNext" });
       }
     });
+    // Voice preview (design §4): audition a canned sample clip. The machine's
+    // `preview` transition is idle-only and callActive-gated, so a preview can
+    // never talk over live TTS or an active call — the gating lives there, not
+    // here. Playback rides the same audio:load channel as conversation TTS.
+    EventBus.on("audio:preview", (detail) => {
+      if (outputActor && detail?.url) {
+        outputActor.send({ type: "preview", source: detail.url });
+      }
+    });
+    // Track the call boundary so previews are refused for its whole duration,
+    // even between the call's own utterances (session:* originate in
+    // ConversationMachine — the canonical call-boundary signal, not the DOM).
+    EventBus.on("session:started", () => {
+      if (outputActor) {
+        outputActor.send({ type: "callStarted" });
+      }
+    });
+    EventBus.on("session:ended", () => {
+      if (outputActor) {
+        outputActor.send({ type: "callEnded" });
+      }
+    });
     EventBus.on("audio:skipCurrent", async (e) => {
       // pause both offscreen and onscreen audio
       this.stopOnscreenAudio();

--- a/src/chatbots/ClaudeVoiceMenu.ts
+++ b/src/chatbots/ClaudeVoiceMenu.ts
@@ -5,6 +5,8 @@ import { Chatbot } from "./Chatbot";
 import chevronSvgContent from "../icons/claude-chevron.svg?raw";
 import volumeSvgContent from "../icons/volume-mid.svg?raw";
 import volumeMutedSvgContent from "../icons/volume-muted.svg?raw";
+import playSvgContent from "../icons/play.svg?raw";
+import EventBus from "../events/EventBus";
 import { SpeechSynthesisModule } from "../tts/SpeechSynthesisModule";
 import getMessage from "../i18n";
 import { openSettings } from "../popup/popupopener";
@@ -333,10 +335,40 @@ export class ClaudeVoiceMenu extends VoiceSelector {
 
     item.appendChild(content);
 
-    // Add checkmark container - positioned as second column in grid
+    // Trailing controls occupy the grid's second column. Wrapping them (rather
+    // than widening the grid to a new `grid-cols-[…]` arbitrary value claude.ai
+    // may not compile — cluster-J trap) keeps the existing 2-column template
+    // intact and lets the ▶ + checkmark sit together, styled by SayPi's own SCSS.
+    const trailing = document.createElement("div");
+    trailing.classList.add("saypi-voice-trailing");
+
+    // Choice by ear (design §4): a free ▶ preview, a SEPARATE target from
+    // selecting the row, rendered only when the server serves a sample clip.
+    if (voice && voice.sample_url) {
+      const sampleUrl = voice.sample_url;
+      const preview = document.createElement("button");
+      preview.type = "button";
+      // Kept out of the roving focus for now (the menu has no keyboard model);
+      // still mouse-operable and screen-reader-labelled.
+      preview.tabIndex = -1;
+      preview.classList.add("saypi-voice-preview");
+      preview.setAttribute("aria-label", getMessage("voicesPreview", [voice.name]));
+      addSvgToButton(preview, playSvgContent, "w-4", "h-4");
+      preview.addEventListener("click", (e) => {
+        // The row div carries the select listener; stopPropagation is the
+        // single invariant that keeps play and select as distinct targets.
+        e.stopPropagation();
+        EventBus.emit("audio:preview", { url: sampleUrl });
+      });
+      trailing.appendChild(preview);
+    }
+
+    // Checkmark container - updateSelectedVoice finds it by descendant query,
+    // so nesting it under `trailing` is transparent to selection rendering.
     const checkmarkContainer = document.createElement("div");
     checkmarkContainer.classList.add("checkmark-container");
-    item.appendChild(checkmarkContainer);
+    trailing.appendChild(checkmarkContainer);
+    item.appendChild(trailing);
 
     item.addEventListener("click", () => this.handleVoiceSelection(voice, item));
     

--- a/src/icons/play.svg
+++ b/src/icons/play.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"></path></svg>

--- a/src/state-machines/AudioOutputMachine.ts
+++ b/src/state-machines/AudioOutputMachine.ts
@@ -25,6 +25,14 @@ type ChangeVoiceEvent = {
   voice: MatchableVoice | null;
 };
 type ReplayingAudioEvent = { type: "replaying" };
+// A free canned voice-sample audition (design §4). Deliberately carries a
+// `source` that mismatches the selected voice/provider; the `preview`
+// transition arms `replaying` so `shouldSkip` lets it through.
+type PreviewEvent = { type: "preview"; source: string };
+// Call-boundary signals (from ConversationMachine's session:* events) that gate
+// previews out of an active call even between utterances (idle-but-in-a-call).
+type CallStartedEvent = { type: "callStarted" };
+type CallEndedEvent = { type: "callEnded" };
 type AudioOutputEvent =
   | LoadstartEvent
   | { type: "skipNext" }
@@ -37,7 +45,10 @@ type AudioOutputEvent =
   | { type: "emptied" }
   | ChangeProviderEvent
   | ChangeVoiceEvent
-  | ReplayingAudioEvent;
+  | ReplayingAudioEvent
+  | PreviewEvent
+  | CallStartedEvent
+  | CallEndedEvent;
 
 type AudioOutputContext = {
   skip: boolean;
@@ -45,6 +56,10 @@ type AudioOutputContext = {
   replaying: boolean;
   provider: AudioProvider;
   voice: MatchableVoice | null;
+  // True while a voice call is live. A preview must never talk over a call, so
+  // it is refused while this is set even though the machine may be idle between
+  // the call's own utterances.
+  callActive: boolean;
 };
 
 export const audioOutputMachine = setup({
@@ -73,6 +88,22 @@ export const audioOutputMachine = setup({
     setSkip: assign({
       skip: true,
     }),
+    setCallActive: assign({
+      callActive: true,
+    }),
+    clearCallActive: assign({
+      callActive: false,
+    }),
+    // Kick the actual load on the same channel live TTS uses. The real
+    // <audio> `loadstart` then advances the machine (rest -> loading);
+    // `replaying` (armed by the preview transition) keeps the mismatched
+    // sample from being skipped. This reuses the machine-wide `replaying`
+    // exemption, which assumes the NEXT loadstart is this preview's own — safe
+    // because a preview is only reachable from a resting state (nothing else is
+    // loading a track to race it), and `loading.entry` clears the flag at once.
+    startPreview: ({ event }) => {
+      EventBus.emit("audio:load", { url: (event as PreviewEvent).source });
+    },
     emitEvent: (_, params: { eventName: string }) => {
       EventBus.emit(params.eventName);
     },
@@ -97,6 +128,7 @@ export const audioOutputMachine = setup({
     },
   },
   guards: {
+    notCallActive: ({ context }) => !context.callActive,
     shouldSkip: ({ context, event }) => {
       const shouldSkip = context.skip === true;
 
@@ -129,6 +161,7 @@ export const audioOutputMachine = setup({
     replaying: false,
     provider: audioProviders.getDefault(),
     voice: null,
+    callActive: false,
   },
   id: "audioOutput",
   initial: "idle",
@@ -141,6 +174,12 @@ export const audioOutputMachine = setup({
     },
     replaying: {
       actions: "setReplaying",
+    },
+    callStarted: {
+      actions: "setCallActive",
+    },
+    callEnded: {
+      actions: "clearCallActive",
     },
   },
   states: {
@@ -173,6 +212,19 @@ export const audioOutputMachine = setup({
           description: `Do not play the next track.`,
           actions: "setSkip",
         },
+        // A preview is allowed from every RESTING state — idle here, plus the
+        // non-playing `loaded` substates (ready/paused/ended below). It is
+        // deliberately ABSENT from `loading` and `loaded.playing`, where the
+        // event is unhandled and dropped, so a preview can never talk over
+        // audio that is loading or playing. `notCallActive` closes the
+        // resting-but-in-a-call gap. Internal (no target): the ensuing real
+        // `loadstart` advances the machine, exempted from shouldSkip by the
+        // armed `replaying` flag; `clearSkip` stops a lingering skip (armed to
+        // suppress Pi auto-play) from swallowing an intentional audition.
+        preview: {
+          guard: "notCallActive",
+          actions: ["clearSkip", "setReplaying", "startPreview"],
+        },
       },
     },
     loading: {
@@ -198,6 +250,11 @@ export const audioOutputMachine = setup({
           on: {
             play: {
               target: "playing",
+            },
+            // Resting state (loaded, not yet playing) — allow previews. See idle.
+            preview: {
+              guard: "notCallActive",
+              actions: ["clearSkip", "setReplaying", "startPreview"],
             },
           },
         },
@@ -236,6 +293,13 @@ export const audioOutputMachine = setup({
                 target: "playing",
               },
             ],
+            // A paused reply is not audible — allow previews (and the intro on a
+            // mid-turn voice change). Otherwise pausing TTS would dead-end the
+            // voice menu. See idle.
+            preview: {
+              guard: "notCallActive",
+              actions: ["clearSkip", "setReplaying", "startPreview"],
+            },
           },
         },
         ended: {
@@ -250,6 +314,15 @@ export const audioOutputMachine = setup({
               target: "ready",
               description:
                 "An ended track is seeked back to earlier in the track.",
+            },
+            // A finished track parks the machine here (not idle), so a preview
+            // must also be reachable from `ended` — otherwise the SECOND ▶ tap
+            // (or the first tap after a TTS reply ends) would be silently
+            // dropped and the menu would look broken. Same guard/actions as
+            // idle; nothing is audible in `ended`, so it never double-talks.
+            preview: {
+              guard: "notCallActive",
+              actions: ["clearSkip", "setReplaying", "startPreview"],
             },
           },
         },

--- a/src/styles/voices.scss
+++ b/src/styles/voices.scss
@@ -29,6 +29,40 @@ button.saypi-more-voices {
   opacity: 0.7;
   font-size: 0.9em;
 }
+// ▶ free-sample preview affordance in the in-page voice menus (design §4).
+// A target of its own, separate from selecting the row. Fully SayPi-styled so
+// it renders identically on every host (never relying on the host's Tailwind),
+// and it resets host button chrome that would otherwise bleed in.
+.saypi-voice-trailing {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+button.saypi-voice-preview {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 9999px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.75;
+}
+button.saypi-voice-preview:hover {
+  opacity: 1;
+  background: rgba(127, 127, 127, 0.18);
+}
+button.saypi-voice-preview svg {
+  display: block;
+  width: 1rem;
+  height: 1rem;
+}
 #saypi-voice-settings button.selected.paola {
   background-color: rgb(200, 200, 200);
   border-color: rgb(200, 200, 200);

--- a/src/tts/SpeechModel.ts
+++ b/src/tts/SpeechModel.ts
@@ -277,6 +277,7 @@ interface SpeechSynthesisVoiceRemote extends SpeechSynthesisVoice {
   accent?: string;        // e.g., "American", "British"
   description?: string;   // short human-friendly description
   languages?: string[];   // ISO codes the voice can speak, e.g. ["en", "ja"]
+  sample_url?: string;    // free ~2s canned preview clip; server-served when present (design §4)
 }
 
 interface MatchableVoice {

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -374,7 +374,13 @@ class SpeechSynthesisModule {
     return utterance;
   }
 
-  speak(speech: SpeechUtterance, chatbot?: Chatbot): void {
+  /**
+   * @param preview When true, playback routes through the gated `audio:preview`
+   *   channel (idle- and call-gated by AudioOutputMachine) instead of loading
+   *   directly — so a voice audition never talks over live TTS or an active
+   *   call. Normal conversation playback leaves this false.
+   */
+  speak(speech: SpeechUtterance, chatbot?: Chatbot, preview: boolean = false): void {
     if (isPlaceholderUtterance(speech)) {
       // Expected whenever voice is off (the auto-TTS path yields a placeholder):
       // a no-op, not a warning. Debug-level so it doesn't spam the console
@@ -390,7 +396,9 @@ class SpeechSynthesisModule {
     // Start audio playback with utterance.uri as the audio source
     const appId = chatbot ? chatbot.getID() : ChatbotIdentifier.getAppId();
     getUtteranceURI(speech, appId).then((uri) => {
-      EventBus.emit("audio:load", { url: uri }); // indirectly calls AudioModule.loadAudio
+      // audio:preview is gated (never over live TTS / a call); audio:load loads
+      // directly. Both are handled by AudioModule → the shared audio element.
+      EventBus.emit(preview ? "audio:preview" : "audio:load", { url: uri });
     });
   }
 

--- a/src/tts/VoiceMenu.ts
+++ b/src/tts/VoiceMenu.ts
@@ -503,8 +503,10 @@ export abstract class VoiceSelector {
     if (voice.default && isBuiltInVoiceProvider(this.chatbot)) {
       const introductionUrl = this.chatbot.getVoiceIntroductionUrl(voice.id);
       if (introductionUrl) {
-        // play the introduction audio
-        EventBus.emit("audio:load", { url: introductionUrl });
+        // Play the introduction through the GATED preview channel so a mid-turn
+        // voice change never talks over live TTS / an active call (it is
+        // suppressed instead) — was an ungated audio:load.
+        EventBus.emit("audio:preview", { url: introductionUrl });
       }
     } else {
       // Introduce the custom voice through the SAME finalized streaming path the
@@ -523,7 +525,9 @@ export abstract class VoiceSelector {
         .createCompletedSpeechStream(introduction, this.chatbot)
         .then((utterance) => {
           utterance.voice = voice;
-          speechSynthesis.speak(utterance);
+          // preview=true routes playback through the gated audio:preview channel
+          // so this audition never talks over live TTS / an active call.
+          speechSynthesis.speak(utterance, this.chatbot, true);
         });
     }
   }

--- a/test/audio/AudioModulePreviewWiring.spec.ts
+++ b/test/audio/AudioModulePreviewWiring.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Voice-preview wiring guard (design §4). The AudioOutputMachine's `preview`,
+ * `callStarted` and `callEnded` events are unit-tested in
+ * AudioOutputMachine-preview.spec.ts, but the machine only acts on them if
+ * AudioModule bridges the EventBus signals to `outputActor.send(...)`. That
+ * bridge is untyped JS crossing a string-keyed seam (state-machines/README.md
+ * cluster E), so `tsc` cannot catch a rename or a dropped object arg.
+ *
+ * Importing AudioModule.js pulls in the whole content-script bootstrap, so —
+ * following the repo's source-scanning wiring guards (#320/#420) — assert the
+ * three load-bearing bridge lines exist with an OBJECT-form send.
+ */
+const root = resolve(__dirname, "..", "..");
+const audioModule = readFileSync(
+  resolve(root, "src/audio/AudioModule.js"),
+  "utf8"
+);
+
+describe("voice-preview AudioModule wiring", () => {
+  it("bridges EventBus 'audio:preview' to the output actor's `preview` event (with source)", () => {
+    expect(audioModule).toMatch(
+      /EventBus\.on\(\s*["']audio:preview["'][\s\S]*?outputActor\.send\(\s*\{\s*type:\s*["']preview["'][\s\S]*?source[\s\S]*?\}/
+    );
+  });
+
+  it("bridges session:started to the output actor's `callStarted` event", () => {
+    expect(audioModule).toMatch(
+      /EventBus\.on\(\s*["']session:started["'][\s\S]*?outputActor\.send\(\s*\{\s*type:\s*["']callStarted["']\s*\}/
+    );
+  });
+
+  it("bridges session:ended to the output actor's `callEnded` event", () => {
+    expect(audioModule).toMatch(
+      /EventBus\.on\(\s*["']session:ended["'][\s\S]*?outputActor\.send\(\s*\{\s*type:\s*["']callEnded["']\s*\}/
+    );
+  });
+});

--- a/test/chatbots/ClaudeVoiceMenu-preview.spec.ts
+++ b/test/chatbots/ClaudeVoiceMenu-preview.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ConfigModule reads injected env at import time; stub it (mirrors other specs).
+vi.mock("../../src/ConfigModule", () => ({
+  config: {
+    appServerUrl: "https://app.example.com",
+    apiServerUrl: "https://api.saypi.ai",
+    GA_MEASUREMENT_ID: "x",
+    GA_API_SECRET: "x",
+    GA_ENDPOINT: "x",
+  },
+}));
+
+vi.mock("../../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({
+    isAuthenticated: () => true,
+    getClaims: () => ({ ttsQuotaRemaining: 1000 }),
+  }),
+}));
+
+vi.mock("../../src/popup/popupopener", () => ({
+  openSettings: vi.fn(),
+}));
+
+// Spy the EventBus so we can assert the preview audition is emitted.
+const emit = vi.fn();
+vi.mock("../../src/events/EventBus.js", () => ({
+  default: {
+    emit: (...args: any[]) => emit(...args),
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+  },
+}));
+
+import { ClaudeVoiceMenu } from "../../src/chatbots/ClaudeVoiceMenu";
+import { ElevenLabsVoice } from "../data/Voices";
+import { SpeechSynthesisVoiceRemote } from "../../src/tts/SpeechModel";
+
+const SAMPLE = "https://api.saypi.ai/voices/nova/sample.mp3";
+
+function withSample(
+  id: string,
+  name: string,
+  sampleUrl?: string
+): SpeechSynthesisVoiceRemote {
+  const v = new ElevenLabsVoice(id, name);
+  v.sample_url = sampleUrl;
+  return v;
+}
+
+// Bypass the heavy constructor (pattern from ClaudeVoiceMenu-curation.spec.ts).
+function makeMenu(): any {
+  const menu = Object.create(ClaudeVoiceMenu.prototype);
+  menu.chatbot = {} as any;
+  menu.userPreferences = {
+    getVoice: vi.fn(async () => null),
+    setVoice: vi.fn(async () => {}),
+    unsetVoice: vi.fn(async () => {}),
+  };
+  menu.element = document.createElement("div");
+  document.body.appendChild(menu.element);
+  menu.menuButton = document.createElement("button");
+  menu.menuContent = document.createElement("div");
+  menu.toggleMenu = vi.fn();
+  return menu;
+}
+
+function rowFor(menu: any, voiceName: string): HTMLElement | undefined {
+  return Array.from(
+    menu.menuContent.querySelectorAll("[role='menuitem']")
+  ).find(
+    (el) => (el as HTMLElement).dataset.voiceName === voiceName
+  ) as HTMLElement | undefined;
+}
+
+beforeEach(() => {
+  emit.mockClear();
+  document.body.innerHTML = "";
+});
+
+describe("ClaudeVoiceMenu voice preview (▶)", () => {
+  it("renders a ▶ preview button only on rows whose voice has a sample_url", () => {
+    const menu = makeMenu();
+    menu.populateVoices(
+      [withSample("a", "Nova", SAMPLE), withSample("b", "Ash", undefined)],
+      menu.element
+    );
+    expect(
+      rowFor(menu, "Nova")!.querySelector("button.saypi-voice-preview")
+    ).toBeTruthy();
+    expect(
+      rowFor(menu, "Ash")!.querySelector("button.saypi-voice-preview")
+    ).toBeNull();
+  });
+
+  it("never renders a ▶ on the Voice off row", () => {
+    const menu = makeMenu();
+    menu.populateVoices([withSample("a", "Nova", SAMPLE)], menu.element);
+    const off = menu.menuContent.querySelector(
+      "[data-voice-name='voice-off']"
+    ) as HTMLElement | null;
+    expect(off?.querySelector("button.saypi-voice-preview")).toBeFalsy();
+  });
+
+  it("auditions the sample (audio:preview) without selecting the voice when ▶ is clicked", () => {
+    const menu = makeMenu();
+    menu.populateVoices([withSample("a", "Nova", SAMPLE)], menu.element);
+    const btn = rowFor(menu, "Nova")!.querySelector(
+      "button.saypi-voice-preview"
+    ) as HTMLElement;
+    btn.click();
+    expect(emit).toHaveBeenCalledWith("audio:preview", { url: SAMPLE });
+    // Separate target: the row's select handler (setVoice + toggleMenu) must
+    // NOT fire — stopPropagation keeps play and select distinct.
+    expect(menu.userPreferences.setVoice).not.toHaveBeenCalled();
+    expect(menu.toggleMenu).not.toHaveBeenCalled();
+  });
+});

--- a/test/data/Voices.ts
+++ b/test/data/Voices.ts
@@ -39,6 +39,7 @@ class ElevenLabsVoice extends Voice implements SpeechSynthesisVoiceRemote {
   accent?: string;
   description?: string;
   languages?: string[];
+  sample_url?: string;
 
   constructor(id: string, name: string, gender?: string, accent?: string, description?: string, languages?: string[]) {
     super(id, name, 0.3, 1000, "ElevenLabs");
@@ -60,6 +61,7 @@ class OpenAIVoice extends Voice implements SpeechSynthesisVoiceRemote {
   gender?: string;
   accent?: string;
   description?: string;
+  sample_url?: string;
 
   constructor(id: string, name: string, gender?: string, accent?: string, description?: string) {
     super(id, name, 0.015, 50, "OpenAI");

--- a/test/settings/tabs/voices-controller.spec.tsx
+++ b/test/settings/tabs/voices-controller.spec.tsx
@@ -23,8 +23,19 @@ function makeDeps(overrides: Partial<Record<string, any>> = {}) {
     getVoice: vi.fn(async () => null as SpeechSynthesisVoiceRemote | null),
     setVoice: vi.fn(async () => {}),
     isAuthenticated: vi.fn(() => true),
+    playPreview: vi.fn((_voice: SpeechSynthesisVoiceRemote) => {}),
     ...overrides,
   };
+}
+
+function voiceWithSample(
+  id: string,
+  name: string,
+  sampleUrl?: string
+): SpeechSynthesisVoiceRemote {
+  const v = new ElevenLabsVoice(id, name);
+  v.sample_url = sampleUrl;
+  return v;
 }
 
 async function mount(deps = makeDeps()) {
@@ -192,6 +203,66 @@ describe("VoicesController", () => {
           "#voice-catalog [data-voice-id='v1'] .voice-row-desc"
         )
       ).toBeNull();
+    });
+  });
+
+  // Choice by ear (design §4): a free canned preview clip, rendered only when
+  // the server serves a sample_url — a separate target from "Use this voice".
+  describe("voice preview (▶)", () => {
+    it("renders a ▶ button only on rows whose voice has a sample_url", async () => {
+      const withClip = voiceWithSample(
+        "withclip",
+        "Nova",
+        "https://api.saypi.ai/voices/nova/sample.mp3"
+      );
+      const noClip = voiceWithSample("noclip", "Ash", undefined);
+      const deps = makeDeps({ getVoices: vi.fn(async () => [withClip, noClip]) });
+      const { container } = await mount(deps);
+      const previewOf = (id: string) =>
+        container.querySelector(
+          `#voice-catalog [data-voice-id='${id}'] button.voice-preview`
+        );
+      expect(previewOf("withclip")).toBeTruthy();
+      expect(previewOf("noclip")).toBeNull();
+    });
+
+    it("plays the sample without selecting the voice when ▶ is clicked", async () => {
+      const withClip = voiceWithSample(
+        "withclip",
+        "Nova",
+        "https://api.saypi.ai/voices/nova/sample.mp3"
+      );
+      const deps = makeDeps({ getVoices: vi.fn(async () => [withClip]) });
+      const { container } = await mount(deps);
+      const btn = container.querySelector(
+        "#voice-catalog [data-voice-id='withclip'] button.voice-preview"
+      ) as HTMLElement;
+      btn.click();
+      await flushAsync();
+      expect(deps.playPreview).toHaveBeenCalledTimes(1);
+      expect(deps.playPreview).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "withclip" })
+      );
+      // Preview must not select — that is the "Use this voice" button's job.
+      expect(deps.setVoice).not.toHaveBeenCalled();
+    });
+
+    it("offers ▶ on the current voice's row too (the 'Your voice' card previews)", async () => {
+      const current = voiceWithSample(
+        "withclip",
+        "Nova",
+        "https://api.saypi.ai/voices/nova/sample.mp3"
+      );
+      const deps = makeDeps({
+        getVoices: vi.fn(async () => [current]),
+        getVoice: vi.fn(async () => current),
+      });
+      const { container } = await mount(deps);
+      const row = container.querySelector(
+        "#voice-catalog [data-voice-id='withclip']"
+      ) as HTMLElement;
+      expect(row.classList.contains("current")).toBe(true);
+      expect(row.querySelector("button.voice-preview")).toBeTruthy();
     });
   });
 });

--- a/test/state-machines/AudioOutputMachine-preview.spec.ts
+++ b/test/state-machines/AudioOutputMachine-preview.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTestActor } from "./support/testActor";
+
+// ---------------------------------------------------------------------------
+// Behavior suite for the voice-PREVIEW capability of AudioOutputMachine
+// (design 2026-07-02-voice-selection-ux.md §4 / handoff §"Client preview
+// playback"). A preview plays a free canned sample clip when the user taps ▶
+// on a voice row. The one hard requirement: a preview must NEVER talk over
+// live TTS or an active call. The machine enforces that structurally —
+//
+//   • `preview` is only wired in `idle`, so it is silently dropped while the
+//     machine is `loading`/`loaded.*` (i.e. while live TTS is in flight); and
+//   • a `callActive` context flag (set by `callStarted`/`callEnded`, driven
+//     from ConversationMachine's session:* events) guards the idle case where
+//     a call is live but momentarily between utterances.
+//
+// A permitted preview reuses the existing `replaying` flag so its deliberately
+// source-mismatched clip is not killed by the `shouldSkip` guard, then emits
+// `audio:load` on the SAME channel live TTS uses — no new offscreen plumbing.
+//
+// Mock surface mirrors AudioOutputMachine-characterization.spec.ts.
+// ---------------------------------------------------------------------------
+
+const emit = vi.fn();
+vi.mock("../../src/events/EventBus.js", () => ({
+  default: {
+    emit: (...args: any[]) => emit(...args),
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/tts/SpeechSynthesisModule", () => ({
+  SpeechSynthesisModule: { getInstance: () => ({}) },
+}));
+
+vi.mock("../../src/prefs/PreferenceModule", () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({ getLanguage: () => Promise.resolve("en") }),
+  },
+}));
+
+vi.mock("../../src/tts/SpeechSourceParsers", () => ({
+  PiSpeechSourceParser: vi.fn().mockImplementation(() => ({
+    parse: () => null,
+  })),
+  SayPiSpeechSourceParser: vi.fn().mockImplementation(() => ({
+    parse: () => Promise.resolve(null),
+  })),
+}));
+
+import { audioOutputMachine } from "../../src/state-machines/AudioOutputMachine";
+import { audioProviders } from "../../src/tts/SpeechModel";
+
+const piProvider = audioProviders.Pi;
+const PI_SRC = "https://pi.ai/audio/track-1.mp3";
+// A canned sample lives on api.saypi.ai and is deliberately NOT the selected
+// voice's source, so it exercises the mismatch-exempt (replaying) path.
+const SAMPLE_URL = "https://api.saypi.ai/voices/nova/sample.mp3";
+
+describe("AudioOutputMachine — voice preview playback", () => {
+  let service: any;
+
+  beforeEach(() => {
+    emit.mockClear();
+    service = createTestActor(audioOutputMachine);
+    service.start();
+  });
+
+  afterEach(() => {
+    try {
+      service?.stop();
+    } catch {}
+  });
+
+  describe("preview from idle (nothing playing, no call)", () => {
+    it("emits audio:load with the sample url and marks the track as replaying", () => {
+      service.send({ type: "preview", source: SAMPLE_URL });
+      // Stays in idle: the real <audio> loadstart (driven by AudioModule) is
+      // what advances the machine — preview only arms + kicks the load.
+      expect(service.state.matches("idle")).toBe(true);
+      expect(service.state.context.replaying).toBe(true);
+      expect(emit).toHaveBeenCalledWith("audio:load", { url: SAMPLE_URL });
+    });
+
+    it("the armed replaying flag exempts the mismatched sample from shouldSkip", () => {
+      // No provider/voice selected (default None) => the sample source would
+      // normally be skipped as a mismatch. preview must let it through.
+      service.send({ type: "preview", source: SAMPLE_URL });
+      service.send({ type: "loadstart", source: SAMPLE_URL });
+      expect(service.state.matches("loading")).toBe(true);
+      expect(emit).not.toHaveBeenCalledWith("audio:skipCurrent");
+    });
+  });
+
+  describe("preview never talks over live TTS", () => {
+    function driveToPlaying() {
+      service.send({ type: "changeProvider", provider: piProvider });
+      service.send({ type: "loadstart", source: PI_SRC });
+      service.send({ type: "loadedmetadata" });
+      service.send({ type: "play", source: PI_SRC });
+    }
+
+    it("is suppressed while a track is playing (no audio:load, state unchanged)", () => {
+      driveToPlaying();
+      expect(service.state.matches({ loaded: "playing" })).toBe(true);
+      emit.mockClear();
+      service.send({ type: "preview", source: SAMPLE_URL });
+      expect(emit).not.toHaveBeenCalledWith("audio:load", { url: SAMPLE_URL });
+      expect(service.state.matches({ loaded: "playing" })).toBe(true);
+    });
+
+    it("is suppressed while loading a track", () => {
+      service.send({ type: "changeProvider", provider: piProvider });
+      service.send({ type: "loadstart", source: PI_SRC }); // -> loading
+      expect(service.state.matches("loading")).toBe(true);
+      emit.mockClear();
+      service.send({ type: "preview", source: SAMPLE_URL });
+      expect(emit).not.toHaveBeenCalledWith("audio:load", { url: SAMPLE_URL });
+      expect(service.state.matches("loading")).toBe(true);
+    });
+  });
+
+  describe("preview is allowed from every resting (non-audible) state", () => {
+    function driveToReady() {
+      service.send({ type: "changeProvider", provider: piProvider });
+      service.send({ type: "loadstart", source: PI_SRC });
+      service.send({ type: "loadedmetadata" }); // -> loaded.ready
+    }
+
+    it("allows a preview from loaded.ready (loaded but not yet playing)", () => {
+      driveToReady();
+      expect(service.state.matches({ loaded: "ready" })).toBe(true);
+      emit.mockClear();
+      service.send({ type: "preview", source: SAMPLE_URL });
+      expect(emit).toHaveBeenCalledWith("audio:load", { url: SAMPLE_URL });
+    });
+
+    it("allows a preview from loaded.paused (a paused reply is not audible)", () => {
+      driveToReady();
+      service.send({ type: "play", source: PI_SRC }); // -> playing
+      service.send({ type: "pause" }); // -> paused
+      expect(service.state.matches({ loaded: "paused" })).toBe(true);
+      emit.mockClear();
+      service.send({ type: "preview", source: SAMPLE_URL });
+      expect(emit).toHaveBeenCalledWith("audio:load", { url: SAMPLE_URL });
+    });
+  });
+
+  describe("a lingering skip flag never swallows an intentional preview", () => {
+    it("clears an armed skip so the preview's own load is not skipped", () => {
+      // skip can be armed (audio:skipNext, Pi auto-play suppression) and left
+      // unconsumed into a later idle. A deliberate ▶ tap must still play.
+      service.send({ type: "skipNext" }); // skip = true
+      service.send({ type: "preview", source: SAMPLE_URL });
+      service.send({ type: "loadstart", source: SAMPLE_URL }); // the preview's own load
+      expect(service.state.matches("loading")).toBe(true);
+      expect(emit).not.toHaveBeenCalledWith("audio:skipCurrent");
+    });
+  });
+
+  describe("the menu stays usable after a preview finishes", () => {
+    it("allows a second preview once the first has ended (rests in loaded.ended, not idle)", () => {
+      const SECOND = "https://api.saypi.ai/voices/ash/sample.mp3";
+      // Play the first preview clip through to completion.
+      service.send({ type: "preview", source: SAMPLE_URL });
+      service.send({ type: "loadstart", source: SAMPLE_URL });
+      service.send({ type: "loadedmetadata" });
+      service.send({ type: "play", source: SAMPLE_URL });
+      service.send({ type: "ended" });
+      expect(service.state.matches({ loaded: "ended" })).toBe(true);
+      emit.mockClear();
+      // A second ▶ tap must audition again — not be silently dropped because
+      // the finished clip left the machine parked in loaded.ended.
+      service.send({ type: "preview", source: SECOND });
+      expect(emit).toHaveBeenCalledWith("audio:load", { url: SECOND });
+    });
+  });
+
+  describe("preview never talks over an active call", () => {
+    it("callStarted/callEnded toggle context.callActive without leaving idle", () => {
+      expect(service.state.context.callActive).toBe(false);
+      service.send({ type: "callStarted" });
+      expect(service.state.context.callActive).toBe(true);
+      expect(service.state.matches("idle")).toBe(true);
+      service.send({ type: "callEnded" });
+      expect(service.state.context.callActive).toBe(false);
+    });
+
+    it("is dropped while a call is active (idle but callActive), allowed once it ends", () => {
+      service.send({ type: "callStarted" });
+      service.send({ type: "preview", source: SAMPLE_URL });
+      expect(emit).not.toHaveBeenCalledWith("audio:load", { url: SAMPLE_URL });
+
+      service.send({ type: "callEnded" });
+      service.send({ type: "preview", source: SAMPLE_URL });
+      expect(emit).toHaveBeenCalledWith("audio:load", { url: SAMPLE_URL });
+    });
+  });
+});

--- a/test/tts/SpeechSynthesisModule.spec.ts
+++ b/test/tts/SpeechSynthesisModule.spec.ts
@@ -188,6 +188,40 @@ describe("SpeechSynthesisModule", () => {
     expect(utterance).toBe(mockUtterance);
   });
 
+  // A voice audition (introduceVoice) must route its playback through the gated
+  // audio:preview channel so it never talks over live TTS or an active call
+  // (design §4). Normal conversation playback still loads directly.
+  describe("speak() playback channel", () => {
+    const utterance = {
+      id: "u1",
+      lang: "en-US",
+      voice: mockVoices[0],
+      uri: "https://api.saypi.ai/speak/u1/stream?voice_id=x",
+      provider: audioProviders.SayPi,
+      toString: () => "u1",
+    } as any;
+
+    it("emits audio:load for normal playback (preview omitted)", async () => {
+      const emitSpy = vi.spyOn(EventBus, "emit");
+      speechSynthesisModule.speak(utterance, { getID: () => "claude" } as any);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(emitSpy).toHaveBeenCalledWith("audio:load", {
+        url: utterance.uri,
+      });
+      expect(emitSpy).not.toHaveBeenCalledWith("audio:preview", expect.anything());
+    });
+
+    it("emits audio:preview (the gated channel) when preview is true", async () => {
+      const emitSpy = vi.spyOn(EventBus, "emit");
+      speechSynthesisModule.speak(utterance, { getID: () => "claude" } as any, true);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(emitSpy).toHaveBeenCalledWith("audio:preview", {
+        url: utterance.uri,
+      });
+      expect(emitSpy).not.toHaveBeenCalledWith("audio:load", expect.anything());
+    });
+  });
+
   it("createCompletedSpeechStream sends no text and finalizes nothing when voice is off (#375)", async () => {
     (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(null);
 

--- a/test/tts/VoiceIntroduction.spec.ts
+++ b/test/tts/VoiceIntroduction.spec.ts
@@ -29,6 +29,11 @@ vi.mock("../../src/tts/SpeechSynthesisModule", () => ({
   },
 }));
 
+const emitMock = vi.fn();
+vi.mock("../../src/events/EventBus", () => ({
+  default: { emit: (...args: any[]) => emitMock(...args), on: vi.fn(), off: vi.fn() },
+}));
+
 import { VoiceSelector } from "../../src/tts/VoiceMenu";
 
 class TestVoiceSelector extends VoiceSelector {
@@ -99,5 +104,56 @@ describe("VoiceSelector.introduceVoice — streaming source (#375)", () => {
     expect(createCompletedSpeechStreamMock).not.toHaveBeenCalled();
     expect(createSpeechMock).not.toHaveBeenCalled();
     expect(speakMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Phase 1.5 (founder-chosen): route the existing select-time audition through
+ * the gated preview path, so selecting a voice mid-turn no longer talks over
+ * live TTS / an active call — it is suppressed instead. The audition still
+ * SYNTHESIZES (metered) for custom voices; only its PLAYBACK is gated. The
+ * metered synthesis itself is retired later (Phase 2, server-gated on clips).
+ */
+describe("VoiceSelector.introduceVoice — routes audition through the gated preview path", () => {
+  const customVoice: any = { id: "vabc", name: "Jarnathan", default: false, powered_by: "inflection.ai" };
+
+  beforeEach(() => {
+    createCompletedSpeechStreamMock.mockReset().mockResolvedValue({ voice: null });
+    createSpeechMock.mockReset().mockResolvedValue({ voice: null });
+    speakMock.mockReset();
+    emitMock.mockReset();
+    getMessageMock.mockReset().mockImplementation((key: string) => `intro:${key}`);
+  });
+
+  it("plays a custom-voice audition through speak(..., preview=true), not ungated", async () => {
+    const el = document.createElement("div");
+    const chatbot: any = { getID: () => "claude" }; // custom-voice branch
+    const selector = new TestVoiceSelector(chatbot, {} as any, el);
+
+    selector.introduceVoice(customVoice);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(speakMock).toHaveBeenCalledTimes(1);
+    // The 3rd arg is the preview flag: true routes playback through audio:preview.
+    expect(speakMock.mock.calls[0][2]).toBe(true);
+  });
+
+  it("plays a built-in voice audition via audio:preview, not the ungated audio:load", () => {
+    const el = document.createElement("div");
+    // A built-in provider (has getVoiceIntroductionUrl) with a default voice.
+    const chatbot: any = {
+      getID: () => "pi",
+      getExtraVoices: () => [],
+      getVoiceIntroductionUrl: (id: string) => `https://pi.ai/intro/${id}`,
+    };
+    const selector = new TestVoiceSelector(chatbot, {} as any, el);
+    const builtInVoice: any = { id: "1", name: "Pi 1", default: true, powered_by: "inflection.ai" };
+
+    selector.introduceVoice(builtInVoice);
+
+    expect(emitMock).toHaveBeenCalledWith("audio:preview", {
+      url: "https://pi.ai/intro/1",
+    });
+    expect(emitMock).not.toHaveBeenCalledWith("audio:load", expect.anything());
   });
 });


### PR DESCRIPTION
## What & why

Implements the **"Client preview playback"** phase of the voices rollout ([handoff route map](doc/plans/2026-07-03-voices-rollout-handoff.md), design [§4](doc/plans/2026-07-02-voice-selection-ux.md)): *choice by ear* — a free **▶ preview** affordance on voice rows that auditions a canned ~2s sample clip, plus the plumbing to play it **without ever talking over live TTS or an active call**.

**Ships dormant.** The ▶ renders on **zero** voices until saypi-api serves a `sample_url` field — additive, optional, hidden-when-absent, exactly the [#284](https://github.com/Pedal-Intelligence/saypi-userscript/pull/284) dormant-until-served pattern. Nothing changes for users on merge; the client is ready and the ball is in saypi-api's court for the asset pipeline.

## The gate (the load-bearing part — `AudioOutputMachine`, XState v5)

"Never double-talk" is enforced structurally:

- A `preview` event is handled **only in resting states** — `idle` + `loaded.{ready,paused,ended}` — and **dropped while `loading` / `loaded.playing`**, so a preview can never talk over audio that is loading or playing.
- A `callActive` context flag (set/cleared from `ConversationMachine`'s `session:started`/`session:ended` — the canonical call boundary, **not** the call-button DOM) closes the resting-but-in-a-call gap.
- A permitted preview clears any lingering `skip`, arms the existing `replaying` flag (so its deliberately source-mismatched clip isn't killed by `shouldSkip`), then emits `audio:load` on the **same channel** conversation TTS uses — no new offscreen plumbing, the three hand-synced audio-event lists untouched.

## Founder scope decision (2026-07-03): "also fix the double-talk now"

Beyond the dormant ▶, this reroutes the existing `introduceVoice()` **select-time** audition through the gated path (`speak(…, preview=true)` / `audio:preview`). Selecting a voice mid-TTS/mid-call is now **suppressed rather than interrupting**; on a normal selection (idle/ended/paused/ready) the intro still plays. The metered *synthesis* itself is retired later (Phase 2, when clips exist).

## Surfaces (▶ = its own target, separate from select, gated on `voice.sample_url`)

| Surface | How |
|---|---|
| **claude.ai / chatgpt.com** | Trailing checkmark column wrapped in `.saypi-voice-trailing`; ▶ beside the checkmark; `e.stopPropagation()` keeps play ≠ select. **SayPi-owned SCSS — no new arbitrary Tailwind** the host might not compile (grid template unchanged; cluster-J trap avoided). |
| **Settings → Voices tab** | Its own document (no machine/call/TTS) → previews via a single reused `Audio()` element, injected as `playPreview` for testability. ▶ on current rows too. |
| **pi.ai** | **Deferred** — the row *is* a `<button>` that gets `disabled`, so a ▶ can't nest; it needs a restructure touching fragile Pi-menu assumptions (the area that spawned Patch A's Pi7/8 bugs). Pi already gets the gated audition-on-select via the reroute. Ships last with real-host verify. → follow-up issue. |

## Tests

All unit/contract — a **dormant** affordance can't be real-host-verified yet (per the caution map). `tsc` + Vitest (1699) + Jest green.

- **`AudioOutputMachine-preview.spec.ts`** — the interrupt-safety proof: plays from every resting state + arms replaying; suppressed while loading/playing; dropped during a call, allowed after; second-preview-after-ended; lingering-skip doesn't swallow.
- **`AudioModulePreviewWiring.spec.ts`** — source-scan guard for the untyped EventBus→actor bridge (cluster E).
- **`voices-controller.spec.tsx`**, **`ClaudeVoiceMenu-preview.spec.ts`** — ▶ gated on `sample_url`, separate from select, absent on non-voice rows.
- **`VoiceIntroduction.spec.ts`**, **`SpeechSynthesisModule.spec.ts`** — the reroute + the `speak` preview flag.

## Adversarial review (multi-agent) — findings addressed

- **[medium]** preview was also dropped in `loaded.paused`/`loaded.ready` (dead menu / dropped intro when a reply is paused) → fixed (preview allowed from all resting states).
- **[low]** a lingering `skip` flag could swallow the preview's own load → fixed (`clearSkip` in the preview transitions).
- **[uncertain]** the pre-existing global-`replaying` microtask race → documented; unreachable from a resting state, and the load-bearing `shouldSkip` guard is left untouched.

## Follow-ups (not in this PR)

- Pi menu ▶ (restructure + Layer-4 verify once clips exist).
- Retire the metered `introduceVoice` synthesis (Phase 2, server-gated).
- Keyboard reachability of the in-host ▶ (the Claude menu has no roving-tabindex model today; v1 is mouse + `aria-label`).
- One new i18n key `voicesPreview` (English only) — a `npm run translate` run is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)