### PR TITLE
fix(dictation): stop deriving fallback target IDs from mutable placeholder text

### DIFF
--- a/src/state-machines/DictationMachine.ts
+++ b/src/state-machines/DictationMachine.ts
@@ -274,17 +274,30 @@ function smartJoinTranscriptions(transcriptions: Record<number, string>): string
   return result;
 }
 
+// Fallback identifiers for elements with no stable `id`, cached by element identity
+// (not by attribute value) so they stay valid even if the element's other attributes
+// change during a dictation session (e.g. UniversalDictationModule swaps `placeholder`
+// to "Recording..."/"Transcribing..." while the same field is being dictated into).
+const fallbackTargetIds = new WeakMap<HTMLElement, string>();
+let fallbackTargetIdCounter = 0;
+
 function getTargetElementId(element: HTMLElement): string {
   // Generate a unique identifier for the target element
   if (element.id) {
     return element.id;
   }
-  // Fallback: use a combination of tag name and attributes to create unique ID
+  const cached = fallbackTargetIds.get(element);
+  if (cached) {
+    return cached;
+  }
+  // First time seeing this element: derive a readable prefix from its tag/class/name,
+  // plus a counter to guarantee uniqueness, then cache it for the element's lifetime.
   const tagName = element.tagName.toLowerCase();
   const className = element.className || '';
   const name = element.getAttribute('name') || '';
-  const placeholder = element.getAttribute('placeholder') || '';
-  return `${tagName}-${className}-${name}-${placeholder}`.replace(/\s+/g, '-');
+  const id = `${tagName}-${className}-${name}-${++fallbackTargetIdCounter}`.replace(/\s+/g, '-');
+  fallbackTargetIds.set(element, id);
+  return id;
 }
 
 /**

--- a/src/state-machines/DictationMachine.ts
+++ b/src/state-machines/DictationMachine.ts
@@ -282,7 +282,12 @@ const fallbackTargetIds = new WeakMap<HTMLElement, string>();
 let fallbackTargetIdCounter = 0;
 
 function getTargetElementId(element: HTMLElement): string {
-  // Generate a unique identifier for the target element
+  // Generate a unique identifier for the target element.
+  // NOTE: this assumes an element's `id`-presence doesn't change mid-session — if
+  // something ever assigned an `id` to a target between registration and a later
+  // lookup, the same class of key-drift bug this function was fixed for (#507)
+  // would recur (registered under the fallback key, looked up under the new `id`).
+  // No such mutation exists in UniversalDictationModule today.
   if (element.id) {
     return element.id;
   }

--- a/test/state-machines/DictationMachine-Refinement.spec.ts
+++ b/test/state-machines/DictationMachine-Refinement.spec.ts
@@ -1207,4 +1207,68 @@ describe('DictationMachine - Dual-Phase Refinement', () => {
       expect(service.getSnapshot().matches('idle')).toBe(true);
     });
   });
+
+  describe('Target ID Stability (issue #507)', () => {
+    it('should refine a target whose placeholder changes between segment capture and refinement', async () => {
+      service.start();
+
+      // An id-less, name-less field whose placeholder is mutated mid-dictation —
+      // mirrors real composers with no stable `id` (e.g. Grok's "Ask anything"
+      // textarea) combined with UniversalDictationModule's own placeholder swap
+      // during recording (e.g. to "Recording..."). The element identity never
+      // changes; only its placeholder attribute does.
+      const target = document.createElement('textarea');
+      target.placeholder = 'Ask anything';
+
+      service.send({ type: 'saypi:startDictation', targetElement: target });
+      service.send({ type: 'saypi:callReady' });
+      service.send({ type: 'saypi:audio:connected', deviceId: 'test', deviceLabel: 'Test Mic' });
+      service.send({ type: 'saypi:session:assigned', session_id: 'test-session' });
+
+      // Two segments so refinement isn't skipped for lack of context.
+      for (let i = 0; i < 2; i++) {
+        service.send({ type: 'saypi:userSpeaking' });
+
+        const mockFrames = new Float32Array(1000);
+        const mockBlob = new Blob([new ArrayBuffer(4000)]);
+
+        vi.mocked(TranscriptionModule.getCurrentSequenceNumber).mockReturnValue(i * 2 + 1);
+        vi.mocked(TranscriptionModule.uploadAudioWithRetry).mockImplementationOnce(resolveUpload(i * 2 + 2));
+
+        service.send({
+          type: 'saypi:userStoppedSpeaking',
+          duration: 1000,
+          blob: mockBlob,
+          frames: mockFrames,
+        });
+
+        service.send({
+          type: 'saypi:transcribed',
+          text: `segment ${i}`,
+          sequenceNumber: i * 2 + 2,
+        });
+      }
+
+      // Sanity check: refinement is indeed pending for this target before we mutate it.
+      expect(service.getSnapshot().context.refinementPendingForTargets.size).toBe(1);
+
+      // Simulate UniversalDictationModule swapping the placeholder while the same
+      // dictation session continues (the real-world trigger for this bug).
+      target.placeholder = 'Recording...';
+
+      vi.mocked(TranscriptionModule.uploadAudioForRefinement).mockClear();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Wait for the endpoint-triggered refinement delay (mocked to 100ms) to fire,
+      // plus time for the refinement Promise to resolve.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('No element found for pending refinement target')
+      );
+      expect(TranscriptionModule.uploadAudioForRefinement).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/test/state-machines/DictationMachine.spec.ts
+++ b/test/state-machines/DictationMachine.spec.ts
@@ -428,10 +428,11 @@ describe('DictationMachine', () => {
         sequenceNumber: 1,
       });
       
-      // Should create entry using fallback identifier
+      // Should create entry using a fallback identifier derived from tag/class/name —
+      // not from `placeholder`, which is mutable during a dictation session (issue #507).
       const targetIds = Object.keys(service.state.context.transcriptionsByTarget);
       expect(targetIds.length).toBe(1);
-      expect(targetIds[0]).toMatch(/input-form-control-test-input-Test-placeholder/);
+      expect(targetIds[0]).toMatch(/^input-form-control-test-input-\d+$/);
     });
   });
 


### PR DESCRIPTION
## Summary
- `getTargetElementId()`'s fallback identifier for id-less dictation targets baked in the element's `placeholder` attribute — but `UniversalDictationModule` itself rewrites that placeholder mid-session (e.g. to "Recording...") to show dictation progress, so the key used to register a target's audio/refinement state drifts from the key later used to look it up.
- This makes contextual refinement (the second phase of dual-phase transcription) silently no-op on any field without a stable `id` — reproduced live on x.com/i/grok's "Ask anything" composer while scoping baseline universal-dictation support for Grok. The local test fixture never caught this because all its fields have stable `id`s.
- Fix: cache a per-element fallback ID in a `WeakMap`, generated once and independent of any later attribute mutation.

## Test plan
- [x] Added a fail-first regression test (`DictationMachine-Refinement.spec.ts`, "Target ID Stability (issue #507)") that mutates an id-less field's placeholder between segment capture and refinement; confirmed it reproduces the exact `"No element found for pending refinement target"` warning before the fix, and passes after.
- [x] Updated an existing test that had encoded the old (buggy) placeholder-based key format as expected behavior.
- [x] `npm test` green: `tsc --noEmit`, Jest (2/2), Vitest (205 files / 1795 tests, 1 pre-existing skip).

Fixes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4uuEsKVySbRV9XRQa2ebc