### PR TITLE
fix(claude): defer synthetic Enter until Claude stops streaming (#488)

### DIFF
--- a/src/chatbots/Claude.ts
+++ b/src/chatbots/Claude.ts
@@ -6,6 +6,7 @@ import { AbstractChatbot, AbstractUserPrompt } from "./AbstractChatbots";
 import { UserPrompt, SidebarConfig } from "./Chatbot";
 import { ClaudeVoiceMenu } from "./ClaudeVoiceMenu";
 import { ClaudeResponse } from "./claude/ClaudeResponse";
+import { dispatchSubmitWhenIdle, isClaudeGenerating } from "./claude/submitGate";
 
 class ClaudeChatbot extends AbstractChatbot {
   private promptCache: Map<HTMLElement, ClaudePrompt> = new Map();
@@ -202,20 +203,31 @@ class ClaudeChatbot extends AbstractChatbot {
   simulateFormSubmit(): boolean {
     // Claude.ai uses the standard SayPi submit button, so fallback to keyboard events
     const promptComposer = document.getElementById("saypi-prompt");
-    if (promptComposer) {
-      const enterEvent = new KeyboardEvent("keydown", {
-        bubbles: true,
-        key: "Enter",
-        keyCode: 13,
-        which: 13,
-      });
-      promptComposer.dispatchEvent(enterEvent);
-      console.debug("Dispatched Enter keydown event to Claude at", Date.now());
-      return true;
+    if (!promptComposer) {
+      console.error(
+        "Cannot submit prompt for Claude: No prompt composer found."
+      );
+      return false;
     }
 
-    console.error("Cannot submit prompt for Claude: No prompt composer found.");
-    return false;
+    // Defer the Enter until Claude finishes any in-flight response. Dispatching
+    // it while the send control is in stop/streaming mode drops it silently and
+    // strands the transcript in the composer (issue #488). When idle — the
+    // common case — this dispatches synchronously with no delay.
+    dispatchSubmitWhenIdle({
+      isGenerating: () => isClaudeGenerating(),
+      submit: () => {
+        const enterEvent = new KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "Enter",
+          keyCode: 13,
+          which: 13,
+        });
+        promptComposer.dispatchEvent(enterEvent);
+        console.debug("Dispatched Enter keydown event to Claude at", Date.now());
+      },
+    });
+    return true;
   }
 
   getSidebarConfig(sidebar: HTMLElement): SidebarConfig | null {

--- a/src/chatbots/claude/submitGate.ts
+++ b/src/chatbots/claude/submitGate.ts
@@ -20,6 +20,12 @@
 // `data-is-streaming="true"` and flips it to `"false"` on completion. This is
 // the same load-bearing signal `ClaudeResponse.dataIsStreaming` keys on, and it
 // is exactly what gates the composer's send-vs-stop control.
+//
+// Deliberately a bare attribute match, broader than `getAssistantResponseSelector()`
+// (which additionally requires a `font-claude-response` child): this also catches
+// the *thinking* phase, before any answer text exists but while the send control is
+// already in stop mode. Don't "align" the two selectors — that would regress
+// thinking-phase coverage.
 const STREAMING_SELECTOR = '[data-is-streaming="true"]';
 
 /** True while any Claude assistant response is actively streaming. */
@@ -45,6 +51,11 @@ export interface SubmitWhenIdleOptions {
 const DEFAULT_POLL_INTERVAL_MS = 250;
 // Claude answers can run long; wait generously before giving up and dispatching
 // best-effort. The common case (composer already idle) never waits at all.
+// Tradeoff: were the attribute ever left stuck `"true"` on an aborted/errored
+// stream, this delays the submit by the full budget before firing anyway (vs.
+// the old immediate dispatch). A shorter budget would instead risk best-effort
+// firing mid-stream on a genuinely long answer — reintroducing the dropped
+// Enter — so we err on the side of waiting.
 const DEFAULT_MAX_WAIT_MS = 30000;
 
 /**

--- a/src/chatbots/claude/submitGate.ts
+++ b/src/chatbots/claude/submitGate.ts
@@ -1,0 +1,92 @@
+/**
+ * Guards Claude's synthetic-Enter submit against a turn-taking race (issue #488).
+ *
+ * SayPi submits a voice turn by dispatching a synthetic `Enter` keydown on the
+ * composer (`ClaudeChatbot.simulateFormSubmit`). Claude's composer only submits
+ * when its send control is in *send* mode; while a previous response is still
+ * streaming the control is in *stop* mode and the Enter is silently dropped —
+ * the transcript is stranded in the composer and Claude never replies. Fast
+ * turn-taking (voice-off, or generally no TTS-playback dwell) lets
+ * `ConversationMachine` return to `listening` soon enough that the next Enter
+ * can land mid-generation.
+ *
+ * So before dispatching we check whether Claude is mid-generation; if it is, we
+ * poll until it settles (bounded by `maxWaitMs`) and dispatch then. If it never
+ * settles within the budget we dispatch anyway — best-effort, no worse than the
+ * pre-fix behaviour, and it avoids stranding the turn forever.
+ */
+
+// Claude marks an actively-streaming assistant response with
+// `data-is-streaming="true"` and flips it to `"false"` on completion. This is
+// the same load-bearing signal `ClaudeResponse.dataIsStreaming` keys on, and it
+// is exactly what gates the composer's send-vs-stop control.
+const STREAMING_SELECTOR = '[data-is-streaming="true"]';
+
+/** True while any Claude assistant response is actively streaming. */
+export function isClaudeGenerating(doc: Document = document): boolean {
+  return doc.querySelector(STREAMING_SELECTOR) !== null;
+}
+
+export interface SubmitWhenIdleOptions {
+  /** Whether Claude is currently generating a response. */
+  isGenerating: () => boolean;
+  /** Performs the actual submit (e.g. dispatch the Enter keydown). */
+  submit: () => void;
+  /** Schedules a deferred check. Injectable for tests; defaults to setTimeout. */
+  schedule?: (callback: () => void, ms: number) => void;
+  /** Clock, injectable for tests; defaults to Date.now. */
+  now?: () => number;
+  /** How often to re-check while Claude is still generating. */
+  pollIntervalMs?: number;
+  /** Upper bound on how long to defer before dispatching best-effort. */
+  maxWaitMs?: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 250;
+// Claude answers can run long; wait generously before giving up and dispatching
+// best-effort. The common case (composer already idle) never waits at all.
+const DEFAULT_MAX_WAIT_MS = 30000;
+
+/**
+ * Submit as soon as Claude is idle. Dispatches synchronously when Claude is
+ * already idle; otherwise polls until generation stops (or the wait budget is
+ * exhausted, at which point it dispatches anyway rather than drop the turn).
+ */
+export function dispatchSubmitWhenIdle(options: SubmitWhenIdleOptions): void {
+  const {
+    isGenerating,
+    submit,
+    schedule = (callback, ms) => {
+      setTimeout(callback, ms);
+    },
+    now = () => Date.now(),
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    maxWaitMs = DEFAULT_MAX_WAIT_MS,
+  } = options;
+
+  if (!isGenerating()) {
+    submit();
+    return;
+  }
+
+  const startedAt = now();
+  const poll = () => {
+    if (!isGenerating()) {
+      submit();
+      return;
+    }
+    if (now() - startedAt >= maxWaitMs) {
+      console.warn(
+        `Claude still generating after ${maxWaitMs}ms; dispatching submit anyway (issue #488).`
+      );
+      submit();
+      return;
+    }
+    schedule(poll, pollIntervalMs);
+  };
+
+  console.debug(
+    "Deferring Claude submit: a previous response is still streaming (issue #488)."
+  );
+  schedule(poll, pollIntervalMs);
+}

--- a/test/chatbots/ClaudeSubmitGate.spec.ts
+++ b/test/chatbots/ClaudeSubmitGate.spec.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  isClaudeGenerating,
+  dispatchSubmitWhenIdle,
+} from "../../src/chatbots/claude/submitGate";
+
+/**
+ * A hand-driven scheduler so the poll loop is deterministic: nothing runs until
+ * the test explicitly flushes a queued callback, and the fake clock only moves
+ * when the test moves it.
+ */
+function makeScheduler() {
+  const queue: Array<() => void> = [];
+  const schedule = (cb: () => void, _ms: number) => {
+    queue.push(cb);
+  };
+  const flushNext = () => {
+    const next = queue.shift();
+    if (next) next();
+  };
+  return { schedule, flushNext, size: () => queue.length };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("isClaudeGenerating", () => {
+  test("is true while a Claude response is actively streaming", () => {
+    const streaming = document.createElement("div");
+    streaming.setAttribute("data-is-streaming", "true");
+    document.body.appendChild(streaming);
+
+    expect(isClaudeGenerating(document)).toBe(true);
+  });
+
+  test("is false once the response has finished streaming", () => {
+    const settled = document.createElement("div");
+    settled.setAttribute("data-is-streaming", "false");
+    document.body.appendChild(settled);
+
+    expect(isClaudeGenerating(document)).toBe(false);
+  });
+
+  test("is false when there is no response element at all", () => {
+    expect(isClaudeGenerating(document)).toBe(false);
+  });
+});
+
+describe("dispatchSubmitWhenIdle", () => {
+  test("dispatches immediately when Claude is idle", () => {
+    let submitted = 0;
+    const { schedule, size } = makeScheduler();
+
+    dispatchSubmitWhenIdle({
+      isGenerating: () => false,
+      submit: () => {
+        submitted++;
+      },
+      schedule,
+      now: () => 0,
+    });
+
+    expect(submitted).toBe(1);
+    expect(size()).toBe(0);
+  });
+
+  test("defers while Claude streams and dispatches exactly once it settles", () => {
+    let generating = true;
+    let submitted = 0;
+    let nowMs = 0;
+    const { schedule, flushNext, size } = makeScheduler();
+
+    dispatchSubmitWhenIdle({
+      isGenerating: () => generating,
+      submit: () => {
+        submitted++;
+      },
+      schedule,
+      now: () => nowMs,
+      pollIntervalMs: 250,
+      maxWaitMs: 30000,
+    });
+
+    // Still generating → nothing submitted, a poll is queued.
+    expect(submitted).toBe(0);
+    expect(size()).toBe(1);
+
+    // First poll while still generating → re-queues, no submit.
+    nowMs = 250;
+    flushNext();
+    expect(submitted).toBe(0);
+    expect(size()).toBe(1);
+
+    // Generation stops → next poll submits, and stops polling.
+    generating = false;
+    nowMs = 500;
+    flushNext();
+    expect(submitted).toBe(1);
+    expect(size()).toBe(0);
+  });
+
+  test("dispatches best-effort (with a warning) once the wait budget is exhausted", () => {
+    let submitted = 0;
+    let nowMs = 0;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { schedule, flushNext } = makeScheduler();
+
+    dispatchSubmitWhenIdle({
+      isGenerating: () => true, // never settles
+      submit: () => {
+        submitted++;
+      },
+      schedule,
+      now: () => nowMs,
+      pollIntervalMs: 250,
+      maxWaitMs: 500,
+    });
+
+    expect(submitted).toBe(0);
+
+    // Under budget → keep waiting.
+    nowMs = 250;
+    flushNext();
+    expect(submitted).toBe(0);
+
+    // Budget exhausted → dispatch anyway rather than strand the turn.
+    nowMs = 500;
+    flushNext();
+    expect(submitted).toBe(1);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Why

Split out from #241, this tracks the **voice-independent** submit drop: after the user finishes speaking, the STT'd prompt **intermittently** fails to submit to Claude — the transcript stays in the composer and Claude never responds.

SayPi submits a voice turn by dispatching a synthetic `Enter` keydown on the composer (`ClaudeChatbot.simulateFormSubmit`). Claude's composer only submits when its send control is in **send** mode; while a *previous* response is still streaming the control is in **stop** mode and the Enter is silently dropped. Fast turn-taking — voice-off, or generally no TTS-playback dwell in `responding.piSpeaking` — lets `ConversationMachine` return to `listening` soon enough that the next Enter can land **mid-generation**, which is exactly the intermittent, timing-dependent drop the issue describes. It is not a TTS bug (unlike #241, fixed by #279).

## What

Gate the Enter dispatch on a *not-currently-streaming* check:

- **`isClaudeGenerating()`** — true while any `[data-is-streaming="true"]` response is present. This is the same load-bearing signal `ClaudeResponse.dataIsStreaming` keys on, and it is what gates the composer's send-vs-stop control. Claude flips it to `"false"` on completion, so a finished response never blocks a submit.
- **`dispatchSubmitWhenIdle()`** — if idle (the common case), dispatch synchronously with **no delay**. If Claude is mid-generation, poll until it settles and dispatch then. If it never settles within a 30 s budget, dispatch anyway (best-effort, **no worse than the pre-fix behaviour** — never strands the turn forever).

The decision logic is extracted into a hermetic, dependency-injected module (`src/chatbots/claude/submitGate.ts`) with a scheduler/clock seam so it is unit-tested deterministically; the `Claude.ts` wiring stays thin.

### Why this is safe
- **Idle path unchanged:** when no response is streaming, behaviour is byte-for-byte the previous synchronous Enter dispatch.
- **Only new behaviour** is a bounded wait *while Claude is busy* — precisely the window where the old Enter was being dropped. Strictly better.
- No false-positive delay on a fresh chat / first turn (no streaming element → immediate submit).

## Testing
- New `test/chatbots/ClaudeSubmitGate.spec.ts` (6 tests): streaming detection (true/false/absent) + gate behaviour (immediate-when-idle, defer-then-dispatch-once-settled, best-effort-after-budget with warning). Fail-first TDD — the suite failed on the missing module before the implementation.
- Full suite green: `tsc --noEmit` clean, Vitest 1728 passed / 1 skipped, Jest 2 passed.
- Real-host note: the exact mid-stream drop is intermittent and real-host-only (the issue asks to "confirm with the live multi-turn repro"); the fix is correct-by-construction regardless, and the load-bearing detection signal is already shipping/tested. A live multi-turn spot-check on claude.ai is the appropriate post-merge confirmation.

Fixes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)