### PR TITLE
fix(tts): don't parse a voice-preview clip as a speech stream (#499)

### DIFF
--- a/src/state-machines/AudioOutputMachine.ts
+++ b/src/state-machines/AudioOutputMachine.ts
@@ -5,6 +5,7 @@ import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import {
   PiSpeechSourceParser,
   SayPiSpeechSourceParser,
+  isVoiceSampleUrl,
 } from "../tts/SpeechSourceParsers";
 import {
   AudioProvider,
@@ -345,6 +346,12 @@ async function getSpeechFromAudioSource(
       const userLang = await userPreferences.getLanguage();
       return new PiSpeechSourceParser(userLang).parse(source);
     } else if (audioProviders.SayPi.matches(source)) {
+      // A canned preview clip (…/voices/<id>/sample) is a static audio file with
+      // no transcript — not a streaming-speech source. The `audioProviders.SayPi`
+      // gate matches by hostname alone, so it also catches these; skip resolution
+      // silently rather than let the stream parser throw "is not a streaming
+      // speech URL" and log a spurious error on every ▶ preview / voice audition.
+      if (isVoiceSampleUrl(source)) return null;
       return await new SayPiSpeechSourceParser(
         SpeechSynthesisModule.getInstance()
       ).parse(source);

--- a/src/tts/SpeechSourceParsers.ts
+++ b/src/tts/SpeechSourceParsers.ts
@@ -140,4 +140,29 @@ class SayPiSpeechSourceParser implements SpeechSourceParser {
     }
   }
 }
-export { SpeechSourceParser, PiSpeechSourceParser, SayPiSpeechSourceParser };
+/**
+ * A canned voice-PREVIEW clip — `…/voices/<id>/sample` (optionally `?v=<hash>`).
+ * It is a static audio file with no transcript/speech-marks, unlike a
+ * `…/speak/<id>/stream` TTS stream (see {@link SayPiSpeechSourceParser}). The
+ * audio-output path plays it directly, so it must NOT be handed to the stream
+ * parser — doing so throws "is not a streaming speech URL" and logs a spurious
+ * error on every ▶ preview / voice audition (found live on claude.ai 2026-07-05).
+ */
+function isVoiceSampleUrl(source: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch (_) {
+    return false;
+  }
+  const segments = url.pathname.split("/");
+  const voicesIndex = segments.indexOf("voices");
+  return voicesIndex !== -1 && segments[voicesIndex + 2] === "sample";
+}
+
+export {
+  SpeechSourceParser,
+  PiSpeechSourceParser,
+  SayPiSpeechSourceParser,
+  isVoiceSampleUrl,
+};

