### PR TITLE
feat(voices): audition the free sample_url clip instead of metered synthesis

### DIFF
--- a/doc/plans/2026-07-03-voice-preview-playback-impl.md
+++ b/doc/plans/2026-07-03-voice-preview-playback-impl.md
@@ -74,8 +74,6 @@ actually existing.
   A's Pi7/8 bugs). Since the ▶ is dormant and Pi already gets the gated
   audition-on-select via the reroute, this ships **last** with real-host (Layer
   4 CDP) verification once clips exist. Tracked in a follow-up issue.
-- **Retiring the metered `introduceVoice` synthesis** — Phase 2, when
-  GET /voices serves `sample_url`.
 - **Keyboard reachability of the in-host ▶** — the Claude menu has no roving
   tabindex model today; v1 is mouse + `aria-label`. Its own backlog item.
 
@@ -91,10 +89,28 @@ actually existing.
 - `VoiceIntroduction.spec.ts`, `SpeechSynthesisModule.spec.ts` — the reroute +
   the `speak` preview flag.
 
+## Phase 2 — DONE (2026-07-04, PR #484)
+
+saypi-api shipped the `sample_url` pipeline (saypi-api #292 / #294, merged **and
+deployed** — live `/voices` serves `https://api.saypi.ai/voices/<id>/sample?v=<hash>`,
+`200 audio/mpeg`, unauthenticated, ~2s volume-normalized, versioned). So the
+feature is no longer dormant, and Phase 2 landed: **`introduceVoice` now plays the
+free clip instead of the metered synthesis** whenever a voice carries `sample_url`.
+Metered live-TTS survives only as the fallback for clip-less voices (custom
+clones); Pi's built-in static intro URLs are unchanged. This closes the
+`introduceVoice()` metered-preview quota-burn defect flagged on the post-flip watch
+list. Data path verified statically end-to-end (fetch returns `sample_url` verbatim
+→ `SayPi.matches()` by hostname → `host_permissions`/CSP accept `api.saypi.ai`);
+the remaining check is a Layer-4 (CDP) real-host spot-check on live claude.ai.
+
 ## Pending / coordination
 
 - One new i18n key `voicesPreview` (English only) — a founder `npm run translate`
   run is pending (adds to the ~16 keys already awaiting).
-- **saypi-api**: serve `sample_url` as a static, free, `api.saypi.ai`-hosted
-  clip (so provider-match + offscreen CSP + zero billing all hold). Client is
-  dormant until then — same handoff shape as the manifest work.
+- **Pi menu ▶** (see Deferred) still needs the row restructure + Layer-4 verify —
+  saypi-userscript #483. Pi voices carry no `sample_url`, so Pi keeps the metered
+  fallback audition; the ▶ there is a separate affordance.
+- **saypi-api curation manifest** (§5 fields: `featured`/`section`/`recommended`/
+  `language`/`sibling_id`/`deprecated` + measured chars-per-minute) — saypi-api
+  #293, still open; consumed by future client patches (Patch B/C), blocks nothing
+  shipped today.

