### PR TITLE
feat(voices): consume the GET /voices curation manifest (§5)

### DIFF
--- a/doc/plans/2026-07-04-curation-manifest-consumption-impl.md
+++ b/doc/plans/2026-07-04-curation-manifest-consumption-impl.md
@@ -1,0 +1,84 @@
+# Consuming the curation manifest (§5) — implementation record
+
+> Phase: "Curation-as-API" client consumption, from
+> [2026-07-02-voice-selection-ux.md §5](2026-07-02-voice-selection-ux.md) and the
+> [rollout handoff](2026-07-03-voices-rollout-handoff.md). Server side shipped in
+> **saypi-api #293** (closed + deployed 2026-07-04); this is the client half.
+
+## What changed
+
+`GET /voices` now serves a curation manifest on every voice. Before this change
+the client derived tier and the in-host shortlist from local heuristics
+(`powered_by` + price + a hardcoded popularity rank), with a comment promising to
+move server-side "once the API carries curation metadata." It now does.
+
+The whole change funnels through two pure functions in `src/tts/VoiceCuration.ts`,
+so all three surfaces (Pi menu, Claude/ChatGPT menu, settings Voices tab) inherit
+it with no per-surface edits:
+
+- **`getVoiceTier`** — prefers the server `section` (`hd` → hd; `everyday` /
+  `language` → everyday) and falls back to the price/`powered_by` heuristic when
+  `section` is absent. Drives the HD chip and the settings hd/everyday split.
+- **`curateShortlist`** — when the catalog carries `featured`, the in-host
+  shortlist *is* the server's featured set (in server order, current-voice pinned
+  first, capped, filled to cap in server order if the featured set is short).
+  When no voice carries `featured`, it falls back to the old local
+  `pickHdFeatured` + popularity-rank path.
+- **`visibleCatalog`** (new, exported) — drops `deprecated` voices before a
+  catalog is offered, **except the user's current voice**. Applied inside
+  `curateShortlist` and in `voices-controller.renderCatalog`.
+
+## The contract-discipline gate
+
+Server fields are obeyed *when present* and fall back *when absent* — so the
+client renders correctly against both the new server and any older deployment,
+and nothing regresses if a field disappears. `serverCurated` is detected at the
+field level (`featured !== undefined`), not by whether anything is `true`, so a
+server that legitimately marks nothing featured is still server-driven — and the
+fill-to-cap step keeps the menu populated in server order rather than empty.
+
+The strongest backward-compat proof is that all 16 pre-existing `VoiceCuration`
+tests (whose fixtures carry no manifest fields) stay green untouched.
+
+## Invariants preserved
+
+- **Grandfathering** — a deprecated voice keeps rendering and working if it is
+  the user's current selection. Server-side keeps synthesising TTS for prior
+  selectors; the client only governs catalog *visibility*.
+- **Never an empty menu** — the fill-to-cap step runs on both the server-driven
+  and heuristic paths.
+- **No silent swap** — this phase only *hides* deprecated voices from new
+  selectors. The active deprecation *remap-with-notice* is deliberately **not**
+  here (see below).
+
+## Scope OUT (typed + preserved, not acted on)
+
+These manifest fields are typed on `SpeechSynthesisVoiceRemote` so the data
+survives the client data path, but this phase renders nothing from them — they
+belong to later, founder-gated phases:
+
+- `recommended` — cohort-default adoption is **Patch B** (§7.1 founder
+  default-voice decision + switch-away telemetry, neither of which exists yet).
+- `sibling_id` — Downshift target / active deprecation successor is **Patch B**.
+- `language` — the gated language shelf is **Patch C** (§7.2 / 60dB decision).
+- `chars_per_minute` — minute denominations are **Patch B**, and the field is
+  served as `null` (rates unmeasured) live anyway.
+
+The `#474` identically-named-rows fix keeps its existing languages-subtitle
+heuristic; retrofitting it to `sibling_id` is a separate optional follow-up and
+`sibling_id` is unpopulated live.
+
+## Testing
+
+Pure curation logic → proved entirely at the unit layer (Vitest), fail-first:
+
+- `test/tts/VoiceCuration.spec.ts` — a server-curated fixture whose `featured`
+  set deliberately diverges from what the local heuristic would pick, so a green
+  test proves the client follows the manifest, not its own ranking; plus
+  section-override, fill-to-cap, empty-featured-never-empty, backward-compat
+  fallback, and deprecated/grandfathering cases.
+- `test/settings/tabs/voices-controller.spec.tsx` — deprecated voices hidden from
+  the settings catalog, current-selection survivor kept.
+
+A Layer-4 (CDP) look-check that the live menu now reflects the server's featured
+set is a nice-to-have confirmation, not required for the logic.