--- a/test/state-machines/AudioOutputMachine-preview-source.spec.ts
+++ b/test/state-machines/AudioOutputMachine-preview-source.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTestActor } from "./support/testActor";
+
+// ---------------------------------------------------------------------------
+// Regression suite: a voice PREVIEW must not log a spurious error.
+//
+// Found on live claude.ai (Layer-4 CDP, 2026-07-05): tapping ▶ on a voice with
+// a `sample_url` (or auditioning a voice on select, via #484's reroute) logged
+//
+//   console.error: Failed to get speech from audio source:
+//     Invalid source: https://api.saypi.ai/voices/<id>/sample?v=… is not a
+//     streaming speech URL.
+//
+// on every preview. The clip still played (the error is caught → null), but the
+// noise fires on a now-live, frequent user action.
+//
+// Root cause: `notifySpeechStart` (the `loading` entry action) resolves the
+// audio source to a transcript via `getSpeechFromAudioSource`, which is gated by
+// the HOSTNAME-only `audioProviders.SayPi.matches` (true for api.saypi.ai), then
+// hands the URL to `SayPiSpeechSourceParser.parse`, which only accepts a
+// `/speak/<id>/stream` TTS stream and throws on a `/voices/<id>/sample` clip.
+//
+// CRUCIALLY: the sibling AudioOutputMachine-preview.spec.ts MOCKS
+// SayPiSpeechSourceParser to resolve null, so it never reproduces this. Here the
+// parser is REAL — that's the whole point.
+// ---------------------------------------------------------------------------
+
+const emit = vi.fn();
+vi.mock("../../src/events/EventBus.js", () => ({
+  default: {
+    emit: (...args: any[]) => emit(...args),
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+  },
+}));
+
+// Mock only the heavy leaf module the real SpeechSourceParsers imports — NOT the
+// parsers themselves (a sample URL throws before it ever touches the voiceModule).
+vi.mock("../../src/tts/SpeechSynthesisModule", () => ({
+  SpeechSynthesisModule: { getInstance: () => ({}) },
+}));
+
+vi.mock("../../src/prefs/PreferenceModule", () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({ getLanguage: () => Promise.resolve("en") }),
+  },
+}));
+
+import { audioOutputMachine } from "../../src/state-machines/AudioOutputMachine";
+import { isVoiceSampleUrl } from "../../src/tts/SpeechSourceParsers";
+
+// The exact live sample URL shape (…/voices/<id>/sample?v=<hash>).
+const SAMPLE_URL = "https://api.saypi.ai/voices/c6SfcYrb2t09NHXiT80T/sample?v=a1292da1";
+// A well-formed TTS stream source — must still be treated as a real speech stream.
+const STREAM_URL =
+  "https://api.saypi.ai/speak/5dbec6ff-9ee8-43fa-a9c1-e6bd51e9dfc6/stream?voice_id=ig1TeITnnNlsJtfHxJlW&lang=en-GB";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("AudioOutputMachine — preview source is not mistaken for a speech stream", () => {
+  let service: any;
+  let errorSpy: any;
+
+  beforeEach(() => {
+    emit.mockClear();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    service = createTestActor(audioOutputMachine);
+    service.start();
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    try {
+      service?.stop();
+    } catch {}
+  });
+
+  describe("isVoiceSampleUrl", () => {
+    it("recognises a canned /voices/<id>/sample preview clip", () => {
+      expect(isVoiceSampleUrl(SAMPLE_URL)).toBe(true);
+    });
+
+    it("does NOT match a /speak/<id>/stream TTS source", () => {
+      expect(isVoiceSampleUrl(STREAM_URL)).toBe(false);
+    });
+
+    it("is false for a non-URL or an unrelated audio source", () => {
+      expect(isVoiceSampleUrl("not a url")).toBe(false);
+      expect(isVoiceSampleUrl("https://pi.ai/audio/track-1.mp3")).toBe(false);
+    });
+  });
+
+  it("does NOT log a 'streaming speech URL' error when a preview clip loads", async () => {
+    service.send({ type: "preview", source: SAMPLE_URL });
+    service.send({ type: "loadstart", source: SAMPLE_URL }); // -> loading -> notifySpeechStart
+    await flush();
+    await flush();
+
+    const streamingErr = errorSpy.mock.calls.find((c: any[]) =>
+      String(c[0]).includes("is not a streaming speech URL")
+    );
+    expect(streamingErr).toBeUndefined();
+  });
+
+  it("still logs when a genuinely malformed /speak/ stream fails to resolve (fix stays surgical)", async () => {
+    // Guards against the tempting-but-wrong "just gate on the parser's matches()"
+    // shortcut, which would swallow real diagnostics for broken stream URLs too.
+    const MALFORMED_STREAM = "https://api.saypi.ai/speak/only-an-id"; // no /stream segment
+    service.send({ type: "preview", source: MALFORMED_STREAM });
+    service.send({ type: "loadstart", source: MALFORMED_STREAM });
+    await flush();
+    await flush();
+
+    const streamingErr = errorSpy.mock.calls.find((c: any[]) =>
+      String(c[0]).includes("is not a streaming speech URL")
+    );
+    expect(streamingErr).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

Previewing a voice with a `sample_url` — and, via #484's audition reroute, **selecting any voice** — logged a spurious error on every ▶ tap on claude.ai/chatgpt.com:

```
Failed to get speech from audio source:
  Invalid source: https://api.saypi.ai/voices/<id>/sample?v=<hash> is not a streaming speech URL.
```

The clip still played (the error is caught → `null`), but the noise fired on a now-live, frequent user action. Fixes #499.

## Root cause

`notifySpeechStart` (the `loading`-state entry action in `AudioOutputMachine`) resolves the audio source to a transcript via `getSpeechFromAudioSource`. Its SayPi branch is gated by the **hostname-only** `audioProviders.SayPi.matches` (true for any `api.saypi.ai` URL), then hands the URL to `SayPiSpeechSourceParser.parse`, which only accepts a `/speak/<id>/stream` TTS stream and throws on the preview's `/voices/<id>/sample` clip. A preview sample is a static audio file with no transcript — legitimately not a streaming-speech source.

## Fix

New exported `isVoiceSampleUrl` predicate in `SpeechSourceParsers.ts`; `getSpeechFromAudioSource` short-circuits to `null` for a sample clip before the stream parse. Surgical — a genuinely malformed `/speak/` stream still logs its diagnostic.

## Testing (fail-first TDD)

New `test/state-machines/AudioOutputMachine-preview-source.spec.ts` uses the **real** `SayPiSpeechSourceParser` (the sibling `AudioOutputMachine-preview.spec.ts` mocks it to resolve `null`, which is exactly why this went unseen). It reproduces the exact live error string red→green, plus a `isVoiceSampleUrl` unit table and a guard that a malformed `/speak/` still logs. Full gate green (tsc + Jest + 1791 Vitest).

## How it was found

The owed real-host (Layer-4 CDP) verification of #482/#484/#486 now that `OPENAI_TTS_ENABLED` + `sample_url` are live. Everything else verified **healthy** on claude.ai: ▶ renders on all rows and plays end-to-end via the offscreen path, the curated capped shortlist + HD chips are correct (`Voice off, Jarnathan[HD], Juniper[HD], Ash, Coral, Nova, Onyx, More voices…`), the #485 warm-cache reopen crash is gone, and the 405s in the console are host noise (Claude's own MCP endpoints), not SayPi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WmjGuAUmFGQBZukitHp4L