--- a/src/tts/VoiceMenu.ts
+++ b/src/tts/VoiceMenu.ts
@@ -488,6 +488,39 @@ export abstract class VoiceSelector {
   }
 
   introduceVoice(voice: SpeechSynthesisVoiceRemote): void {
+    // Prefer the free, server-served canned clip (design §4) whenever the catalog
+    // provides one. Playing it costs NO TTS quota — the whole point of "choice by
+    // ear should be free" — and it routes through the GATED preview channel so a
+    // mid-turn voice change is suppressed rather than talking over live TTS / an
+    // active call. This retires the metered live-TTS audition (below) for every
+    // voice the catalog can pre-render; the metered path now survives only as the
+    // fallback for voices with no clip (e.g. a user's private custom clone). It is
+    // also the same sound the ▶ preview button plays, so both auditions agree.
+    if (voice.sample_url) {
+      EventBus.emit("audio:preview", { url: voice.sample_url });
+      return;
+    }
+
+    // Built-in providers (Pi) supply their own free static intro clip per voice.
+    if (voice.default && isBuiltInVoiceProvider(this.chatbot)) {
+      const introductionUrl = this.chatbot.getVoiceIntroductionUrl(voice.id);
+      if (introductionUrl) {
+        // Play the introduction through the GATED preview channel so a mid-turn
+        // voice change never talks over live TTS / an active call (it is
+        // suppressed instead) — was an ungated audio:load.
+        EventBus.emit("audio:preview", { url: introductionUrl });
+      }
+      return;
+    }
+
+    // Fallback — metered live-TTS synthesis, only for voices with no canned clip.
+    // Introduce the custom voice through the SAME finalized streaming path the
+    // conversation-turn TTS uses (open → send text → finalize), so the resulting
+    // `…/speak/<id>/stream` source plays. A plain non-streaming createSpeech yields
+    // a `…/speak/<id>` URL the audio-output parser rejects ("is not a streaming
+    // speech URL"); an un-finalized stream 405s on playback — both left the intro
+    // silent (#375). introduceVoice runs after setVoice persists, so the stream's
+    // preferred voice is the just-selected voice.
     const lastMessage = getMostRecentAssistantMessage(this.chatbot);
     const name = voice.name.toLowerCase().replace(" ", "_");
     // Most SayPi voices have no voice-specific `voiceIntroduction_<name>` script
@@ -500,36 +533,19 @@ export abstract class VoiceSelector {
       lastMessage?.text ||
       getMessage(`voiceIntroduction_${name}`) ||
       getMessage("voiceIntroductionGeneric", [voice.name]);
-    if (voice.default && isBuiltInVoiceProvider(this.chatbot)) {
-      const introductionUrl = this.chatbot.getVoiceIntroductionUrl(voice.id);
-      if (introductionUrl) {
-        // Play the introduction through the GATED preview channel so a mid-turn
-        // voice change never talks over live TTS / an active call (it is
-        // suppressed instead) — was an ungated audio:load.
-        EventBus.emit("audio:preview", { url: introductionUrl });
-      }
-    } else {
-      // Introduce the custom voice through the SAME finalized streaming path the
-      // conversation-turn TTS uses (open → send text → finalize), so the resulting
-      // `…/speak/<id>/stream` source plays. A plain non-streaming createSpeech yields
-      // a `…/speak/<id>` URL the audio-output parser rejects ("is not a streaming
-      // speech URL"); an un-finalized stream 405s on playback — both left the intro
-      // silent (#375). introduceVoice runs after setVoice persists, so the stream's
-      // preferred voice is the just-selected voice.
-      if (!introduction || !introduction.trim()) {
-        // Nothing to say — don't synthesize an empty stream (no audio + a 405).
-        return;
-      }
-      const speechSynthesis = SpeechSynthesisModule.getInstance();
-      speechSynthesis
-        .createCompletedSpeechStream(introduction, this.chatbot)
-        .then((utterance) => {
-          utterance.voice = voice;
-          // preview=true routes playback through the gated audio:preview channel
-          // so this audition never talks over live TTS / an active call.
-          speechSynthesis.speak(utterance, this.chatbot, true);
-        });
+    if (!introduction || !introduction.trim()) {
+      // Nothing to say — don't synthesize an empty stream (no audio + a 405).
+      return;
     }
+    const speechSynthesis = SpeechSynthesisModule.getInstance();
+    speechSynthesis
+      .createCompletedSpeechStream(introduction, this.chatbot)
+      .then((utterance) => {
+        utterance.voice = voice;
+        // preview=true routes playback through the gated audio:preview channel
+        // so this audition never talks over live TTS / an active call.
+        speechSynthesis.speak(utterance, this.chatbot, true);
+      });
   }
 
   // Listen for additions of custom voice buttons and update selections

--- a/test/tts/VoiceIntroduction.spec.ts
+++ b/test/tts/VoiceIntroduction.spec.ts
@@ -157,3 +157,90 @@ describe("VoiceSelector.introduceVoice — routes audition through the gated pre
     expect(emitMock).not.toHaveBeenCalledWith("audio:load", expect.anything());
   });
 });