--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -1,6 +1,6 @@
 import getMessage from "../../../../src/i18n";
 import { SpeechSynthesisVoiceRemote } from "../../../../src/tts/SpeechModel";
-import { getVoiceTier } from "../../../../src/tts/VoiceCuration";
+import { getVoiceTier, visibleCatalog } from "../../../../src/tts/VoiceCuration";
 import { SpeechSynthesisModule } from "../../../../src/tts/SpeechSynthesisModule";
 import { UserPreferenceModule } from "../../../../src/prefs/PreferenceModule";
 import { getJwtManagerSync } from "../../../../src/JwtManager";
@@ -118,7 +118,9 @@ export class VoicesController {
     if (voices.length === 0) {
       // Signed out → /voices legitimately returns [] (401): prompt sign-in.
       // Signed in with an empty catalog means the fetch failed — telling an
-      // authenticated user to sign in would be wrong and confusing.
+      // authenticated user to sign in would be wrong and confusing. This runs
+      // on the RAW catalog (before the deprecated filter) so the signed-out vs
+      // fetch-failure distinction is never masked by retirement.
       const emptyKey = this.deps.isAuthenticated()
         ? "voicesNoneAvailable"
         : "signInForTTS";
@@ -130,8 +132,12 @@ export class VoicesController {
       return;
     }
 
-    const hd = voices.filter((voice) => getVoiceTier(voice) === "hd");
-    const everyday = voices.filter(
+    // Retirement (design §5): deprecated voices drop out of the catalog for new
+    // selectors, but the user's current voice always survives (grandfathering).
+    const shown = visibleCatalog(voices, current?.id ?? null);
+
+    const hd = shown.filter((voice) => getVoiceTier(voice) === "hd");
+    const everyday = shown.filter(
       (voice) => getVoiceTier(voice) === "everyday"
     );
 
@@ -150,7 +156,7 @@ export class VoicesController {
       );
     } else {
       // Single-tier catalog (today's state): a flat list, no shelf chrome.
-      catalog.appendChild(this.renderList(voices, current));
+      catalog.appendChild(this.renderList(shown, current));
     }
   }
 

--- a/src/tts/SpeechModel.ts
+++ b/src/tts/SpeechModel.ts
@@ -278,6 +278,18 @@ interface SpeechSynthesisVoiceRemote extends SpeechSynthesisVoice {
   description?: string;   // short human-friendly description
   languages?: string[];   // ISO codes the voice can speak, e.g. ["en", "ja"]
   sample_url?: string;    // free ~2s canned preview clip; server-served when present (design §4)
+  // Curation manifest (design §5; saypi-api #293). All additive and optional —
+  // the client obeys them when present and falls back to local heuristics when
+  // absent. featured/section/deprecated are consumed today; recommended,
+  // sibling_id, language and chars_per_minute are preserved for later phases
+  // (defaults + rails, language shelf) but not yet acted on.
+  featured?: boolean;         // in the in-host shortlist for this app
+  section?: string;           // shelf key: "hd" | "everyday" | "language"
+  recommended?: boolean;      // the default for this (host, locale, plan) cohort — exactly one
+  sibling_id?: string;        // "everyday sibling" of an HD voice (Downshift + deprecation successor)
+  deprecated?: boolean;       // retired: hidden from the catalog, still served to prior selectors
+  language?: string;          // BCP-47 tag driving the gated language shelf (§6)
+  chars_per_minute?: number;  // measured speaking rate (drives minute denominations; null until measured)
 }
 
 interface MatchableVoice {

--- a/src/tts/VoiceCuration.ts
+++ b/src/tts/VoiceCuration.ts
@@ -5,9 +5,15 @@ import { SpeechSynthesisVoiceRemote } from "./SpeechModel";
  *
  * The in-host voice menus stay capped at a constant size while the server
  * catalog grows; the full catalog lives one click deeper (extension settings).
- * Until GET /voices carries curation metadata (featured/section/recommended),
- * tier and featured-set are derived locally from fields the API already serves
- * (powered_by + price), per the rollout plan's confirmed contract.
+ *
+ * GET /voices now carries a curation manifest (saypi-api #293): `section` gives
+ * the tier, `featured` marks the in-host shortlist, and `deprecated` retires a
+ * voice. The client obeys those fields when present and falls back to the local
+ * price/rank heuristic when they are absent, so it renders correctly against
+ * both new and old server deployments (the additive-optional contract). Two
+ * invariants the manifest can never override: a deprecated voice keeps
+ * rendering (and working) if it is the user's current selection
+ * (grandfathering), and the menu never renders empty.
  */
 
 export type VoiceTier = "hd" | "everyday";
@@ -45,11 +51,32 @@ const EVERYDAY_RANK = [
 ];
 
 export function getVoiceTier(voice: SpeechSynthesisVoiceRemote): VoiceTier {
+  // The server's shelf key is authoritative when present (design §5). Only "hd"
+  // drives the premium tier / HD chip; "everyday" and the "language" shelf both
+  // read as everyday for tier purposes (the language shelf itself is Patch C).
+  if (voice.section === "hd") return "hd";
+  if (voice.section === "everyday" || voice.section === "language") {
+    return "everyday";
+  }
+  // Fallback for catalogs that don't carry the manifest yet.
   const credits = voice.price_per_thousand_chars_in_credits;
   if (typeof credits === "number" && !isNaN(credits)) {
     return credits >= HD_CREDITS_THRESHOLD ? "hd" : "everyday";
   }
   return voice.powered_by === "ElevenLabs" ? "hd" : "everyday";
+}
+
+/**
+ * Drop retired (deprecated) voices before a catalog is offered to new selectors
+ * — EXCEPT the user's current voice, which must always keep rendering
+ * (grandfathering, design §5). The server keeps synthesising TTS for prior
+ * selectors; this governs only what the menus and settings catalog show.
+ */
+export function visibleCatalog(
+  voices: SpeechSynthesisVoiceRemote[],
+  currentVoiceId: string | null
+): SpeechSynthesisVoiceRemote[] {
+  return voices.filter((v) => !v.deprecated || v.id === currentVoiceId);
 }
 
 export interface CuratedShortlist {
@@ -115,16 +142,25 @@ function pickHdFeatured(
 
 /**
  * Order and cap a voice catalog for an in-host menu: pin the user's current
- * voice first (it must never vanish from the menu), then the featured premium
- * pair, then value voices by popularity rank, then fill any spare capacity in
- * server order (covers single-tier catalogs).
+ * voice first (it must never vanish from the menu), then the shortlist — the
+ * server's `featured` set when the manifest is present, otherwise the local
+ * featured pair + value voices by popularity rank — then fill any spare
+ * capacity in server order (covers single-tier catalogs and short featured
+ * sets). Deprecated voices are dropped first, except the current one.
  */
 export function curateShortlist(
   voices: SpeechSynthesisVoiceRemote[],
   currentVoiceId: string | null,
   cap: number
 ): CuratedShortlist {
-  const tiersCoexist = new Set(voices.map(getVoiceTier)).size > 1;
+  const catalog = visibleCatalog(voices, currentVoiceId);
+  // Once the server serves `featured`, it drives shortlist membership; until
+  // then the local price/rank heuristic does. Detected at the field level so a
+  // server that marks nothing featured still counts as server-curated (the
+  // fill-to-cap below then keeps the menu populated in server order).
+  const serverCurated = catalog.some((voice) => voice.featured !== undefined);
+
+  const tiersCoexist = new Set(catalog.map(getVoiceTier)).size > 1;
 
   const shortlist: SpeechSynthesisVoiceRemote[] = [];
   const taken = new Set<string>();
@@ -136,27 +172,33 @@ export function curateShortlist(
   };
 
   const current = currentVoiceId
-    ? voices.find((voice) => voice.id === currentVoiceId)
+    ? catalog.find((voice) => voice.id === currentVoiceId)
     : undefined;
   if (current) take(current);
 
-  pickHdFeatured(voices.filter((v) => getVoiceTier(v) === "hd")).forEach(take);
+  if (serverCurated) {
+    catalog.filter((voice) => voice.featured).forEach(take);
+  } else {
+    pickHdFeatured(catalog.filter((v) => getVoiceTier(v) === "hd")).forEach(
+      take
+    );
 
-  voices
-    .map((voice, serverIndex) => ({ voice, serverIndex }))
-    .filter(({ voice }) => getVoiceTier(voice) === "everyday")
-    .sort(
-      (a, b) =>
-        everydayRank(a.voice) - everydayRank(b.voice) ||
-        a.serverIndex - b.serverIndex
-    )
-    .forEach(({ voice }) => take(voice));
+    catalog
+      .map((voice, serverIndex) => ({ voice, serverIndex }))
+      .filter(({ voice }) => getVoiceTier(voice) === "everyday")
+      .sort(
+        (a, b) =>
+          everydayRank(a.voice) - everydayRank(b.voice) ||
+          a.serverIndex - b.serverIndex
+      )
+      .forEach(({ voice }) => take(voice));
+  }
 
-  voices.forEach(take);
+  catalog.forEach(take);
 
   return {
     voices: shortlist,
-    hiddenCount: voices.length - shortlist.length,
+    hiddenCount: catalog.length - shortlist.length,
     tiersCoexist,
   };
 }

--- a/test/settings/tabs/voices-controller.spec.tsx
+++ b/test/settings/tabs/voices-controller.spec.tsx
@@ -265,4 +265,43 @@ describe("VoicesController", () => {
       expect(row.querySelector("button.voice-preview")).toBeTruthy();
     });
   });
+
+  // Retirement (design §5): a deprecated voice drops out of the catalog for new
+  // selectors, but a user already on one keeps seeing and using it forever
+  // (grandfathering — never a silent swap).
+  describe("deprecated voices (grandfathering)", () => {
+    function deprecate(
+      v: SpeechSynthesisVoiceRemote
+    ): SpeechSynthesisVoiceRemote {
+      v.deprecated = true;
+      return v;
+    }
+
+    it("hides a deprecated voice from the catalog", async () => {
+      const live = new ElevenLabsVoice("live", "Live");
+      const retired = deprecate(new ElevenLabsVoice("retired", "Retired"));
+      const deps = makeDeps({ getVoices: vi.fn(async () => [live, retired]) });
+      const { container } = await mount(deps);
+      expect(
+        container.querySelector("#voice-catalog [data-voice-id='live']")
+      ).toBeTruthy();
+      expect(
+        container.querySelector("#voice-catalog [data-voice-id='retired']")
+      ).toBeNull();
+    });
+
+    it("keeps rendering a deprecated voice that is the user's current selection", async () => {
+      const retired = deprecate(new ElevenLabsVoice("retired", "Retired"));
+      const deps = makeDeps({
+        getVoices: vi.fn(async () => [retired]),
+        getVoice: vi.fn(async () => retired),
+      });
+      const { container } = await mount(deps);
+      const row = container.querySelector(
+        "#voice-catalog [data-voice-id='retired']"
+      ) as HTMLElement;
+      expect(row).toBeTruthy();
+      expect(row.classList.contains("current")).toBe(true);
+    });
+  });
 });

--- a/test/tts/VoiceCuration.spec.ts
+++ b/test/tts/VoiceCuration.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getVoiceTier,
   curateShortlist,
+  visibleCatalog,
   CLAUDE_MENU_CAP,
   PI_MENU_CAP,
 } from "../../src/tts/VoiceCuration";
