### PR TITLE
fix(dictation): decorate elements that become contenteditable via attribute mutation (#502)

### DIFF
--- a/src/UniversalDictationModule.ts
+++ b/src/UniversalDictationModule.ts
@@ -79,6 +79,18 @@ export class UniversalDictationModule {
   private startObserving(): void {
     this.observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
+        // An existing element's contenteditable changed — re-check it for decoration.
+        // Rich-text editors (e.g. Mistral Le Chat's ProseMirror) set
+        // contenteditable="true" on a node that's ALREADY in the DOM rather than
+        // inserting a new one, so the childList paths below never see it. Without
+        // this, decoration hinges on a race with the initial scan (#502).
+        if (mutation.type === "attributes") {
+          if (mutation.target instanceof HTMLElement) {
+            this.findAndDecorateInputs(mutation.target);
+          }
+          return;
+        }
+
         [...mutation.addedNodes]
           .filter((node) => node instanceof HTMLElement)
           .forEach((node) => {
@@ -98,6 +110,9 @@ export class UniversalDictationModule {
     this.observer.observe(document.body, {
       childList: true,
       subtree: true,
+      // Also react when a node BECOMES contenteditable in place (#502).
+      attributes: true,
+      attributeFilter: ["contenteditable"],
     });
   }
 

--- a/test/UniversalDictationModule-RootNodeDecoration.spec.ts
+++ b/test/UniversalDictationModule-RootNodeDecoration.spec.ts
@@ -99,4 +99,24 @@ describe("UniversalDictationModule — root-node decoration (issue #502)", () =>
 
     expect(document.querySelectorAll(".saypi-dictation-button").length).toBe(1);
   });
+
+  it("decorates an element that BECOMES contenteditable via an attribute mutation (Mistral's real mechanism)", async () => {
+    // A Layer-4 DOM probe (3/3 runs) showed Mistral's ProseMirror composer div is
+    // present early (no childList insertion) and gets contenteditable="true" set on
+    // it later via an ATTRIBUTES mutation. A childList-only observer never re-checks
+    // that node, so it's only decorated if it happened to be editable at the initial
+    // scan — a race that leaves the button missing on the slow path (#502).
+    const composer = document.createElement("div");
+    composer.className = "ProseMirror";
+    document.body.appendChild(composer); // not contenteditable yet
+    await flushMutations();
+    // Not decoratable while it lacks contenteditable="true".
+    expect(document.querySelectorAll(".saypi-dictation-button").length).toBe(0);
+
+    // ProseMirror turns the existing node into an editor.
+    composer.setAttribute("contenteditable", "true");
+    await flushMutations();
+
+    expect(document.querySelectorAll(".saypi-dictation-button").length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Why (and why #503 wasn't enough)

#503 closed a real gap — fields inserted as a bare `[contenteditable]` **root node** (childList) weren't decorated. But it did **not** fix Mistral, and I reopened #502 after a Layer-4 DOM probe found the actual mechanism.

**Probe (MutationObserver installed at `document_start`, no extension, 3/3 consistent runs on chat.mistral.ai):**
```
childListHits: []
attrHits: [{ tag: "DIV", cls: "ProseMirror ProseMirror-focused", from: null, to: "true" }]
```
Mistral's ProseMirror composer div is present early (**no** childList insertion of it), and ProseMirror sets `contenteditable="true"` on that **existing** node via an **attributes mutation**. The `MutationObserver` watched `childList` only, so it never re-checked that node — #503's self-match never fired for it. Decoration therefore hinged on a race with the initial `decorateExistingElements()` scan:

- **Fast path** — editable before the scan → decorated (`button=true`). This is why my earlier sweeps showed `button=true` on *both* the fix-less and fixed builds.
- **Slow path** — editable only after the scan, via the attribute mutation the observer ignored → **never decorated** (`button=false`, the filed state).

## Fix

The observer now also watches `attributes` with `attributeFilter: ["contenteditable"]`; on such a mutation it runs `findAndDecorateInputs(target)`, which — via #503's self-match — decorates the node once it matches `[contenteditable="true"]`. The two changes compose (#503 is the enabler; this adds the missing trigger).

## Tests

Fail-first Vitest case (real module + real `MutationObserver`, deterministic — models the exact mechanism): an element appended **without** `contenteditable` is not decorated (0 buttons); setting `contenteditable="true"` on it then decorates it (1 button). **0 before this change.** The existing root-node and descendant cases still pass.

Full merge gate green locally (`tsc` + Jest + Vitest, 205 files).

## Verification note

The real-host bug is a hydration race, so a real-host `button=true` can't by itself distinguish fixed from unfixed (the fast path decorates either way) — the **deterministic unit test** is the authoritative proof, modelling the exact attribute-mutation mechanism the probe found. Real-host confirmation of the fixed build follows in comments.

Fixes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)