+
+/**
+ * Phase 2 (server-gated on canned clips — now live): once saypi-api serves a free
+ * `sample_url` per voice (design §4), the select-time audition plays that FREE clip
+ * through the gated preview channel instead of synthesizing "Hi, I'm X" via the
+ * METERED live-TTS path. Auditioning a voice must no longer burn the user's TTS
+ * quota (the `introduceVoice()` metered-preview defect, amplified post-flip by
+ * novelty). Metered synthesis stays ONLY as the fallback for voices that carry no
+ * clip (e.g. a user's private custom clone the catalog can't pre-render).
+ */
+describe("VoiceSelector.introduceVoice — prefers the free sample_url clip over metered synthesis (Phase 2)", () => {
+  beforeEach(() => {
+    createCompletedSpeechStreamMock.mockReset().mockResolvedValue({ voice: null });
+    createSpeechMock.mockReset().mockResolvedValue({ voice: null });
+    speakMock.mockReset();
+    emitMock.mockReset();
+    getMessageMock.mockReset().mockImplementation((key: string) => `intro:${key}`);
+  });
+
+  it("plays the free sample_url clip via audio:preview and does NOT synthesize (no quota spend)", async () => {
+    const el = document.createElement("div");
+    const chatbot: any = { getID: () => "claude" }; // catalog voice on a non-built-in host
+    const selector = new TestVoiceSelector(chatbot, {} as any, el);
+    const sampleUrl = "https://api.saypi.ai/voices/nova/sample?v=abc123";
+    const catalogVoice: any = {
+      id: "nova",
+      name: "Nova",
+      default: false,
+      powered_by: "OpenAI",
+      sample_url: sampleUrl,
+    };
+
+    selector.introduceVoice(catalogVoice);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(emitMock).toHaveBeenCalledWith("audio:preview", { url: sampleUrl });
+    // The metered live-TTS path must NOT run when a free clip exists.
+    expect(createCompletedSpeechStreamMock).not.toHaveBeenCalled();
+    expect(speakMock).not.toHaveBeenCalled();
+  });
+
+  it("still falls back to gated metered synthesis for a voice with no sample_url (custom clone)", async () => {
+    const el = document.createElement("div");
+    const chatbot: any = { getID: () => "claude" };
+    const selector = new TestVoiceSelector(chatbot, {} as any, el);
+    // A user's private clone carries no pre-rendered catalog clip.
+    const customClone: any = { id: "vabc", name: "Jarnathan", default: false, powered_by: "ElevenLabs" };
+
+    selector.introduceVoice(customClone);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(createCompletedSpeechStreamMock).toHaveBeenCalledTimes(1);
+    expect(speakMock).toHaveBeenCalledTimes(1);
+    expect(speakMock.mock.calls[0][2]).toBe(true); // still gated (preview=true)
+    // No free clip → nothing played directly through the preview channel.
+    expect(emitMock).not.toHaveBeenCalledWith(
+      "audio:preview",
+      expect.objectContaining({ url: expect.stringContaining("/sample") })
+    );
+  });
+
+  it("prefers sample_url even for a built-in default voice when the catalog serves one", () => {
+    const el = document.createElement("div");
+    const chatbot: any = {
+      getID: () => "pi",
+      getExtraVoices: () => [],
+      getVoiceIntroductionUrl: (id: string) => `https://pi.ai/intro/${id}`,
+    };
+    const selector = new TestVoiceSelector(chatbot, {} as any, el);
+    const sampleUrl = "https://api.saypi.ai/voices/1/sample?v=zzz";
+    const builtInVoice: any = {
+      id: "1",
+      name: "Pi 1",
+      default: true,
+      powered_by: "inflection.ai",
+      sample_url: sampleUrl,
+    };
+
+    selector.introduceVoice(builtInVoice);
+
+    // The canonical catalog clip wins over the provider's own intro URL.
+    expect(emitMock).toHaveBeenCalledWith("audio:preview", { url: sampleUrl });
+    expect(emitMock).not.toHaveBeenCalledWith("audio:preview", {
+      url: "https://pi.ai/intro/1",
+    });
+  });
+});


### PR DESCRIPTION
## What

Now that saypi-api serves a per-voice **`sample_url`** (design §4, live via [saypi-api #292](https://github.com/Pedal-Intelligence/saypi-api/issues/292) / #294), the **select-time voice audition** (`VoiceMenu.introduceVoice`) plays that **free**, volume-normalized canned clip through the gated preview channel — instead of synthesizing *"Hi, I'm X"* over the **metered** live-TTS path.

## Why

This is **Phase 2** of the preview-playback rollout (the handoff plan: *"when canned clips exist, **retire** `introduceVoice()`'s metered live-TTS path; don't extend it"*), and it closes a **live quota-burn defect**. `OPENAI_TTS_ENABLED` is now on in prod, so `/voices` returns ~13–20 voices per host — and every audition currently spends the user's TTS quota. It was called out on the post-flip watch list as *"the `introduceVoice()` metered-preview defect, amplified by novelty."* Free canned clips are exactly what makes "choice by ear" free.

The clip is also the same sound the ▶ preview button ([#482](https://github.com/Pedal-Intelligence/saypi-userscript/pull/482)) plays, so the two auditions now agree.

## Behavior

`introduceVoice` now resolves in priority order:

1. **`voice.sample_url` present** → play the free clip via `audio:preview` (gated; suppressed mid-turn). **No quota spend.**
2. **Built-in provider default voice** (Pi) → its own free static intro URL — unchanged.
3. **Fallback** → metered live-TTS synthesis, only for voices the catalog can't pre-render (e.g. a user's private custom clone). The #375 streaming-source + empty-intro guards are preserved.

Pi voices carry no `sample_url`, so Pi behavior is fully preserved (route 2/3). Claude/ChatGPT catalog voices now take route 1. **Grandfathering-safe:** only the audition *playback source* changes — never the stored or selected voice.

Per the "collapse vestigial structure" guidance, the `getMostRecentAssistantMessage`/i18n `introduction` computation moved into the fallback branch — the old built-in branch computed but never used it (dead-code collapse, zero behavior change).

## Testing

Fail-first (Layer 1–2, Vitest) in `test/tts/VoiceIntroduction.spec.ts`:
- voice with `sample_url` → plays `audio:preview` with the clip, **no** `createCompletedSpeechStream`/`speak` (proves no quota spend);
- voice without `sample_url` → still falls back to gated metered synthesis (`speak(…, preview=true)`);
- `sample_url` wins over a built-in provider's own intro URL.

Full required gate green locally: `tsc --noEmit` ✅, Jest ✅, Vitest (1702 passed, 1 skipped) ✅.

**Not covered here** (needs the founder's browser): a Layer-4 real-host spot-check that the audition audibly plays the clip on live claude.ai. The data path is verified statically end-to-end (live `/voices` serves `sample_url`; `TextToSpeechService.getVoices` returns it verbatim; `SayPi.matches()` + `host_permissions` + CSP all accept `api.saypi.ai`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)