@@ -189,5 +190,178 @@ describe("curateShortlist", () => {
     const result = curateShortlist(piFlipDay, "voice3", PI_MENU_CAP);
     expect(result.voices.length).toBe(PI_MENU_CAP);
     expect(result.voices.map((v) => v.id)).not.toContain("voice3");
+  });
+});
+
+// --- §5 curation-manifest consumption (saypi-api #293) --------------------
+// GET /voices now serves featured/section/recommended/deprecated/... on each
+// voice. When those fields are present the client obeys them instead of the
+// local price/rank heuristic; when absent it falls back (contract discipline).
+
+type Manifest = Partial<
+  Pick<
+    SpeechSynthesisVoiceRemote,
+    | "featured"
+    | "section"
+    | "recommended"
+    | "deprecated"
+    | "sibling_id"
+    | "language"
+    | "chars_per_minute"
+  >
+>;
+
+function withManifest(
+  v: SpeechSynthesisVoiceRemote,
+  m: Manifest
+): SpeechSynthesisVoiceRemote {
+  return { ...v, ...m };
+}
+
+// A server-curated catalog mirroring the live shape (3 ElevenLabs "hd" +
+// 10 OpenAI "everyday"). The featured set is deliberately DIVERGENT from what
+// the local heuristic would pick (onyx/sage/shimmer are low-rank everyday
+// voices the heuristic would never shortlist) — so a green test proves the
+// client follows the server manifest, not its own ranking.
+const FEATURED_IDS = new Set([
+  "ig1TeITnnNlsJtfHxJlW", // Paola (hd)
+  "bWJPewAagbymiJXZcxnh", // Joey (hd)
+  "onyx",
+  "sage",
+  "shimmer",
+]);
+const curated = piFlipDay.map((v) =>
+  withManifest(v, {
+    featured: FEATURED_IDS.has(v.id),
+    section: v.powered_by === "ElevenLabs" ? "hd" : "everyday",
+  })
+);
+
+describe("getVoiceTier with a server section", () => {
+  it("prefers section:hd over a value price", () => {
+    expect(
+      getVoiceTier(withManifest(voice("x", "X", "OpenAI", 50), { section: "hd" }))
+    ).toBe("hd");
+  });
+
+  it("prefers section:everyday over a premium price", () => {
+    expect(
+      getVoiceTier(
+        withManifest(voice("y", "Y", "ElevenLabs", 1000), { section: "everyday" })
+      )
+    ).toBe("everyday");
+  });
+
+  it("treats a language-shelf section as everyday for the HD chip", () => {
+    expect(
+      getVoiceTier(
+        withManifest(voice("z", "Z", "60dB", undefined), { section: "language" })
+      )
+    ).toBe("everyday");
+  });
+
+  it("falls back to the price/provider heuristic when section is absent", () => {
+    expect(getVoiceTier(voice("w", "W", "ElevenLabs", 1000))).toBe("hd");
+  });
+});
+
+describe("curateShortlist with a server-curated catalog", () => {
+  it("draws the shortlist from the server featured set, in server order", () => {
+    const result = curateShortlist(curated, null, PI_MENU_CAP);
+    expect(result.voices.map((v) => v.name)).toEqual([
+      "Paola",
+      "Joey",
+      "Onyx",
+      "Sage",
+      "Shimmer",
+    ]);
+  });
+
+  it("pins the current voice first, then the server featured set", () => {
+    const result = curateShortlist(curated, "alloy", CLAUDE_MENU_CAP);
+    expect(result.voices.map((v) => v.name)).toEqual([
+      "Alloy",
+      "Paola",
+      "Joey",
+      "Onyx",
+      "Sage",
+      "Shimmer",
+    ]);
+  });
+
+  it("fills to the cap in server order when fewer voices are featured than the cap", () => {
+    const result = curateShortlist(curated, null, CLAUDE_MENU_CAP); // 5 featured, cap 6
+    expect(result.voices.length).toBe(CLAUDE_MENU_CAP);
+    // the 6th slot is the next un-taken voice in server order (Paola v3)
+    expect(result.voices[5].id).toBe("paola-v3");
+  });
+
+  it("never yields an empty menu when the server marks nothing featured", () => {
+    const noneFeatured = piFlipDay.map((v) =>
+      withManifest(v, {
+        featured: false,
+        section: v.powered_by === "ElevenLabs" ? "hd" : "everyday",
+      })
+    );
+    const result = curateShortlist(noneFeatured, null, PI_MENU_CAP);
+    expect(result.voices.length).toBe(PI_MENU_CAP);
+    // filled straight down the server order
+    expect(result.voices.map((v) => v.id)).toEqual(
+      piFlipDay.slice(0, PI_MENU_CAP).map((v) => v.id)
+    );
+  });
+
+  it("still uses the local heuristic for a catalog with no manifest fields", () => {
+    // piFlipDay carries no featured field → heuristic path (backward compat)
+    const result = curateShortlist(piFlipDay, null, PI_MENU_CAP);
+    const everyday = result.voices
+      .filter((v) => getVoiceTier(v) === "everyday")
+      .map((v) => v.name);
+    expect(everyday).toEqual(["Coral", "Nova", "Ash"].slice(0, everyday.length));
+  });
+});
+
+describe("curateShortlist grandfathering (deprecated voices)", () => {
+  it("excludes a deprecated voice even when the server featured it", () => {
+    const withDeprecated = curated.map((v) =>
+      v.id === "onyx" ? withManifest(v, { deprecated: true }) : v
+    );
+    const result = curateShortlist(withDeprecated, null, CLAUDE_MENU_CAP);
+    expect(result.voices.map((v) => v.id)).not.toContain("onyx");
+  });
+
+  it("drops deprecated voices from the selectable count behind the door", () => {
+    const withDeprecated = curated.map((v) =>
+      v.id === "alloy" ? withManifest(v, { deprecated: true }) : v
+    );
+    const result = curateShortlist(withDeprecated, null, CLAUDE_MENU_CAP);
+    // 13 catalog − 1 deprecated − 6 shown = 6 behind the door
+    expect(result.hiddenCount).toBe(6);
+  });
+
+  it("keeps rendering the user's current voice even after it is deprecated (grandfathering)", () => {
+    const withDeprecated = curated.map((v) =>
+      v.id === "alloy" ? withManifest(v, { deprecated: true }) : v
+    );
+    const result = curateShortlist(withDeprecated, "alloy", CLAUDE_MENU_CAP);
+    expect(result.voices[0].id).toBe("alloy");
+  });
+});
+
+describe("visibleCatalog", () => {
+  const a = voice("a", "A", "OpenAI", 50);
+  const b = withManifest(voice("b", "B", "OpenAI", 50), { deprecated: true });
+  const c = voice("c", "C", "OpenAI", 50);
+
+  it("hides deprecated voices from new selectors", () => {
+    expect(visibleCatalog([a, b, c], null).map((v) => v.id)).toEqual(["a", "c"]);
+  });
+
+  it("keeps a deprecated voice that is the current selection", () => {
+    expect(visibleCatalog([a, b, c], "b").map((v) => v.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
   });
 });


### PR DESCRIPTION
## What & why

`GET /voices` now serves a **curation manifest** (saypi-api #293, closed + deployed 2026-07-04). Until now the client derived voice tier and the in-host shortlist from local heuristics, with a standing comment promising to move that logic server-side "once the API carries curation metadata." It now does — this is the client half of design [§5 "Curation-as-API"](../blob/main/doc/plans/2026-07-02-voice-selection-ux.md).

The founder's editorial judgment (which voices are featured, their tier, retirement) becomes a runtime object: re-shelve, re-feature, or retire a voice server-side with no store release, and every user's menu stays capped by construction.

## What changed

Everything funnels through two pure functions in `src/tts/VoiceCuration.ts`, so all three surfaces (Pi menu, Claude/ChatGPT menu, settings Voices tab) inherit it with no per-surface edits:

- **`getVoiceTier`** — prefers the server `section` (`hd` → hd; `everyday`/`language` → everyday); falls back to the price/`powered_by` heuristic when `section` is absent.
- **`curateShortlist`** — when the catalog carries `featured`, the in-host shortlist **is** the server's featured set (server order, current-voice pinned first, capped, filled to cap in server order if the featured set is short); otherwise the existing local `pickHdFeatured` + popularity-rank path.
- **`visibleCatalog`** (new, exported) — drops `deprecated` voices before a catalog is offered, **except the user's current voice**. Applied in `curateShortlist` and `voices-controller.renderCatalog`.

## Contract discipline (dormant-safe, either-order)

Server fields are obeyed *when present* and fall back *when absent*, so the client renders correctly against both the new server and any older deployment. `serverCurated` is detected at the field level (`featured !== undefined`), not by whether anything is `true` — so a server that legitimately marks nothing featured is still server-driven, and the fill-to-cap step keeps the menu populated (never empty) in server order.

The strongest backward-compat proof: **all 16 pre-existing `VoiceCuration` tests stay green untouched** (their fixtures carry no manifest fields → heuristic path).

## Invariants preserved

- **Grandfathering** — a deprecated voice keeps rendering *and working* if it is the user's current selection. The server keeps synthesising TTS for prior selectors; the client only governs catalog *visibility*.
- **No silent swap** — this phase only *hides* deprecated voices from new selectors. The active deprecation *remap-with-notice* is Patch B, deliberately **not** here.
- **Never an empty menu.**

## Scope OUT (typed + preserved, not acted on)

`recommended` (cohort default → **Patch B**, needs the §7.1 founder decision + switch-away telemetry), `sibling_id` (Downshift/remap → **Patch B**), `language` (language shelf → **Patch C**, §7.2/60dB), and `chars_per_minute` (minute denominations → **Patch B**; served `null` live anyway) are typed on `SpeechSynthesisVoiceRemote` so the data survives the client path, but nothing is rendered from them.

## Testing (Fail-First TDD, Layer 1–2)

Pure curation logic → proved entirely at the unit layer, red→green:

- `test/tts/VoiceCuration.spec.ts` (+14) — a server-curated fixture whose `featured` set (Onyx/Sage/Shimmer) **deliberately diverges** from what the local heuristic would pick, so a green test proves the client follows the manifest, not its own ranking; plus section-override, fill-to-cap, empty-featured-never-empty, backward-compat fallback, and deprecated/grandfathering cases.
- `test/settings/tabs/voices-controller.spec.tsx` (+2) — deprecated voices hidden from the settings catalog; current-selection survivor kept.

Full required gate green locally: `tsc --noEmit` clean, Vitest **1720 passed / 1 skipped (194 files)**, Jest pass.

Impl record: `doc/plans/2026-07-04-curation-manifest-consumption-impl.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)