### PR TITLE
refactor(voices): row taxonomy + model-driven idempotent render for the voice menus

### DIFF
--- a/doc/plans/2026-07-04-voice-menu-row-refactor.md
+++ b/doc/plans/2026-07-04-voice-menu-row-refactor.md
@@ -1,0 +1,1064 @@
+# Voice Menu Row/Model Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure the `VoiceSelector` base (src/tts/VoiceMenu.ts) and its host subclasses so a voice row is a first-class unit with positive classification, selection/pin state is derived from the stored preference (not recovered from the DOM), and there is one idempotent render path — making the next menu affordance (#483's ▶ on Pi, per-voice delete, etc.) a JSDOM-unit-testable afternoon instead of a real-host-verified half-day.
+
+**Architecture:** Split the current three-jobs-in-one base into (1) a slim generic `VoiceSelector` (auth/preference wiring + a gather-then-render `refreshMenu`), (2) a new `GridVoiceSelector` layer owning the button-grid rendering for Pi's two surfaces (row factory, reconciler, host-row adoption, selection render), and (3) a tiny `VoiceMenuControls` taxonomy module (positive, exhaustive classification of every interactive element). `ClaudeVoiceMenu` migrates to the slim base contract (renderMenu receives the stored voice; the pin field and the read-selection-from-button-label fallback die) but its rendering is NOT redesigned. `VoiceCuration.ts` is untouched. No Preact — host-injected widgets stay imperative per doc/preact-component-conventions.md.
+
+**Tech Stack:** TypeScript, Vitest + JSDOM (existing harness style: `vi.mock` for ConfigModule/JwtManager/i18n/EventBus/SpeechSynthesisModule; `Object.create(Proto)` to bypass heavy constructors).
+
+**Worktree:** `.worktrees/voice-menu-row-refactor` (branch `refactor/voice-menu-rows`). ALL file paths below are relative to the worktree root — never edit the main checkout (memory: worktree-edit-path-trap).
+
+---
+
+## Design invariants this refactor must not drop (test-pinned)
+
+1. **Current-voice-never-vanishes:** the stored voice always renders on a capped surface. Mechanism changes from async pin-recursion to passing the stored id into `curateShortlist` (which already pins current first) at every render.
+2. **Never a silent swap / stale mark:** selection marks are a pure render of the stored preference. *Deliberate improvement:* when the stored voice is not visible in the menu, NO row is marked (today a stale row can keep its highlight).
+3. **Deprecated grandfathering:** `curateShortlist`/`visibleCatalog` behavior unchanged (file untouched); assert through the render.
+4. **Unknown elements are inert:** a nested ▶ (or any future control) is never adopted, never counted as a Pi voice, never given a select handler, never torn down by a re-render (#485, the ▶-deselects trap).
+5. **Pi7/Pi8 extras survive re-renders; pins are not wiped** (the Patch A regression class).
+6. **Door: exactly one, after the SayPi block, always present on surfaces that show it (#472).**
+7. **Preserved quirks (behavior-preserving on purpose):** extras render with today's appearance (custom-voice class + flair, inserted at top); the uncapped Pi settings grid does not filter deprecated voices (pre-existing gap, not this refactor's job); `unmarkRowSelected` still wipes inline styles (`setAttribute("style","")`) exactly as today.
+
+## Element taxonomy (the positive classification)
+
+| Kind | Marker | Meaning |
+|---|---|---|
+| `custom-voice` | `.saypi-custom-voice` | SayPi catalog voice row (select target) |
+| `restored-voice` | `.saypi-restored-voice` | default-flagged catalog voice row SayPi re-adds |
+| `door` | `.saypi-more-voices` | "More voices" → settings catalog |
+| `preview` | `.saypi-voice-preview` | ▶ free-sample playback (#482) |
+| `host-voice` | `data-saypi-host-voice` | host-native button ADOPTED at the single adoption site |
+| `unknown` | none of the above | **inert** — SayPi code never acts on it |
+
+Adoption (the only place unmarked elements are touched): direct-child `<button>`s of a grid container classify as `unknown` → stamped `data-saypi-host-voice` + given the unset-voice click handler ONCE (the attribute doubles as the idempotence guard — fixes today's duplicate-listener-per-expand in `registerVoiceChangeHandler`).
+
+CSS coupling to preserve: row roots keep `.saypi-voice-button` (`voices.scss` visibility rules key on it under `#saypi-voice-menu`), the door keeps `.saypi-more-voices`, ▶ keeps `.saypi-voice-preview`.
+
+## Known deletions (collapse vestigial structure)
+
+From `src/tts/VoiceMenu.ts`: `selectedVoiceButton`, `pinnedCustomVoiceId`, `isBuiltInVoiceButton`, `registerVoiceChangeHandler`, `markButtonAsSelectedVoice`/`unmarkButtonAsSelectedVoice` (move to grid as row helpers), the teardown half of `refreshMenu` (+ its 100 ms sleep), `addVoicesToSelector`, `populateVoices`, `populateDefaultVoices`, `populateCustomVoices`, `removeCustomVoiceRows`, `addMoreVoicesDoor`, `addVoiceButtonAdditionListener`/`handleButtonAddition` (move to grid, taxonomy-routed), `addMissingPiVoices` (folded into the grid render), `getCustomVoiceCap`/`showsMoreVoicesDoor` (move to grid).
+From `src/chatbots/ClaudeVoiceMenu.ts`: the read-selection-from-button-label block, the async getVoice-else-repopulate fallback + pin writeback in `populateVoices`, all `pinnedCustomVoiceId` uses.
+From `src/chatbots/PiVoiceMenu.ts`: `PiVoiceSettings.handleExistingVoiceButtons` (adoption in render covers it), the 3-call expand sequence.
+
+---
+
+### Task 0: Baseline — prove the worktree is green
+
+**Files:** none (verification only)
+
+- [ ] **Step 0.1: Install deps + run the voice-related suite in the worktree**
+
+```bash
+cd /Users/rosscado/SayPi/saypi-userscript/.worktrees/voice-menu-row-refactor
+npm ci 2>&1 | tail -3
+npx vitest run test/tts/ test/chatbots/ 2>&1 | tail -15
+```
+Expected: all existing specs PASS. Record the pass/test counts as the characterization baseline.
+
+- [ ] **Step 0.2: Type-check baseline**
+
+```bash
+npx wxt prepare && npm run typecheck
+```
+Expected: exit 0 (`.wxt/` is tracked but `wxt prepare` regenerates safely in the worktree; do NOT `git add -A` — memory: worktree-wxt-is-tracked).
+
+### Task 1: `VoiceMenuControls` taxonomy module (TDD)
+
+**Files:**
+- Create: `src/tts/VoiceMenuControls.ts`
+- Test: `test/tts/VoiceMenuControls.spec.ts`
+
+- [ ] **Step 1.1: Write the failing spec**
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  classifyControl,
+  markAdopted,
+  HOST_VOICE_ATTR,
+} from "../../src/tts/VoiceMenuControls";
+
+function button(...classes: string[]): HTMLButtonElement {
+  const b = document.createElement("button");
+  b.classList.add(...classes);
+  return b;
+}
+
+describe("VoiceMenuControls.classifyControl — positive, exhaustive taxonomy", () => {
+  it("classifies each SayPi control kind by its positive marker", () => {
+    expect(classifyControl(button("saypi-voice-button", "saypi-custom-voice"))).toBe("custom-voice");
+    expect(classifyControl(button("saypi-voice-button", "saypi-restored-voice"))).toBe("restored-voice");
+    expect(classifyControl(button("saypi-voice-button", "saypi-more-voices"))).toBe("door");
+    expect(classifyControl(button("saypi-voice-preview"))).toBe("preview");
+  });
+
+  it("classifies an adopted host button as host-voice", () => {
+    const b = button();
+    markAdopted(b);
+    expect(b.getAttribute(HOST_VOICE_ATTR)).toBe("true");
+    expect(classifyControl(b)).toBe("host-voice");
+  });
+
+  it("returns unknown for anything unmarked — new elements are inert until opted in", () => {
+    expect(classifyControl(button())).toBe("unknown");
+    expect(classifyControl(button("some-host-class"))).toBe("unknown");
+    expect(classifyControl(document.createElement("div"))).toBe("unknown");
+  });
+
+  it("gives the nested ▶ preview priority over row-level markers (a preview inside a marked row is still a preview)", () => {
+    expect(classifyControl(button("saypi-voice-preview", "saypi-voice-button"))).toBe("preview");
+  });
+});
+```
+
+- [ ] **Step 1.2: Run to verify failure** — `npx vitest run test/tts/VoiceMenuControls.spec.ts` → FAIL (module not found).
+
+- [ ] **Step 1.3: Implement**
+
+```ts
+/**
+ * Positive, exhaustive classification of every interactive element SayPi's
+ * voice menus may encounter. The old model classified by ABSENCE ("lacks
+ * saypi-voice-button ⇒ built-in host voice"), which made every new element
+ * guilty until proven innocent — a nested ▶ read as a host voice would unset
+ * the user's voice on click (#483's blocker) and miscount Pi's native voices.
+ * Here every kind is declared by a marker it CARRIES; `unknown` is inert.
+ */
+export type VoiceMenuControlKind =
+  | "custom-voice"
+  | "restored-voice"
+  | "door"
+  | "preview"
+  | "host-voice"
+  | "unknown";
+
+/** Stamped at the single adoption site; doubles as the attached-once guard. */
+export const HOST_VOICE_ATTR = "data-saypi-host-voice";
+
+export function classifyControl(el: Element): VoiceMenuControlKind {
+  if (el.classList.contains("saypi-voice-preview")) return "preview";
+  if (el.classList.contains("saypi-more-voices")) return "door";
+  if (el.classList.contains("saypi-custom-voice")) return "custom-voice";
+  if (el.classList.contains("saypi-restored-voice")) return "restored-voice";
+  if (el.hasAttribute(HOST_VOICE_ATTR)) return "host-voice";
+  return "unknown";
+}
+
+export function markAdopted(el: Element): void {
+  el.setAttribute(HOST_VOICE_ATTR, "true");
+}
+```
+
+- [ ] **Step 1.4: Run to verify pass** — same command → PASS.
+- [ ] **Step 1.5: Commit** — `git add src/tts/VoiceMenuControls.ts test/tts/VoiceMenuControls.spec.ts && git commit -m "refactor(voices): positive element taxonomy for voice-menu controls"`
+
+### Task 2: `GridVoiceSelector` — row factory + idempotent reconciling render (TDD)
+
+**Files:**
+- Create: `src/tts/GridVoiceSelector.ts`
+- Modify: `src/tts/VoiceMenu.ts` (slim the base; new `refreshMenu` contract)
+- Test: `test/tts/GridVoiceSelector.spec.ts`
+
+The base and grid change together (the grid needs the new abstract contract), so this task lands them as one commit with the new spec; existing-spec updates follow in Task 3.
+
+- [ ] **Step 2.1: Write the failing GridVoiceSelector spec** (`test/tts/GridVoiceSelector.spec.ts`)
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/ConfigModule", () => ({
+  config: { appServerUrl: "https://app.example.com", apiServerUrl: "https://api.saypi.ai",
+    GA_MEASUREMENT_ID: "x", GA_API_SECRET: "x", GA_ENDPOINT: "x" },
+}));
+vi.mock("../../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({ isAuthenticated: () => true, getClaims: () => null }),
+}));
+const openSettingsMock = vi.fn();
+vi.mock("../../src/popup/popupopener", () => ({
+  openSettings: (...args: unknown[]) => openSettingsMock(...args),
+}));
+vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
+vi.mock("../../src/events/EventBus", () => ({
+  default: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+import { GridVoiceSelector } from "../../src/tts/GridVoiceSelector";
+import { HOST_VOICE_ATTR } from "../../src/tts/VoiceMenuControls";
+import { ElevenLabsVoice, OpenAIVoice, openAiMockVoices } from "../data/Voices";
+import { SpeechSynthesisVoiceRemote } from "../../src/tts/SpeechModel";
+
+class TestGrid extends GridVoiceSelector {
+  cap: number | null = 5;
+  getId() { return "test-grid"; }
+  getButtonClasses() { return ["mb-1"]; }
+  protected override getCustomVoiceCap() { return this.cap; }
+}
+
+const piCustoms = [
+  new ElevenLabsVoice("ig1TeITnnNlsJtfHxJlW", "Paola"),
+  new ElevenLabsVoice("bWJPewAagbymiJXZcxnh", "Joey"),
+  new ElevenLabsVoice("paola-v3", "Paola", "F"),
+  ...openAiMockVoices,
+]; // 13 custom voices, tiers coexist
+
+function extraVoice(id: string, name: string): SpeechSynthesisVoiceRemote {
+  return new OpenAIVoice(id, name);
+}
+
+function makeGrid(opts: {
+  stored?: SpeechSynthesisVoiceRemote | null;
+  provider?: boolean;
+  cap?: number | null;
+} = {}): { grid: any; el: HTMLElement } {
+  const grid: any = Object.create(TestGrid.prototype);
+  grid.cap = opts.cap === undefined ? 5 : opts.cap;
+  grid.chatbot = opts.provider
+    ? { getID: () => "pi",
+        getExtraVoices: () => [extraVoice("voice7", "Pi 7"), extraVoice("voice8", "Pi 8")],
+        getVoiceIntroductionUrl: () => "https://pi.ai/intro.mp3" }
+    : { getID: () => "pi" };
+  grid.userPreferences = {
+    getVoice: vi.fn(async () => opts.stored ?? null),
+    setVoice: vi.fn(async () => {}),
+    unsetVoice: vi.fn(async () => {}),
+  };
+  grid.element = document.createElement("div");
+  grid.introduceVoice = vi.fn();
+  return { grid, el: grid.element };
+}
+
+const rowsOf = (el: HTMLElement) => Array.from(el.querySelectorAll<HTMLElement>(".saypi-custom-voice"));
+const idsOf = (el: HTMLElement) => rowsOf(el).map(r => r.dataset.voiceId);
+
+beforeEach(() => { openSettingsMock.mockReset(); document.body.innerHTML = ""; });
+
+describe("GridVoiceSelector.renderMenu — one idempotent render path", () => {
+  it("caps SayPi rows and always renders exactly one door", () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    expect(rowsOf(el).length).toBe(5);
+    expect(el.querySelectorAll(".saypi-more-voices").length).toBe(1);
+  });
+
+  it("is idempotent: rendering the same inputs twice yields identical DOM", () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    const first = el.innerHTML;
+    grid.renderMenu(piCustoms, null);
+    expect(el.innerHTML).toBe(first);
+    expect(el.querySelectorAll(".saypi-more-voices").length).toBe(1);
+  });
+
+  it("keeps DOM identity of surviving rows across re-renders (no listener churn)", () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    const before = rowsOf(el)[0];
+    grid.renderMenu(piCustoms, null);
+    expect(rowsOf(el)[0]).toBe(before);
+  });
+
+  it("always shows the stored voice, synchronously, even when the cap would hide it", () => {
+    const shimmer = openAiMockVoices.find(v => v.name === "Shimmer")!;
+    const { grid, el } = makeGrid({ stored: shimmer });
+    grid.renderMenu(piCustoms, shimmer);          // no flushAsync, no recursion
+    expect(idsOf(el)).toContain("shimmer");
+    expect(rowsOf(el).length).toBe(5);
+    expect((el.querySelector('[data-voice-id="shimmer"]') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders the stored voice's row selected and no other", () => {
+    const coral = openAiMockVoices.find(v => v.name === "Coral")!;
+    const { grid, el } = makeGrid({ stored: coral });
+    grid.renderMenu(piCustoms, coral);
+    const selected = el.querySelectorAll(".selected");
+    expect(selected.length).toBe(1);
+    expect((selected[0] as HTMLElement).dataset.voiceId).toBe("coral");
+  });
+
+  it("switching the stored voice on re-render moves the mark and un-hides the new voice (no stale mark, no vanish)", () => {
+    const shimmer = openAiMockVoices.find(v => v.name === "Shimmer")!;
+    const coral = openAiMockVoices.find(v => v.name === "Coral")!;
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, shimmer);
+    grid.renderMenu(piCustoms, coral);
+    expect(idsOf(el)).toContain("coral");
+    expect(idsOf(el)).not.toContain("shimmer");   // stale pin gone, stateless
+    const selected = el.querySelectorAll(".selected");
+    expect(selected.length).toBe(1);
+    expect((selected[0] as HTMLElement).dataset.voiceId).toBe("coral");
+  });
+
+  it("uncapped surfaces render the whole catalog with no tier badges", () => {
+    const { grid, el } = makeGrid({ cap: null });
+    grid.renderMenu(piCustoms, null);
+    expect(rowsOf(el).length).toBe(piCustoms.length);
+    expect(el.querySelector(".voice-tier")).toBeNull();
+    expect(el.querySelector(".saypi-more-voices")).toBeNull(); // showsMoreVoicesDoor()=false at cap null
+  });
+});
+
+describe("GridVoiceSelector — host-row adoption (positive classification)", () => {
+  it("adopts pre-existing host buttons: marks them and wires unset-on-click exactly once across renders", async () => {
+    const { grid, el } = makeGrid();
+    const hostBtn = document.createElement("button");
+    hostBtn.textContent = "Pi 1";
+    el.appendChild(hostBtn);
+    grid.renderMenu(piCustoms, null);
+    grid.renderMenu(piCustoms, null);            // second render must not double-bind
+    expect(hostBtn.getAttribute(HOST_VOICE_ATTR)).toBe("true");
+    hostBtn.click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(grid.userPreferences.unsetVoice).toHaveBeenCalledTimes(1);
+    expect(hostBtn.classList.contains("selected")).toBe(true);
+  });
+
+  it("voice-off selection leaves host rows untouched but clears SayPi rows", () => {
+    const coral = openAiMockVoices.find(v => v.name === "Coral")!;
+    const { grid, el } = makeGrid();
+    const hostBtn = document.createElement("button");
+    el.appendChild(hostBtn);
+    grid.renderMenu(piCustoms, coral);
+    grid.renderMenu(piCustoms, null);
+    expect(el.querySelectorAll(".saypi-custom-voice.selected").length).toBe(0);
+  });
+});
+
+describe("GridVoiceSelector — Pi extras top-up (was addMissingPiVoices)", () => {
+  it("tops up Pi's account-gated extras for provider chatbots when fewer than 8 host rows", () => {
+    const { grid, el } = makeGrid({ provider: true });
+    grid.renderMenu(piCustoms, null);
+    expect(idsOf(el)).toContain("voice7");
+    expect(idsOf(el)).toContain("voice8");
+  });
+
+  it("extras survive re-renders alongside a shortlist-hidden stored voice (the Patch A regression)", () => {
+    const shimmer = openAiMockVoices.find(v => v.name === "Shimmer")!;
+    const { grid, el } = makeGrid({ provider: true });
+    grid.renderMenu(piCustoms, shimmer);
+    grid.renderMenu(piCustoms, shimmer);
+    grid.renderMenu(piCustoms, shimmer);
+    const ids = idsOf(el);
+    expect(ids).toContain("shimmer");
+    expect(ids).toContain("voice7");
+    expect(ids).toContain("voice8");
+  });
+
+  it("does not top up for chatbots without built-in voices", () => {
+    const { grid, el } = makeGrid({ provider: false });
+    grid.renderMenu(piCustoms, null);
+    expect(idsOf(el)).not.toContain("voice7");
+  });
+});
+
+describe("GridVoiceSelector — unknown elements are inert (#485 / ▶-deselects trap)", () => {
+  function nestedPreviewFixture(el: HTMLElement): HTMLButtonElement {
+    // A future Pi row: wrapper div holding a ▶ — the #483 shape.
+    const rowWrapper = document.createElement("div");
+    const preview = document.createElement("button");
+    preview.classList.add("saypi-voice-preview");
+    rowWrapper.appendChild(preview);
+    el.appendChild(rowWrapper);
+    return preview;
+  }
+
+  it("re-render never throws on, removes, adopts, or counts a nested ▶", () => {
+    const { grid, el } = makeGrid({ provider: true });
+    const preview = nestedPreviewFixture(el);
+    expect(() => grid.renderMenu(piCustoms, null)).not.toThrow();
+    expect(el.contains(preview)).toBe(true);
+    expect(preview.hasAttribute(HOST_VOICE_ATTR)).toBe(false);
+    expect(idsOf(el)).toContain("voice7"); // ▶ not miscounted as a host voice
+  });
+
+  it("clicking a ▶ never unsets or sets the voice", async () => {
+    const { grid, el } = makeGrid();
+    const preview = nestedPreviewFixture(el);
+    grid.renderMenu(piCustoms, null);
+    preview.click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(grid.userPreferences.unsetVoice).not.toHaveBeenCalled();
+    expect(grid.userPreferences.setVoice).not.toHaveBeenCalled();
+  });
+
+  it("a DIRECT-CHILD ▶ (door-style SayPi control) is still not adopted — positive marks win over position", () => {
+    const { grid, el } = makeGrid();
+    const preview = document.createElement("button");
+    preview.classList.add("saypi-voice-preview");
+    el.appendChild(preview);
+    grid.renderMenu(piCustoms, null);
+    expect(preview.hasAttribute(HOST_VOICE_ATTR)).toBe(false);
+  });
+});
+
+describe("GridVoiceSelector — selection via rows (click paths)", () => {
+  it("clicking a SayPi row persists the voice, marks exactly that row, and introduces the voice", async () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    const row = el.querySelector('[data-voice-id="coral"]') as HTMLButtonElement;
+    row.click();
+    await new Promise(r => setTimeout(r, 0));
+    expect(grid.userPreferences.setVoice).toHaveBeenCalled();
+    expect(row.classList.contains("selected")).toBe(true);
+    expect(el.querySelectorAll(".selected").length).toBe(1);
+    expect(grid.introduceVoice).toHaveBeenCalled();
+  });
+
+  it("tier badge appears on HD rows only while tiers coexist", () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    const paola = el.querySelector('[data-voice-id="ig1TeITnnNlsJtfHxJlW"]');
+    // Paola is HD and featured, so present under the cap; badge because tiers coexist.
+    expect(paola?.querySelector(".voice-tier")?.textContent).toBe("HD");
+  });
+});
+```
+
+- [ ] **Step 2.2: Run to verify failure** — `npx vitest run test/tts/GridVoiceSelector.spec.ts` → FAIL (module not found).
+
+- [ ] **Step 2.3: Slim the base `src/tts/VoiceMenu.ts`**
+
+Keep lines 1–146 (imports, `BuiltInVoiceProvider` + guard, class head, constructor, the two `register*Handler`s, `ttsRequiresSignIn`) with these changes, then REPLACE everything from `registerVoiceChangeHandler` (line 149) through `getPositionFromEnd` with the block below, keeping `introduceVoice` and `getPositionFromEnd` verbatim and keeping `parseSvgRoot`/`addSvgToButton` at the bottom. Remove now-unused imports (`getResourceUrl`, `openSettings`, `curateShortlist`, `getVoiceTier`) — `getMessage`, `getMostRecentAssistantMessage`, `SpeechSynthesisModule`, `EventBus`, `getJwtManagerSync` remain used.
+
+```ts
+export abstract class VoiceSelector {
+  protected chatbot: Chatbot;
+  protected userPreferences: UserPreferenceModule;
+  protected element: HTMLElement;
+  // (selectedVoiceButton and pinnedCustomVoiceId are GONE: selection/pin state
+  // is derived from the stored preference at render time, never mirrored.)
+
+  // constructor unchanged
+
+  abstract getId(): string;
+  abstract getButtonClasses(): string[];
+
+  /**
+   * THE single render path: given the fetched catalog + the stored voice,
+   * make this selector's DOM reflect them. Must be idempotent — callable
+   * repeatedly with the same inputs and converging on the same DOM.
+   * Implementations: GridVoiceSelector (Pi's button grids), ClaudeVoiceMenu
+   * (dropdown). Everything renders from state; nothing recovers state from
+   * the DOM.
+   */
+  protected abstract renderMenu(
+    voices: SpeechSynthesisVoiceRemote[],
+    storedVoice: SpeechSynthesisVoiceRemote | null
+  ): void;
+
+  /**
+   * Reflect an externally-changed stored voice on this surface without a
+   * repopulate (and therefore without disturbing an open menu).
+   */
+  protected abstract applySelectedVoice(
+    voice: SpeechSynthesisVoiceRemote | null
+  ): void;
+
+  /**
+   * Gather-then-render: fetch the catalog and the stored voice TOGETHER, then
+   * render once. Passing the stored voice into the render is what lets
+   * curateShortlist pin the current voice synchronously — the old
+   * render-then-detect-then-re-render pin recursion (and the pin field) died
+   * with this. Also gone: the old teardown half, which fed a descendant
+   * `querySelectorAll("button")` to direct-child-only `removeChild` — the
+   * #485 crash. Renders reconcile; nothing bulk-removes buttons.
+   */
+  async refreshMenu(): Promise<void> {
+    const speechSynthesis = SpeechSynthesisModule.getInstance();
+    const [voices, storedVoice] = await Promise.all([
+      speechSynthesis.getVoices(this.chatbot),
+      this.userPreferences.getVoice(this.chatbot),
+    ]);
+    this.renderMenu(voices ?? [], storedVoice ?? null);
+  }
+
+  protected addIdVoiceMenu(element: HTMLElement): void {
+    element.id = this.getId();
+  }
+
+  // ttsRequiresSignIn unchanged (already above)
+  // introduceVoice unchanged (verbatim from current file)
+  // getPositionFromEnd unchanged
+}
+```
+
+In `registerAuthenticationChangeHandler`, replace the body's repopulate call:
+
+```ts
+      const voiceSelector = document.getElementById(this.getId());
+      if (voiceSelector) {
+        this.refreshMenu();
+      }
+```
+
+`registerVoicePreferenceChangeHandler` is unchanged (it already routes through `applySelectedVoice`, now abstract).
+
+- [ ] **Step 2.4: Create `src/tts/GridVoiceSelector.ts`**
+
+```ts
+import { getResourceUrl } from "../ResourceModule";
+import getMessage from "../i18n";
+import { openSettings } from "../popup/popupopener";
+import { SpeechSynthesisVoiceRemote } from "./SpeechModel";
+import { curateShortlist, getVoiceTier } from "./VoiceCuration";
+import { VoiceSelector, isBuiltInVoiceProvider } from "./VoiceMenu";
+import {
+  classifyControl,
+  markAdopted,
+  HOST_VOICE_ATTR,
+} from "./VoiceMenuControls";
+
+/** Pi ships 8 native voices; below this we top up with account-gated extras. */
+const HOST_NATIVE_VOICE_COUNT = 8;
+
+/**
+ * Button-grid voice surfaces (Pi's in-chat menu and Pi's settings grid): the
+ * host owns the container (and re-creates it at will — Pi rebuilds its menu on
+ * every expand), SayPi owns its rows within it. renderMenu is a
+ * RECONCILIATION against that host-owned container, not a wipe-and-rebuild:
+ * SayPi rows are inserted/moved/removed by id, host rows are adopted (marked +
+ * wired) exactly once, and unknown elements are never touched (#485).
+ *
+ * A row is currently rendered as a single <button> (the row root IS the
+ * select target). When a row grows a trailing affordance (#483's ▶), ONLY
+ * createVoiceRow/createRestoredRow and selectTargetOf change — every other
+ * consumer addresses rows via [data-voice-id] roots and the taxonomy.
+ */
+export abstract class GridVoiceSelector extends VoiceSelector {
+  /**
+   * Max SayPi (custom) voice rows this surface shows before tucking the rest
+   * behind the "More voices" door. null = uncapped (Pi's settings grid).
+   */
+  protected getCustomVoiceCap(): number | null {
+    return null;
+  }
+
+  /**
+   * Whether this surface renders the "More voices" door. Capped surfaces
+   * always do (it is the navigation path to the catalog, not an overflow
+   * marker — #472); uncapped surfaces opt in (PiVoiceSettings).
+   */
+  protected showsMoreVoicesDoor(): boolean {
+    return this.getCustomVoiceCap() !== null;
+  }
+
+  protected renderMenu(
+    voices: SpeechSynthesisVoiceRemote[],
+    storedVoice: SpeechSynthesisVoiceRemote | null
+  ): void {
+    const container = this.element;
+    const defaults = voices.filter((voice) => voice.default);
+    const customs = voices.filter((voice) => !voice.default);
+
+    // 1. Adopt host-native rows (positive mark + unset handler, exactly once).
+    this.adoptHostRows(container);
+
+    // 2. SayPi catalog rows. The stored voice id goes straight into
+    //    curateShortlist, whose first rule is current-voice-first — the
+    //    "stored voice never vanishes" invariant, synchronously.
+    const cap = this.getCustomVoiceCap();
+    const curated =
+      cap === null
+        ? { voices: customs, hiddenCount: 0, tiersCoexist: false }
+        : curateShortlist(customs, storedVoice?.id ?? null, cap);
+    this.reconcileCustomRows(
+      container,
+      curated.voices,
+      new Set(customs.map((voice) => voice.id)),
+      curated.tiersCoexist
+    );
+
+    // 3. Default-flagged catalog voices render as restored rows at the end.
+    this.renderRestoredRows(container, defaults);
+
+    // 4. Pi's account-gated extras: top up when the host shows fewer native
+    //    rows than its full set. Their ids are not in the SayPi catalog id
+    //    set, so reconciliation never removes them (Pi 7/8 must survive).
+    if (
+      isBuiltInVoiceProvider(this.chatbot) &&
+      this.countHostRows(container) < HOST_NATIVE_VOICE_COUNT
+    ) {
+      this.ensureExtraRows(
+        container,
+        this.chatbot.getExtraVoices(),
+        curated.tiersCoexist
+      );
+    }
+
+    // 5. The door.
+    if (this.showsMoreVoicesDoor()) {
+      this.ensureDoor(container);
+    }
+
+    // 6. Selection is a pure render of the stored preference.
+    this.renderSelection(storedVoice);
+  }
+
+  /**
+   * External voice change (settings page, another surface): re-mark rows from
+   * the new value. If the voice's row is not visible (shortlist-hidden), no
+   * row is marked — a deliberate improvement over the old stale-highlight —
+   * and the next renderMenu shows it via curateShortlist's current-first rule.
+   */
+  protected applySelectedVoice(
+    voice: SpeechSynthesisVoiceRemote | null
+  ): void {
+    this.renderSelection(voice);
+  }
+
+  // ---- rows -----------------------------------------------------------
+
+  private rowFor(container: HTMLElement, voiceId: string): HTMLElement | null {
+    return container.querySelector<HTMLElement>(
+      `[data-voice-id="${voiceId}"]`
+    );
+  }
+
+  private allRows(): HTMLElement[] {
+    return Array.from(
+      this.element.querySelectorAll<HTMLElement>(
+        `.saypi-custom-voice, .saypi-restored-voice, [${HOST_VOICE_ATTR}]`
+      )
+    );
+  }
+
+  /**
+   * The one seam that knows a row root is (today) the select button itself.
+   * A wrapper-row future changes this to `row.querySelector("button.…")`.
+   */
+  private selectTargetOf(row: HTMLElement): HTMLButtonElement {
+    return row as HTMLButtonElement;
+  }
+
+  /** SayPi catalog voice row. Today's exact DOM: button > name span [+ tier] + flair. */
+  protected createVoiceRow(
+    voice: SpeechSynthesisVoiceRemote,
+    showTier: boolean
+  ): HTMLElement {
+    const row = document.createElement("button");
+    row.type = "button";
+    row.classList.add(
+      ...this.getButtonClasses(),
+      "saypi-voice-button",
+      "saypi-custom-voice",
+      voice.name.toLowerCase().replace(" ", "-")
+    );
+    const name = document.createElement("span");
+    name.classList.add("voice-name");
+    name.innerText = voice.name;
+    row.appendChild(name);
+    this.syncTierBadge(row, voice, showTier);
+    const flair = document.createElement("img");
+    flair.classList.add("flair");
+    flair.src = getResourceUrl("icons/logos/saypi.png");
+    flair.alt = "Say, Pi logo";
+    flair.title = getMessage("enhancedVoice", ["Say, Pi"]);
+    row.appendChild(flair);
+    row.dataset.voiceId = voice.id;
+    row.addEventListener("click", () => {
+      this.userPreferences.setVoice(voice, this.chatbot).then(() => {
+        console.log(`Selected voice: ${voice.name}`);
+        this.renderSelection(voice);
+        this.introduceVoice(voice);
+      });
+    });
+    return row;
+  }
+
+  /** Default-flagged catalog voice re-added by SayPi (plain label, no flair). */
+  protected createRestoredRow(voice: SpeechSynthesisVoiceRemote): HTMLElement {
+    const row = document.createElement("button");
+    row.type = "button";
+    row.classList.add(
+      ...this.getButtonClasses(),
+      "saypi-voice-button",
+      "saypi-restored-voice",
+      voice.name.toLowerCase().replace(" ", "-")
+    );
+    row.innerText = voice.name;
+    row.dataset.voiceId = voice.id;
+    row.addEventListener("click", () => {
+      this.userPreferences.setVoice(voice, this.chatbot).then(() => {
+        console.log(`Selected voice: ${voice.name}`);
+        this.renderSelection(voice);
+        this.introduceVoice(voice);
+      });
+    });
+    return row;
+  }
+
+  /** Quiet HD suffix, added or removed so re-renders converge (idempotence). */
+  private syncTierBadge(
+    row: HTMLElement,
+    voice: SpeechSynthesisVoiceRemote,
+    showTier: boolean
+  ): void {
+    const existing = row.querySelector(".voice-tier");
+    const wanted = showTier && getVoiceTier(voice) === "hd";
+    if (wanted && !existing) {
+      const tier = document.createElement("span");
+      tier.classList.add("voice-tier");
+      tier.textContent = "HD";
+      tier.title = getMessage("hdVoicesAllowanceNote");
+      const name = row.querySelector(".voice-name");
+      if (name) {
+        name.insertAdjacentElement("afterend", tier);
+      } else {
+        row.appendChild(tier);
+      }
+    } else if (!wanted && existing) {
+      existing.remove();
+    }
+  }
+
+  // ---- reconciliation --------------------------------------------------
+
+  /**
+   * Make the SayPi catalog block match the plan: remove catalog rows that
+   * fell out of it (scoped to this catalog's ids so extras and other
+   * sources' rows survive), then walk the plan bottom-up inserting each row
+   * at the top — existing rows are MOVED, not recreated, so DOM identity and
+   * listeners survive; the result is plan order at the top of the container.
+   */
+  private reconcileCustomRows(
+    container: HTMLElement,
+    plan: SpeechSynthesisVoiceRemote[],
+    catalogIds: Set<string>,
+    showTier: boolean
+  ): void {
+    const planIds = new Set(plan.map((voice) => voice.id));
+    Array.from(
+      container.querySelectorAll<HTMLElement>(".saypi-custom-voice")
+    ).forEach((row) => {
+      const id = row.dataset.voiceId;
+      if (id && catalogIds.has(id) && !planIds.has(id)) {
+        row.remove();
+      }
+    });
+    for (let i = plan.length - 1; i >= 0; i--) {
+      const voice = plan[i];
+      let row = this.rowFor(container, voice.id);
+      if (row) {
+        this.syncTierBadge(row, voice, showTier);
+      } else {
+        row = this.createVoiceRow(voice, showTier);
+      }
+      container.insertBefore(row, container.firstChild);
+    }
+  }
+
+  private renderRestoredRows(
+    container: HTMLElement,
+    defaults: SpeechSynthesisVoiceRemote[]
+  ): void {
+    defaults.forEach((voice) => {
+      const existing = this.rowFor(container, voice.id);
+      if (existing) {
+        container.appendChild(existing); // keep the block at the end (today's move-to-end)
+        return;
+      }
+      container.appendChild(this.createRestoredRow(voice));
+    });
+  }
+
+  /**
+   * Account-gated extras render exactly like catalog rows (today's shipped
+   * appearance: custom class + flair, inserted at the top) but are ensured
+   * present rather than reconciled — the cap never applies to them.
+   */
+  private ensureExtraRows(
+    container: HTMLElement,
+    extras: SpeechSynthesisVoiceRemote[],
+    showTier: boolean
+  ): void {
+    extras
+      .slice()
+      .reverse()
+      .forEach((voice) => {
+        if (!this.rowFor(container, voice.id)) {
+          container.insertBefore(
+            this.createVoiceRow(voice, showTier),
+            container.firstChild
+          );
+        }
+      });
+  }
+
+  /** Exactly one door, parked after the last SayPi row. Idempotent. */
+  private ensureDoor(container: HTMLElement): void {
+    let door = container.querySelector<HTMLButtonElement>(
+      "button.saypi-more-voices"
+    );
+    if (!door) {
+      door = document.createElement("button");
+      door.type = "button";
+      // saypi-voice-button keeps it under the menu's expand/collapse
+      // visibility rules (voices.scss); saypi-more-voices classifies it as
+      // the door (never a voice row).
+      door.classList.add(
+        ...this.getButtonClasses(),
+        "saypi-voice-button",
+        "saypi-more-voices"
+      );
+      door.textContent = getMessage("moreVoices");
+      door.addEventListener("click", () => {
+        openSettings("voices");
+      });
+    }
+    const customRows = container.querySelectorAll(".saypi-custom-voice");
+    const lastCustom = customRows[customRows.length - 1];
+    if (lastCustom) {
+      lastCustom.insertAdjacentElement("afterend", door);
+    } else {
+      container.appendChild(door);
+    }
+  }
+
+  // ---- selection -------------------------------------------------------
+
+  /**
+   * Pure render of "which voice is selected" across every known row kind.
+   * null (voice off / host default): SayPi rows are cleared; host rows keep
+   * whatever state the host renders natively.
+   */
+  protected renderSelection(voice: SpeechSynthesisVoiceRemote | null): void {
+    const rows = this.allRows();
+    if (!voice) {
+      rows
+        .filter((row) => classifyControl(row) !== "host-voice")
+        .forEach((row) => this.unmarkRowSelected(row));
+      return;
+    }
+    rows.forEach((row) => this.unmarkRowSelected(row));
+    const target = this.rowFor(this.element, voice.id);
+    if (target) {
+      this.markRowSelected(target);
+    }
+  }
+
+  protected markRowSelected(row: HTMLElement): void {
+    const button = this.selectTargetOf(row);
+    button.disabled = true;
+    button.classList.add("selected", "bg-neutral-300", "text-primary-700");
+    button.classList.remove("hover:bg-neutral-300");
+  }
+
+  protected unmarkRowSelected(row: HTMLElement): void {
+    const button = this.selectTargetOf(row);
+    button.disabled = false;
+    button.classList.remove("selected", "bg-neutral-300", "text-primary-700");
+    button.classList.add("hover:bg-neutral-300", "border-neutral-500");
+    button.setAttribute("style", ""); // strip inline styles from host/builtin buttons (settings page)
+  }
+
+  // ---- host adoption -----------------------------------------------------
+
+  /**
+   * THE single site that may act on unmarked elements: a direct-child
+   * <button> classifying as "unknown" is a host-native voice row — stamp it
+   * (positive from here on) and wire unset-voice. The stamp doubles as the
+   * bound-once guard, so repeated renders (Pi re-expands) never double-bind.
+   */
+  private adoptHostRows(container: HTMLElement): void {
+    Array.from(container.children).forEach((child) => {
+      if (
+        child instanceof HTMLButtonElement &&
+        classifyControl(child) === "unknown"
+      ) {
+        this.adoptHostRow(child);
+      }
+    });
+  }
+
+  private adoptHostRow(button: HTMLButtonElement): void {
+    markAdopted(button);
+    button.addEventListener("click", () => {
+      this.userPreferences.unsetVoice(this.chatbot).then(() => {
+        this.allRows().forEach((row) => this.unmarkRowSelected(row));
+        this.markRowSelected(button);
+      });
+    });
+  }
+
+  private countHostRows(container: HTMLElement): number {
+    return container.querySelectorAll(`[${HOST_VOICE_ATTR}]`).length;
+  }
+
+  // ---- late host mutations ----------------------------------------------
+
+  /**
+   * Pi inserts its native voice buttons asynchronously; adopt them as they
+   * arrive and re-render selection so a host row never shows selected while
+   * a SayPi voice is stored. Additions of SayPi's own rows re-run the same
+   * idempotent selection render (harmless).
+   */
+  addVoiceButtonAdditionListener(voiceMenu: HTMLElement): void {
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type !== "childList") continue;
+        for (const node of mutation.addedNodes) {
+          if (node instanceof HTMLButtonElement) {
+            this.handleRowAddition(node);
+          }
+        }
+      }
+    });
+    observer.observe(voiceMenu, { childList: true });
+  }
+
+  protected handleRowAddition(button: HTMLButtonElement): void {
+    if (
+      button.parentElement === this.element &&
+      classifyControl(button) === "unknown"
+    ) {
+      this.adoptHostRow(button);
+    }
+    this.userPreferences.getVoice(this.chatbot).then((voice) => {
+      if (voice) {
+        this.renderSelection(voice);
+      }
+    });
+  }
+}
+```
+
+- [ ] **Step 2.5: Run the new spec** — `npx vitest run test/tts/GridVoiceSelector.spec.ts test/tts/VoiceMenuControls.spec.ts` → PASS. (Other suites are expected red until Tasks 3–4; do not run the full suite yet.)
+
+- [ ] **Step 2.6: Commit** — `git add src/tts/VoiceMenu.ts src/tts/GridVoiceSelector.ts test/tts/GridVoiceSelector.spec.ts && git commit -m "refactor(voices): slim VoiceSelector base + reconciling GridVoiceSelector"`
+
+### Task 3: Rewire Pi surfaces + update the Pi/base specs
+
+**Files:**
+- Modify: `src/chatbots/PiVoiceMenu.ts`
+- Modify: `test/chatbots/PiVoiceMenu-curation.spec.ts`, `test/chatbots/VoiceMenu-preference-sync.spec.ts`, `test/tts/VoiceMenu.spec.ts`, `test/tts/VoiceMenuRefresh.spec.ts`
+
+- [ ] **Step 3.1: PiVoiceMenu / PiVoiceSettings**
+
+`PiVoiceMenu extends GridVoiceSelector` (import from `../tts/GridVoiceSelector`; drop the `VoiceSelector` import). Constructor, `getId`, `getCustomVoiceCap`, `getButtonClasses`, `restyleVoiceMenuControls` unchanged. Replace the expand branch of `addVoiceMenuExpansionListener`'s observer callback:
+
+```ts
+            if (
+              node instanceof HTMLElement &&
+              node.nodeName === "BUTTON" &&
+              node.getAttribute("aria-label") &&
+              node === audioControlsContainer.firstChild
+            ) {
+              voiceMenu.classList.add("expanded");
+              // Pi recreates its native menu on every expand: re-adopt the
+              // fresh host rows and re-render SayPi's block from state. When
+              // TTS is off we still adopt + top up Pi's extras (and the
+              // door), just with no SayPi catalog rows.
+              this.userPreferences.getTextToSpeechEnabled().then((enabled) => {
+                if (enabled) {
+                  this.refreshMenu();
+                } else {
+                  this.renderMenu([], null);
+                }
+              });
+            }
+```
+
+`PiVoiceSettings extends GridVoiceSelector`; constructor becomes:
+
+```ts
+  constructor(
+    chatbot: Chatbot,
+    userPreferences: UserPreferenceModule,
+    element: HTMLElement
+  ) {
+    super(chatbot, userPreferences, element);
+    this.addIdVoiceMenu(element);
+    // One gather-then-render covers what four calls did: catalog rows,
+    // Pi top-ups, adoption of Pi's pre-existing buttons, and selection.
+    this.refreshMenu();
+  }
+```
+
+Delete `handleExistingVoiceButtons`. Remove the now-unused `SpeechSynthesisModule` import if nothing else uses it.
+
+- [ ] **Step 3.2: Update `test/chatbots/PiVoiceMenu-curation.spec.ts`** — mechanical transform, invariants preserved:
+  - `makeMenu(currentVoice)` keeps constructing via `Object.create(PiVoiceMenu.prototype)`; add `menu.introduceVoice = vi.fn();`.
+  - Every `menu.populateVoices(voices, selector)` becomes `menu.element = selector; menu.renderMenu(voices, stored)` where `stored` is the voice previously wired through the `getVoice` mock (pass `null` where none). Drop the `flushAsync()` calls that existed only to let the pin recursion settle (keep any that flush click handlers).
+  - The "keeps the pin when a partial built-ins-only populate runs" test becomes the extras-survival form: give `menu.chatbot = { getID: () => "pi", getExtraVoices: () => [voice7, voice8], getVoiceIntroductionUrl: () => "" }` and assert after `renderMenu(full, shimmer)` ×2 that ids contain `shimmer`, `voice7`, `voice8` (mirrors the GridVoiceSelector spec; keep it here as the Pi-surface regression pin).
+  - The "clears a stale pin" test becomes: `renderMenu(full, shimmer)` then `renderMenu(full, coral)` on the same element → ids contain `coral`, not `shimmer` (stateless now, but keep as the regression tombstone).
+- [ ] **Step 3.3: Update `test/chatbots/VoiceMenu-preference-sync.spec.ts`** — `makePiMenu` unchanged; `menu.populateVoices(piVoices, menu.element)` → `menu.renderMenu(piVoices, stored())` with `menu.cap`-irrelevant (PiVoiceMenu cap 5 > 2 voices). Claude half is updated in Task 4 (keep it failing until then if running file-by-file).
+- [ ] **Step 3.4: Update `test/tts/VoiceMenu.spec.ts`** — `TestVoiceSelector` gains no-op `renderMenu`/`applySelectedVoice` implementations. The two `addMissingPiVoices` capability tests move onto a minimal `TestGrid extends GridVoiceSelector` (cap null): provider chatbot + `renderMenu([], null)` → `getExtraVoices` called; Claude-ish chatbot → a spy on `createVoiceRow` (or absence of `[data-voice-id="voice7"]`) shows no top-up. ClaudeVoiceMenu #268 tests unchanged.
+- [ ] **Step 3.5: Rewrite `test/tts/VoiceMenuRefresh.spec.ts`** — the #485 invariant now lives structurally in the reconciler; replace the teardown-focused tests with: (a) base `refreshMenu()` on a `TestGrid` whose container holds a menuitem div + nested ▶ resolves without throwing and leaves the ▶ in place (`getVoices` mock returns `[]`); (b) a tombstone comment explaining the old crash and why bulk teardown no longer exists.
+- [ ] **Step 3.6: Run** — `npx vitest run test/tts/ test/chatbots/PiVoiceMenu-curation.spec.ts test/chatbots/VoiceMenu-preference-sync.spec.ts` → all PASS except the Claude half of preference-sync (updated next task); if anything Pi-side fails, fix before proceeding.
+- [ ] **Step 3.7: Commit** — `git add -u src test && git commit -m "refactor(voices): Pi surfaces render through GridVoiceSelector"` (explicit paths; never `git add -A` in a worktree).
+
+### Task 4: Migrate ClaudeVoiceMenu to the slim contract
+
+**Files:**
+- Modify: `src/chatbots/ClaudeVoiceMenu.ts`
+- Modify: `test/chatbots/ClaudeVoiceMenu-curation.spec.ts`, `test/chatbots/ClaudeVoiceMenu-preview.spec.ts`, `test/chatbots/ClaudeVoiceMenu-button-alignment.spec.ts`, `test/chatbots/VoiceMenu-preference-sync.spec.ts` (Claude half), `test/tts/VoiceMenu.spec.ts` (if signatures pinch)
+
+- [ ] **Step 4.1: `populateVoices` → `renderMenu(voices, storedVoice)`**
+
+Rename the override to `protected override renderMenu(voices: SpeechSynthesisVoiceRemote[], storedVoice: SpeechSynthesisVoiceRemote | null): void` (return type void). Inside:
+  - DELETE the `currentSelectedVoice`-from-button-label block (lines reading `.voice-name` textContent) — `storedVoice` replaces it.
+  - `curateShortlist(voices, storedVoice?.id ?? null, CLAUDE_MENU_CAP)` — the pin field read dies.
+  - `this.menuButton = this.createVoiceButton(storedVoice, this.ttsRequiresSignIn(noVoicesAvailable))` — correct label on FIRST render, no off-then-update flash.
+  - Replace the entire trailing `if (currentSelectedVoice) … else { getVoice().then(pin-writeback / conditional re-populate) }` block with one line: `this.updateSelectedVoice(storedVoice);`
+  - Keep everything else (heuristics, cleanupExistingElements, voice-off item, shortlist items, footnote, door, separators) verbatim.
+- [ ] **Step 4.2: `applySelectedVoice` override** shrinks to:
+
+```ts
+  protected override applySelectedVoice(
+    voice: SpeechSynthesisVoiceRemote | null
+  ): void {
+    // Dropdown surface: reflect the change on the trigger + checkmarks. If
+    // the shortlist is hiding the voice, no pin is needed — the menu re-renders
+    // from refreshMenu() on every open, and curateShortlist puts the stored
+    // voice first. Never tears the menu down, so safe while it is open.
+    this.updateSelectedVoice(voice);
+  }
+```
+- [ ] **Step 4.3: `initializeVoiceSelector`** — replace `speechSynthesis.getVoices(chatbot).then((voices) => { this.populateVoices(voices, this.element); … })` with `this.refreshMenu().then(() => { … })` keeping the click-outside listener + initialized-flag wiring inside the `.then`. Drop the now-unused `SpeechSynthesisModule` import and the `chatbot` parameter if unused. `toggleMenu` needs no change (already `this.refreshMenu().then(position)`; note the base no longer sleeps 100 ms — flag for the Layer-4 check).
+- [ ] **Step 4.4: Update Claude specs** — read each; transform `menu.populateVoices(voices, el)` → `menu.renderMenu(voices, stored)` with the stored voice passed explicitly (was via `userPreferences.getVoice` mock + flush). `handleVoiceSelection`/`createMenuItem`/preview tests are signature-stable. Preference-sync Claude half: `menu.populateVoices(claudeMockVoices, menu.element)` → `menu.renderMenu(claudeMockVoices, stored())`.
+- [ ] **Step 4.5: Run** — `npx vitest run test/tts/ test/chatbots/` → ALL PASS.
+- [ ] **Step 4.6: Commit** — `git add -u src test && git commit -m "refactor(voices): ClaudeVoiceMenu renders from gathered state (pin + label-read fallback die)"`
+
+### Task 5: Cross-surface invariant suite
+
+**Files:**
+- Create: `test/tts/VoiceMenuInvariants.spec.ts`
+
+- [ ] **Step 5.1: Write the suite** (harness identical to GridVoiceSelector.spec; TestGrid cap 5). Cases — each with a one-line comment naming the shipped incident it pins:
+  1. **Grandfathering:** a `deprecated: true` stored voice still renders + can be marked selected; a deprecated non-stored voice does not render.
+  2. **Current-voice-never-vanishes across N re-renders** with shuffled catalog order.
+  3. **No silent swap:** after `renderSelection(voiceA)` then external `applySelectedVoice(voiceB)`, exactly voiceB's row is marked; with voiceB hidden, NO row is marked (the deliberate stale-mark fix).
+  4. **Door singularity + placement:** after 3 renders with varying stored voices, exactly one door, positioned after the last `.saypi-custom-voice`.
+  5. **Adoption idempotence under the MutationObserver path:** simulate Pi re-adding a host button + `handleRowAddition` twice → one listener (unsetVoice called once per click).
+  6. **Taxonomy completeness:** every interactive element the grid ever creates (`createVoiceRow`, `createRestoredRow`, door) classifies as non-`unknown` — guards "new row type forgot its marker" (walk `element.querySelectorAll("button")` after a full provider render; assert no `unknown`).
+- [ ] **Step 5.2: Run + commit** — `npx vitest run test/tts/VoiceMenuInvariants.spec.ts` → PASS; `git add test/tts/VoiceMenuInvariants.spec.ts && git commit -m "test(voices): pin the voice-menu invariants (grandfathering, no-vanish, no-silent-swap, inert-unknowns)"`
+
+### Task 6: Full gates
+
+- [ ] **Step 6.1:** `npm test` (tsc + Jest + Vitest) in the worktree → exit 0. Fix any type fallout (likely: removed exports still imported somewhere — `grep -rn "isBuiltInVoiceButton\|addMissingPiVoices\|populateCustomVoices\|addVoicesToSelector" src test`).
+- [ ] **Step 6.2:** Layer 3 E2E: `npm run e2e:build && npm run test:e2e` → green (content-script bootstrap untouched, but the suite is the required gate).
+- [ ] **Step 6.3: Commit any fixups** — `git add -u && git commit -m "refactor(voices): fixups from full test gate"` (only if changes).
+
+### Task 7: Layer-4 real-host look-check (the one this refactor earns)
+
+Voice-menu code is reserve-zone (caution map cluster: host-DOM + billed TTS). Tests prove logic; only the real hosts prove pixels + host-recreated-DOM timing.
+
+- [ ] **Step 7.1:** `node scripts/layer4cdp.mjs verify https://pi.ai` (headed real Chrome; loads the dev extension). Expect: clean voice turn, no console errors.
+- [ ] **Step 7.2:** Pi menu probe via CDP: open the voice menu (click the audio-controls toggle), assert `#saypi-voice-menu.expanded` has SayPi rows + exactly one door + selected mark on the stored voice; screenshot. Then click a SayPi voice; reopen; assert the mark moved. Screenshot both states.
+- [ ] **Step 7.3:** `node scripts/layer4cdp.mjs verify https://claude.ai` + probe: open the voice dropdown twice in a row (the rebuild-on-open path, #485's stage), assert rows + ▶ previews render, no `NotFoundError`/console errors; screenshot. Check the trigger label shows the stored voice immediately on page load (the label-fallback deletion).
+- [ ] **Step 7.4:** If the founder's machine/browser is unavailable, stop and report exactly which checks ran and which are pending — do NOT claim real-host verification that didn't happen.
+
+### Task 8: PR
+
+- [ ] **Step 8.1:** Push branch, open PR titled `refactor(voices): row taxonomy + model-driven idempotent render for the voice menus`, body: the one-outcome framing (row as first-class unit), the five properties → where each landed, the two deliberate behavior changes (stale-mark clears; extras carry restored semantics in classification but today's appearance), the deleted-machinery list, and the Layer-4 evidence (screenshots). Reference #483 (unblocked), #485 (structural fix), the caution-map §6 refactor candidate.
+- [ ] **Step 8.2:** Per memory `auto-merge-ready-prs`: enable auto-merge (squash) once CI is green.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** row-as-unit → GridVoiceSelector row factory + `selectTargetOf` seam (Task 2); positive taxonomy → Task 1 + adoption site; state-model → gather-then-render `refreshMenu`, pin field deleted (Tasks 2–4); one idempotent render → `renderMenu` + reconciler (Task 2); host contract → base/grid split + Claude on slim base (Tasks 2, 4); tested invariants → Task 5. Scope exclusions honored: VoiceCuration untouched, Claude rendering not redesigned, no Preact.
+- **Type consistency check:** `renderMenu(voices, storedVoice)` protected abstract on base; grid + Claude implement; Pi expansion listener calls `this.renderMenu([], null)` (protected-within-subclass OK); `refreshMenu(): Promise<void>` public (Claude `toggleMenu` + tests call it).
+- **Known judgment calls (flag in PR):** extras keep custom-row appearance (pixels) while gaining reconciliation exemption via catalog-id scoping; `renderSelection(null)` leaves host rows alone; dropped 100 ms post-refresh sleep (watch Claude menu positioning at L4); stale-mark now clears when stored voice is hidden.

--- a/src/chatbots/ClaudeVoiceMenu.ts
+++ b/src/chatbots/ClaudeVoiceMenu.ts
@@ -7,7 +7,6 @@ import volumeSvgContent from "../icons/volume-mid.svg?raw";
 import volumeMutedSvgContent from "../icons/volume-muted.svg?raw";
 import playSvgContent from "../icons/play.svg?raw";
 import EventBus from "../events/EventBus";
-import { SpeechSynthesisModule } from "../tts/SpeechSynthesisModule";
 import getMessage from "../i18n";
 import { openSettings } from "../popup/popupopener";
 import { getJwtManagerSync } from "../JwtManager";
@@ -24,7 +23,7 @@ import {
 export class ClaudeVoiceMenu extends VoiceSelector {
   private menuButton: HTMLButtonElement;
   private menuContent: HTMLDivElement;
-  // Heuristics to avoid clutter – computed per dataset in populateVoices
+  // Heuristics to avoid clutter – computed per dataset in renderMenu
   private showAccent: boolean = false;
   private showGender: boolean = false;
   private showTier: boolean = false;
@@ -48,7 +47,7 @@ export class ClaudeVoiceMenu extends VoiceSelector {
     // Clean up any existing voice selector elements before initializing
     this.cleanupExistingElements(this.element);
 
-    this.initializeVoiceSelector(chatbot);
+    this.initializeVoiceSelector();
   }
 
   getId(): string {
@@ -678,24 +677,14 @@ export class ClaudeVoiceMenu extends VoiceSelector {
   /**
    * The Claude selector is a dropdown, not a button grid: reflect an
    * externally-changed voice on the trigger button + row checkmarks. If the
-   * shortlist is hiding the new voice, pin it for the next populate — the
-   * menu rebuilds from the (now-correct) button label on every open, so the
-   * row appears then. Never tears the menu down, so safe while it is open.
+   * shortlist is hiding the voice, no pin is needed — the menu re-renders
+   * from refreshMenu() on every open, and curateShortlist puts the stored
+   * voice first. Never tears the menu down, so safe while it is open.
    */
   protected override applySelectedVoice(
     voice: SpeechSynthesisVoiceRemote | null
   ): void {
     this.updateSelectedVoice(voice);
-    if (!voice) {
-      this.pinnedCustomVoiceId = null;
-      return;
-    }
-    const hasRow = Array.from(
-      this.menuContent.querySelectorAll<HTMLElement>("[role='menuitem']")
-    ).some((item) => item.dataset.voiceName === voice.name);
-    if (!hasRow) {
-      this.pinnedCustomVoiceId = voice.id;
-    }
   }
 
   private updateSelectedVoice(
@@ -735,10 +724,20 @@ export class ClaudeVoiceMenu extends VoiceSelector {
     });
   }
 
-  override populateVoices(
+  /**
+   * The dropdown's single render path: rebuild the trigger button + menu
+   * content from the given catalog and stored voice. The stored voice arrives
+   * WITH the catalog (gather-then-render), so the trigger label is right on
+   * the first paint and curateShortlist pins the current voice synchronously
+   * — the old read-selection-from-the-button-label block and the async
+   * getVoice fallback (with its pin writeback + conditional re-populate) are
+   * gone.
+   */
+  protected override renderMenu(
     voices: SpeechSynthesisVoiceRemote[],
-    voiceSelector: HTMLElement
-  ): boolean {
+    storedVoice: SpeechSynthesisVoiceRemote | null
+  ): void {
+    const voiceSelector = this.element;
     // Compute heuristics to decide what to show across this dataset
     try {
       const accents = new Set(
@@ -754,27 +753,12 @@ export class ClaudeVoiceMenu extends VoiceSelector {
       this.showAccent = this.showGender = false;
     }
 
-    // Get the currently selected voice before recreating the menu
-    let currentSelectedVoice: SpeechSynthesisVoiceRemote | null = null;
-
-    // Try to get from the current button if it exists
-    if (this.menuButton && this.menuButton.parentElement === voiceSelector) {
-      const voiceNameElement = this.menuButton.querySelector(".voice-name");
-      if (voiceNameElement) {
-        const currentVoiceName = voiceNameElement.textContent;
-        if (currentVoiceName && currentVoiceName !== getMessage("voiceOff")) {
-          // Find the voice object that matches the current selection
-          currentSelectedVoice = voices.find(voice => voice.name === currentVoiceName) || null;
-        }
-      }
-    }
-
     // The menu shows a constant-size shortlist however large the catalog
     // grows; the full catalog lives behind the "More voices…" door in the
     // extension settings (doc/plans/2026-07-02-voice-selection-ux.md §3).
     const curated = curateShortlist(
       voices,
-      currentSelectedVoice?.id ?? this.pinnedCustomVoiceId,
+      storedVoice?.id ?? null,
       CLAUDE_MENU_CAP
     );
     this.showTier = curated.tiersCoexist;
@@ -787,7 +771,7 @@ export class ClaudeVoiceMenu extends VoiceSelector {
 
     // Recreate the menu button and content from scratch
     this.menuButton = this.createVoiceButton(
-      currentSelectedVoice,
+      storedVoice,
       this.ttsRequiresSignIn(noVoicesAvailable)
     );
     voiceSelector.appendChild(this.menuButton);
@@ -829,42 +813,8 @@ export class ClaudeVoiceMenu extends VoiceSelector {
     // Add subtle separators for easier scanning
     this.applyItemSeparators();
 
-    // If we found a selected voice from the button, update the menu items to show selection
-    if (currentSelectedVoice) {
-      this.updateSelectedVoice(currentSelectedVoice);
-    } else {
-      // Fall back to getting the voice from preferences asynchronously
-      this.userPreferences.getVoice(this.chatbot).then((voice) => {
-        this.updateSelectedVoice(voice);
-        // The stored voice must never vanish from the menu: if the shortlist
-        // hid it, remember it as pinned. The pin persists on the instance so
-        // every later populate includes it synchronously.
-        const storedId =
-          voice && voices.some((v) => v.id === voice.id) ? voice.id : null;
-        if (!storedId) {
-          this.pinnedCustomVoiceId = null;
-          return;
-        }
-        if (curated.voices.some((v) => v.id === storedId)) {
-          // Visible without help; drop a pin left over from a previous voice.
-          if (
-            this.pinnedCustomVoiceId &&
-            this.pinnedCustomVoiceId !== storedId
-          ) {
-            this.pinnedCustomVoiceId = null;
-          }
-          return;
-        }
-        this.pinnedCustomVoiceId = storedId;
-        // Never rebuild a menu the user has open — the teardown would close
-        // it mid-interaction. The pin applies on the next populate instead.
-        if (this.menuButton.getAttribute("aria-expanded") !== "true") {
-          this.populateVoices(voices, voiceSelector);
-        }
-      });
-    }
-
-    return !noVoicesAvailable;
+    // Selection is a pure render of the stored voice we were handed.
+    this.updateSelectedVoice(storedVoice);
   }
 
   /**
@@ -908,21 +858,17 @@ export class ClaudeVoiceMenu extends VoiceSelector {
     });
   }
 
-  private initializeVoiceSelector(chatbot: Chatbot): void {
+  private initializeVoiceSelector(): void {
     // Prevent double initialization
     if (this.element.dataset.voiceSelectorInitialized === "true") {
       logger.debug("[status] Voice selector already initialized, skipping");
       return;
     }
 
-    const speechSynthesis = SpeechSynthesisModule.getInstance();
     logger.debug("[status] Initializing voice selector");
-    speechSynthesis.getVoices(chatbot).then((voices) => {
-      this.populateVoices(voices, this.element);
-
-      // Note: populateVoices() now handles restoring the selected voice,
-      // so we don't need to call updateSelectedVoice() here anymore
-
+    // Gather-then-render: the base fetches the catalog AND the stored voice,
+    // so the trigger label + checkmarks are correct on the first paint.
+    this.refreshMenu().then(() => {
       // Close menu when clicking outside - only add if not already added
       if (!this.element.dataset.clickListenerAdded) {
         document.addEventListener("click", (event) => {

--- a/src/chatbots/PiVoiceMenu.ts
+++ b/src/chatbots/PiVoiceMenu.ts
@@ -1,13 +1,12 @@
 import { Observation } from "../dom/Observation";
 import EventBus from "../events/EventBus";
 import { audioProviders } from "../tts/SpeechModel";
-import { SpeechSynthesisModule } from "../tts/SpeechSynthesisModule";
-import { VoiceSelector } from "../tts/VoiceMenu";
+import { GridVoiceSelector } from "../tts/GridVoiceSelector";
 import { PI_MENU_CAP } from "../tts/VoiceCuration";
 import { Chatbot } from "./Chatbot";
 import { UserPreferenceModule } from "../prefs/PreferenceModule";
 
-export class PiVoiceMenu extends VoiceSelector {
+export class PiVoiceMenu extends GridVoiceSelector {
   constructor(
     chatbot: Chatbot,
     userPreferences: UserPreferenceModule,
@@ -132,12 +131,17 @@ export class PiVoiceMenu extends VoiceSelector {
               node === audioControlsContainer.firstChild
             ) {
               voiceMenu.classList.add("expanded");
-              // mark the selected voice each time the menu is expanded (because pi.ai recreates the menu each time)
+              // Pi recreates its native menu on every expand: re-adopt the
+              // fresh host rows and re-render SayPi's block from state. When
+              // TTS is off we still adopt + top up Pi's extras (and the
+              // door), just with no SayPi catalog rows.
               this.userPreferences.getTextToSpeechEnabled().then((enabled) => {
-                if (enabled) this.addVoicesToSelector(voiceMenu);
+                if (enabled) {
+                  this.refreshMenu();
+                } else {
+                  this.renderMenu([], null);
+                }
               });
-              this.addMissingPiVoices(voiceMenu);
-              this.registerVoiceChangeHandler(voiceMenu);
             }
           }
           for (let node of mutation.removedNodes) {
@@ -160,7 +164,7 @@ export class PiVoiceMenu extends VoiceSelector {
   }
 }
 
-export class PiVoiceSettings extends VoiceSelector {
+export class PiVoiceSettings extends GridVoiceSelector {
   constructor(
     chatbot: Chatbot,
     userPreferences: UserPreferenceModule,
@@ -168,14 +172,10 @@ export class PiVoiceSettings extends VoiceSelector {
   ) {
     super(chatbot, userPreferences, element);
     this.addIdVoiceMenu(element);
-    SpeechSynthesisModule.getInstance()
-      .getVoices(chatbot)
-      .then((multilingualVoices) => {
-        this.populateVoices(multilingualVoices, element);
-        this.addMissingPiVoices(element);
-        this.handleExistingVoiceButtons(element);
-        this.registerVoiceChangeHandler(element);
-      });
+    // One gather-then-render covers what four calls did before: catalog rows,
+    // Pi's extra-voice top-up, adoption of Pi's pre-existing native buttons,
+    // and selection marking.
+    this.refreshMenu();
   }
 
   getId(): string {
@@ -203,14 +203,4 @@ export class PiVoiceSettings extends VoiceSelector {
       "border-neutral-500",
     ];
   }
-
-  handleExistingVoiceButtons(voiceMenu: HTMLElement): void {
-    const voiceButtons = Array.from(voiceMenu.querySelectorAll("button"));
-    if (!voiceButtons || voiceButtons.length === 0) {
-      return;
-    }
-    voiceButtons.forEach((button) => {
-      this.handleButtonAddition(button as HTMLButtonElement);
-    });
-  }
-} 
+}

--- a/src/tts/GridVoiceSelector.ts
+++ b/src/tts/GridVoiceSelector.ts
@@ -1,0 +1,425 @@
+import { getResourceUrl } from "../ResourceModule";
+import getMessage from "../i18n";
+import { openSettings } from "../popup/popupopener";
+import { SpeechSynthesisVoiceRemote } from "./SpeechModel";
+import { curateShortlist, getVoiceTier } from "./VoiceCuration";
+import { VoiceSelector, isBuiltInVoiceProvider } from "./VoiceMenu";
+import {
+  classifyControl,
+  markAdopted,
+  HOST_VOICE_ATTR,
+} from "./VoiceMenuControls";
+
+/** Pi ships 8 native voices; below this we top up with account-gated extras. */
+const HOST_NATIVE_VOICE_COUNT = 8;
+
+/**
+ * Button-grid voice surfaces (Pi's in-chat menu and Pi's settings grid): the
+ * host owns the container (and re-creates it at will — Pi rebuilds its menu on
+ * every expand), SayPi owns its rows within it. renderMenu is a
+ * RECONCILIATION against that host-owned container, not a wipe-and-rebuild:
+ * SayPi rows are inserted/moved/removed by id, host rows are adopted (marked +
+ * wired) exactly once, and unknown elements are never touched (#485).
+ *
+ * A row is currently rendered as a single <button> (the row root IS the
+ * select target). When a row grows a trailing affordance (#483's ▶), ONLY
+ * createVoiceRow/createRestoredRow and selectTargetOf change — every other
+ * consumer addresses rows via [data-voice-id] roots and the taxonomy.
+ */
+export abstract class GridVoiceSelector extends VoiceSelector {
+  /**
+   * Max SayPi (custom) voice rows this surface shows before tucking the rest
+   * behind the "More voices" door. null = uncapped (Pi's settings grid);
+   * in-host menus override (doc/plans/2026-07-02-voice-selection-ux.md §3).
+   */
+  protected getCustomVoiceCap(): number | null {
+    return null;
+  }
+
+  /**
+   * Whether this surface renders the "More voices" door. Capped surfaces
+   * always do (it is the navigation path to the catalog, not an overflow
+   * marker — #472); uncapped surfaces opt in (PiVoiceSettings).
+   */
+  protected showsMoreVoicesDoor(): boolean {
+    return this.getCustomVoiceCap() !== null;
+  }
+
+  protected renderMenu(
+    voices: SpeechSynthesisVoiceRemote[],
+    storedVoice: SpeechSynthesisVoiceRemote | null
+  ): void {
+    const container = this.element;
+    const defaults = voices.filter((voice) => voice.default);
+    const customs = voices.filter((voice) => !voice.default);
+
+    // 1. Adopt host-native rows (positive mark + unset handler, exactly once).
+    this.adoptHostRows(container);
+
+    // 2. SayPi catalog rows. The stored voice id goes straight into
+    //    curateShortlist, whose first rule is current-voice-first — the
+    //    "stored voice never vanishes" invariant, synchronously.
+    const cap = this.getCustomVoiceCap();
+    const curated =
+      cap === null
+        ? { voices: customs, hiddenCount: 0, tiersCoexist: false }
+        : curateShortlist(customs, storedVoice?.id ?? null, cap);
+    this.reconcileCustomRows(
+      container,
+      curated.voices,
+      new Set(customs.map((voice) => voice.id)),
+      curated.tiersCoexist
+    );
+
+    // 3. Default-flagged catalog voices render as restored rows at the end.
+    this.renderRestoredRows(container, defaults);
+
+    // 4. Pi's account-gated extras: top up when the host shows fewer native
+    //    rows than its full set. Their ids are not in the SayPi catalog id
+    //    set, so reconciliation never removes them (Pi 7/8 must survive
+    //    every re-render — the Patch A regression).
+    if (
+      isBuiltInVoiceProvider(this.chatbot) &&
+      this.countHostRows(container) < HOST_NATIVE_VOICE_COUNT
+    ) {
+      this.ensureExtraRows(
+        container,
+        this.chatbot.getExtraVoices(),
+        curated.tiersCoexist
+      );
+    }
+
+    // 5. The door.
+    if (this.showsMoreVoicesDoor()) {
+      this.ensureDoor(container);
+    }
+
+    // 6. Selection is a pure render of the stored preference.
+    this.renderSelection(storedVoice);
+  }
+
+  /**
+   * External voice change (settings page, another surface): re-mark rows from
+   * the new value. If the voice's row is not visible (shortlist-hidden), no
+   * row is marked — a deliberate improvement over the old stale highlight —
+   * and the next renderMenu shows it via curateShortlist's current-first rule.
+   */
+  protected applySelectedVoice(
+    voice: SpeechSynthesisVoiceRemote | null
+  ): void {
+    this.renderSelection(voice);
+  }
+
+  // ---- rows ---------------------------------------------------------------
+
+  private rowFor(container: HTMLElement, voiceId: string): HTMLElement | null {
+    return container.querySelector<HTMLElement>(`[data-voice-id="${voiceId}"]`);
+  }
+
+  private allRows(): HTMLElement[] {
+    return Array.from(
+      this.element.querySelectorAll<HTMLElement>(
+        `.saypi-custom-voice, .saypi-restored-voice, [${HOST_VOICE_ATTR}]`
+      )
+    );
+  }
+
+  /**
+   * The one seam that knows a row root is (today) the select button itself.
+   * A wrapper-row future changes this to a query for the row's select button.
+   */
+  private selectTargetOf(row: HTMLElement): HTMLButtonElement {
+    return row as HTMLButtonElement;
+  }
+
+  /** SayPi catalog voice row: button > name span [+ tier badge] + flair. */
+  protected createVoiceRow(
+    voice: SpeechSynthesisVoiceRemote,
+    showTier: boolean
+  ): HTMLElement {
+    const row = document.createElement("button");
+    row.type = "button";
+    row.classList.add(
+      ...this.getButtonClasses(),
+      "saypi-voice-button",
+      "saypi-custom-voice",
+      voice.name.toLowerCase().replace(" ", "-")
+    );
+    const name = document.createElement("span");
+    name.classList.add("voice-name");
+    name.innerText = voice.name;
+    row.appendChild(name);
+    this.syncTierBadge(row, voice, showTier);
+    const flair = document.createElement("img");
+    flair.classList.add("flair");
+    flair.src = getResourceUrl("icons/logos/saypi.png");
+    flair.alt = "Say, Pi logo";
+    flair.title = getMessage("enhancedVoice", ["Say, Pi"]);
+    row.appendChild(flair);
+    row.dataset.voiceId = voice.id;
+    row.addEventListener("click", () => {
+      this.userPreferences.setVoice(voice, this.chatbot).then(() => {
+        console.log(`Selected voice: ${voice.name}`);
+        this.renderSelection(voice);
+        this.introduceVoice(voice);
+      });
+    });
+    return row;
+  }
+
+  /** Default-flagged catalog voice re-added by SayPi (plain label, no flair). */
+  protected createRestoredRow(voice: SpeechSynthesisVoiceRemote): HTMLElement {
+    const row = document.createElement("button");
+    row.type = "button";
+    row.classList.add(
+      ...this.getButtonClasses(),
+      "saypi-voice-button",
+      "saypi-restored-voice",
+      voice.name.toLowerCase().replace(" ", "-")
+    );
+    row.innerText = voice.name;
+    row.dataset.voiceId = voice.id;
+    row.addEventListener("click", () => {
+      this.userPreferences.setVoice(voice, this.chatbot).then(() => {
+        console.log(`Selected voice: ${voice.name}`);
+        this.renderSelection(voice);
+        this.introduceVoice(voice);
+      });
+    });
+    return row;
+  }
+
+  /** Quiet HD suffix, added or removed so re-renders converge (idempotence). */
+  private syncTierBadge(
+    row: HTMLElement,
+    voice: SpeechSynthesisVoiceRemote,
+    showTier: boolean
+  ): void {
+    const existing = row.querySelector(".voice-tier");
+    const wanted = showTier && getVoiceTier(voice) === "hd";
+    if (wanted && !existing) {
+      const tier = document.createElement("span");
+      tier.classList.add("voice-tier");
+      tier.textContent = "HD";
+      tier.title = getMessage("hdVoicesAllowanceNote");
+      const name = row.querySelector(".voice-name");
+      if (name) {
+        name.insertAdjacentElement("afterend", tier);
+      } else {
+        row.appendChild(tier);
+      }
+    } else if (!wanted && existing) {
+      existing.remove();
+    }
+  }
+
+  // ---- reconciliation -------------------------------------------------------
+
+  /**
+   * Make the SayPi catalog block match the plan: remove catalog rows that
+   * fell out of it (scoped to this catalog's ids so extras and other
+   * sources' rows survive), then walk the plan bottom-up inserting each row
+   * at the top — existing rows are MOVED, not recreated, so DOM identity and
+   * listeners survive; the result is plan order at the top of the container.
+   */
+  private reconcileCustomRows(
+    container: HTMLElement,
+    plan: SpeechSynthesisVoiceRemote[],
+    catalogIds: Set<string>,
+    showTier: boolean
+  ): void {
+    const planIds = new Set(plan.map((voice) => voice.id));
+    Array.from(
+      container.querySelectorAll<HTMLElement>(".saypi-custom-voice")
+    ).forEach((row) => {
+      const id = row.dataset.voiceId;
+      if (id && catalogIds.has(id) && !planIds.has(id)) {
+        row.remove();
+      }
+    });
+    for (let i = plan.length - 1; i >= 0; i--) {
+      const voice = plan[i];
+      let row = this.rowFor(container, voice.id);
+      if (row) {
+        this.syncTierBadge(row, voice, showTier);
+      } else {
+        row = this.createVoiceRow(voice, showTier);
+      }
+      container.insertBefore(row, container.firstChild);
+    }
+  }
+
+  private renderRestoredRows(
+    container: HTMLElement,
+    defaults: SpeechSynthesisVoiceRemote[]
+  ): void {
+    defaults.forEach((voice) => {
+      const existing = this.rowFor(container, voice.id);
+      if (existing) {
+        container.appendChild(existing); // keep the block at the end (move-to-end)
+        return;
+      }
+      container.appendChild(this.createRestoredRow(voice));
+    });
+  }
+
+  /**
+   * Account-gated extras render exactly like catalog rows (today's shipped
+   * appearance: custom class + flair, inserted at the top) but are ensured
+   * present rather than reconciled — the cap never applies to them.
+   */
+  private ensureExtraRows(
+    container: HTMLElement,
+    extras: SpeechSynthesisVoiceRemote[],
+    showTier: boolean
+  ): void {
+    extras
+      .slice()
+      .reverse()
+      .forEach((voice) => {
+        if (!this.rowFor(container, voice.id)) {
+          container.insertBefore(
+            this.createVoiceRow(voice, showTier),
+            container.firstChild
+          );
+        }
+      });
+  }
+
+  /** Exactly one door, parked after the last SayPi row. Idempotent. */
+  private ensureDoor(container: HTMLElement): void {
+    let door = container.querySelector<HTMLButtonElement>(
+      "button.saypi-more-voices"
+    );
+    if (!door) {
+      door = document.createElement("button");
+      door.type = "button";
+      // saypi-voice-button keeps it under the menu's expand/collapse
+      // visibility rules (voices.scss); saypi-more-voices classifies it as
+      // the door (never a voice row).
+      door.classList.add(
+        ...this.getButtonClasses(),
+        "saypi-voice-button",
+        "saypi-more-voices"
+      );
+      door.textContent = getMessage("moreVoices");
+      door.addEventListener("click", () => {
+        openSettings("voices");
+      });
+    }
+    const customRows = container.querySelectorAll(".saypi-custom-voice");
+    const lastCustom = customRows[customRows.length - 1];
+    if (lastCustom) {
+      lastCustom.insertAdjacentElement("afterend", door);
+    } else {
+      container.appendChild(door);
+    }
+  }
+
+  // ---- selection ------------------------------------------------------------
+
+  /**
+   * Pure render of "which voice is selected" across every known row kind.
+   * null (voice off / host default): SayPi rows are cleared; host rows keep
+   * whatever state the host renders natively.
+   */
+  protected renderSelection(voice: SpeechSynthesisVoiceRemote | null): void {
+    const rows = this.allRows();
+    if (!voice) {
+      rows
+        .filter((row) => classifyControl(row) !== "host-voice")
+        .forEach((row) => this.unmarkRowSelected(row));
+      return;
+    }
+    rows.forEach((row) => this.unmarkRowSelected(row));
+    const target = this.rowFor(this.element, voice.id);
+    if (target) {
+      this.markRowSelected(target);
+    }
+  }
+
+  protected markRowSelected(row: HTMLElement): void {
+    const button = this.selectTargetOf(row);
+    button.disabled = true;
+    button.classList.add("selected", "bg-neutral-300", "text-primary-700");
+    button.classList.remove("hover:bg-neutral-300");
+  }
+
+  protected unmarkRowSelected(row: HTMLElement): void {
+    const button = this.selectTargetOf(row);
+    button.disabled = false;
+    button.classList.remove("selected", "bg-neutral-300", "text-primary-700");
+    button.classList.add("hover:bg-neutral-300", "border-neutral-500");
+    button.setAttribute("style", ""); // strip inline styles from host/builtin buttons on the settings page
+  }
+
+  // ---- host adoption ----------------------------------------------------------
+
+  /**
+   * THE single site that may act on unmarked elements: a direct-child
+   * <button> classifying as "unknown" is a host-native voice row — stamp it
+   * (positively classified from here on) and wire unset-voice. The stamp
+   * doubles as the wired-once guard, so repeated renders (Pi re-expands)
+   * never double-bind.
+   */
+  private adoptHostRows(container: HTMLElement): void {
+    Array.from(container.children).forEach((child) => {
+      if (
+        child instanceof HTMLButtonElement &&
+        classifyControl(child) === "unknown"
+      ) {
+        this.adoptHostRow(child);
+      }
+    });
+  }
+
+  private adoptHostRow(button: HTMLButtonElement): void {
+    markAdopted(button);
+    button.addEventListener("click", () => {
+      this.userPreferences.unsetVoice(this.chatbot).then(() => {
+        this.allRows().forEach((row) => this.unmarkRowSelected(row));
+        this.markRowSelected(button);
+      });
+    });
+  }
+
+  private countHostRows(container: HTMLElement): number {
+    return container.querySelectorAll(`[${HOST_VOICE_ATTR}]`).length;
+  }
+
+  // ---- late host mutations ------------------------------------------------------
+
+  /**
+   * Pi inserts its native voice buttons asynchronously; adopt them as they
+   * arrive and re-render selection so a host row never shows selected while
+   * a SayPi voice is stored. Additions of SayPi's own rows re-run the same
+   * idempotent selection render (harmless).
+   */
+  addVoiceButtonAdditionListener(voiceMenu: HTMLElement): void {
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type !== "childList") continue;
+        for (const node of mutation.addedNodes) {
+          if (node instanceof HTMLButtonElement) {
+            this.handleRowAddition(node);
+          }
+        }
+      }
+    });
+    observer.observe(voiceMenu, { childList: true });
+  }
+
+  protected handleRowAddition(button: HTMLButtonElement): void {
+    if (
+      button.parentElement === this.element &&
+      classifyControl(button) === "unknown"
+    ) {
+      this.adoptHostRow(button);
+    }
+    this.userPreferences.getVoice(this.chatbot).then((voice) => {
+      if (voice) {
+        this.renderSelection(voice);
+      }
+    });
+  }
+}

--- a/src/tts/VoiceMenu.ts
+++ b/src/tts/VoiceMenu.ts
@@ -1,6 +1,8 @@
-// Pi-specific voice menu classes have been moved to src/chatbots/PiVoiceMenu.ts
-// This file now contains only the generic/abstract base for voice controls.
-import { getResourceUrl } from "../ResourceModule";
+// The generic/abstract base for voice selectors. Rendering machinery lives in
+// the surface-specific layers: GridVoiceSelector (Pi's button grids) and
+// ClaudeVoiceMenu (dropdown). This base owns only the cross-surface concerns:
+// event wiring (auth, external preference changes), the gather-then-render
+// refresh cycle, and voice introduction playback.
 import { Chatbot } from "../chatbots/Chatbot";
 import { getMostRecentAssistantMessage } from "../dom/ChatHistory";
 import EventBus from "../events/EventBus";
@@ -9,8 +11,6 @@ import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { SpeechSynthesisVoiceRemote } from "./SpeechModel";
 import { SpeechSynthesisModule } from "./SpeechSynthesisModule";
 import { getJwtManagerSync } from "../JwtManager";
-import { openSettings } from "../popup/popupopener";
-import { curateShortlist, getVoiceTier } from "./VoiceCuration";
 
 /**
  * A chatbot that ships its own set of built-in voices, with introduction audio
@@ -39,9 +39,9 @@ export abstract class VoiceSelector {
   protected chatbot: Chatbot;
   protected userPreferences: UserPreferenceModule;
   protected element: HTMLElement;
-  protected selectedVoiceButton: HTMLButtonElement | null = null;
-  /** Set when the stored voice would otherwise be hidden by the shortlist cap. */
-  protected pinnedCustomVoiceId: string | null = null;
+  // No selection or pin fields: "which voice is selected" is the stored
+  // preference, fetched at render time. The DOM is a render of that state,
+  // never the place it is recovered from.
 
   constructor(
     chatbot: Chatbot,
@@ -59,17 +59,56 @@ export abstract class VoiceSelector {
   abstract getButtonClasses(): string[];
 
   /**
+   * THE single render path: given the fetched catalog + the stored voice,
+   * make this selector's DOM reflect them. Must be idempotent — callable
+   * repeatedly with the same inputs and converging on the same DOM.
+   * Implementations: GridVoiceSelector (Pi's button grids), ClaudeVoiceMenu
+   * (dropdown).
+   */
+  protected abstract renderMenu(
+    voices: SpeechSynthesisVoiceRemote[],
+    storedVoice: SpeechSynthesisVoiceRemote | null
+  ): void;
+
+  /**
+   * Reflect an externally-changed stored voice on this surface without a
+   * repopulate (and therefore without disturbing an open menu).
+   */
+  protected abstract applySelectedVoice(
+    voice: SpeechSynthesisVoiceRemote | null
+  ): void;
+
+  /**
+   * Gather-then-render: fetch the catalog and the stored voice TOGETHER, then
+   * render once. Handing the stored voice to the render is what lets
+   * curateShortlist pin the current voice synchronously — the old
+   * render-then-detect-then-re-render pin recursion (and the pin field) died
+   * with this. Also gone: the old teardown half, which fed a descendant
+   * `querySelectorAll("button")` to direct-child-only `removeChild` — the
+   * #485 crash. Renders reconcile; nothing bulk-removes buttons.
+   */
+  async refreshMenu(): Promise<void> {
+    const speechSynthesis = SpeechSynthesisModule.getInstance();
+    const [voices, storedVoice] = await Promise.all([
+      speechSynthesis.getVoices(this.chatbot),
+      this.userPreferences.getVoice(this.chatbot),
+    ]);
+    this.renderMenu(voices ?? [], storedVoice ?? null);
+  }
+
+  /**
    * Registers an event listener to handle authentication status changes.
    * This allows the voice menu to update dynamically when a user signs in.
    */
   protected registerAuthenticationChangeHandler(): void {
-    EventBus.on('saypi:auth:status-changed', (isAuthenticated: boolean) => {
+    EventBus.on("saypi:auth:status-changed", (isAuthenticated: boolean) => {
       // Authentication status changed, refresh the voice selector
-      console.log(`User has logged ${isAuthenticated ? "in" : "out"}, refreshing voice selector`);
-      const id = this.getId();
-      const voiceSelector = document.getElementById(id);
+      console.log(
+        `User has logged ${isAuthenticated ? "in" : "out"}, refreshing voice selector`
+      );
+      const voiceSelector = document.getElementById(this.getId());
       if (voiceSelector) {
-        this.addVoicesToSelector(voiceSelector as HTMLElement);
+        this.refreshMenu();
       }
     });
   }
@@ -108,33 +147,6 @@ export abstract class VoiceSelector {
   }
 
   /**
-   * Reflect an externally-changed stored voice on this surface without a
-   * repopulate (and therefore without disturbing an open menu). The base
-   * covers button-grid surfaces (Pi's menus); dropdown-style selectors
-   * override (ClaudeVoiceMenu).
-   */
-  protected applySelectedVoice(voice: SpeechSynthesisVoiceRemote | null): void {
-    if (!voice) {
-      this.element
-        .querySelectorAll<HTMLButtonElement>("button.saypi-custom-voice")
-        .forEach((button) => this.unmarkButtonAsSelectedVoice(button));
-      return;
-    }
-    const target = this.element.querySelector<HTMLButtonElement>(
-      `button[data-voice-id="${voice.id}"]`
-    );
-    if (!target) {
-      // Hidden by the shortlist cap: pin it so the next populate shows it.
-      this.pinnedCustomVoiceId = voice.id;
-      return;
-    }
-    this.element.querySelectorAll("button").forEach((button) => {
-      this.unmarkButtonAsSelectedVoice(button as HTMLButtonElement);
-    });
-    this.markButtonAsSelectedVoice(target);
-  }
-
-  /**
    * Text-to-speech via Say, Pi requires authentication. When the user is signed
    * out AND there are no voices to offer (the /voices request returns [] on a
    * 401), the selector should present as unavailable / sign-in-required.
@@ -145,355 +157,8 @@ export abstract class VoiceSelector {
     return noVoicesAvailable && !getJwtManagerSync().isAuthenticated();
   }
 
-  // Voice selection management
-  registerVoiceChangeHandler(menu: HTMLElement): boolean {
-    const voiceButtons = Array.from(menu.querySelectorAll("button"));
-    if (!voiceButtons || voiceButtons.length === 0) {
-      return false;
-    }
-    const builtInPiVoiceButtons = voiceButtons.filter((button) =>
-      this.isBuiltInVoiceButton(button)
-    );
-    builtInPiVoiceButtons.forEach((button) => {
-      button.addEventListener("click", () => {
-        this.userPreferences.unsetVoice(this.chatbot).then(() => {
-          if (this.selectedVoiceButton) {
-            this.unmarkButtonAsSelectedVoice(this.selectedVoiceButton);
-          }
-          this.markButtonAsSelectedVoice(button);
-        });
-      });
-    });
-    return true;
-  }
   protected addIdVoiceMenu(element: HTMLElement): void {
     element.id = this.getId();
-  }
-  protected markButtonAsSelectedVoice(button: HTMLButtonElement): void {
-    button.disabled = true;
-    button.classList.add("selected", "bg-neutral-300", "text-primary-700");
-    button.classList.remove("hover:bg-neutral-300");
-
-    if (this.selectedVoiceButton) {
-      this.unmarkButtonAsSelectedVoice(this.selectedVoiceButton);
-    }
-    this.selectedVoiceButton = button;
-  }
-
-  protected unmarkButtonAsSelectedVoice(button: HTMLButtonElement): void {
-    button.disabled = false;
-    button.classList.remove("selected", "bg-neutral-300", "text-primary-700");
-    button.classList.add("hover:bg-neutral-300", "border-neutral-500");
-    button.setAttribute("style", ""); // remove inline styles from builtin voice buttons on voice settings page
-  }
-
-  protected isBuiltInVoiceButton(button: HTMLButtonElement): boolean {
-    // Every SayPi-injected row carries the positive marker; anything without
-    // it is a host-native (built-in) button. Safer than enumerating SayPi
-    // row types — new rows are excluded by construction.
-    return !button.classList.contains("saypi-voice-button");
-  }
-
-  /**
-   * Max SayPi (custom) voice rows this surface shows before tucking the rest
-   * behind a "More voices" door. null = uncapped (the default — e.g. Pi's own
-   * settings-page grid); in-host menus override
-   * (doc/plans/2026-07-02-voice-selection-ux.md §3).
-   */
-  protected getCustomVoiceCap(): number | null {
-    return null;
-  }
-
-  /**
-   * Whether this surface renders the "More voices" door to the settings
-   * catalog. The door is the navigation path to the full catalog, not an
-   * overflow marker, so capped surfaces always show it; uncapped surfaces
-   * opt in (Pi's settings grid does — #472).
-   */
-  protected showsMoreVoicesDoor(): boolean {
-    return this.getCustomVoiceCap() !== null;
-  }
-
-  async refreshMenu(): Promise<void> {
-    // Remove the voice buttons from the selector. Scope to DIRECT children:
-    // `removeChild` only removes direct children, so the query that feeds it must
-    // match only those. A bare `querySelectorAll("button")` also matches buttons
-    // nested inside menu items (e.g. the ▶ `.saypi-voice-preview` control added in
-    // #482), and `removeChild` throws `NotFoundError` on a non-child — which aborts
-    // the rebuild and makes the whole menu vanish on open. (Pre-#482 every match was
-    // a direct child, so this was latent.) Nested buttons are cleared by the item
-    // rebuild in `populateVoices`, not here.
-    const voiceButtons = Array.from(this.element.children).filter(
-      (el): el is HTMLButtonElement => el.tagName === "BUTTON"
-    );
-    voiceButtons.forEach((button) => {
-      this.unmarkButtonAsSelectedVoice(button);
-      this.element.removeChild(button);
-    });
-    // add voices to the selector
-    await this.addVoicesToSelector(this.element);
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-
-  addVoicesToSelector(voiceSelector: HTMLElement): void {
-    const speechSynthesis = SpeechSynthesisModule.getInstance();
-    speechSynthesis.getVoices(this.chatbot).then((voices) => {
-      this.populateVoices(voices, voiceSelector);
-    });
-  }
-
-  populateVoices(
-    voices: SpeechSynthesisVoiceRemote[],
-    voiceSelector: HTMLElement
-  ): boolean {
-    if (!voices || voices.length === 0) {
-      console.log("No voices found");
-      return false;
-    }
-
-    // filter voices into default and custom voices based on the voice.default property
-    const defaultVoices = voices.filter((voice) => voice.default);
-    const customVoices = voices.filter((voice) => !voice.default);
-
-    this.populateDefaultVoices(defaultVoices, voiceSelector);
-
-    const cap = this.getCustomVoiceCap();
-    if (cap === null) {
-      this.populateCustomVoices(customVoices, voiceSelector);
-      if (this.showsMoreVoicesDoor()) {
-        this.addMoreVoicesDoor(voiceSelector);
-      }
-      return true;
-    }
-
-    // Capped surface: show a curated shortlist of SayPi voices (built-in host
-    // voices above are never capped), with a door to the full catalog.
-    const curated = curateShortlist(
-      customVoices,
-      this.pinnedCustomVoiceId,
-      cap
-    );
-    this.populateCustomVoices(
-      curated.voices,
-      voiceSelector,
-      curated.tiersCoexist
-    );
-    if (this.showsMoreVoicesDoor()) {
-      this.addMoreVoicesDoor(voiceSelector);
-    }
-
-    // The stored voice must never vanish from the menu: if the cap hid it,
-    // pin it and re-render the SayPi block once. Runs only when this call
-    // could actually hide something — partial lists (addMissingPiVoices
-    // passes Pi's built-in top-ups alone) must not disturb the pin state.
-    if (customVoices.length > cap) {
-      this.userPreferences.getVoice(this.chatbot).then((voice) => {
-        const storedCustomId =
-          voice && customVoices.some((v) => v.id === voice.id)
-            ? voice.id
-            : null;
-        if (!storedCustomId) {
-          this.pinnedCustomVoiceId = null;
-          return;
-        }
-        if (curated.voices.some((v) => v.id === storedCustomId)) {
-          // Visible without help; drop a pin left over from a previous voice.
-          if (
-            this.pinnedCustomVoiceId &&
-            this.pinnedCustomVoiceId !== storedCustomId
-          ) {
-            this.pinnedCustomVoiceId = null;
-          }
-          return;
-        }
-        if (this.pinnedCustomVoiceId !== storedCustomId) {
-          this.pinnedCustomVoiceId = storedCustomId;
-          this.removeCustomVoiceRows(
-            voiceSelector,
-            new Set(customVoices.map((v) => v.id))
-          );
-          this.populateVoices(voices, voiceSelector);
-        }
-      });
-    }
-
-    return true;
-  }
-
-  /**
-   * Remove this catalog's SayPi voice rows (and the door) ahead of a
-   * re-render. Scoped to the given ids so rows from other sources — Pi's
-   * extra built-ins arrive via a separate populate call — survive.
-   */
-  private removeCustomVoiceRows(
-    voiceSelector: HTMLElement,
-    catalogIds: Set<string>
-  ): void {
-    voiceSelector
-      .querySelectorAll<HTMLButtonElement>("button.saypi-custom-voice")
-      .forEach((button) => {
-        const id = button.dataset.voiceId;
-        if (id && catalogIds.has(id)) {
-          button.remove();
-        }
-      });
-    voiceSelector
-      .querySelectorAll("button.saypi-more-voices")
-      .forEach((button) => button.remove());
-  }
-
-  /**
-   * The muted final row of the SayPi block, linking to the full voice catalog
-   * in the extension settings. Styled like the host's own rows. Idempotent:
-   * an existing door is moved back into place rather than duplicated.
-   */
-  private addMoreVoicesDoor(voiceSelector: HTMLElement): void {
-    let door = voiceSelector.querySelector<HTMLButtonElement>(
-      "button.saypi-more-voices"
-    );
-    if (!door) {
-      door = document.createElement("button");
-      door.type = "button";
-      // saypi-voice-button keeps it under the menu's expand/collapse visibility
-      // rules (voices.scss); saypi-more-voices exempts it from voice-selection
-      // handling (isBuiltInVoiceButton).
-      door.classList.add(
-        ...this.getButtonClasses(),
-        "saypi-voice-button",
-        "saypi-more-voices"
-      );
-      door.textContent = getMessage("moreVoices");
-      door.addEventListener("click", () => {
-        openSettings("voices");
-      });
-    }
-    const customButtons = voiceSelector.querySelectorAll(
-      "button.saypi-custom-voice"
-    );
-    const lastCustom = customButtons[customButtons.length - 1];
-    if (lastCustom) {
-      lastCustom.insertAdjacentElement("afterend", door);
-    } else {
-      voiceSelector.appendChild(door);
-    }
-  }
-
-  populateDefaultVoices(
-    defaultVoices: SpeechSynthesisVoiceRemote[],
-    voiceSelector: HTMLElement
-  ): void {
-    const defaultVoiceButtons = Array(defaultVoices.length);
-
-    defaultVoices.forEach((voice) => {
-      // if not already in the menu, add the voice
-      if (voiceSelector.querySelector(`button[data-voice-id="${voice.id}"]`)) {
-        // voice already in menu, move voice to end of menu and skip to next voice
-        const button = voiceSelector.querySelector(
-          `button[data-voice-id="${voice.id}"]`
-        );
-        voiceSelector.appendChild(button as HTMLElement);
-
-        return;
-      }
-      const button = document.createElement("button");
-      // template: <button type="button" class="mb-1 rounded px-2 py-3 text-center hover:bg-neutral-300">Pi 6</button>
-      button.type = "button";
-      const additionalClasses = ["saypi-voice-button", "saypi-restored-voice"];
-      const combinedClasses = [
-        ...this.getButtonClasses(),
-        ...additionalClasses,
-        voice.name.toLowerCase().replace(" ", "-"),
-      ];
-      button.classList.add(...combinedClasses);
-      button.innerText = voice.name;
-      button.addEventListener("click", () => {
-        this.userPreferences.setVoice(voice, this.chatbot).then(() => {
-          console.log(`Selected voice: ${voice.name}`);
-          defaultVoiceButtons.forEach((button) => {
-            this.unmarkButtonAsSelectedVoice(button);
-          });
-          const voiceButtons = voiceSelector.querySelectorAll("button");
-          voiceButtons.forEach((button) => {
-            this.unmarkButtonAsSelectedVoice(button as HTMLButtonElement);
-          });
-          this.markButtonAsSelectedVoice(button);
-          this.introduceVoice(voice);
-        });
-      });
-      button.dataset.voiceId = voice.id;
-      defaultVoiceButtons.push(button);
-    });
-
-    defaultVoiceButtons.forEach((button) => {
-      voiceSelector.appendChild(button);
-    });
-  }
-
-  populateCustomVoices(
-    customVoices: SpeechSynthesisVoiceRemote[],
-    voiceSelector: HTMLElement,
-    showTier: boolean = false
-  ): void {
-    const customVoiceButtons = Array(customVoices.length);
-
-    customVoices.forEach((voice) => {
-      // if not already in the menu, add the voice
-      if (voiceSelector.querySelector(`button[data-voice-id="${voice.id}"]`)) {
-        // voice already in menu, skip to next voice
-        return;
-      }
-      const button = document.createElement("button");
-      // template: <button type="button" class="mb-1 rounded px-2 py-3 text-center hover:bg-neutral-300">Pi 6</button>
-      button.type = "button";
-      const additionalClasses = ["saypi-voice-button", "saypi-custom-voice"];
-      const combinedClasses = [
-        ...this.getButtonClasses(),
-        ...additionalClasses,
-        voice.name.toLowerCase().replace(" ", "-"),
-      ];
-      button.classList.add(...combinedClasses);
-      const name = document.createElement("span");
-      name.classList.add("voice-name");
-      name.innerText = voice.name;
-      button.appendChild(name);
-      // Quiet tier suffix on premium rows, only while tiers coexist
-      // (doc/plans/2026-07-02-voice-selection-ux.md §3 — no chips, no prices on Pi).
-      if (showTier && getVoiceTier(voice) === "hd") {
-        const tier = document.createElement("span");
-        tier.classList.add("voice-tier");
-        tier.textContent = "HD";
-        tier.title = getMessage("hdVoicesAllowanceNote");
-        button.appendChild(tier);
-      }
-      const flair = document.createElement("img");
-      flair.classList.add("flair");
-      flair.src = getResourceUrl("icons/logos/saypi.png");
-      flair.alt = "Say, Pi logo";
-      flair.title = getMessage("enhancedVoice", ["Say, Pi"]);
-      button.appendChild(flair);
-      button.addEventListener("click", () => {
-        this.userPreferences.setVoice(voice, this.chatbot).then(() => {
-          console.log(`Selected voice: ${voice.name}`);
-          customVoiceButtons.forEach((button) => {
-            this.unmarkButtonAsSelectedVoice(button);
-          });
-          const voiceButtons = voiceSelector.querySelectorAll("button");
-          voiceButtons.forEach((button) => {
-            if (this.isBuiltInVoiceButton(button as HTMLButtonElement)) {
-              this.unmarkButtonAsSelectedVoice(button as HTMLButtonElement);
-            }
-          });
-          this.markButtonAsSelectedVoice(button);
-          this.introduceVoice(voice);
-        });
-      });
-      button.dataset.voiceId = voice.id;
-      customVoiceButtons.push(button);
-    });
-
-    customVoiceButtons.reverse().forEach((button) => {
-      voiceSelector.insertBefore(button, voiceSelector.firstChild);
-    });
   }
 
   introduceVoice(voice: SpeechSynthesisVoiceRemote): void {
@@ -555,71 +220,6 @@ export abstract class VoiceSelector {
         // so this audition never talks over live TTS / an active call.
         speechSynthesis.speak(utterance, this.chatbot, true);
       });
-  }
-
-  // Listen for additions of custom voice buttons and update selections
-  addVoiceButtonAdditionListener(voiceMenu: HTMLElement): void {
-    const observerCallback = (
-      mutationsList: MutationRecord[],
-      observer: MutationObserver
-    ) => {
-      for (let mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          for (let node of mutation.addedNodes) {
-            if (
-              node.nodeName === "BUTTON" &&
-              node instanceof HTMLButtonElement
-            ) {
-              const button = node as HTMLButtonElement;
-              this.handleButtonAddition(button);
-            }
-          }
-        }
-      }
-    };
-    const observer = new MutationObserver(observerCallback);
-    observer.observe(voiceMenu, { childList: true });
-  }
-
-  handleButtonAddition(button: HTMLButtonElement): void {
-    // a voice button was added to the menu that is not a custom voice button
-    // if a voice is selected, mark the button as selected
-    this.userPreferences.getVoice(this.chatbot).then((voice) => {
-      const customVoiceIsSelected = voice !== null;
-      if (customVoiceIsSelected) {
-        if (this.isBuiltInVoiceButton(button)) {
-          this.unmarkButtonAsSelectedVoice(button);
-        } else if (button.dataset.voiceId === voice.id) {
-          // unmark all other buttons and mark this one as selected
-          const voiceButtons = Array.from(
-            this.element.querySelectorAll("button")
-          );
-          voiceButtons.forEach((btn) => {
-            this.unmarkButtonAsSelectedVoice(btn as HTMLButtonElement);
-          });
-          this.markButtonAsSelectedVoice(button);
-        }
-      }
-    });
-  }
-
-  addMissingPiVoices(voiceSelector: HTMLElement) {
-    // only for chatbots that ship their own built-in voices (Pi.ai)
-    if (!isBuiltInVoiceProvider(this.chatbot)) {
-      return;
-    }
-    // count the number of original Pi voices in the menu
-    let piVoices = 0;
-    const voiceButtons = Array.from(voiceSelector.querySelectorAll("button"));
-    voiceButtons.forEach((button) => {
-      if (this.isBuiltInVoiceButton(button as HTMLButtonElement)) {
-        piVoices++;
-      }
-    });
-    // if fewer than 8 Pi voices, add the missing Pi voices to the menu
-    if (piVoices < 8) {
-      this.populateVoices(this.chatbot.getExtraVoices(), voiceSelector);
-    }
   }
 
   /**

--- a/src/tts/VoiceMenuControls.ts
+++ b/src/tts/VoiceMenuControls.ts
@@ -1,0 +1,37 @@
+/**
+ * Positive, exhaustive classification of every interactive element SayPi's
+ * voice menus may encounter. The old model classified by ABSENCE ("lacks
+ * saypi-voice-button ⇒ built-in host voice"), which made every new element
+ * guilty until proven innocent — a nested ▶ read as a host voice would unset
+ * the user's voice on click (#483's blocker) and miscount Pi's native voices.
+ * Here every kind is declared by a marker it CARRIES; `unknown` is inert:
+ * SayPi code never selects, tears down, counts, or wires an unknown element.
+ */
+export type VoiceMenuControlKind =
+  | "custom-voice"
+  | "restored-voice"
+  | "door"
+  | "preview"
+  | "host-voice"
+  | "unknown";
+
+/**
+ * Stamped on a host-native voice button at the single adoption site
+ * (GridVoiceSelector.adoptHostRow); doubles as the wired-exactly-once guard.
+ */
+export const HOST_VOICE_ATTR = "data-saypi-host-voice";
+
+export function classifyControl(el: Element): VoiceMenuControlKind {
+  // Preview first: a ▶ nested inside (or sharing markers with) a row must
+  // never be read as the row itself.
+  if (el.classList.contains("saypi-voice-preview")) return "preview";
+  if (el.classList.contains("saypi-more-voices")) return "door";
+  if (el.classList.contains("saypi-custom-voice")) return "custom-voice";
+  if (el.classList.contains("saypi-restored-voice")) return "restored-voice";
+  if (el.hasAttribute(HOST_VOICE_ATTR)) return "host-voice";
+  return "unknown";
+}
+
+export function markAdopted(el: Element): void {
+  el.setAttribute(HOST_VOICE_ATTR, "true");
+}

--- a/test/chatbots/ClaudeVoiceMenu-curation.spec.ts
+++ b/test/chatbots/ClaudeVoiceMenu-curation.spec.ts
@@ -33,13 +33,14 @@ const flipDayCatalog: SpeechSynthesisVoiceRemote[] = [
   ...openAiMockVoices,
 ]; // 20 voices — the claude.ai payload once OPENAI_TTS_ENABLED flips
 
-// Bypass the heavy constructor; populateVoices only needs prototype methods
-// plus the fields it reads (pattern from VoiceMenu.spec.ts).
-function makeMenu(currentVoice: SpeechSynthesisVoiceRemote | null = null): any {
+// Bypass the heavy constructor; renderMenu only needs prototype methods
+// plus the fields it reads (pattern from VoiceMenu.spec.ts). The stored
+// voice is passed straight into renderMenu (gather-then-render).
+function makeMenu(): any {
   const menu = Object.create(ClaudeVoiceMenu.prototype);
   menu.chatbot = {} as any;
   menu.userPreferences = {
-    getVoice: vi.fn(async () => currentVoice),
+    getVoice: vi.fn(async () => null),
     setVoice: vi.fn(async () => {}),
     unsetVoice: vi.fn(async () => {}),
   };
@@ -63,10 +64,6 @@ function voiceRows(menu: any): HTMLElement[] {
   ) as HTMLElement[];
 }
 
-function flushAsync(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 beforeEach(() => {
   openSettingsMock.mockReset();
   document.body.innerHTML = "";
@@ -75,20 +72,20 @@ beforeEach(() => {
 describe("ClaudeVoiceMenu shortlist cap + door (flip-day catalog)", () => {
   it("renders at most CLAUDE_MENU_CAP voice rows from a 20-voice catalog", () => {
     const menu = makeMenu();
-    menu.populateVoices(flipDayCatalog, menu.element);
+    menu.renderMenu(flipDayCatalog, null);
     expect(voiceRows(menu).length).toBe(CLAUDE_MENU_CAP);
   });
 
   it("renders a 'More voices…' door row when voices are hidden", () => {
     const menu = makeMenu();
-    menu.populateVoices(flipDayCatalog, menu.element);
+    menu.renderMenu(flipDayCatalog, null);
     const door = menu.menuContent.querySelector("[data-action='more-voices']");
     expect(door).not.toBeNull();
   });
 
   it("opens the extension settings when the door row is clicked", () => {
     const menu = makeMenu();
-    menu.populateVoices(flipDayCatalog, menu.element);
+    menu.renderMenu(flipDayCatalog, null);
     const door = menu.menuContent.querySelector(
       "[data-action='more-voices']"
     ) as HTMLElement;
@@ -98,14 +95,14 @@ describe("ClaudeVoiceMenu shortlist cap + door (flip-day catalog)", () => {
 
   it("keeps the door row even when the whole catalog fits the cap (#472)", () => {
     const menu = makeMenu();
-    menu.populateVoices(flipDayCatalog.slice(0, 3), menu.element);
+    menu.renderMenu(flipDayCatalog.slice(0, 3), null);
     const door = menu.menuContent.querySelector("[data-action='more-voices']");
     expect(door).not.toBeNull();
   });
 
   it("keeps the Voice off item", () => {
     const menu = makeMenu();
-    menu.populateVoices(flipDayCatalog, menu.element);
+    menu.renderMenu(flipDayCatalog, null);
     const off = menu.menuContent.querySelector("[data-voice-name='voice-off']");
     expect(off).not.toBeNull();
   });
@@ -114,7 +111,7 @@ describe("ClaudeVoiceMenu shortlist cap + door (flip-day catalog)", () => {
 describe("ClaudeVoiceMenu tier signalling", () => {
   it("marks HD rows with an HD chip when tiers coexist, and never shows raw prices", () => {
     const menu = makeMenu();
-    menu.populateVoices(flipDayCatalog, menu.element);
+    menu.renderMenu(flipDayCatalog, null);
     const rows = voiceRows(menu);
     const jarnathan = rows.find((r) => r.dataset.voiceName === "Jarnathan")!;
     const coral = rows.find((r) => r.dataset.voiceName === "Coral")!;
@@ -125,21 +122,21 @@ describe("ClaudeVoiceMenu tier signalling", () => {
 
   it("shows a single footer note about HD allowance burn when tiers coexist", () => {
     const menu = makeMenu();
-    menu.populateVoices(flipDayCatalog, menu.element);
+    menu.renderMenu(flipDayCatalog, null);
     const footer = menu.menuContent.querySelector(".saypi-voice-footnote");
     expect(footer).not.toBeNull();
   });
 
   it("shows no HD chips and no footer for a single-tier catalog (pre-flip)", () => {
     const menu = makeMenu();
-    menu.populateVoices(claudeMockVoices, menu.element);
+    menu.renderMenu(claudeMockVoices, null);
     expect(menu.menuContent.textContent).not.toContain("HD");
     expect(menu.menuContent.querySelector(".saypi-voice-footnote")).toBeNull();
   });
 
   it("still caps and offers the door for the single-tier pre-flip catalog", () => {
     const menu = makeMenu();
-    menu.populateVoices(claudeMockVoices, menu.element); // 10 ElevenLabs voices
+    menu.renderMenu(claudeMockVoices, null); // 10 ElevenLabs voices
     expect(voiceRows(menu).length).toBe(CLAUDE_MENU_CAP);
     expect(
       menu.menuContent.querySelector("[data-action='more-voices']")
@@ -147,60 +144,54 @@ describe("ClaudeVoiceMenu tier signalling", () => {
   });
 });
 
-describe("ClaudeVoiceMenu current-voice pinning", () => {
-  it("re-renders with the stored voice pinned first when it was not in the shortlist", async () => {
+describe("ClaudeVoiceMenu current-voice visibility (was: pinning)", () => {
+  it("renders the stored voice first, synchronously, when the shortlist would have hidden it", () => {
     const lucy = claudeMockVoices.find((v) => v.name === "Lucy")!;
-    const menu = makeMenu(lucy);
-    menu.populateVoices(flipDayCatalog, menu.element);
-    await flushAsync();
+    const menu = makeMenu();
+    menu.renderMenu(flipDayCatalog, lucy); // no flushAsync — no pin round-trip
     const rows = voiceRows(menu);
     expect(rows[0].dataset.voiceName).toBe("Lucy");
     expect(rows.length).toBe(CLAUDE_MENU_CAP);
   });
 
-  it("does not re-render when the stored voice is already featured", async () => {
+  it("does not duplicate a stored voice that is already featured", () => {
     const jarnathan = claudeMockVoices.find((v) => v.name === "Jarnathan")!;
-    const menu = makeMenu(jarnathan);
-    menu.populateVoices(flipDayCatalog, menu.element);
-    await flushAsync();
+    const menu = makeMenu();
+    menu.renderMenu(flipDayCatalog, jarnathan);
     const rows = voiceRows(menu);
     const jarnathans = rows.filter((r) => r.dataset.voiceName === "Jarnathan");
     expect(jarnathans.length).toBe(1);
     expect(rows.length).toBe(CLAUDE_MENU_CAP);
   });
 
-  it("persists the pin so the next populate renders the stored voice synchronously", async () => {
+  it("every re-render includes the stored voice — no pin state to persist or wipe", () => {
     const lucy = claudeMockVoices.find((v) => v.name === "Lucy")!;
-    const menu = makeMenu(lucy);
-    menu.populateVoices(flipDayCatalog, menu.element);
-    await flushAsync(); // async pin + one re-render
-    // A fresh populate (e.g. menu reopened) must include Lucy immediately,
-    // without waiting for another async round-trip.
-    menu.populateVoices(flipDayCatalog, menu.element);
+    const menu = makeMenu();
+    menu.renderMenu(flipDayCatalog, lucy);
+    menu.renderMenu(flipDayCatalog, lucy); // e.g. menu reopened
     const rows = voiceRows(menu);
     expect(rows[0].dataset.voiceName).toBe("Lucy");
   });
 
-  it("defers the pin re-render while the menu is open instead of tearing it down", async () => {
+  it("an external voice change never tears down an open menu (applySelectedVoice only re-marks)", () => {
     const lucy = claudeMockVoices.find((v) => v.name === "Lucy")!;
-    const menu = makeMenu(lucy);
-    menu.populateVoices(flipDayCatalog, menu.element);
-    // Simulate the menu being open when the async pin lands.
+    const menu = makeMenu();
+    menu.renderMenu(flipDayCatalog, null);
+    // Simulate the menu being open when a settings-page change lands.
     menu.menuButton.setAttribute("aria-expanded", "true");
     const openMenuContent = menu.menuContent;
-    await flushAsync();
+    menu.applySelectedVoice(lucy);
     // The open menu must not be destroyed out from under the user…
     expect(menu.menuContent).toBe(openMenuContent);
-    // …but the pin is remembered for the next populate.
-    menu.menuButton.setAttribute("aria-expanded", "false");
-    menu.populateVoices(flipDayCatalog, menu.element);
+    // …and the next render (menu reopened → refreshMenu) shows Lucy first.
+    menu.renderMenu(flipDayCatalog, lucy);
     const rows = voiceRows(menu);
     expect(rows[0].dataset.voiceName).toBe("Lucy");
   });
 
   it("passes the Voices tab as the door's settings destination (#471)", () => {
     const menu = makeMenu();
-    menu.populateVoices(flipDayCatalog, menu.element);
+    menu.renderMenu(flipDayCatalog, null);
     const door = menu.menuContent.querySelector(
       "[data-action='more-voices']"
     ) as HTMLElement;

--- a/test/chatbots/ClaudeVoiceMenu-preview.spec.ts
+++ b/test/chatbots/ClaudeVoiceMenu-preview.spec.ts
@@ -82,9 +82,9 @@ beforeEach(() => {
 describe("ClaudeVoiceMenu voice preview (▶)", () => {
   it("renders a ▶ preview button only on rows whose voice has a sample_url", () => {
     const menu = makeMenu();
-    menu.populateVoices(
+    menu.renderMenu(
       [withSample("a", "Nova", SAMPLE), withSample("b", "Ash", undefined)],
-      menu.element
+      null
     );
     expect(
       rowFor(menu, "Nova")!.querySelector("button.saypi-voice-preview")
@@ -96,7 +96,7 @@ describe("ClaudeVoiceMenu voice preview (▶)", () => {
 
   it("never renders a ▶ on the Voice off row", () => {
     const menu = makeMenu();
-    menu.populateVoices([withSample("a", "Nova", SAMPLE)], menu.element);
+    menu.renderMenu([withSample("a", "Nova", SAMPLE)], null);
     const off = menu.menuContent.querySelector(
       "[data-voice-name='voice-off']"
     ) as HTMLElement | null;
@@ -105,7 +105,7 @@ describe("ClaudeVoiceMenu voice preview (▶)", () => {
 
   it("auditions the sample (audio:preview) without selecting the voice when ▶ is clicked", () => {
     const menu = makeMenu();
-    menu.populateVoices([withSample("a", "Nova", SAMPLE)], menu.element);
+    menu.renderMenu([withSample("a", "Nova", SAMPLE)], null);
     const btn = rowFor(menu, "Nova")!.querySelector(
       "button.saypi-voice-preview"
     ) as HTMLElement;

--- a/test/chatbots/PiVoiceMenu-curation.spec.ts
+++ b/test/chatbots/PiVoiceMenu-curation.spec.ts
@@ -50,26 +50,25 @@ function builtInVoice(id: string, name: string): SpeechSynthesisVoiceRemote {
 }
 const piBuiltIns = [builtInVoice("voice1", "Pi 1"), builtInVoice("voice2", "Pi 2")];
 
-// Bypass the heavy constructor (DOM observers); populateVoices only needs
-// prototype methods plus the fields it reads.
-function makeMenu(currentVoice: SpeechSynthesisVoiceRemote | null = null): any {
+// Bypass the heavy constructor (DOM observers); renderMenu only needs
+// prototype methods plus the fields it reads. renderMenu targets
+// menu.element — the stored voice is passed in directly (gather-then-render),
+// so no getVoice mock choreography or flushAsync is needed.
+function makeMenu(): any {
   const menu = Object.create(PiVoiceMenu.prototype);
-  menu.chatbot = {} as any;
+  menu.chatbot = { getID: () => "pi" } as any;
   menu.userPreferences = {
-    getVoice: vi.fn(async () => currentVoice),
+    getVoice: vi.fn(async () => null),
     setVoice: vi.fn(async () => {}),
     unsetVoice: vi.fn(async () => {}),
   };
   menu.element = document.createElement("div");
+  menu.introduceVoice = vi.fn();
   return menu;
 }
 
 function customRows(selector: HTMLElement): HTMLButtonElement[] {
   return Array.from(selector.querySelectorAll("button.saypi-custom-voice"));
-}
-
-function flushAsync(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 beforeEach(() => {
@@ -80,26 +79,23 @@ beforeEach(() => {
 describe("PiVoiceMenu shortlist cap + door", () => {
   it("caps SayPi (custom) rows at PI_MENU_CAP on the flip-day catalog", () => {
     const menu = makeMenu();
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    expect(customRows(selector).length).toBe(PI_MENU_CAP);
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], null);
+    expect(customRows(menu.element).length).toBe(PI_MENU_CAP);
   });
 
   it("never caps Pi's own built-in voice rows", () => {
     const menu = makeMenu();
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], null);
     const builtInRows = Array.from(
-      selector.querySelectorAll("button.saypi-restored-voice")
+      menu.element.querySelectorAll("button.saypi-restored-voice")
     );
     expect(builtInRows.length).toBe(piBuiltIns.length);
   });
 
   it("adds a muted 'More voices' button after the SayPi block when voices are hidden", () => {
     const menu = makeMenu();
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    const door = selector.querySelector(
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], null);
+    const door = menu.element.querySelector(
       "button.saypi-more-voices"
     ) as HTMLButtonElement;
     expect(door).not.toBeNull();
@@ -109,10 +105,9 @@ describe("PiVoiceMenu shortlist cap + door", () => {
 
   it("still shows the door when the catalog fits the cap — it's the path to the catalog, not an overflow marker (#472)", () => {
     const menu = makeMenu();
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piElevenLabs], selector);
-    expect(customRows(selector).length).toBe(piElevenLabs.length);
-    const door = selector.querySelector(
+    menu.renderMenu([...piBuiltIns, ...piElevenLabs], null);
+    expect(customRows(menu.element).length).toBe(piElevenLabs.length);
+    const door = menu.element.querySelector(
       "button.saypi-more-voices"
     ) as HTMLButtonElement;
     expect(door).not.toBeNull();
@@ -124,22 +119,22 @@ describe("PiVoiceMenu shortlist cap + door", () => {
 describe("PiVoiceSettings door (#472)", () => {
   function makeSettings(): any {
     const settings = Object.create(PiVoiceSettings.prototype);
-    settings.chatbot = {} as any;
+    settings.chatbot = { getID: () => "pi" } as any;
     settings.userPreferences = {
       getVoice: vi.fn(async () => null),
       setVoice: vi.fn(async () => {}),
       unsetVoice: vi.fn(async () => {}),
     };
     settings.element = document.createElement("div");
+    settings.introduceVoice = vi.fn();
     return settings;
   }
 
   it("appends a 'More voices' door to the uncapped settings grid", () => {
     const settings = makeSettings();
-    const grid = document.createElement("div");
-    settings.populateVoices([...piElevenLabs], grid);
-    expect(customRows(grid).length).toBe(piElevenLabs.length); // grid stays uncapped
-    const door = grid.querySelector(
+    settings.renderMenu([...piElevenLabs], null);
+    expect(customRows(settings.element).length).toBe(piElevenLabs.length); // grid stays uncapped
+    const door = settings.element.querySelector(
       "button.saypi-more-voices"
     ) as HTMLButtonElement;
     expect(door).not.toBeNull();
@@ -147,21 +142,21 @@ describe("PiVoiceSettings door (#472)", () => {
     expect(openSettingsMock).toHaveBeenCalledWith("voices");
   });
 
-  it("does not duplicate the door on repeated populates", () => {
+  it("does not duplicate the door on repeated renders", () => {
     const settings = makeSettings();
-    const grid = document.createElement("div");
-    settings.populateVoices([...piElevenLabs], grid);
-    settings.populateVoices([...piElevenLabs], grid);
-    expect(grid.querySelectorAll("button.saypi-more-voices").length).toBe(1);
+    settings.renderMenu([...piElevenLabs], null);
+    settings.renderMenu([...piElevenLabs], null);
+    expect(
+      settings.element.querySelectorAll("button.saypi-more-voices").length
+    ).toBe(1);
   });
 });
 
 describe("PiVoiceMenu tier badge", () => {
   it("suffixes premium rows with a quiet HD badge only when tiers coexist", () => {
     const menu = makeMenu();
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    const rows = customRows(selector);
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], null);
+    const rows = customRows(menu.element);
     const paola = rows.find(
       (r) => r.dataset.voiceId === "ig1TeITnnNlsJtfHxJlW"
     )!;
@@ -172,72 +167,60 @@ describe("PiVoiceMenu tier badge", () => {
 
   it("shows no badge for today's single-tier catalog", () => {
     const menu = makeMenu();
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piElevenLabs], selector);
-    expect(selector.querySelector(".voice-tier")).toBeNull();
+    menu.renderMenu([...piBuiltIns, ...piElevenLabs], null);
+    expect(menu.element.querySelector(".voice-tier")).toBeNull();
   });
 });
 
-describe("PiVoiceMenu current-voice pinning", () => {
-  it("re-renders with the stored voice visible when the cap would have hidden it", async () => {
+describe("PiVoiceMenu current-voice visibility", () => {
+  it("renders the stored voice visible when the cap would have hidden it — synchronously, no pin recursion", () => {
     const shimmer = openAiMockVoices.find((v) => v.name === "Shimmer")!;
-    const menu = makeMenu(shimmer);
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    await flushAsync();
-    const rows = customRows(selector);
+    const menu = makeMenu();
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], shimmer);
+    const rows = customRows(menu.element);
     const ids = rows.map((r) => r.dataset.voiceId);
     expect(ids).toContain("shimmer");
     expect(rows.length).toBe(PI_MENU_CAP);
   });
 
-  it("does not duplicate the door row when populateVoices runs again on the same menu", async () => {
+  it("does not duplicate the door row when renderMenu runs again on the same menu", () => {
     const menu = makeMenu();
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    await flushAsync();
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    await flushAsync();
-    expect(selector.querySelectorAll("button.saypi-more-voices").length).toBe(1);
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], null);
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], null);
+    expect(
+      menu.element.querySelectorAll("button.saypi-more-voices").length
+    ).toBe(1);
   });
 
-  it("keeps the pin when a partial built-ins-only populate runs (addMissingPiVoices path)", async () => {
+  it("keeps Pi's extra voices AND the hidden stored voice across re-renders (was: partial-populate pin wipe / Pi7-8 deletion)", () => {
     const shimmer = openAiMockVoices.find((v) => v.name === "Shimmer")!;
-    const menu = makeMenu(shimmer);
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    await flushAsync(); // pin applied, Shimmer visible
-    // Pi tops the menu up with its own extra voices (voice7/voice8 are
-    // default=false, so they arrive as a customs-only partial list).
-    const extras = [builtInVoice("voice7", "Pi 7"), builtInVoice("voice8", "Pi 8")];
-    extras.forEach((v) => ((v as any).default = false));
-    menu.populateVoices(extras, selector);
-    await flushAsync();
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    await flushAsync();
-    const ids = customRows(selector).map((r) => r.dataset.voiceId);
+    const menu = makeMenu();
+    // Pi tops the menu up with its own account-gated extra voices; these are
+    // rendered by the same pass now, never via a separate partial populate.
+    menu.chatbot = {
+      getID: () => "pi",
+      getExtraVoices: () => [
+        new OpenAIVoice("voice7", "Pi 7"),
+        new OpenAIVoice("voice8", "Pi 8"),
+      ],
+      getVoiceIntroductionUrl: () => "https://pi.ai/intro.mp3",
+    } as any;
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], shimmer);
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], shimmer);
+    const ids = customRows(menu.element).map((r) => r.dataset.voiceId);
     expect(ids).toContain("shimmer");
-    // ...and the pin re-render must not have deleted the extra built-ins.
+    // ...and the re-render must not have deleted the extras.
     expect(ids).toContain("voice7");
     expect(ids).toContain("voice8");
   });
 
-  it("clears a stale pin after the user switches to a featured voice", async () => {
+  it("stops showing a previously-pinned voice once the user switches to a featured voice (was: stale pin)", () => {
     const shimmer = openAiMockVoices.find((v) => v.name === "Shimmer")!;
     const coral = openAiMockVoices.find((v) => v.name === "Coral")!;
-    let stored: any = shimmer;
     const menu = makeMenu();
-    menu.userPreferences.getVoice = vi.fn(async () => stored);
-    const selector = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    await flushAsync(); // pin = shimmer
-    stored = coral; // user picked a featured voice
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], selector);
-    await flushAsync(); // stale pin detected and cleared
-    const rebuilt = document.createElement("div");
-    menu.populateVoices([...piBuiltIns, ...piFlipDay], rebuilt);
-    await flushAsync();
-    const ids = customRows(rebuilt).map((r) => r.dataset.voiceId);
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], shimmer);
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], coral);
+    const ids = customRows(menu.element).map((r) => r.dataset.voiceId);
     expect(ids).not.toContain("shimmer");
     expect(ids).toContain("coral");
   });

--- a/test/chatbots/VoiceMenu-preference-sync.spec.ts
+++ b/test/chatbots/VoiceMenu-preference-sync.spec.ts
@@ -152,7 +152,7 @@ describe("PiVoiceMenu reacts to settings-page voice changes (#475)", () => {
     const joey = piVoices[1];
     let stored: SpeechSynthesisVoiceRemote | null = paola;
     const menu = makePiMenu(() => stored);
-    menu.populateVoices(piVoices, menu.element);
+    menu.renderMenu(piVoices, stored);
     await flushAsync();
 
     stored = joey;

--- a/test/chatbots/VoiceMenu-preference-sync.spec.ts
+++ b/test/chatbots/VoiceMenu-preference-sync.spec.ts
@@ -95,7 +95,7 @@ describe("ClaudeVoiceMenu reacts to settings-page voice changes (#475)", () => {
     const jarnathan = claudeMockVoices.find((v) => v.name === "Jarnathan")!;
     let stored: SpeechSynthesisVoiceRemote | null = cassidy;
     const menu = makeClaudeMenu(() => stored);
-    menu.populateVoices(claudeMockVoices, menu.element);
+    menu.renderMenu(claudeMockVoices, cassidy);
     await flushAsync();
     expect(
       menu.menuButton.querySelector(".voice-name")?.textContent
@@ -118,7 +118,7 @@ describe("ClaudeVoiceMenu reacts to settings-page voice changes (#475)", () => {
     const cassidy = claudeMockVoices.find((v) => v.name === "Cassidy")!;
     let stored: SpeechSynthesisVoiceRemote | null = cassidy;
     const menu = makeClaudeMenu(() => stored);
-    menu.populateVoices(claudeMockVoices, menu.element);
+    menu.renderMenu(claudeMockVoices, cassidy);
     await flushAsync();
 
     emitVoiceChange("some-pi-voice", "pi");
@@ -133,7 +133,7 @@ describe("ClaudeVoiceMenu reacts to settings-page voice changes (#475)", () => {
     const cassidy = claudeMockVoices.find((v) => v.name === "Cassidy")!;
     let stored: SpeechSynthesisVoiceRemote | null = cassidy;
     const menu = makeClaudeMenu(() => stored);
-    menu.populateVoices(claudeMockVoices, menu.element);
+    menu.renderMenu(claudeMockVoices, cassidy);
     await flushAsync();
 
     stored = null;

--- a/test/tts/GridVoiceSelector.spec.ts
+++ b/test/tts/GridVoiceSelector.spec.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ConfigModule reads injected env at import time; stub it (mirrors other specs).
+vi.mock("../../src/ConfigModule", () => ({
+  config: {
+    appServerUrl: "https://app.example.com",
+    apiServerUrl: "https://api.saypi.ai",
+    GA_MEASUREMENT_ID: "x",
+    GA_API_SECRET: "x",
+    GA_ENDPOINT: "x",
+  },
+}));
+vi.mock("../../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({
+    isAuthenticated: () => true,
+    getClaims: () => null,
+  }),
+}));
+const openSettingsMock = vi.fn();
+vi.mock("../../src/popup/popupopener", () => ({
+  openSettings: (...args: unknown[]) => openSettingsMock(...args),
+}));
+vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
+vi.mock("../../src/events/EventBus", () => ({
+  default: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+import { GridVoiceSelector } from "../../src/tts/GridVoiceSelector";
+import { HOST_VOICE_ATTR } from "../../src/tts/VoiceMenuControls";
+import { ElevenLabsVoice, OpenAIVoice, openAiMockVoices } from "../data/Voices";
+import { SpeechSynthesisVoiceRemote } from "../../src/tts/SpeechModel";
+
+class TestGrid extends GridVoiceSelector {
+  cap: number | null = 5;
+  getId() {
+    return "test-grid";
+  }
+  getButtonClasses() {
+    return ["mb-1"];
+  }
+  protected override getCustomVoiceCap() {
+    return this.cap;
+  }
+}
+
+const piCustoms = [
+  new ElevenLabsVoice("ig1TeITnnNlsJtfHxJlW", "Paola"),
+  new ElevenLabsVoice("bWJPewAagbymiJXZcxnh", "Joey"),
+  new ElevenLabsVoice("paola-v3", "Paola", "F"),
+  ...openAiMockVoices,
+]; // 13 custom voices, HD + everyday tiers coexist
+
+function extraVoice(id: string, name: string): SpeechSynthesisVoiceRemote {
+  return new OpenAIVoice(id, name);
+}
+
+function makeGrid(
+  opts: {
+    stored?: SpeechSynthesisVoiceRemote | null;
+    provider?: boolean;
+    cap?: number | null;
+  } = {}
+): { grid: any; el: HTMLElement } {
+  const grid: any = Object.create(TestGrid.prototype);
+  grid.cap = opts.cap === undefined ? 5 : opts.cap;
+  grid.chatbot = opts.provider
+    ? {
+        getID: () => "pi",
+        getExtraVoices: () => [
+          extraVoice("voice7", "Pi 7"),
+          extraVoice("voice8", "Pi 8"),
+        ],
+        getVoiceIntroductionUrl: () => "https://pi.ai/intro.mp3",
+      }
+    : { getID: () => "pi" };
+  grid.userPreferences = {
+    getVoice: vi.fn(async () => opts.stored ?? null),
+    setVoice: vi.fn(async () => {}),
+    unsetVoice: vi.fn(async () => {}),
+  };
+  grid.element = document.createElement("div");
+  grid.introduceVoice = vi.fn();
+  return { grid, el: grid.element };
+}
+
+const rowsOf = (el: HTMLElement) =>
+  Array.from(el.querySelectorAll<HTMLElement>(".saypi-custom-voice"));
+const idsOf = (el: HTMLElement) => rowsOf(el).map((r) => r.dataset.voiceId);
+
+beforeEach(() => {
+  openSettingsMock.mockReset();
+  document.body.innerHTML = "";
+});
+
+describe("GridVoiceSelector.renderMenu — one idempotent render path", () => {
+  it("caps SayPi rows and always renders exactly one door", () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    expect(rowsOf(el).length).toBe(5);
+    expect(el.querySelectorAll(".saypi-more-voices").length).toBe(1);
+  });
+
+  it("is idempotent: rendering the same inputs twice yields identical DOM", () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    const first = el.innerHTML;
+    grid.renderMenu(piCustoms, null);
+    expect(el.innerHTML).toBe(first);
+    expect(el.querySelectorAll(".saypi-more-voices").length).toBe(1);
+  });
+
+  it("keeps DOM identity of surviving rows across re-renders (no listener churn)", () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    const before = rowsOf(el)[0];
+    grid.renderMenu(piCustoms, null);
+    expect(rowsOf(el)[0]).toBe(before);
+  });
+
+  it("always shows the stored voice, synchronously, even when the cap would hide it", () => {
+    const shimmer = openAiMockVoices.find((v) => v.name === "Shimmer")!;
+    const { grid, el } = makeGrid({ stored: shimmer });
+    grid.renderMenu(piCustoms, shimmer); // no flushAsync, no pin recursion
+    expect(idsOf(el)).toContain("shimmer");
+    expect(rowsOf(el).length).toBe(5);
+    expect(
+      (el.querySelector('[data-voice-id="shimmer"]') as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
+  });
+
+  it("renders the stored voice's row selected and no other", () => {
+    const coral = openAiMockVoices.find((v) => v.name === "Coral")!;
+    const { grid, el } = makeGrid({ stored: coral });
+    grid.renderMenu(piCustoms, coral);
+    const selected = el.querySelectorAll(".selected");
+    expect(selected.length).toBe(1);
+    expect((selected[0] as HTMLElement).dataset.voiceId).toBe("coral");
+  });
+
+  it("switching the stored voice on re-render moves the mark and un-hides the new voice (no stale mark, no vanish)", () => {
+    const shimmer = openAiMockVoices.find((v) => v.name === "Shimmer")!;
+    const coral = openAiMockVoices.find((v) => v.name === "Coral")!;
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, shimmer);
+    grid.renderMenu(piCustoms, coral);
+    expect(idsOf(el)).toContain("coral");
+    expect(idsOf(el)).not.toContain("shimmer"); // stale pin gone, stateless
+    const selected = el.querySelectorAll(".selected");
+    expect(selected.length).toBe(1);
+    expect((selected[0] as HTMLElement).dataset.voiceId).toBe("coral");
+  });
+
+  it("uncapped surfaces render the whole catalog with no tier badges and no door by default", () => {
+    const { grid, el } = makeGrid({ cap: null });
+    grid.renderMenu(piCustoms, null);
+    expect(rowsOf(el).length).toBe(piCustoms.length);
+    expect(el.querySelector(".voice-tier")).toBeNull();
+    expect(el.querySelector(".saypi-more-voices")).toBeNull();
+  });
+});
+
+describe("GridVoiceSelector — host-row adoption (positive classification)", () => {
+  it("adopts pre-existing host buttons: marks them and wires unset-on-click exactly once across renders", async () => {
+    const { grid, el } = makeGrid();
+    const hostBtn = document.createElement("button");
+    hostBtn.textContent = "Pi 1";
+    el.appendChild(hostBtn);
+    grid.renderMenu(piCustoms, null);
+    grid.renderMenu(piCustoms, null); // second render must not double-bind
+    expect(hostBtn.getAttribute(HOST_VOICE_ATTR)).toBe("true");
+    hostBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(grid.userPreferences.unsetVoice).toHaveBeenCalledTimes(1);
+    expect(hostBtn.classList.contains("selected")).toBe(true);
+  });
+
+  it("voice-off selection leaves host rows untouched but clears SayPi rows", () => {
+    const coral = openAiMockVoices.find((v) => v.name === "Coral")!;
+    const { grid, el } = makeGrid();
+    const hostBtn = document.createElement("button");
+    el.appendChild(hostBtn);
+    grid.renderMenu(piCustoms, coral);
+    grid.renderMenu(piCustoms, null);
+    expect(el.querySelectorAll(".saypi-custom-voice.selected").length).toBe(0);
+  });
+});
+
+describe("GridVoiceSelector — Pi extras top-up (was addMissingPiVoices)", () => {
+  it("tops up Pi's account-gated extras for provider chatbots when fewer than 8 host rows", () => {
+    const { grid, el } = makeGrid({ provider: true });
+    grid.renderMenu(piCustoms, null);
+    expect(idsOf(el)).toContain("voice7");
+    expect(idsOf(el)).toContain("voice8");
+  });
+
+  it("extras survive re-renders alongside a shortlist-hidden stored voice (the Patch A regression)", () => {
+    const shimmer = openAiMockVoices.find((v) => v.name === "Shimmer")!;
+    const { grid, el } = makeGrid({ provider: true });
+    grid.renderMenu(piCustoms, shimmer);
+    grid.renderMenu(piCustoms, shimmer);
+    grid.renderMenu(piCustoms, shimmer);
+    const ids = idsOf(el);
+    expect(ids).toContain("shimmer");
+    expect(ids).toContain("voice7");
+    expect(ids).toContain("voice8");
+  });
+
+  it("does not top up for chatbots without built-in voices", () => {
+    const { grid, el } = makeGrid({ provider: false });
+    grid.renderMenu(piCustoms, null);
+    expect(idsOf(el)).not.toContain("voice7");
+  });
+});
+
+describe("GridVoiceSelector — unknown elements are inert (#485 / ▶-deselects trap)", () => {
+  function nestedPreviewFixture(el: HTMLElement): HTMLButtonElement {
+    // A future Pi row: wrapper div holding a ▶ — the #483 shape.
+    const rowWrapper = document.createElement("div");
+    const preview = document.createElement("button");
+    preview.classList.add("saypi-voice-preview");
+    rowWrapper.appendChild(preview);
+    el.appendChild(rowWrapper);
+    return preview;
+  }
+
+  it("re-render never throws on, removes, adopts, or counts a nested ▶", () => {
+    const { grid, el } = makeGrid({ provider: true });
+    const preview = nestedPreviewFixture(el);
+    expect(() => grid.renderMenu(piCustoms, null)).not.toThrow();
+    expect(el.contains(preview)).toBe(true);
+    expect(preview.hasAttribute(HOST_VOICE_ATTR)).toBe(false);
+    expect(idsOf(el)).toContain("voice7"); // ▶ not miscounted as a host voice
+  });
+
+  it("clicking a ▶ never unsets or sets the voice", async () => {
+    const { grid, el } = makeGrid();
+    const preview = nestedPreviewFixture(el);
+    grid.renderMenu(piCustoms, null);
+    preview.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(grid.userPreferences.unsetVoice).not.toHaveBeenCalled();
+    expect(grid.userPreferences.setVoice).not.toHaveBeenCalled();
+  });
+
+  it("a DIRECT-CHILD ▶ (SayPi-marked control) is still not adopted — positive marks win over position", () => {
+    const { grid, el } = makeGrid();
+    const preview = document.createElement("button");
+    preview.classList.add("saypi-voice-preview");
+    el.appendChild(preview);
+    grid.renderMenu(piCustoms, null);
+    expect(preview.hasAttribute(HOST_VOICE_ATTR)).toBe(false);
+  });
+});
+
+describe("GridVoiceSelector — selection via rows (click paths)", () => {
+  it("clicking a SayPi row persists the voice, marks exactly that row, and introduces the voice", async () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    const row = el.querySelector('[data-voice-id="coral"]') as HTMLButtonElement;
+    row.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(grid.userPreferences.setVoice).toHaveBeenCalled();
+    expect(row.classList.contains("selected")).toBe(true);
+    expect(el.querySelectorAll(".selected").length).toBe(1);
+    expect(grid.introduceVoice).toHaveBeenCalled();
+  });
+
+  it("tier badge appears on HD rows only while tiers coexist", () => {
+    const { grid, el } = makeGrid();
+    grid.renderMenu(piCustoms, null);
+    const paola = el.querySelector('[data-voice-id="ig1TeITnnNlsJtfHxJlW"]');
+    // Paola is HD and featured, so present under the cap; badge because tiers coexist.
+    expect(paola?.querySelector(".voice-tier")?.textContent).toBe("HD");
+  });
+});

--- a/test/tts/VoiceIntroduction.spec.ts
+++ b/test/tts/VoiceIntroduction.spec.ts
@@ -43,6 +43,8 @@ class TestVoiceSelector extends VoiceSelector {
   getButtonClasses(): string[] {
     return [];
   }
+  protected renderMenu(): void {}
+  protected applySelectedVoice(): void {}
 }
 
 /**

--- a/test/tts/VoiceMenu.spec.ts
+++ b/test/tts/VoiceMenu.spec.ts
@@ -20,6 +20,8 @@ vi.mock("../../src/JwtManager", () => ({
 }));
 
 import { VoiceSelector } from "../../src/tts/VoiceMenu";
+import { GridVoiceSelector } from "../../src/tts/GridVoiceSelector";
+import { SpeechSynthesisVoiceRemote } from "../../src/tts/SpeechModel";
 import { ClaudeVoiceMenu } from "../../src/chatbots/ClaudeVoiceMenu";
 
 // Minimal concrete selector to exercise base-class logic.
@@ -30,6 +32,8 @@ class TestVoiceSelector extends VoiceSelector {
   getButtonClasses(): string[] {
     return [];
   }
+  protected renderMenu(): void {}
+  protected applySelectedVoice(): void {}
 }
 
 describe("VoiceSelector.ttsRequiresSignIn", () => {
@@ -57,39 +61,52 @@ describe("VoiceSelector.ttsRequiresSignIn", () => {
   });
 });
 
-describe("VoiceSelector built-in-voice-provider capability detection", () => {
-  // The base class adds a chatbot's own built-in voices (e.g. Pi.ai's native
-  // voices + introduction audio) when the chatbot can provide them. This used
-  // to be gated on `instanceof PiAIChatbot`, which forced VoiceMenu to import
-  // the concrete Pi chatbot and created a VoiceMenu -> Pi -> PiVoiceMenu ->
-  // VoiceMenu import cycle. The gate is now a structural capability check, so
+describe("GridVoiceSelector built-in-voice-provider capability detection", () => {
+  // The grid render tops up a chatbot's own built-in voices (e.g. Pi.ai's
+  // account-gated extras) when the chatbot can provide them. This used to be
+  // gated on `instanceof PiAIChatbot`, which forced VoiceMenu to import the
+  // concrete Pi chatbot and created a VoiceMenu -> Pi -> PiVoiceMenu ->
+  // VoiceMenu import cycle. The gate is a structural capability check, so
   // any chatbot exposing getExtraVoices()/getVoiceIntroductionUrl() qualifies.
-  function makeSelector(chatbot: unknown): TestVoiceSelector {
-    return new TestVoiceSelector(
-      chatbot as any,
-      {} as any,
-      document.createElement("div"),
-    );
+  class TestGrid extends GridVoiceSelector {
+    getId(): string {
+      return "test-grid-capability";
+    }
+    getButtonClasses(): string[] {
+      return [];
+    }
+  }
+
+  function makeGrid(chatbot: unknown): any {
+    const grid: any = Object.create(TestGrid.prototype);
+    grid.chatbot = chatbot;
+    grid.userPreferences = {
+      getVoice: vi.fn(async () => null),
+      setVoice: vi.fn(async () => {}),
+      unsetVoice: vi.fn(async () => {}),
+    };
+    grid.element = document.createElement("div");
+    return grid;
   }
 
   it("requests extra voices from a chatbot that provides its own built-in voices", () => {
-    const getExtraVoices = vi.fn(() => []);
+    const getExtraVoices = vi.fn((): SpeechSynthesisVoiceRemote[] => []);
     const chatbot = {
       getExtraVoices,
       getVoiceIntroductionUrl: vi.fn(() => ""),
     };
-    const selector = makeSelector(chatbot);
-    // An empty menu has 0 built-in voices, i.e. below the 8-voice threshold.
-    selector.addMissingPiVoices(document.createElement("div"));
+    const grid = makeGrid(chatbot);
+    // An empty menu has 0 adopted host rows, i.e. below the 8-voice threshold.
+    grid.renderMenu([], null);
     expect(getExtraVoices).toHaveBeenCalled();
   });
 
   it("does nothing for a chatbot without built-in voices (e.g. Claude)", () => {
     const chatbot = { getName: () => "Claude" };
-    const selector = makeSelector(chatbot);
-    const populateSpy = vi.spyOn(selector as any, "populateVoices");
-    selector.addMissingPiVoices(document.createElement("div"));
-    expect(populateSpy).not.toHaveBeenCalled();
+    const grid = makeGrid(chatbot);
+    grid.renderMenu([], null);
+    // No extras requested, so no rows appear in the empty render.
+    expect(grid.element.querySelectorAll("[data-voice-id]").length).toBe(0);
   });
 });
 

--- a/test/tts/VoiceMenuControls.spec.ts
+++ b/test/tts/VoiceMenuControls.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyControl,
+  markAdopted,
+  HOST_VOICE_ATTR,
+} from "../../src/tts/VoiceMenuControls";
+
+function button(...classes: string[]): HTMLButtonElement {
+  const b = document.createElement("button");
+  b.classList.add(...classes);
+  return b;
+}
+
+describe("VoiceMenuControls.classifyControl — positive, exhaustive taxonomy", () => {
+  it("classifies each SayPi control kind by its positive marker", () => {
+    expect(
+      classifyControl(button("saypi-voice-button", "saypi-custom-voice"))
+    ).toBe("custom-voice");
+    expect(
+      classifyControl(button("saypi-voice-button", "saypi-restored-voice"))
+    ).toBe("restored-voice");
+    expect(
+      classifyControl(button("saypi-voice-button", "saypi-more-voices"))
+    ).toBe("door");
+    expect(classifyControl(button("saypi-voice-preview"))).toBe("preview");
+  });
+
+  it("classifies an adopted host button as host-voice", () => {
+    const b = button();
+    markAdopted(b);
+    expect(b.getAttribute(HOST_VOICE_ATTR)).toBe("true");
+    expect(classifyControl(b)).toBe("host-voice");
+  });
+
+  it("returns unknown for anything unmarked — new elements are inert until opted in", () => {
+    expect(classifyControl(button())).toBe("unknown");
+    expect(classifyControl(button("some-host-class"))).toBe("unknown");
+    expect(classifyControl(document.createElement("div"))).toBe("unknown");
+  });
+
+  it("gives the ▶ preview priority over row-level markers (a preview inside a marked row is still a preview)", () => {
+    expect(
+      classifyControl(button("saypi-voice-preview", "saypi-voice-button"))
+    ).toBe("preview");
+  });
+});

--- a/test/tts/VoiceMenuInvariants.spec.ts
+++ b/test/tts/VoiceMenuInvariants.spec.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ConfigModule reads injected env at import time; stub it (mirrors other specs).
+vi.mock("../../src/ConfigModule", () => ({
+  config: {
+    appServerUrl: "https://app.example.com",
+    apiServerUrl: "https://api.saypi.ai",
+    GA_MEASUREMENT_ID: "x",
+    GA_API_SECRET: "x",
+    GA_ENDPOINT: "x",
+  },
+}));
+vi.mock("../../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({
+    isAuthenticated: () => true,
+    getClaims: () => null,
+  }),
+}));
+const openSettingsMock = vi.fn();
+vi.mock("../../src/popup/popupopener", () => ({
+  openSettings: (...args: unknown[]) => openSettingsMock(...args),
+}));
+vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
+vi.mock("../../src/events/EventBus", () => ({
+  default: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+import { GridVoiceSelector } from "../../src/tts/GridVoiceSelector";
+import { classifyControl } from "../../src/tts/VoiceMenuControls";
+import { ElevenLabsVoice, OpenAIVoice, openAiMockVoices } from "../data/Voices";
+import { SpeechSynthesisVoiceRemote } from "../../src/tts/SpeechModel";
+
+/**
+ * The shipped guarantees of the voice menus, pinned as tests so a future
+ * restructure of this code cannot quietly drop one. Each case names the
+ * incident (or trap) it guards against.
+ */
+
+class TestGrid extends GridVoiceSelector {
+  getId() {
+    return "invariants-grid";
+  }
+  getButtonClasses() {
+    return ["mb-1"];
+  }
+  protected override getCustomVoiceCap(): number | null {
+    return 5;
+  }
+}
+
+const catalog: SpeechSynthesisVoiceRemote[] = [
+  new ElevenLabsVoice("ig1TeITnnNlsJtfHxJlW", "Paola"),
+  new ElevenLabsVoice("bWJPewAagbymiJXZcxnh", "Joey"),
+  ...openAiMockVoices,
+]; // 12 custom voices, tiers coexist
+
+function makeGrid(): { grid: any; el: HTMLElement } {
+  const grid: any = Object.create(TestGrid.prototype);
+  grid.chatbot = {
+    getID: () => "pi",
+    getExtraVoices: () => [
+      new OpenAIVoice("voice7", "Pi 7"),
+      new OpenAIVoice("voice8", "Pi 8"),
+    ],
+    getVoiceIntroductionUrl: () => "https://pi.ai/intro.mp3",
+  };
+  grid.userPreferences = {
+    getVoice: vi.fn(async () => null),
+    setVoice: vi.fn(async () => {}),
+    unsetVoice: vi.fn(async () => {}),
+  };
+  grid.element = document.createElement("div");
+  grid.introduceVoice = vi.fn();
+  return { grid, el: grid.element };
+}
+
+const idsOf = (el: HTMLElement) =>
+  Array.from(el.querySelectorAll<HTMLElement>(".saypi-custom-voice")).map(
+    (r) => r.dataset.voiceId
+  );
+
+beforeEach(() => {
+  openSettingsMock.mockReset();
+  document.body.innerHTML = "";
+});
+
+describe("Voice menu invariants", () => {
+  it("grandfathering: a deprecated voice keeps rendering (and selectable) iff it is the stored voice", () => {
+    // Design §5: the server retires voices via `deprecated`, but a user who
+    // already chose one must never lose it (voice-choice-ux plan).
+    const deprecated = new OpenAIVoice("ballad", "Ballad") as any;
+    deprecated.deprecated = true;
+    const others = catalog.filter((v) => v.id !== "ballad");
+    const { grid, el } = makeGrid();
+
+    // Not stored → dropped from the menu entirely.
+    grid.renderMenu([...others, deprecated], null);
+    expect(idsOf(el)).not.toContain("ballad");
+
+    // Stored → renders (first) and carries the selected mark.
+    grid.renderMenu([...others, deprecated], deprecated);
+    expect(idsOf(el)).toContain("ballad");
+    const row = el.querySelector('[data-voice-id="ballad"]') as HTMLButtonElement;
+    expect(row.classList.contains("selected")).toBe(true);
+  });
+
+  it("current-voice-never-vanishes: survives repeated re-renders with shuffled catalog order", () => {
+    // The Patch A regression class: re-renders on shared state used to be
+    // able to drop the stored (shortlist-hidden) voice.
+    const shimmer = openAiMockVoices.find((v) => v.name === "Shimmer")!;
+    const { grid, el } = makeGrid();
+    const shuffles = [
+      catalog,
+      [...catalog].reverse(),
+      [...catalog.slice(4), ...catalog.slice(0, 4)],
+    ];
+    for (const order of shuffles) {
+      grid.renderMenu(order, shimmer);
+      expect(idsOf(el)).toContain("shimmer");
+    }
+  });
+
+  it("no silent swap: an external voice change marks exactly the new row; a hidden new voice leaves NO row marked", () => {
+    // The ▶-deselects trap's cousin: a stale highlight lying about which
+    // voice will actually speak. If the stored voice is not visible, showing
+    // nothing selected is the truth (the old code left the previous row lit).
+    const coral = openAiMockVoices.find((v) => v.name === "Coral")!;
+    const nova = openAiMockVoices.find((v) => v.name === "Nova")!;
+    const { grid, el } = makeGrid();
+    grid.renderMenu(catalog, coral);
+    expect(
+      (el.querySelector(".selected") as HTMLElement).dataset.voiceId
+    ).toBe("coral");
+
+    // External switch to another visible voice: the mark moves.
+    grid.applySelectedVoice(nova);
+    const selected = el.querySelectorAll(".selected");
+    expect(selected.length).toBe(1);
+    expect((selected[0] as HTMLElement).dataset.voiceId).toBe("nova");
+
+    // External switch to a voice the shortlist is hiding: nothing is marked
+    // (the next full render will surface it via curateShortlist).
+    const hidden = openAiMockVoices.find((v) => v.name === "Ballad")!;
+    if (idsOf(el).includes("ballad")) throw new Error("fixture: expected ballad hidden");
+    grid.applySelectedVoice(hidden);
+    expect(el.querySelectorAll(".selected").length).toBe(0);
+  });
+
+  it("door singularity: exactly one door, after the last SayPi row, across renders with changing stored voices", () => {
+    const coral = openAiMockVoices.find((v) => v.name === "Coral")!;
+    const shimmer = openAiMockVoices.find((v) => v.name === "Shimmer")!;
+    const { grid, el } = makeGrid();
+    grid.renderMenu(catalog, null);
+    grid.renderMenu(catalog, shimmer);
+    grid.renderMenu(catalog, coral);
+    const doors = el.querySelectorAll(".saypi-more-voices");
+    expect(doors.length).toBe(1);
+    const customRows = el.querySelectorAll(".saypi-custom-voice");
+    const lastCustom = customRows[customRows.length - 1];
+    expect(lastCustom.nextElementSibling).toBe(doors[0]);
+  });
+
+  it("adoption idempotence: a host button seen by render AND the mutation observer path is wired exactly once", async () => {
+    // registerVoiceChangeHandler used to add a fresh click listener on every
+    // Pi menu expand; the adoption stamp is the wired-once guard now.
+    const { grid, el } = makeGrid();
+    const hostBtn = document.createElement("button");
+    hostBtn.textContent = "Pi 1";
+    el.appendChild(hostBtn);
+    grid.renderMenu(catalog, null);
+    grid.handleRowAddition(hostBtn); // observer sees it again
+    grid.renderMenu(catalog, null); // and another expand re-renders
+    hostBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(grid.userPreferences.unsetVoice).toHaveBeenCalledTimes(1);
+  });
+
+  it("taxonomy completeness: every interactive element the grid creates classifies as non-unknown", () => {
+    // Guards "new row type forgot its positive marker" — an unknown SayPi
+    // control would be adopted as a host voice and unset the user's voice
+    // on click (the original ▶ trap).
+    const coral = openAiMockVoices.find((v) => v.name === "Coral")!;
+    const { grid, el } = makeGrid();
+    // Include a default-flagged voice so restored rows are exercised too.
+    const builtIn = new OpenAIVoice("voice1", "Pi 1") as any;
+    builtIn.default = true;
+    grid.renderMenu([builtIn, ...catalog], coral);
+    const buttons = Array.from(el.querySelectorAll("button"));
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      expect(classifyControl(button)).not.toBe("unknown");
+    }
+  });
+});

--- a/test/tts/VoiceMenuRefresh.spec.ts
+++ b/test/tts/VoiceMenuRefresh.spec.ts
@@ -4,9 +4,6 @@ vi.mock("../../src/ConfigModule", () => ({
   config: { appServerUrl: "https://app.example.com", apiServerUrl: "https://api.saypi.ai" },
 }));
 
-// Break the VoiceMenu -> Pi -> PiVoiceMenu -> VoiceMenu import cycle.
-vi.mock("../../src/chatbots/Pi", () => ({ PiAIChatbot: class {} }));
-
 vi.mock("../../src/JwtManager", () => ({
   getJwtManagerSync: () => ({ isAuthenticated: () => true, getClaims: () => null }),
 }));
@@ -14,8 +11,8 @@ vi.mock("../../src/JwtManager", () => ({
 vi.mock("../../src/dom/ChatHistory", () => ({ getMostRecentAssistantMessage: () => undefined }));
 vi.mock("../../src/i18n", () => ({ default: (key: string) => key }));
 
-// refreshMenu re-populates via getVoices(); return [] so the test isolates the
-// TEARDOWN half (the crash) — re-population is exercised elsewhere.
+// refreshMenu gathers via getVoices() + getVoice(); return [] so the test
+// isolates the render-with-nested-buttons-present path.
 const getVoicesMock = vi.fn().mockResolvedValue([]);
 vi.mock("../../src/tts/SpeechSynthesisModule", () => ({
   SpeechSynthesisModule: {
@@ -32,11 +29,11 @@ vi.mock("../../src/events/EventBus", () => ({
   default: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
 }));
 
-import { VoiceSelector } from "../../src/tts/VoiceMenu";
+import { GridVoiceSelector } from "../../src/tts/GridVoiceSelector";
 
-class TestVoiceSelector extends VoiceSelector {
+class TestGrid extends GridVoiceSelector {
   getId(): string {
-    return "test-voice-selector";
+    return "test-grid-refresh";
   }
   getButtonClasses(): string[] {
     return [];
@@ -44,27 +41,33 @@ class TestVoiceSelector extends VoiceSelector {
 }
 
 /**
- * Regression (#482 lit up live by saypi-api's `sample_url`): the ▶ preview is a
- * `<button class="saypi-voice-preview">` NESTED inside each menu item. Base
- * `refreshMenu` tore down voices with
- *   this.element.querySelectorAll("button").forEach(b => this.element.removeChild(b))
- * — a DESCENDANT query fed to a DIRECT-CHILD-only removeChild. The nested preview
- * button is matched but is not a direct child of `element`, so `removeChild` threw
- * `NotFoundError`, aborting the menu build → the menu "disappeared" on open.
- * Pre-#482 there were no nested buttons, so every match was a direct child and it
- * never threw (a latent fragility). The teardown must only touch direct children.
+ * Tombstone for #485 (surfaced by #482's nested ▶ preview buttons): the old
+ * base `refreshMenu` began with a bulk teardown that fed a DESCENDANT
+ * `querySelectorAll("button")` into direct-child-only `removeChild`. The
+ * nested ▶ matched but was not a direct child, so `removeChild` threw
+ * `NotFoundError`, aborting the rebuild — the menu "vanished" on open.
+ *
+ * That teardown no longer exists ANYWHERE: renders reconcile SayPi-owned rows
+ * by id and never bulk-remove buttons, so the crash is structurally
+ * impossible, not guarded against. These tests pin the surviving contract:
+ * a refresh with nested/unknown buttons present must resolve and leave them
+ * untouched.
  */
-describe("VoiceSelector.refreshMenu — tolerates nested (preview) buttons in menu items", () => {
+describe("refreshMenu with nested (preview) buttons present (#485 tombstone)", () => {
   beforeEach(() => {
     getVoicesMock.mockClear().mockResolvedValue([]);
   });
 
-  function buildElementWithNestedButton(): HTMLDivElement {
+  function buildElementWithNestedButton(): {
+    element: HTMLDivElement;
+    directHostBtn: HTMLButtonElement;
+    preview: HTMLButtonElement;
+  } {
     const element = document.createElement("div");
-    // Legacy direct-child voice button — the shape refreshMenu is meant to clear.
-    const voiceBtn = document.createElement("button");
-    voiceBtn.textContent = "Alloy";
-    element.appendChild(voiceBtn);
+    // A host-native direct-child voice button (adopted, never removed by us).
+    const directHostBtn = document.createElement("button");
+    directHostBtn.textContent = "Pi 1";
+    element.appendChild(directHostBtn);
     // A menu item div whose trailing controls hold a NESTED ▶ preview button
     // (the #482 structure that surfaced only once sample_url went live).
     const item = document.createElement("div");
@@ -76,34 +79,40 @@ describe("VoiceSelector.refreshMenu — tolerates nested (preview) buttons in me
     trailing.appendChild(preview);
     item.appendChild(trailing);
     element.appendChild(item);
-    return element;
+    return { element, directHostBtn, preview };
   }
 
-  it("does not throw when a menu item contains a nested <button> not a direct child", async () => {
-    const element = buildElementWithNestedButton();
-    const chatbot: any = { getID: () => "claude" };
-    const selector = new TestVoiceSelector(chatbot, {} as any, element);
+  function makeGrid(element: HTMLElement): TestGrid {
+    const grid: any = Object.create(TestGrid.prototype);
+    grid.chatbot = { getID: () => "claude" };
+    grid.userPreferences = {
+      getVoice: vi.fn(async () => null),
+      setVoice: vi.fn(async () => {}),
+      unsetVoice: vi.fn(async () => {}),
+    };
+    grid.element = element;
+    return grid as TestGrid;
+  }
 
-    // Pre-fix: rejects with NotFoundError from removeChild on the nested button.
-    await expect(selector.refreshMenu()).resolves.toBeUndefined();
+  it("resolves without throwing when a menu item contains a nested <button> that is not a direct child", async () => {
+    const { element } = buildElementWithNestedButton();
+    const grid = makeGrid(element);
+
+    // Pre-refactor: rejected with NotFoundError from removeChild on the
+    // nested button.
+    await expect(grid.refreshMenu()).resolves.toBeUndefined();
   });
 
-  it("removes the direct-child voice buttons but leaves nested preview buttons for the item rebuild", async () => {
-    const element = buildElementWithNestedButton();
-    const chatbot: any = { getID: () => "claude" };
-    const selector = new TestVoiceSelector(chatbot, {} as any, element);
+  it("leaves both the host's direct-child button and the nested ▶ in place — renders reconcile, they never bulk-remove", async () => {
+    const { element, directHostBtn, preview } = buildElementWithNestedButton();
+    const grid = makeGrid(element);
 
-    await selector.refreshMenu();
+    await grid.refreshMenu();
 
-    // The direct-child voice button is gone (its normal teardown). Filter on
-    // `children` rather than `:scope > button` — jsdom's `:scope` combinator
-    // wrongly matches nested descendants, which is the very quirk under test.
-    const directChildButtons = Array.from(element.children).filter(
-      (el) => el.tagName === "BUTTON"
-    );
-    expect(directChildButtons).toHaveLength(0);
-    // The nested preview button is untouched — removeChild could never remove it,
-    // and the item div is rebuilt wholesale by populateVoices, not here.
-    expect(element.querySelector(".saypi-voice-preview")).not.toBeNull();
+    // The host's own button survives (it is adopted, not torn down)...
+    expect(element.contains(directHostBtn)).toBe(true);
+    // ...and the nested preview button is untouched and unclassified as a row.
+    expect(element.contains(preview)).toBe(true);
+    expect(preview.hasAttribute("data-saypi-host-voice")).toBe(false);
   });
 });

--- a/test/vitest.setup.js
+++ b/test/vitest.setup.js
@@ -35,6 +35,7 @@ Object.defineProperties(global, {
   HTMLInputElement: { value: dom.window.HTMLInputElement },
   HTMLTextAreaElement: { value: dom.window.HTMLTextAreaElement },
   HTMLDivElement: { value: dom.window.HTMLDivElement },
+  HTMLButtonElement: { value: dom.window.HTMLButtonElement },
   DOMParser: { value: dom.window.DOMParser },
   SVGElement: { value: dom.window.SVGElement },
   Event: { value: dom.window.Event },


### PR DESCRIPTION
## Why

The same failure kept recurring in `src/tts/VoiceMenu.ts`: #485 (bulk `querySelectorAll("button")` teardown crashed on #482's nested ▶), the Patch A pin-wipe / Pi7-8 deletion (imperative re-render on shared state), #483 stuck (a row that IS a `<button>` can't grow a ▶ sibling), and the classify-by-absence trap (any unmarked element read as a host voice — clicking it would unset the user's voice). Each was the code's shape biting, not a one-off. The caution map lists this refactor as a wanted candidate (§6: "the VoiceMenu populate paths → one button factory + SelectionState").

## What changed

**`src/tts/VoiceMenuControls.ts` (new) — positive, exhaustive taxonomy.** Every interactive element declares what it IS (`custom-voice` / `restored-voice` / `door` / `preview` / `host-voice`); anything unmarked is **inert**. Host buttons are adopted (stamped + wired) at exactly one site; the stamp doubles as the wired-once guard, fixing the duplicate-listener-per-expand in the old `registerVoiceChangeHandler`.

**`src/tts/VoiceMenu.ts` — slim generic base.** Keeps cross-surface concerns only (auth/pref wiring, `introduceVoice`, `ttsRequiresSignIn`) plus the new contract: `refreshMenu()` **gathers** the catalog AND the stored voice together, then calls the single abstract `renderMenu(voices, storedVoice)`. Selection/pin state is never mirrored in fields or recovered from the DOM — the stored preference is the model; the DOM is a render of it.

**`src/tts/GridVoiceSelector.ts` (new) — reconciling render for Pi's button grids.** Row factory + id-scoped reconciliation (insert/move/remove by `data-voice-id`; unchanged rows keep DOM identity and listeners). Nothing bulk-removes buttons, so the #485 crash class is structurally impossible, not guarded against. The pin field and its render→detect→re-render recursion die: the stored id goes straight into `curateShortlist`, whose current-first rule pins synchronously. The row root is still the `<button>` today — `selectTargetOf` is the one seam a wrapper-row future (#483's ▶) changes.

**Hosts.** `PiVoiceMenu`/`PiVoiceSettings` move onto the grid (expand listener collapses to one gather-then-render; `handleExistingVoiceButtons` and the 3-call expand sequence die). `ClaudeVoiceMenu` migrates to the base contract but its rendering is deliberately NOT redesigned — `populateVoices` becomes `renderMenu(voices, stored)`, deleting the read-selection-from-button-label block, the async getVoice fallback + pin writeback, and `pinnedCustomVoiceId`. `VoiceCuration.ts` untouched. No Preact (per doc/preact-component-conventions.md).

## Deliberate behavior changes (small, both improvements)

- **No stale mark:** when the stored voice isn't visible in the menu, NO row shows selected (previously the old row could keep its highlight — a lie about what would speak). Next full render surfaces the voice via curation.
- **Claude trigger label is right on first paint** (it received the stored voice with the catalog; no more voice-off-then-update flash).

## Tests

- New: `VoiceMenuControls.spec` (taxonomy), `GridVoiceSelector.spec` (17 cases: idempotence, DOM-identity, cap/door, extras survival, adoption, ▶-inertness), `VoiceMenuInvariants.spec` (grandfathering, current-voice-never-vanishes, no-silent-swap, door singularity, adoption idempotence, taxonomy completeness).
- Existing voice specs transformed to drive `renderMenu` directly; every product invariant assertion preserved (and the flushAsync pin choreography deleted).
- Gates: `npm test` (tsc + Jest + Vitest, 198 files / 1755 tests) ✅ · Layer 3 E2E (13/13) ✅

## Layer-4 real-host evidence

- **claude.ai ✅** — opened the dropdown twice in a row (the rebuild-on-open path, #485's stage): identical state both rounds — 6 voices + voice-off, 6 ▶ previews, exactly one door, stored voice (Jarnathan) checked and on the trigger from first paint. Zero console errors.
- **pi.ai ⚠️ blocked by a pre-existing live defect, NOT this PR** — the SayPi block never renders in Pi's in-chat menu on **main either**. A/B probe (baseline d1b06bf vs this branch): byte-identical behavior — Pi's native menu opens, `.expanded` never fires, zero SayPi rows, zero console errors, both builds. Filed as **#491** with the full evidence. Decoration itself (call button etc.) verified working with this build on live pi.ai.

Unblocks #483; refs #485, #470/#472, #491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1oVsdBKdATjojxQprFhR4