### PR TITLE
feat(endpointing): emit turn-outcome events for the endpointing eval (#505)

### DIFF
--- a/src/TurnOutcomeModule.ts
+++ b/src/TurnOutcomeModule.ts
@@ -1,0 +1,88 @@
+import { callApi } from "./ApiClient";
+import { config } from "./ConfigModule";
+import { logger } from "./LoggingModule.js";
+
+/**
+ * Turn-outcome reporting for the endpointing (turn-detection) eval — issue #505.
+ *
+ * After SayPi auto-submits an endpointing-driven prompt, a "resume window" runs
+ * from the submit until the assistant's response starts. The only non-circular
+ * ground truth for "did the user actually finish their turn?" is whether the
+ * user started speaking again inside that window (a resume = we cut them off).
+ * This module POSTs that observation to the SayPi API so the server can score
+ * how good `pFinishedSpeaking` is at deciding when a turn ended.
+ *
+ * The payload is deliberately **text-free** (privacy): booleans, timestamps, a
+ * sequence number and an optional score only — never transcript content. See
+ * saypi-api PR #310 (endpoint) and `docs/llm/endpointing-turn-signal-spec.md`
+ * (PR #309) for the server-side contract and rationale.
+ */
+export interface TurnOutcomeInput {
+  /** Correlation key — the same session id sent on /transcribe. */
+  sessionId?: string;
+  /** sequenceNumber of the last utterance in the turn (the endpointing decision point). */
+  lastSequenceNumber?: number;
+  /** Only "auto" turns are scored; manual sends never reach this module. */
+  trigger?: "auto" | "manual";
+  /** Did the user start speaking again inside the resume window? */
+  userResumed: boolean;
+  /** When SayPi submitted the prompt (epoch ms, our clock). */
+  submittedAt: number;
+  /** Window close: TTS start, or reply-text-appears if TTS is off (epoch ms); null if it never started. */
+  responseStartedAt: number | null;
+  /** If the user resumed, when (epoch ms); null otherwise. */
+  resumedAt: number | null;
+  /** VAD speech-offset of the final clip — the moment the user actually stopped (epoch ms). */
+  lastSpeechEndedAt: number | null;
+  /** Optional — the score from the last /transcribe response. */
+  pFinishedSpeaking?: number | null;
+  /** Optional — pi / claude / chatgpt, for filtering. */
+  app?: string | null;
+}
+
+function toIso(ms: number | null | undefined): string | null {
+  return ms == null ? null : new Date(ms).toISOString();
+}
+
+/**
+ * Fire-and-forget POST of a single turn-outcome event. Never awaited, never
+ * retried, never throws to the caller: a dropped event just leaves that turn to
+ * the server-side fallback — the UX must not depend on it.
+ *
+ * Skips entirely when the correlation keys (session id, sequence number) are
+ * absent, since the server has nothing to join the event to.
+ */
+export function postTurnOutcome(input: TurnOutcomeInput): void {
+  if (!input.sessionId || input.lastSequenceNumber == null) {
+    logger.debug(
+      "[TurnOutcome] skipping post — missing correlation key",
+      { hasSession: !!input.sessionId, seq: input.lastSequenceNumber }
+    );
+    return;
+  }
+
+  const body = {
+    session_id: input.sessionId,
+    last_sequence_number: input.lastSequenceNumber,
+    trigger: input.trigger ?? "auto",
+    user_resumed: input.userResumed,
+    submitted_at: toIso(input.submittedAt),
+    response_started_at: toIso(input.responseStartedAt),
+    resumed_at: toIso(input.resumedAt),
+    last_speech_ended_at: toIso(input.lastSpeechEndedAt),
+    p_finished_speaking: input.pFinishedSpeaking ?? null,
+    app: input.app ?? null,
+  };
+
+  try {
+    void callApi(`${config.apiServerUrl}/turn-outcome`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).catch((err) => {
+      logger.debug("[TurnOutcome] post failed (ignored)", err);
+    });
+  } catch (err) {
+    logger.debug("[TurnOutcome] post threw (ignored)", err);
+  }
+}

--- a/src/state-machines/ConversationMachine.ts
+++ b/src/state-machines/ConversationMachine.ts
@@ -24,6 +24,8 @@ import { Chatbot, UserPrompt } from "../chatbots/Chatbot";
 import { ImmersionStateChecker } from "../ImmersionServiceLite";
 import TranscriptionErrorManager from "../error-management/TranscriptionErrorManager";
 import { logger } from "../LoggingModule";
+import { ChatbotIdentifier } from "../chatbots/ChatbotIdentifier";
+import { postTurnOutcome } from "../TurnOutcomeModule";
 
 type ConversationTranscribedEvent = {
   type: "saypi:transcribed";
@@ -94,6 +96,19 @@ type ConversationEvent =
   | { type: "saypi:piStoppedWriting" }
   | ConversationUserPreferenceChangedEvent;
 
+// Snapshot of the correlation data captured at the moment of auto-submit, used
+// to emit a turn-outcome event once the resume window closes (issue #505). Taken
+// at submit time because the transcript buffer is cleared on `listening` exit.
+interface PendingTurnOutcome {
+  submittedAt: number;            // epoch ms, our clock
+  sessionId?: string;
+  lastSequenceNumber?: number;    // the endpointing decision point
+  pFinishedSpeaking?: number;     // score from the last /transcribe response
+  lastSpeechEndedAt: number;      // when the user stopped speaking (timeUserStoppedSpeaking)
+  app?: string;                   // pi / claude / chatgpt
+  isMaintenance: boolean;         // suppressed buffer flush — excluded from the eval
+}
+
 interface ConversationContext {
   transcriptions: Record<number, string>;
   isTranscribing: boolean; // duplicate of state.matches("listening.converting.transcribing")
@@ -104,6 +119,9 @@ interface ConversationContext {
   sessionId?: string;
   shouldRespond?: boolean; // should Pi respond the next time the user finishes speaking?
   isMaintainanceMessage?: boolean; // is the current message a maintainance message?
+  lastSequenceNumber?: number; // highest sequenceNumber seen this turn (endpointing decision point)
+  lastPFinishedSpeaking?: number; // pFinishedSpeaking of that same /transcribe response
+  pendingTurnOutcome?: PendingTurnOutcome | null; // snapshot for the in-flight turn's outcome event
 }
 
 function isContextWindowApproachingCapacity(transcriptions: Record<number, string>): boolean {
@@ -257,9 +275,19 @@ const machine = setup({
         });
       }
 
+      // Persist the endpointing decision point for the turn-outcome event (#505):
+      // the highest sequence number seen this turn and the pFinishedSpeaking of
+      // that same /transcribe response, kept together so the reported score and
+      // sequence number always describe the same utterance. Guarding on the
+      // highest seq keeps them consistent even if responses arrive out of order.
+      const prevSeq = context.lastSequenceNumber ?? -1;
+      const isNewestSeq = sequenceNumber >= prevSeq;
+
       return {
         transcriptions,
         shouldRespond: shouldRespondToThis ?? shouldAlwaysRespond(),
+        lastSequenceNumber: isNewestSeq ? sequenceNumber : context.lastSequenceNumber,
+        lastPFinishedSpeaking: isNewestSeq ? e.pFinishedSpeaking : context.lastPFinishedSpeaking,
       };
     }),
 
@@ -492,6 +520,56 @@ const machine = setup({
     notifyPiSpeaking: () => {
       EventBus.emit("saypi:piSpeaking");
     },
+    // Snapshot the turn's correlation data at auto-submit — the moment the resume
+    // window opens (#505). Taken here because the transcript buffer and the
+    // per-turn sequence/score fields are cleared on `listening` exit, which runs
+    // immediately after this state's `always` transition into `responding`.
+    openTurnOutcome: assign(({ context }) => {
+      const seqs = Object.keys(context.transcriptions).map(Number);
+      const lastSequenceNumber =
+        context.lastSequenceNumber ?? (seqs.length ? Math.max(...seqs) : undefined);
+      const pending: PendingTurnOutcome = {
+        submittedAt: Date.now(),
+        sessionId: context.sessionId,
+        lastSequenceNumber,
+        pFinishedSpeaking: context.lastPFinishedSpeaking,
+        lastSpeechEndedAt: context.timeUserStoppedSpeaking,
+        app: ChatbotIdentifier.getAppId(),
+        isMaintenance: !!context.isMaintainanceMessage,
+      };
+      return { pendingTurnOutcome: pending };
+    }),
+    // Close the resume window and report the outcome (#505). Fired on the single
+    // transition that leaves `responding.piThinking`, so exactly once per turn.
+    // Maintenance messages (suppressed buffer flushes) are excluded from the eval.
+    emitTurnOutcome: (
+      { context },
+      params: { kind: "response-started" | "resumed" | "no-response" }
+    ) => {
+      const pending = context.pendingTurnOutcome;
+      if (!pending || pending.isMaintenance) {
+        return;
+      }
+      const now = Date.now();
+      postTurnOutcome({
+        sessionId: pending.sessionId,
+        lastSequenceNumber: pending.lastSequenceNumber,
+        trigger: "auto",
+        userResumed: params.kind === "resumed",
+        submittedAt: pending.submittedAt,
+        responseStartedAt: params.kind === "response-started" ? now : null,
+        resumedAt: params.kind === "resumed" ? now : null,
+        lastSpeechEndedAt: pending.lastSpeechEndedAt,
+        pFinishedSpeaking: pending.pFinishedSpeaking ?? null,
+        app: pending.app ?? null,
+      });
+    },
+    // Drop any in-flight turn-outcome snapshot (#505). `pendingTurnOutcome` means
+    // "an auto-submitted turn awaiting its outcome", so entering `responding`
+    // by a path that is NOT our own auto-submit (the `saypi:piThinking` handler)
+    // must clear it — otherwise a subsequent response-start would re-emit a stale
+    // prior-turn snapshot as if it were a fresh auto-submit.
+    clearPendingTurnOutcome: assign({ pendingTurnOutcome: null }),
     clearPendingTranscriptionsAction: () => {
       // discard in-flight transcriptions. Called after a successful submission
       clearPendingTranscriptions();
@@ -499,6 +577,8 @@ const machine = setup({
     clearTranscriptsAction: assign({
       transcriptions: () => ({}),
       shouldRespond: () => shouldAlwaysRespond(), // reset response trigger for next message
+      lastSequenceNumber: () => undefined, // reset endpointing decision point for next turn (#505)
+      lastPFinishedSpeaking: () => undefined,
     }),
     updatePreferences: assign({ shouldRespond: () => shouldAlwaysRespond() }),
     setMaintainanceFlag: assign(({ context }) => {
@@ -1054,6 +1134,9 @@ const machine = setup({
                   },
                   {
                     type: "setMaintainanceFlag",
+                  },
+                  {
+                    type: "openTurnOutcome",
                   }
                 ],
                 exit: ["acknowledgeUserInput"],
@@ -1181,6 +1264,10 @@ const machine = setup({
               {
                 type: "acknowledgeUserInput",
               },
+              {
+                // Not our auto-submit path — discard any stale turn snapshot (#505).
+                type: "clearPendingTurnOutcome",
+              },
             ],
           },
           "saypi:piSpeaking": {
@@ -1262,11 +1349,41 @@ const machine = setup({
         states: {
           piThinking: {
             on: {
+              // Resume-window CLOSE (#505). v1 closes on the FIRST response signal
+              // to leave piThinking — piWriting (text) or piSpeaking (TTS). With
+              // TTS on the order is piThinking->piWriting->piSpeaking, so v1 closes
+              // at text-appear rather than the spec's preferred TTS-start; this
+              // slightly under-counts resumes in the text-shown-not-yet-spoken gap.
+              // Deliberate v1 simplification (founder-approved) — spec-fidelity is
+              // tracked in #510. Emitting on the single piThinking exit keeps it to
+              // exactly one event per turn.
               "saypi:piSpeaking": {
                 target: "piSpeaking",
+                actions: {
+                  type: "emitTurnOutcome",
+                  params: { kind: "response-started" },
+                },
               },
               "saypi:piWriting": {
                 target: "piWriting",
+                actions: {
+                  type: "emitTurnOutcome",
+                  params: { kind: "response-started" },
+                },
+              },
+              // The user resumed speaking before the response started — a
+              // false finish (we cut them off). Captured only when interruptions
+              // are enabled (the default); this is the same transition the parent
+              // `responding` region uses, with the outcome emit attached. (#505)
+              "saypi:userSpeaking": {
+                target: "#conversation.responding.userInterrupting",
+                guard: {
+                  type: "interruptionsAllowed",
+                },
+                actions: {
+                  type: "emitTurnOutcome",
+                  params: { kind: "resumed" },
+                },
               },
             },
             after: {
@@ -1276,6 +1393,11 @@ const machine = setup({
                   guard: {
                     type: "wasListening",
                   },
+                  // Window close: the response never started. (#505)
+                  actions: {
+                    type: "emitTurnOutcome",
+                    params: { kind: "no-response" },
+                  },
                   description:
                     "Fallback: Pi's response was never detected as written/spoken (e.g. host DOM drift broke completion detection). Recover the call's listening state instead of staying stuck on 'thinking', and restore the prompt placeholder via the exit action.",
                 },
@@ -1283,6 +1405,10 @@ const machine = setup({
                   target: "#conversation.inactive",
                   guard: {
                     type: "wasInactive",
+                  },
+                  actions: {
+                    type: "emitTurnOutcome",
+                    params: { kind: "no-response" },
                   },
                   description:
                     "Fallback when Pi was responding outside a call: return to inactive and restore the placeholder.",

--- a/test/TurnOutcomeModule.spec.ts
+++ b/test/TurnOutcomeModule.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --------------------------------------------------------------------------
+// Unit tests for the turn-outcome POST client (issue #505). This module is the
+// thin, text-free reporter that fires a fire-and-forget POST to the SayPi API's
+// /turn-outcome endpoint once a resume window closes. It must:
+//   - hit `${apiServerUrl}/turn-outcome` with a JSON body,
+//   - map its numeric (epoch-ms) timestamps to ISO-8601 strings (or null),
+//   - use snake_case field names matching the API contract,
+//   - carry NO transcript text (booleans, timestamps, a sequence number, a score),
+//   - skip entirely when the correlation keys (session id / sequence number)
+//     are missing — a useless event the server couldn't join.
+// --------------------------------------------------------------------------
+
+const callApiMock = vi.fn(
+  (_url: string, _options?: RequestInit): Promise<Response> =>
+    Promise.resolve(new Response(null, { status: 200 }))
+);
+
+vi.mock("../src/ApiClient", () => ({
+  callApi: (url: string, options?: RequestInit) => callApiMock(url, options),
+}));
+
+vi.mock("../src/ConfigModule", () => ({
+  config: { apiServerUrl: "https://api.example.com" },
+}));
+
+vi.mock("../src/LoggingModule.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { postTurnOutcome } from "../src/TurnOutcomeModule";
+
+describe("postTurnOutcome", () => {
+  beforeEach(() => {
+    callApiMock.mockClear();
+  });
+
+  it("POSTs a text-free turn-outcome to /turn-outcome with ISO timestamps", () => {
+    postTurnOutcome({
+      sessionId: "abc123",
+      lastSequenceNumber: 4,
+      trigger: "auto",
+      userResumed: false,
+      submittedAt: 1_000_000,
+      responseStartedAt: 1_000_500,
+      resumedAt: null,
+      lastSpeechEndedAt: 999_000,
+      pFinishedSpeaking: 0.42,
+      app: "pi",
+    });
+
+    expect(callApiMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = callApiMock.mock.calls[0];
+    expect(url).toBe("https://api.example.com/turn-outcome");
+    expect(opts?.method).toBe("POST");
+
+    const body = JSON.parse(opts!.body as string);
+    expect(body).toEqual({
+      session_id: "abc123",
+      last_sequence_number: 4,
+      trigger: "auto",
+      user_resumed: false,
+      submitted_at: new Date(1_000_000).toISOString(),
+      response_started_at: new Date(1_000_500).toISOString(),
+      resumed_at: null,
+      last_speech_ended_at: new Date(999_000).toISOString(),
+      p_finished_speaking: 0.42,
+      app: "pi",
+    });
+
+    // Privacy: the serialized body must never carry transcript text.
+    expect(opts!.body as string).not.toMatch(/text|transcript|prompt/i);
+  });
+
+  it("nulls out response_started_at / resumed_at when they never happened", () => {
+    postTurnOutcome({
+      sessionId: "s1",
+      lastSequenceNumber: 1,
+      userResumed: true,
+      submittedAt: 2_000_000,
+      responseStartedAt: null,
+      resumedAt: 2_000_300,
+      lastSpeechEndedAt: null,
+    });
+
+    const body = JSON.parse(callApiMock.mock.calls[0][1]!.body as string);
+    expect(body.trigger).toBe("auto"); // defaults to auto
+    expect(body.user_resumed).toBe(true);
+    expect(body.response_started_at).toBeNull();
+    expect(body.resumed_at).toBe(new Date(2_000_300).toISOString());
+    expect(body.last_speech_ended_at).toBeNull();
+    expect(body.p_finished_speaking).toBeNull();
+    expect(body.app).toBeNull();
+  });
+
+  it("skips the POST entirely when the session id is missing (nothing to correlate)", () => {
+    postTurnOutcome({
+      lastSequenceNumber: 1,
+      userResumed: false,
+      submittedAt: 1,
+      responseStartedAt: null,
+      resumedAt: null,
+      lastSpeechEndedAt: null,
+    });
+    expect(callApiMock).not.toHaveBeenCalled();
+  });
+
+  it("skips the POST when the last sequence number is missing (no join key)", () => {
+    postTurnOutcome({
+      sessionId: "s1",
+      userResumed: false,
+      submittedAt: 1,
+      responseStartedAt: null,
+      resumedAt: null,
+      lastSpeechEndedAt: null,
+    });
+    expect(callApiMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/state-machines/ConversationMachine-turnOutcome.spec.ts
+++ b/test/state-machines/ConversationMachine-turnOutcome.spec.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTestActor } from './support/testActor';
+
+// ---------------------------------------------------------------------------
+// Turn-outcome emission wiring (issue #505).
+//
+// The resume window lives entirely in ConversationMachine: it OPENS when the
+// endpointing auto-submit fires (converting.submitting) and CLOSES on the single
+// transition that leaves responding.piThinking:
+//   - piThinking -> piWriting / piSpeaking : the response started (response_started_at = now)
+//   - piThinking -> userInterrupting        : the user resumed first (user_resumed, resumed_at)
+//   - PI_THINKING_TIMEOUT_MS fallback         : response never started (response_started_at = null)
+// piThinking is entered/left exactly once per turn, so exactly one event fires.
+//
+// These tests assert the machine hands the right observation to postTurnOutcome
+// (mocked). The correlation data (session id, last sequence number, score,
+// speech-offset) is snapshotted from context at submit time.
+// ---------------------------------------------------------------------------
+
+// Mutable knobs so a single spec file can exercise both the normal (respond)
+// path and the maintenance-message (suppressed) path.
+const knobs = vi.hoisted(() => ({
+  discretionary: false,
+  allowInterruptions: true,
+  capacity: 1_000_000,
+}));
+
+const postTurnOutcomeMock = vi.hoisted(() => vi.fn());
+vi.mock('../../src/TurnOutcomeModule', () => ({
+  postTurnOutcome: postTurnOutcomeMock,
+}));
+
+vi.mock('../../src/ConfigModule', () => ({
+  config: { apiServerUrl: 'http://api.example.com' },
+}));
+
+vi.mock('../../src/AnimationModule.js', () => ({
+  default: {
+    startAnimation: vi.fn(),
+    stopAnimation: vi.fn(),
+    stopAllAnimations: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/NotificationsModule', () => {
+  class NoopAudible {
+    static instance = new NoopAudible();
+    static getInstance() { return NoopAudible.instance; }
+    listeningStopped() {}
+    callStarted() {}
+    callEnded() {}
+  }
+  class NoopTextual { showNotification() {}; hideNotification() {}; }
+  class NoopVisual { listeningStopped() {}; listeningTimeRemaining() {}; }
+  return {
+    AudibleNotificationsModule: NoopAudible,
+    TextualNotificationsModule: NoopTextual,
+    VisualNotificationsModule: NoopVisual,
+  };
+});
+
+vi.mock('../../src/audio/AudioControlsModule', () => ({
+  default: vi.fn().mockImplementation(() => ({ activateAudioOutput: vi.fn() })),
+}));
+
+vi.mock('../../src/WakeLockModule', () => ({
+  requestWakeLock: vi.fn(),
+  releaseWakeLock: vi.fn(),
+}));
+
+vi.mock('../../src/i18n', () => ({ default: vi.fn(() => 'MSG') }));
+
+const fixedDelayMs = 200;
+vi.mock('../../src/TimerModule', () => ({
+  calculateDelay: vi.fn(() => fixedDelayMs),
+}));
+
+vi.mock('../../src/TranscriptionModule', () => ({
+  uploadAudioWithRetry: vi.fn(() => Promise.resolve(1)),
+  isTranscriptionPending: vi.fn(() => false),
+  clearPendingTranscriptions: vi.fn(),
+  getCurrentSequenceNumber: vi.fn(() => 1),
+}));
+
+vi.mock('../../src/TranscriptMergeService', () => ({
+  TranscriptMergeService: vi.fn().mockImplementation(() => ({
+    mergeTranscriptsLocal: (t: Record<number, string>) => Object.values(t).join(' '),
+  })),
+}));
+
+vi.mock('../../src/prefs/PreferenceModule', () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({
+      getLanguage: () => Promise.resolve('en'),
+      getDiscretionaryMode: () => Promise.resolve(knobs.discretionary),
+      getCachedDiscretionaryMode: () => knobs.discretionary,
+      getCachedAutoSubmit: () => true,
+      getCachedAllowInterruptions: () => knobs.allowInterruptions,
+      getCachedNickname: () => null,
+    }),
+  },
+}));
+
+import { createConversationMachine } from '../../src/state-machines/ConversationMachine';
+
+const spyPrompt = {
+  setMessage(_: string) {},
+  setDraft(_: string) {},
+  setFinal(_: string) {},
+  getDraft() { return ''; },
+  getDefaultPlaceholderText() { return ''; },
+};
+const StubChatbot = {
+  getName: () => 'Pi',
+  getPrompt: (_el?: HTMLElement) => spyPrompt,
+  getContextWindowCapacityCharacters: () => knobs.capacity,
+};
+
+// Drive: place a call, speak one clip, transcribe it, then let the submission
+// delay elapse so the machine auto-submits into responding.piThinking.
+function driveToPiThinking(service: any) {
+  service.send('saypi:call');
+  service.send('saypi:callReady');
+  // session:assigned is only handled once the machine is listening (it lives in
+  // the listening parallel region's `on`), mirroring the real session lifecycle.
+  service.send({ type: 'saypi:session:assigned', session_id: 'sess-1' });
+  service.send('saypi:userSpeaking');
+  const blob = new Blob(['a'], { type: 'audio/webm' });
+  service.send({ type: 'saypi:userStoppedSpeaking', duration: 800, blob });
+  vi.advanceTimersByTime(50);
+  service.send({
+    type: 'saypi:transcribed',
+    text: 'Good evening.',
+    sequenceNumber: 1,
+    pFinishedSpeaking: 0.2,
+    tempo: 0.86,
+  });
+  vi.advanceTimersByTime(fixedDelayMs + 5);
+}
+
+describe('ConversationMachine: turn-outcome emission', () => {
+  let service: any;
+
+  beforeEach(() => {
+    knobs.discretionary = false;
+    knobs.allowInterruptions = true;
+    knobs.capacity = 1_000_000;
+    postTurnOutcomeMock.mockClear();
+    document.body.innerHTML = '<textarea id="saypi-prompt"></textarea>';
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1_000_000));
+    const machine = createConversationMachine(StubChatbot as any);
+    service = createTestActor(machine);
+    service.start();
+  });
+
+  afterEach(() => {
+    try { service?.stop(); } catch {}
+    vi.useRealTimers();
+  });
+
+  it('emits response-started with the turn snapshot when the reply text appears (piWriting)', () => {
+    driveToPiThinking(service);
+    expect(service.state.matches({ responding: 'piThinking' })).toBe(true);
+
+    service.send('saypi:piWriting');
+
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+    const arg = postTurnOutcomeMock.mock.calls[0][0];
+    expect(arg.trigger).toBe('auto');
+    expect(arg.userResumed).toBe(false);
+    expect(arg.resumedAt).toBeNull();
+    expect(typeof arg.responseStartedAt).toBe('number');
+    // correlation snapshot from context
+    expect(arg.sessionId).toBe('sess-1');
+    expect(arg.lastSequenceNumber).toBe(1);
+    expect(arg.pFinishedSpeaking).toBe(0.2);
+    expect(typeof arg.submittedAt).toBe('number');
+    expect(typeof arg.lastSpeechEndedAt).toBe('number');
+    expect(arg.lastSpeechEndedAt).toBeGreaterThan(0);
+  });
+
+  it('emits response-started when TTS begins (piSpeaking)', () => {
+    driveToPiThinking(service);
+    service.send('saypi:piSpeaking');
+
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+    const arg = postTurnOutcomeMock.mock.calls[0][0];
+    expect(arg.userResumed).toBe(false);
+    expect(typeof arg.responseStartedAt).toBe('number');
+  });
+
+  it('emits a resume (false-finish) when the user speaks again before the response starts', () => {
+    driveToPiThinking(service);
+    expect(service.state.matches({ responding: 'piThinking' })).toBe(true);
+
+    // The user resumes mid-window. This is the load-bearing assumption:
+    // saypi:userSpeaking is observable in piThinking and captured as a resume.
+    service.send('saypi:userSpeaking');
+
+    expect(service.state.matches({ responding: 'userInterrupting' })).toBe(true);
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+    const arg = postTurnOutcomeMock.mock.calls[0][0];
+    expect(arg.userResumed).toBe(true);
+    expect(typeof arg.resumedAt).toBe('number');
+    expect(arg.responseStartedAt).toBeNull();
+  });
+
+  it('emits with no response_started_at when piThinking times out (response never starts)', () => {
+    driveToPiThinking(service);
+    expect(service.state.matches({ responding: 'piThinking' })).toBe(true);
+
+    vi.advanceTimersByTime(20_000); // exceed PI_THINKING_TIMEOUT_MS
+
+    expect(service.state.matches({ responding: 'piThinking' })).toBe(false);
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+    const arg = postTurnOutcomeMock.mock.calls[0][0];
+    expect(arg.userResumed).toBe(false);
+    expect(arg.responseStartedAt).toBeNull();
+  });
+
+  it('does NOT re-emit a stale snapshot when piThinking is entered outside the auto-submit path', () => {
+    // Turn 1: a real auto-submit -> response starts -> one emit, then back to listening.
+    driveToPiThinking(service);
+    service.send('saypi:piWriting');
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+    service.send('saypi:piStoppedWriting');
+    expect(service.state.matches('listening')).toBe(true);
+
+    // A later, non-SayPi-submit thinking episode (e.g. the assistant starts
+    // responding to a manually-typed message) enters responding.piThinking via
+    // the listening `saypi:piThinking` handler — NOT via converting.submitting, so
+    // no fresh snapshot is taken. The prior turn's snapshot must not be re-emitted.
+    service.send('saypi:piThinking');
+    expect(service.state.matches({ responding: 'piThinking' })).toBe(true);
+    service.send('saypi:piWriting');
+
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1); // still only turn 1's emit
+  });
+
+  it('does NOT emit for maintenance messages (suppressed, forced buffer flush)', () => {
+    // discretionary mode -> shouldRespond false; tiny context window -> mustRespond
+    // via capacity. Together: mustRespond && !shouldRespond == maintenance.
+    knobs.discretionary = true;
+    knobs.capacity = 1;
+
+    driveToPiThinking(service);
+    expect(service.state.matches({ responding: 'piThinking' })).toBe(true);
+
+    service.send('saypi:piWriting');
+
+    expect(postTurnOutcomeMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #505.

## What & why

Reports a **text-free** turn-outcome to the SayPi API (`POST /turn-outcome`) after every endpointing-driven auto-submit, so the server can score how good `pFinishedSpeaking` is at deciding when a user's turn ended. The only non-circular ground truth for "did the user actually finish?" is whether they started speaking again inside the *resume window* (submit → assistant response starts) — a resume means we cut them off. API side is saypi-api PR #310; design/rationale in PR #309.

## Approach

The whole window already lives in `ConversationMachine`, so this rides existing transitions rather than inventing detection (no VAD/DOM/observer changes):

- **Window OPEN** — `converting.submitting` snapshots the correlation data (session id, last sequence number + its `pFinishedSpeaking`, speech-offset, app) into context. Only the endpointing auto-submit path reaches this state, so every emit is `trigger:"auto"` — manual sends bypass the machine and emit nothing.
- **Window CLOSE** — the single transition that leaves `responding.piThinking`: `piWriting`/`piSpeaking` (response started), `userInterrupting` (user resumed first — a false finish), or the `PI_THINKING_TIMEOUT_MS` fallback (response never started). `piThinking` is entered/left once per turn, so **exactly one** event fires.
- **`postTurnOutcome()`** — a thin, fire-and-forget POST in a new `TurnOutcomeModule`, reusing the shared `callApi` client (JWT/anon + CSP-safe background routing + 401-retry). Never awaited, never retried, never throws to the machine; a dropped event just leaves that turn to the server-side fallback. Payload is booleans, timestamps, a sequence number and an optional score — **no transcript text**.

## Founder-approved v1 decisions

- **Resume detection**: captured when interruptions are ON (the default). When OFF, a resume during `piThinking` isn't captured — an accepted optimism bias for v1.
- **`last_speech_ended_at`**: uses `timeUserStoppedSpeaking` (same clock as `submitted_at`, so latency subtraction is skew-free).
- **Maintenance messages excluded** — suppressed buffer flushes aren't real endpointing decisions.
- **`last_sequence_number`**: highest sequence number assigned in the turn, paired with its `pFinishedSpeaking` from the same `/transcribe` response.
- **Window close = first response signal** (`piWriting`/`piSpeaking`). With TTS on this closes at text-appear rather than the spec's preferred TTS-start; spec-fidelity is a documented follow-up (**#510**).

## Correctness note found in review

Fixed a latent stale-snapshot re-emit: `piThinking` has a second, non-submit entry (the `saypi:piThinking` handler in `listening`, currently emitter-less but wired). Entering `piThinking` that way now clears `pendingTurnOutcome`, so a prior turn's snapshot can't be re-emitted as a spurious `auto` event. Covered by a regression test.

## Known v1 limitations (non-blocking)

- A VAD onset later cancelled as non-speech (`userInterrupting → piSpeaking` on `hasNoAudio`) still emits `user_resumed:true` — slight over-count, defensible under the spec's "VAD detect the user starting to speak" wording.
- The resume wiring is proven at the unit layer by direct event injection; it rides the already-proven barge-in path (`saypi:userSpeaking` → `userInterrupting` during `responding`) rather than being re-verified end-to-end on a live host.

## Tests

- `test/TurnOutcomeModule.spec.ts` — POST body/URL, ISO timestamps, privacy (no text), skip-without-correlation-key.
- `test/state-machines/ConversationMachine-turnOutcome.spec.ts` — response-started (piWriting & piSpeaking), resume/false-finish, timeout, maintenance exclusion, stale-snapshot regression.
- Full suite green (tsc + Jest + Vitest): 207 files, 1804 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)