### PR TITLE
fix(audio): drop deprecated 'unload' listeners from audio lifecycle (#449)

### DIFF
--- a/src/AIChatModule.ts
+++ b/src/AIChatModule.ts
@@ -47,20 +47,13 @@ export class AIChatModule {
       submitErrorHandler.checkForRestorePoint();
 
       new ImmersionService(chatbot).initMode();
-      this.startAudioModule();
+      this.audioModule.start();
       this.isLoaded = true;
     });
 
     // Initialize chat-specific modules
     EventModule.init();
     new DOMObserver(chatbot).observeDOM();
-  }
-
-  private startAudioModule(): void {
-    window.addEventListener("unload", () => {
-      this.audioModule.stop();
-    });
-    this.audioModule.start();
   }
 
   private addVisualisations(container: HTMLElement | null): void {

--- a/src/audio/AudioModule.js
+++ b/src/audio/AudioModule.js
@@ -193,8 +193,6 @@ export default class AudioModule {
     }
   }
 
-  stop() {}
-
   initializeVoiceConverter() {
     const prefs = UserPreferenceModule.getInstance();
     ChatbotService.getChatbot().then((chatbot) => {

--- a/src/saypi.index.js
+++ b/src/saypi.index.js
@@ -173,17 +173,10 @@ import "./styles/pi.scss"; // scoped by chatbot flags, i.e. <body class="pi">
     
     // UniversalDictationModule is already imported statically - just use it
 
-    function startAudioModule() {
-      window.addEventListener("unload", () => {
-        audioModule.stop();
-      });
-      audioModule.start();
-    }
-
     // Start audio module when dictation is needed
     EventBus.on("saypi:dictation:initialized", function () {
       console.log("Starting audio module for dictation");
-      startAudioModule();
+      audioModule.start();
     });
     
     // Initialize Universal Dictation Module

--- a/test/no-deprecated-unload-listener.spec.ts
+++ b/test/no-deprecated-unload-listener.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Regression guard for #449: SayPi used to register
+ * `window.addEventListener("unload", () => audioModule.stop())` in two audio
+ * lifecycle call sites — `src/saypi.index.js` (universal dictation init) and
+ * `src/AIChatModule.ts` (chat-host init).
+ *
+ * `unload` is deprecated in Chrome: pages that register it are logged with
+ * "Permissions policy violation: unload is not allowed in this document" (seen
+ * on the headerless local fixture during the e2e-dictation-sweep) and it can
+ * disable back/forward-cache eligibility. The handler itself was inert —
+ * `AudioModule.stop()` is a no-op with no other callers — so the listeners were
+ * removed outright rather than replaced.
+ *
+ * This scans the REAL source (not a mock) so it both proves the removal and
+ * stops a deprecated `unload` listener from creeping back in. Both the
+ * `addEventListener("unload", …)` form and the equivalent `window.onunload = …`
+ * property form are caught, across `src/` and the `entrypoints/` shims. The
+ * pattern is anchored so it deliberately ignores the out-of-scope, still-
+ * legitimate `beforeunload`/`onbeforeunload` handlers (e.g. the one in
+ * `UniversalDictationModule.ts`).
+ */
+const root = resolve(__dirname, "..");
+const scanRoots = ["src", "entrypoints"].map((d) => resolve(root, d));
+
+// Matches addEventListener("unload"...) / addEventListener('unload'...) and the
+// window.onunload = ... property form, with any whitespace — but NOT their
+// `beforeunload` counterparts (the quote / dot must sit immediately before
+// `unload`, so "beforeunload"/onbeforeunload never match).
+const DEPRECATED_UNLOAD = /addEventListener\(\s*["']unload["']|\.onunload\s*=/;
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectSourceFiles(full));
+    } else if (/\.(ts|tsx|js|jsx|mjs)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const sourceFiles = scanRoots.flatMap(collectSourceFiles);
+
+describe("#449 no deprecated 'unload' event listeners in src/ or entrypoints/", () => {
+  it("sanity: the scan actually walked the source tree", () => {
+    expect(sourceFiles.length).toBeGreaterThan(50);
+  });
+
+  it("registers no window/document 'unload' listeners", () => {
+    const offenders = sourceFiles.filter((file) =>
+      DEPRECATED_UNLOAD.test(readFileSync(file, "utf8"))
+    );
+    const relative = offenders.map((f) => f.slice(root.length + 1));
+    expect(relative).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #449.

## What & why

SayPi registered a deprecated `window.addEventListener("unload", () => audioModule.stop())` in two audio-lifecycle call sites — the chat-host init (`AIChatModule.startAudioModule`) and the universal-dictation init (`startAudioModule` in `saypi.index.js`). Chrome deprecated `unload`: pages that register it get a `Permissions policy violation: unload is not allowed in this document` console warning (surfaced on the headerless local fixture by the `e2e-dictation-sweep` from #448) and can lose back/forward-cache eligibility.

The decisive fact: **`AudioModule.stop()` has been an empty no-op since it was first introduced** (`git log -L` on the method confirms it never had a body), and these two listeners were its *only* callers. So the handlers did nothing — there was no cleanup to preserve. That's why this **removes** the listeners rather than swapping in `pagehide` (a `pagehide` no-op would be equally pointless, and would still have to reason about bfcache-entry firing that this code never needed to handle).

Vestigial-structure cleanup went with it: each now-trivial `startAudioModule()` wrapper was collapsed into its single `audioModule.start()` call site, and the dead `stop()` method was deleted.

## Root cause of the fixture-warns / Mistral-doesn't discrepancy (AC #1)

It is **not** a site header re-enabling `unload`. `chat.mistral.ai`'s `Permissions-Policy` header doesn't mention `unload` at all. The discrepancy is Chrome's gradual **`unload`-deprecation rollout** — a browser-side default-allowlist flip that is scheme/origin/cohort dependent: headerless `http://localhost` is in the "disallowed" cohort (so it warns), `https://chat.mistral.ai` was not at sweep time (so it didn't). The removal is correct regardless of which document sees the warning.

## Why removal is safe (adversarially verified)

Real teardown of the leak-prone resources (offscreen document, VAD port, mic) is **port-disconnect-driven, not unload-driven** — `offscreen_manager.ts` tears down on content-script port disconnect, and `OffscreenVADClient` reconnects lazily; Chrome fires `port.onDisconnect` automatically on page destruction independent of the `unload` event. So nothing that the (inert) unload handler could have reclaimed is now leaked, and dropping the bfcache-blocking listener is the intended improvement.

A three-lens adversarial verification pass (missed-caller hunt · lifecycle/leak · diff+guard soundness) found no reason the removal is unsafe:
- no other caller of `AudioModule.stop()`, no interface/mock/dynamic-dispatch expecting it;
- no code depended on the `unload` listener firing (it was a no-op);
- the out-of-scope `beforeunload` → `destroy()` listener in `UniversalDictationModule` is deliberately untouched.

## Tests

Fail-first TDD: added `test/no-deprecated-unload-listener.spec.ts`, a source-scan regression guard that fails red on the two pre-existing listeners, then passes after removal. It catches both the `addEventListener("unload", …)` and the equivalent `window.onunload = …` forms, scans `src/` and `entrypoints/`, and is anchored to ignore the legitimate `beforeunload`/`onbeforeunload` handlers.

Full required gate green locally: `tsc --noEmit` clean · Jest 2/2 · Vitest 1809 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
