### PR TITLE
fix(tts): stop uncaught synthesis errors when signed out (#268)

### DIFF
--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -298,20 +298,38 @@ class SpeechSynthesisModule {
     const preferedVoice: SpeechSynthesisVoiceRemote | null =
       await this.userPreferences.getVoice(chatbot);
     const preferedLang = await this.userPreferences.getLanguage();
-    if (!preferedVoice) {
-      // Voice off, or the voice was cleared between the provider check and here
-      // (a race when toggling voice mid-response): degrade to a silent placeholder
-      // rather than throwing. The auto-TTS path must treat "no voice" as a no-op,
-      // not an uncaught rejection that aborts message decoration / submission.
+    if (!preferedVoice || !getJwtManagerSync().isAuthenticated()) {
+      // Degrade to a silent placeholder rather than attempting synthesis when:
+      //  - Voice is off, or the voice was cleared between the provider check and
+      //    here (a race when toggling voice mid-response); or
+      //  - The user is signed out. SayPi TTS is an authenticated/premium feature,
+      //    and a user who selected a voice while signed in, then signed out, still
+      //    has that voice persisted — attempting a stream then fails with an
+      //    uncaught "Failed to synthesize speech" (#268). Pi's own voices use a
+      //    different provider and never reach this SayPi-only path.
+      // The auto-TTS path must treat both as a no-op, not an uncaught rejection
+      // that aborts message decoration / submission.
       return new SpeechPlaceholder(preferedLang, audioProviders.None);
     }
     const uuid = generateUUID();
-    const utterance = await this.audioStreamManager.createStream(
-      uuid,
-      preferedVoice,
-      preferedLang,
-      chatbot
-    );
+    let utterance: SpeechUtterance;
+    try {
+      utterance = await this.audioStreamManager.createStream(
+        uuid,
+        preferedVoice,
+        preferedLang,
+        chatbot
+      );
+    } catch (error) {
+      // Defense in depth: any synthesis failure (network, quota, an auth race)
+      // degrades to silence rather than an uncaught rejection on the auto-TTS
+      // path (#268).
+      console.warn(
+        "[SayPi] Speech synthesis stream failed; continuing without audio",
+        error
+      );
+      return new SpeechPlaceholder(preferedLang, audioProviders.None);
+    }
 
     if (messageId) {
       this.activeStreamsByMessageId.set(messageId, utterance);

--- a/test/tts/SpeechSynthesisModule.spec.ts
+++ b/test/tts/SpeechSynthesisModule.spec.ts
@@ -140,6 +140,7 @@ describe("SpeechSynthesisModule", () => {
   });
 
   it("should create a speech stream", async () => {
+    fakeAuth.authenticated = true; // streaming TTS requires an authenticated user
     const mockVoice = mockVoices[0];
     const mockUtterance = {
       id: "uuid",
@@ -162,6 +163,7 @@ describe("SpeechSynthesisModule", () => {
   });
 
   it("createCompletedSpeechStream opens, sends the full text, and finalizes a one-shot stream (#375)", async () => {
+    fakeAuth.authenticated = true; // streaming TTS requires an authenticated user
     const mockUtterance = {
       id: "intro-uuid",
       text: " ",
@@ -236,6 +238,7 @@ describe("SpeechSynthesisModule", () => {
   });
 
   it("reuses an open stream when the same messageId is provided", async () => {
+    fakeAuth.authenticated = true; // streaming TTS requires an authenticated user
     const mockVoice = mockVoices[0];
     const mockUtterance = {
       id: "uuid",
@@ -269,6 +272,40 @@ describe("SpeechSynthesisModule", () => {
 
     expect(isPlaceholderUtterance(utterance)).toBe(true);
     expect(audioStreamManagerMock.createStream).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt TTS synthesis when the user is signed out, even with a voice still selected (#268)", async () => {
+    // SayPi TTS is an authenticated/premium feature. A user who selected a voice
+    // while signed in, then signed out, still has that voice persisted — but the
+    // auto-TTS path must NOT attempt synthesis (it fails with an uncaught
+    // "Failed to synthesize speech"). Degrade to a silent placeholder instead.
+    fakeAuth.authenticated = false; // explicit; also the beforeEach default
+    // getVoice returns the default preferredVoiceMock — a voice IS selected.
+
+    const utterance = await speechSynthesisModule.createSpeechStream(
+      { getID: () => "claude" } as any,
+      "message-signedout"
+    );
+
+    expect(isPlaceholderUtterance(utterance)).toBe(true);
+    expect(audioStreamManagerMock.createStream).not.toHaveBeenCalled();
+  });
+
+  it("degrades to a silent placeholder when stream synthesis fails rather than rejecting (#268)", async () => {
+    // Defense in depth: even for an authenticated user, a synthesis failure
+    // (network, quota, an auth race) must not surface as an uncaught rejection
+    // on the auto-TTS path — it degrades to silence.
+    fakeAuth.authenticated = true;
+    (audioStreamManagerMock.createStream as Mock).mockRejectedValue(
+      new Error("Failed to synthesize speech")
+    );
+
+    const utterance = await speechSynthesisModule.createSpeechStream(
+      { getID: () => "claude" } as any,
+      "message-synthfail"
+    );
+
+    expect(isPlaceholderUtterance(utterance)).toBe(true);
   });
 
   it("keeps native audio for chatbots without a Say Pi voice selection", async () => {


### PR DESCRIPTION
Fixes #268.

## The bug

A user who selects a voice while signed in, then signs out, keeps that voice **persisted** locally. `getActiveAudioProvider` still resolves a persisted voice to the SayPi provider, so the auto-TTS path (`ChatHistory.streamSpeech` → `createSpeechStreamOrPlaceholder` → `createSpeechStream` → `AudioStreamManager.createStream` → `TextToSpeechService.createSpeech`) attempts a stream that fails auth with an uncaught **"Failed to synthesize speech"** — on *every* assistant message, cluttering the console with unhandled promise rejections.

The existing voice-off guard doesn't catch it because a voice *is* selected; the guard only fired for `getVoice() === null`.

## The fix (`createSpeechStream`)

1. **Don't attempt doomed synthesis.** Treat "signed out" the same as "voice off" — degrade to a silent placeholder instead of attempting a stream. SayPi TTS is an authenticated/premium feature; Pi's own voices use a different provider and never reach this SayPi-only path, so signed-out Pi users are unaffected.
2. **Handle failures gracefully (defense in depth).** A `try/catch` around `createStream` degrades *any* synthesis failure (network, quota, an auth race) to a silent placeholder rather than an uncaught rejection that could abort message decoration/submission.

This directly implements the issue's asks #2 ("Don't attempt TTS synthesis when it will predictably fail") and #3 ("Handle errors gracefully — no uncaught promise rejections"). The UI-greying ask (#1) is a separate menu enhancement; the menu already shows a sign-in prompt when the catalog is empty (signed-out `/voices` → 401 → `[]`).

## Testing (Fail-First TDD, Layer 1)

`test/tts/SpeechSynthesisModule.spec.ts`, red→green:
- signed-out + a voice still selected → returns a placeholder **without** calling `createStream`;
- a rejecting `createStream` → degrades to a placeholder rather than throwing.

Three existing tests that exercise the *authenticated* streaming path (`should create a speech stream`, `createCompletedSpeechStream …`, `reuses an open stream …`) were incidentally relying on the signed-out `beforeEach` default while testing stream creation/reuse; they now set `fakeAuth.authenticated = true` to reflect their real intent (only an authenticated user can stream TTS). No assertions were weakened.

Full gate green locally: `tsc --noEmit` clean, Vitest **1722 passed / 1 skipped (194 files)**, Jest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)