### PR TITLE
fix(dictation): decorate input fields inserted as bare root nodes (#502)

### DIFF
--- a/src/UniversalDictationModule.ts
+++ b/src/UniversalDictationModule.ts
@@ -140,10 +140,19 @@ export class UniversalDictationModule {
       '[contenteditable="true"]',
       'input:not([type])',
     ];
+    const selector = inputSelectors.join(", ");
 
-    const inputs = searchRoot.querySelectorAll(inputSelectors.join(", "));
+    // querySelectorAll only matches DESCENDANTS of searchRoot — never searchRoot
+    // itself. When the MutationObserver hands us a field that was inserted as a
+    // bare, already-complete root node (e.g. Mistral Le Chat's ProseMirror
+    // composer), the descendant scan alone misses it, so check the root too (#502).
+    const candidates: Element[] = [];
+    if (searchRoot.matches(selector)) {
+      candidates.push(searchRoot);
+    }
+    candidates.push(...searchRoot.querySelectorAll(selector));
 
-    inputs.forEach((input) => {
+    candidates.forEach((input) => {
       if (input instanceof HTMLElement && !this.decoratedElements.has(input)) {
         this.decorateInput(input);
       }

--- a/test/UniversalDictationModule-RootNodeDecoration.spec.ts
+++ b/test/UniversalDictationModule-RootNodeDecoration.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Regression test for issue #502: on chat.mistral.ai the ProseMirror composer is
+ * inserted into the DOM as a single, already-complete `[contenteditable="true"]`
+ * root node (not nested inside a wrapper that itself gets added). The
+ * MutationObserver hands that node straight to `findAndDecorateInputs()`, which
+ * only ran `searchRoot.querySelectorAll(...)` — a query that by definition matches
+ * *descendants* of `searchRoot`, never `searchRoot` itself. So a matching root
+ * node was never decorated and no `.saypi-dictation-button` ever appeared.
+ *
+ * These tests drive the *real* module (not a re-implementation) through the real
+ * MutationObserver so the decoration path exercised is production's.
+ */
+
+// Return real SVG nodes so createDictationButton's clone/setAttribute/appendChild work.
+const makeSvg = () =>
+  document.createElementNS("http://www.w3.org/2000/svg", "svg") as SVGElement;
+
+// Mock the machine layer: this test only exercises the decoration path
+// (findAndDecorateInputs → decorateInput → createDictationButton), never
+// startDictation. Mocking it here also severs the heavy transitive import chain
+// (DictationMachine → TranscriptionModule → StateMachineService → ThemeManager).
+vi.mock("../src/state-machines/DictationMachine", () => ({
+  createDictationMachine: vi.fn(),
+}));
+
+vi.mock("../src/events/EventBus.js", () => ({
+  default: { emit: vi.fn(), on: vi.fn() },
+}));
+
+vi.mock("../src/icons/IconModule", () => ({
+  IconModule: {
+    bubbleBw: { cloneNode: vi.fn(() => makeSvg()) },
+    bubble: vi.fn(() => makeSvg()),
+  },
+}));
+
+vi.mock("../src/i18n", () => ({
+  default: vi.fn((key: string) => `mocked-${key}`),
+}));
+
+import { UniversalDictationModule } from "../src/UniversalDictationModule";
+
+// JSDOM lacks these; positionButton() uses them during decoration. Stub minimally
+// so full decoration (including button creation) runs without throwing.
+class NoopObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const flushMutations = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("UniversalDictationModule — root-node decoration (issue #502)", () => {
+  let module: UniversalDictationModule;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+
+    (global as any).ResizeObserver = NoopObserver;
+    (global as any).IntersectionObserver = NoopObserver;
+    // isPositionOccupied() calls this; jsdom doesn't implement it.
+    (document as any).elementsFromPoint = () => [];
+
+    // Fresh singleton per test.
+    (UniversalDictationModule as any).instance = undefined;
+    module = UniversalDictationModule.getInstance();
+    module.initialize(); // starts observing document.body + scans existing elements
+  });
+
+  afterEach(() => {
+    module.destroy();
+    (UniversalDictationModule as any).instance = undefined;
+    document.body.innerHTML = "";
+  });
+
+  it("decorates a contenteditable composer inserted as a bare root node (Mistral Le Chat)", async () => {
+    // Mirrors Mistral: the composer arrives as a single already-complete node,
+    // added directly to <body> with no matching descendants of its own.
+    const composer = document.createElement("div");
+    composer.setAttribute("contenteditable", "true");
+    composer.className = "ProseMirror";
+    document.body.appendChild(composer);
+
+    await flushMutations();
+
+    expect(document.querySelectorAll(".saypi-dictation-button").length).toBe(1);
+  });
+
+  it("still decorates a field nested inside an added wrapper (descendant path unchanged)", async () => {
+    const wrapper = document.createElement("div");
+    const textarea = document.createElement("textarea");
+    wrapper.appendChild(textarea);
+    document.body.appendChild(wrapper);
+
+    await flushMutations();
+
+    expect(document.querySelectorAll(".saypi-dictation-button").length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why

On chat.mistral.ai, SayPi's floating `.saypi-dictation-button` never appeared on the composer even though the extension loaded and initialized in dictation mode. Issue #163 lists Mistral (Le Chat) as confirmed-working, so this was a regression. The sweep's console capture showed the tell: `Decorated input element with dictation button` never logged for **any** element on the page.

## Root cause

`UniversalDictationModule`'s `MutationObserver` hands each added node straight to `findAndDecorateInputs(addedElement)`, which only ran:

```ts
searchRoot.querySelectorAll(inputSelectors.join(", "))
```

`querySelectorAll` matches **descendants** of `searchRoot`, never `searchRoot` itself. Mistral's composer is a ProseMirror `[contenteditable="true"]` mounted as a single, already-complete root node *after* client-side hydration — so it's absent at the initial `decorateExistingElements()` scan and only arrives later via the observer, as the added node itself (not nested in a wrapper). It was also the only decoratable text field on the page (the rest are buttons), which is why decoration count was zero, not just one short.

Confirmed the site is **not** excluded: `identifyChatbot("chat.mistral.ai")` → `"web"` (the `chat.` heuristic is scoped to the `openai.com` case only), so `isExcludedSite()` does not bail.

## Fix

`findAndDecorateInputs()` now also checks whether `searchRoot` itself matches the input selectors, in addition to scanning its descendants. The descendant path is unchanged.

## Tests

Fail-first Vitest spec drives the **real** module through the **real** `MutationObserver`:
- a bare `[contenteditable]` root node added to `<body>` now gets a `.saypi-dictation-button` (**0 before the fix**, 1 after) — the exact Mistral scenario;
- a field nested in an added wrapper still decorates (descendant path regression guard).

Full merge gate green locally (`tsc --noEmit` + Jest + Vitest, 205 files).

## Verification status

Layer 1–2 (unit) proves the self-match logic. Real-host confirmation that Mistral's composer actually decorates end-to-end is via `npm run e2e-dictation-sweep mistral` (Layer 4 CDP, founder's browser) — see PR comments for result.

Fixes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)