### PR TITLE
fix(voices): stop the Claude/ChatGPT voice menu crashing on open (nested ▶ button)

### DIFF
--- a/src/tts/VoiceMenu.ts
+++ b/src/tts/VoiceMenu.ts
@@ -215,10 +215,19 @@ export abstract class VoiceSelector {
   }
 
   async refreshMenu(): Promise<void> {
-    // remove all voices from the selector
-    const voiceButtons = Array.from(this.element.querySelectorAll("button"));
+    // Remove the voice buttons from the selector. Scope to DIRECT children:
+    // `removeChild` only removes direct children, so the query that feeds it must
+    // match only those. A bare `querySelectorAll("button")` also matches buttons
+    // nested inside menu items (e.g. the ▶ `.saypi-voice-preview` control added in
+    // #482), and `removeChild` throws `NotFoundError` on a non-child — which aborts
+    // the rebuild and makes the whole menu vanish on open. (Pre-#482 every match was
+    // a direct child, so this was latent.) Nested buttons are cleared by the item
+    // rebuild in `populateVoices`, not here.
+    const voiceButtons = Array.from(this.element.children).filter(
+      (el): el is HTMLButtonElement => el.tagName === "BUTTON"
+    );
     voiceButtons.forEach((button) => {
-      this.unmarkButtonAsSelectedVoice(button as HTMLButtonElement);
+      this.unmarkButtonAsSelectedVoice(button);
       this.element.removeChild(button);
     });
     // add voices to the selector

--- a/test/tts/VoiceMenuRefresh.spec.ts
+++ b/test/tts/VoiceMenuRefresh.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/ConfigModule", () => ({
+  config: { appServerUrl: "https://app.example.com", apiServerUrl: "https://api.saypi.ai" },
+}));
+
+// Break the VoiceMenu -> Pi -> PiVoiceMenu -> VoiceMenu import cycle.
+vi.mock("../../src/chatbots/Pi", () => ({ PiAIChatbot: class {} }));
+
+vi.mock("../../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({ isAuthenticated: () => true, getClaims: () => null }),
+}));
+
+vi.mock("../../src/dom/ChatHistory", () => ({ getMostRecentAssistantMessage: () => undefined }));
+vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
+
+// refreshMenu re-populates via getVoices(); return [] so the test isolates the
+// TEARDOWN half (the crash) — re-population is exercised elsewhere.
+const getVoicesMock = vi.fn().mockResolvedValue([]);
+vi.mock("../../src/tts/SpeechSynthesisModule", () => ({
+  SpeechSynthesisModule: {
+    getInstance: () => ({
+      getVoices: getVoicesMock,
+      createCompletedSpeechStream: vi.fn(),
+      createSpeech: vi.fn(),
+      speak: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../../src/events/EventBus", () => ({
+  default: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+import { VoiceSelector } from "../../src/tts/VoiceMenu";
+
+class TestVoiceSelector extends VoiceSelector {
+  getId(): string {
+    return "test-voice-selector";
+  }
+  getButtonClasses(): string[] {
+    return [];
+  }
+}
+
+/**
+ * Regression (#482 lit up live by saypi-api's `sample_url`): the ▶ preview is a
+ * `<button class="saypi-voice-preview">` NESTED inside each menu item. Base
+ * `refreshMenu` tore down voices with
+ *   this.element.querySelectorAll("button").forEach(b => this.element.removeChild(b))
+ * — a DESCENDANT query fed to a DIRECT-CHILD-only removeChild. The nested preview
+ * button is matched but is not a direct child of `element`, so `removeChild` threw
+ * `NotFoundError`, aborting the menu build → the menu "disappeared" on open.
+ * Pre-#482 there were no nested buttons, so every match was a direct child and it
+ * never threw (a latent fragility). The teardown must only touch direct children.
+ */
+describe("VoiceSelector.refreshMenu — tolerates nested (preview) buttons in menu items", () => {
+  beforeEach(() => {
+    getVoicesMock.mockClear().mockResolvedValue([]);
+  });
+
+  function buildElementWithNestedButton(): HTMLDivElement {
+    const element = document.createElement("div");
+    // Legacy direct-child voice button — the shape refreshMenu is meant to clear.
+    const voiceBtn = document.createElement("button");
+    voiceBtn.textContent = "Alloy";
+    element.appendChild(voiceBtn);
+    // A menu item div whose trailing controls hold a NESTED ▶ preview button
+    // (the #482 structure that surfaced only once sample_url went live).
+    const item = document.createElement("div");
+    item.setAttribute("role", "menuitem");
+    const trailing = document.createElement("div");
+    trailing.classList.add("saypi-voice-trailing");
+    const preview = document.createElement("button");
+    preview.classList.add("saypi-voice-preview");
+    trailing.appendChild(preview);
+    item.appendChild(trailing);
+    element.appendChild(item);
+    return element;
+  }
+
+  it("does not throw when a menu item contains a nested <button> not a direct child", async () => {
+    const element = buildElementWithNestedButton();
+    const chatbot: any = { getID: () => "claude" };
+    const selector = new TestVoiceSelector(chatbot, {} as any, element);
+
+    // Pre-fix: rejects with NotFoundError from removeChild on the nested button.
+    await expect(selector.refreshMenu()).resolves.toBeUndefined();
+  });
+
+  it("removes the direct-child voice buttons but leaves nested preview buttons for the item rebuild", async () => {
+    const element = buildElementWithNestedButton();
+    const chatbot: any = { getID: () => "claude" };
+    const selector = new TestVoiceSelector(chatbot, {} as any, element);
+
+    await selector.refreshMenu();
+
+    // The direct-child voice button is gone (its normal teardown). Filter on
+    // `children` rather than `:scope > button` — jsdom's `:scope` combinator
+    // wrongly matches nested descendants, which is the very quirk under test.
+    const directChildButtons = Array.from(element.children).filter(
+      (el) => el.tagName === "BUTTON"
+    );
+    expect(directChildButtons).toHaveLength(0);
+    // The nested preview button is untouched — removeChild could never remove it,
+    // and the item div is rebuilt wholesale by populateVoices, not here.
+    expect(element.querySelector(".saypi-voice-preview")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

Opening the voice menu on **claude.ai / chatgpt.com** throws and the menu **vanishes**:

```
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at ClaudeVoiceMenu.refreshMenu
    at ClaudeVoiceMenu.toggleMenu
```

Reproduced live on the founder's Chrome (screenshot: menu opens then immediately disappears), and captured in a fail-first unit test with the identical error.

## Root cause

`VoiceSelector.refreshMenu()` (base `src/tts/VoiceMenu.ts`) tore down the existing voices with:

```js
const voiceButtons = Array.from(this.element.querySelectorAll("button")); // descendant search
voiceButtons.forEach((button) => {
  this.unmarkButtonAsSelectedVoice(button);
  this.element.removeChild(button);   // ← direct-child only → throws
});
```

`querySelectorAll("button")` matches **descendants at any depth**, but `Node.removeChild()` only accepts a **direct child**. The ▶ preview button added in #482 (`<button class="saypi-voice-preview">`) is nested inside each menu item, so it's matched by the query but isn't a direct child of `element` → `removeChild` throws → the rebuild aborts → the menu disappears.

**Why it only bit now:** this was latent. Pre-#482 there were no nested buttons, so every match was a direct child and `removeChild` never threw. The ▶ renders **only when a voice carries `sample_url`**, which went live when saypi-api #292/#294 deployed — so the dormant code path lit up and surfaced the fragility. Note #482 isn't in a store release yet, so this is caught **before** it would have broken every user's voice menu on the next release.

## Fix

Scope the teardown to **direct-child** buttons — exactly what `removeChild` requires:

```js
const voiceButtons = Array.from(this.element.children).filter(
  (el) => el.tagName === "BUTTON"
);
```

Provably behavior-preserving: pre-#482 every matched button was already a direct child (or it would have thrown then too), so this removes the identical set and merely stops touching the nested buttons `removeChild` could never remove. Fixes Pi and Claude/ChatGPT alike. Nested buttons are cleared by the item rebuild in `populateVoices`, not here.

Uses a `children` filter rather than `:scope > button` — jsdom's `:scope` combinator wrongly matches nested descendants (verified in-repo), so the portable filter is correct in both jsdom and real Chrome.

## Testing

Fail-first (Vitest) `test/tts/VoiceMenuRefresh.spec.ts`:
- reproduces the exact `NotFoundError` when a menu item holds a nested `.saypi-voice-preview` button (red before the fix);
- asserts direct-child voice buttons are removed while the nested preview button is left for the item rebuild.

Full required gate green locally: `tsc --noEmit` ✅, Jest ✅, Vitest (1704 passed, 1 skipped) ✅.

Real-host confirmation (menu opens + renders the ▶ on live claude.ai with the fixed build) is the recommended follow-up spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)