### PR TITLE
feat(voices): default new installs to the server-recommended voice (Marin)

### DIFF
--- a/src/onboarding/voiceDefaults.ts
+++ b/src/onboarding/voiceDefaults.ts
@@ -1,0 +1,74 @@
+/**
+ * New-install voice defaulting (2026-07-05 shortlist redesign;
+ * doc/plans/2026-07-05-voice-shortlist-pins-design.md).
+ *
+ * On a FRESH install only, each chat host is marked "pending" a default voice.
+ * The first time the user's voice is resolved for a pending host — once signed
+ * in, so the catalog is available — the server-`recommended` voice is adopted,
+ * persisted, and the host is drained from the pending set. Any explicit voice
+ * choice OR "Voice off" also drains the host, so a deliberate off is never
+ * re-defaulted.
+ *
+ * Existing users (extension UPDATE, not install) never get the pending marker,
+ * so their voice — including a deliberate "Voice off", which is stored
+ * identically to "never chose" — is never touched (grandfathering / no silent
+ * swap). Reversible: reverting this code simply stops seeding future installs;
+ * already-adopted users keep a normal, user-changeable voice preference.
+ *
+ * The default itself is server-driven (the `recommended` manifest field), so it
+ * is inert until the server nominates one — the additive-optional contract.
+ *
+ * Logic is dependency-injected (like firstRun.ts) so it unit-tests without a
+ * real `browser`/storage; PreferenceModule + the background worker wire it up.
+ */
+import { isFreshInstall } from "./firstRun";
+
+/** chrome.storage.local key holding the host ids still awaiting a default. */
+export const VOICE_DEFAULT_PENDING_KEY = "saypi_voice_default_pending_hosts";
+
+/** Hosts that get an auto-adopted default voice on a fresh install. */
+export const DEFAULTABLE_HOST_IDS = ["claude", "pi"] as const;
+
+export interface VoiceDefaultStorage {
+  get: (key: string) => Promise<unknown>;
+  set: (key: string, value: unknown) => Promise<void>;
+}
+
+/** Normalise whatever is stored under the pending key to a string[]. */
+export function toPendingHosts(raw: unknown): string[] {
+  return Array.isArray(raw)
+    ? raw.filter((h): h is string => typeof h === "string")
+    : [];
+}
+
+/** Whether a host is still awaiting its first-install default voice. */
+export function isDefaultPending(raw: unknown, hostId: string): boolean {
+  return toPendingHosts(raw).includes(hostId);
+}
+
+/** The pending set with `hostId` removed (drained). */
+export function withHostDrained(raw: unknown, hostId: string): string[] {
+  return toPendingHosts(raw).filter((h) => h !== hostId);
+}
+
+/**
+ * On a fresh install (never an update), mark every defaultable host pending.
+ * Idempotent — a repeated install event won't clobber an in-progress set.
+ * Swallows errors: a failure here must never break installation. Returns
+ * whether the marker was written.
+ */
+export async function seedVoiceDefaultsOnFreshInstall(
+  reason: string | undefined,
+  storage: VoiceDefaultStorage
+): Promise<boolean> {
+  try {
+    if (!isFreshInstall(reason)) return false;
+    const existing = await storage.get(VOICE_DEFAULT_PENDING_KEY);
+    if (existing !== undefined && existing !== null) return false;
+    await storage.set(VOICE_DEFAULT_PENDING_KEY, [...DEFAULTABLE_HOST_IDS]);
+    return true;
+  } catch (e) {
+    console.debug("[VoiceDefaults] Failed to seed pending defaults:", e);
+    return false;
+  }
+}

--- a/src/prefs/PreferenceModule.ts
+++ b/src/prefs/PreferenceModule.ts
@@ -916,6 +916,13 @@ class UserPreferenceModule {
       const voices = await tts.getVoices(chatbotInstance, chatbotId);
       const recommended = (voices ?? []).find((voice) => voice.recommended);
       if (!recommended) return null; // server hasn't nominated a default yet
+      // Re-validate before the terminal write: the /voices fetch above is a real
+      // network round-trip, and a concurrent explicit setVoice/unsetVoice (e.g.
+      // the user turning voice OFF in another tab) may have drained this host
+      // meanwhile. Adopting now would clobber that explicit choice — a silent
+      // swap. If the host is no longer pending, the explicit action won; bail.
+      const pendingNow = await this.getVoiceDefaultPendingRaw();
+      if (!isDefaultPending(pendingNow, chatbotId)) return null;
       // setVoice persists the choice, drains this host, and notifies listeners.
       await this.setVoice(recommended, chatbot);
       return recommended;

--- a/src/prefs/PreferenceModule.ts
+++ b/src/prefs/PreferenceModule.ts
@@ -11,6 +11,11 @@ import { isFirefox, isSafari } from "../UserAgentModule";
 import { getJwtManager, getJwtManagerSync } from "../JwtManager";
 import { Chatbot } from "../chatbots/Chatbot";
 import { ChatbotIdentifier } from "../chatbots/ChatbotIdentifier";
+import {
+  VOICE_DEFAULT_PENDING_KEY,
+  isDefaultPending,
+  withHostDrained,
+} from "../onboarding/voiceDefaults";
 
 type Preference = "speed" | "balanced" | "accuracy" | null;
 type VoicePreference = SpeechSynthesisVoiceRemote | null;
@@ -827,7 +832,9 @@ class UserPreferenceModule {
     const voiceIdToFetch = preferences[chatbotId] ?? null;
 
     if (!voiceIdToFetch) {
-      return null;
+      // No stored voice. On a fresh install this host may still be awaiting its
+      // default — adopt the server-recommended voice once (see maybeAdoptDefaultVoice).
+      return await this.maybeAdoptDefaultVoice(chatbotId, chatbot);
     }
 
     if (PiAIVoice.isPiVoiceId(voiceIdToFetch)) {
@@ -860,6 +867,69 @@ class UserPreferenceModule {
     }
   }
 
+  /**
+   * In-flight guard so rapid first-render getVoice calls for the same host don't
+   * each fetch the catalog and adopt (writes are idempotent, but this avoids
+   * duplicate network calls + userPreferenceChanged emits).
+   */
+  private adoptingDefaultHosts = new Set<string>();
+
+  /** Read the raw first-install "pending default" host set from local storage. */
+  private async getVoiceDefaultPendingRaw(): Promise<unknown> {
+    return await this.getStoredValue(VOICE_DEFAULT_PENDING_KEY, [], "local");
+  }
+
+  /** Remove a host from the first-install pending-default set (idempotent). */
+  private async drainVoiceDefault(chatbotId: string): Promise<void> {
+    const raw = await this.getVoiceDefaultPendingRaw();
+    if (!isDefaultPending(raw, chatbotId)) return;
+    await this.setStoredValue(
+      VOICE_DEFAULT_PENDING_KEY,
+      withHostDrained(raw, chatbotId),
+      "local"
+    );
+  }
+
+  /**
+   * On a fresh install (this host still "pending"), adopt the server-`recommended`
+   * voice the first time it's needed — once signed in, so /voices is populated.
+   * Returns the adopted voice, or null when there's nothing to adopt (host not
+   * pending, signed out, or the server has nominated no recommended voice — in
+   * which case the host stays pending and a later call retries). Never throws.
+   */
+  private async maybeAdoptDefaultVoice(
+    chatbotId: string,
+    chatbot?: Chatbot | string
+  ): Promise<VoicePreference> {
+    const raw = await this.getVoiceDefaultPendingRaw();
+    if (!isDefaultPending(raw, chatbotId)) return null;
+    // /voices needs auth; while signed out the catalog is empty and no default is
+    // knowable — leave the host pending and retry after sign-in.
+    if (!getJwtManagerSync().isAuthenticated()) return null;
+    if (this.adoptingDefaultHosts.has(chatbotId)) return null;
+    this.adoptingDefaultHosts.add(chatbotId);
+    try {
+      const apiServerUrl = config.apiServerUrl;
+      if (!apiServerUrl) return null;
+      const tts = SpeechSynthesisModule.getInstance(apiServerUrl);
+      const chatbotInstance = typeof chatbot === "string" ? undefined : chatbot;
+      const voices = await tts.getVoices(chatbotInstance, chatbotId);
+      const recommended = (voices ?? []).find((voice) => voice.recommended);
+      if (!recommended) return null; // server hasn't nominated a default yet
+      // setVoice persists the choice, drains this host, and notifies listeners.
+      await this.setVoice(recommended, chatbot);
+      return recommended;
+    } catch (e) {
+      console.debug(
+        `[PreferenceModule] default-voice adoption for ${chatbotId} failed:`,
+        e
+      );
+      return null;
+    } finally {
+      this.adoptingDefaultHosts.delete(chatbotId);
+    }
+  }
+
   public async setVoice(voice: SpeechSynthesisVoiceRemote, chatbot?: Chatbot | string): Promise<void> {
     const provider = audioProviders.retrieveProviderByEngine(voice.powered_by);
     const chatbotId = this.resolveChatbotId(chatbot);
@@ -874,6 +944,8 @@ class UserPreferenceModule {
     };
 
     await this.persistVoicePreferences(updatedPreferences);
+    // An explicit voice choice seals this host from first-install auto-defaulting.
+    await this.drainVoiceDefault(chatbotId);
     EventBus.emit("userPreferenceChanged", {
       voiceId: voice.id,
       voice,
@@ -891,6 +963,8 @@ class UserPreferenceModule {
     if (!chatbotId) {
       return;
     }
+    // A deliberate "Voice off" must never be re-defaulted on a fresh install.
+    await this.drainVoiceDefault(chatbotId);
     const preferences = await this.getVoicePreferences();
     if (!(chatbotId in preferences)) {
       EventBus.emit("userPreferenceChanged", {

--- a/src/svc/background.ts
+++ b/src/svc/background.ts
@@ -6,6 +6,7 @@ import { sendOnboardingHint, voiceGoalFromUrl } from "../auth/OnboardingHint";
 import { registerDevReloadHandler, DEV_FEED_SPEECH_MESSAGE } from "../dev/devReload";
 import { pickSyntheticSpeechClip } from "../offscreen/syntheticSpeechPool";
 import { maybeOpenFirstRunTab } from "../onboarding/firstRun";
+import { seedVoiceDefaultsOnFreshInstall } from "../onboarding/voiceDefaults";
 import { detectPermissionLoss, buildPermissionsUrl, MIC_GRANTED_FLAG } from "../permissions/permissionLossDetection";
 
 // Track when PKCE authentication is in progress to prevent cookie listener interference
@@ -443,6 +444,16 @@ browser.runtime.onInstalled.addListener((details) => {
       get: async (key: string) => (await browser.storage.local.get(key))[key],
       set: async (key: string, value: unknown) =>
         browser.storage.local.set({ [key]: value }),
+    },
+  });
+
+  // On a fresh install (never an update), mark the chat hosts as pending a
+  // default voice; the content script then adopts the server-recommended voice
+  // on first use. Existing users are never touched (grandfathering).
+  void seedVoiceDefaultsOnFreshInstall(details.reason, {
+    get: async (key: string) => (await browser.storage.local.get(key))[key],
+    set: async (key: string, value: unknown) => {
+      await browser.storage.local.set({ [key]: value });
     },
   });
 });

--- a/test/onboarding/voiceDefaults.spec.ts
+++ b/test/onboarding/voiceDefaults.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  VOICE_DEFAULT_PENDING_KEY,
+  DEFAULTABLE_HOST_IDS,
+  toPendingHosts,
+  isDefaultPending,
+  withHostDrained,
+  seedVoiceDefaultsOnFreshInstall,
+} from "../../src/onboarding/voiceDefaults";
+
+describe("voiceDefaults pure helpers", () => {
+  it("normalises stored pending values to a string[]", () => {
+    expect(toPendingHosts(["claude", "pi"])).toEqual(["claude", "pi"]);
+    expect(toPendingHosts(["claude", 3, null, "pi"])).toEqual(["claude", "pi"]);
+    expect(toPendingHosts(undefined)).toEqual([]);
+    expect(toPendingHosts("nope")).toEqual([]);
+  });
+
+  it("reports pending membership", () => {
+    expect(isDefaultPending(["claude", "pi"], "claude")).toBe(true);
+    expect(isDefaultPending(["pi"], "claude")).toBe(false);
+    expect(isDefaultPending(undefined, "claude")).toBe(false);
+  });
+
+  it("drains a host from the pending set", () => {
+    expect(withHostDrained(["claude", "pi"], "claude")).toEqual(["pi"]);
+    expect(withHostDrained(["pi"], "claude")).toEqual(["pi"]);
+    expect(withHostDrained(undefined, "claude")).toEqual([]);
+  });
+});
+
+describe("seedVoiceDefaultsOnFreshInstall", () => {
+  const makeStorage = (initial?: unknown) => {
+    const store: Record<string, unknown> = {};
+    if (initial !== undefined) store[VOICE_DEFAULT_PENDING_KEY] = initial;
+    return {
+      store,
+      get: vi.fn((key: string) => Promise.resolve(store[key])),
+      set: vi.fn((key: string, value: unknown) => {
+        store[key] = value;
+        return Promise.resolve();
+      }),
+    };
+  };
+
+  it("marks every defaultable host pending on a fresh install", async () => {
+    const s = makeStorage();
+    const wrote = await seedVoiceDefaultsOnFreshInstall("install", s);
+    expect(wrote).toBe(true);
+    expect(s.store[VOICE_DEFAULT_PENDING_KEY]).toEqual([...DEFAULTABLE_HOST_IDS]);
+  });
+
+  it("does NOT seed on an update (existing users are grandfathered)", async () => {
+    const s = makeStorage();
+    const wrote = await seedVoiceDefaultsOnFreshInstall("update", s);
+    expect(wrote).toBe(false);
+    expect(s.set).not.toHaveBeenCalled();
+    expect(s.store[VOICE_DEFAULT_PENDING_KEY]).toBeUndefined();
+  });
+
+  it("does NOT clobber an already-seeded pending set (repeated install event)", async () => {
+    const s = makeStorage(["pi"]); // claude already drained, pi still pending
+    const wrote = await seedVoiceDefaultsOnFreshInstall("install", s);
+    expect(wrote).toBe(false);
+    expect(s.set).not.toHaveBeenCalled();
+    expect(s.store[VOICE_DEFAULT_PENDING_KEY]).toEqual(["pi"]);
+  });
+
+  it("never throws — a storage failure must not break installation", async () => {
+    const failing = {
+      get: vi.fn(() => Promise.reject(new Error("boom"))),
+      set: vi.fn(() => Promise.resolve()),
+    };
+    await expect(
+      seedVoiceDefaultsOnFreshInstall("install", failing)
+    ).resolves.toBe(false);
+  });
+});

--- a/test/prefs/VoicePreferences.spec.ts
+++ b/test/prefs/VoicePreferences.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SpeechSynthesisVoiceRemote } from '../../src/tts/SpeechModel';
+import { VOICE_DEFAULT_PENDING_KEY } from '../../src/onboarding/voiceDefaults';
 
 const store: Record<string, any> = {};
 let originalChrome: any;
@@ -8,6 +9,7 @@ let originalChrome: any;
 // so tests can make the lookup fail on demand (#456).
 const speechSynthesisMock = vi.hoisted(() => ({
   getVoiceById: vi.fn(),
+  getVoices: vi.fn(),
 }));
 vi.mock('../../src/tts/SpeechSynthesisModule', () => ({
   SpeechSynthesisModule: { getInstance: () => speechSynthesisMock },
@@ -85,6 +87,8 @@ beforeEach(async () => {
 
   fakeAuth.authenticated = false;
   speechSynthesisMock.getVoiceById.mockReset();
+  speechSynthesisMock.getVoices.mockReset();
+  speechSynthesisMock.getVoices.mockResolvedValue([]);
 
   prefsModule = await import('../../src/prefs/PreferenceModule');
   // Allow async initialization to settle
@@ -158,5 +162,98 @@ describe('UserPreferenceModule voice preference across auth changes (#456)', () 
 
     expect(voice).toBeNull();
     expect(store.voicePreferences).toEqual({});
+  });
+});
+
+// New installs (only) adopt the server-`recommended` voice on first use per host.
+// Existing users — including a deliberate "Voice off", stored identically to
+// "never chose" — are never touched (no pending marker), so their voice is never
+// silently swapped. See doc/plans/2026-07-05-voice-shortlist-pins-design.md.
+describe('UserPreferenceModule new-install default voice (Marin, 2026-07-05)', () => {
+  const createRecommendedVoice = (
+    id: string,
+    name: string
+  ): SpeechSynthesisVoiceRemote => ({
+    id,
+    name,
+    lang: 'en-US',
+    price: 0,
+    price_per_thousand_chars_in_usd: 0,
+    price_per_thousand_chars_in_credits: 50,
+    powered_by: 'OpenAI',
+    default: false,
+    localService: false,
+    voiceURI: '',
+    recommended: true,
+  });
+  const marin = createRecommendedVoice('marin-openai', 'Marin');
+
+  it('adopts the server-recommended voice on a fresh install (pending + signed in)', async () => {
+    store[VOICE_DEFAULT_PENDING_KEY] = ['claude', 'pi'];
+    fakeAuth.authenticated = true;
+    speechSynthesisMock.getVoices.mockResolvedValue([
+      { ...createRecommendedVoice('x', 'X'), recommended: false },
+      marin,
+    ]);
+
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    const voice = await prefs.getVoice('claude');
+
+    expect(voice?.id).toBe('marin-openai');
+    expect(store.voicePreferences).toEqual({ claude: 'marin-openai' });
+    // host drained so it never re-adopts
+    expect(store[VOICE_DEFAULT_PENDING_KEY]).toEqual(['pi']);
+  });
+
+  it('does not adopt while signed out (catalog empty / default unknowable)', async () => {
+    store[VOICE_DEFAULT_PENDING_KEY] = ['claude', 'pi'];
+    fakeAuth.authenticated = false;
+
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    expect(await prefs.getVoice('claude')).toBeNull();
+    expect(store.voicePreferences ?? {}).toEqual({}); // nothing adopted
+    expect(store[VOICE_DEFAULT_PENDING_KEY]).toEqual(['claude', 'pi']); // stays pending
+  });
+
+  it('does not adopt when the server has nominated no recommended voice', async () => {
+    store[VOICE_DEFAULT_PENDING_KEY] = ['claude'];
+    fakeAuth.authenticated = true;
+    speechSynthesisMock.getVoices.mockResolvedValue([
+      { ...marin, recommended: false },
+    ]);
+
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    expect(await prefs.getVoice('claude')).toBeNull();
+    expect(store[VOICE_DEFAULT_PENDING_KEY]).toEqual(['claude']); // still pending, retries later
+  });
+
+  it('does not adopt for an existing user (no pending marker)', async () => {
+    fakeAuth.authenticated = true;
+    speechSynthesisMock.getVoices.mockResolvedValue([marin]);
+
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    expect(await prefs.getVoice('claude')).toBeNull();
+    expect(store.voicePreferences ?? {}).toEqual({}); // nothing adopted
+    expect(speechSynthesisMock.getVoices).not.toHaveBeenCalled();
+  });
+
+  it('a deliberate "Voice off" (unsetVoice) drains pending so it is never re-defaulted', async () => {
+    store[VOICE_DEFAULT_PENDING_KEY] = ['claude', 'pi'];
+    fakeAuth.authenticated = true;
+    speechSynthesisMock.getVoices.mockResolvedValue([marin]);
+
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    await prefs.unsetVoice('claude'); // user turns voice off before any adopt
+    expect(store[VOICE_DEFAULT_PENDING_KEY]).toEqual(['pi']);
+
+    expect(await prefs.getVoice('claude')).toBeNull(); // stays off, not re-defaulted
+    expect(store.voicePreferences ?? {}).toEqual({});
+  });
+
+  it('an explicit voice choice drains pending', async () => {
+    store[VOICE_DEFAULT_PENDING_KEY] = ['claude', 'pi'];
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    await prefs.setVoice(createPiVoice('voice2', 'Pi 2'), 'claude');
+    expect(store[VOICE_DEFAULT_PENDING_KEY]).toEqual(['pi']);
   });
 });

--- a/test/prefs/VoicePreferences.spec.ts
+++ b/test/prefs/VoicePreferences.spec.ts
@@ -256,4 +256,29 @@ describe('UserPreferenceModule new-install default voice (Marin, 2026-07-05)', (
     await prefs.setVoice(createPiVoice('voice2', 'Pi 2'), 'claude');
     expect(store[VOICE_DEFAULT_PENDING_KEY]).toEqual(['pi']);
   });
+
+  it('does NOT clobber a "Voice off" made while adoption is mid-flight (TOCTOU)', async () => {
+    // A slow /voices fetch leaves adoption in flight; the user turns voice off in
+    // another tab meanwhile. The in-flight adoption must re-check and bail, not
+    // silently swap Marin back on. (Reviewer-found race, 2026-07-05.)
+    store[VOICE_DEFAULT_PENDING_KEY] = ['claude', 'pi'];
+    fakeAuth.authenticated = true;
+    let resolveVoices: (v: SpeechSynthesisVoiceRemote[]) => void = () => {};
+    speechSynthesisMock.getVoices.mockReturnValue(
+      new Promise((resolve) => {
+        resolveVoices = resolve;
+      })
+    );
+
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    const adopt = prefs.getVoice('claude'); // starts the /voices fetch, in flight
+    await new Promise((r) => setTimeout(r, 0)); // let adoption park on getVoices()
+    await prefs.unsetVoice('claude'); // user turns voice off mid-fetch
+    resolveVoices([marin]);
+    const voice = await adopt;
+
+    expect(voice).toBeNull(); // adoption bailed
+    expect(store.voicePreferences ?? {}).toEqual({}); // stays off, not Marin
+    expect(store[VOICE_DEFAULT_PENDING_KEY]).toEqual(['pi']); // drained by the off
+  });
 });


### PR DESCRIPTION
## What

New installs adopt the server-`recommended` voice (Marin) the first time a host's voice is resolved after sign-in — so a brand-new user hears a real voice instead of silence, without ever choosing one. Second slice of the voice-shortlist redesign (`doc/plans/2026-07-05-voice-shortlist-pins-design.md`); follows #512.

## Invariant-safe rollout — "new installs only" (founder call)

Today "Voice off" and "never chose" are stored **identically** (the key is just deleted), so a blanket default would silently switch TTS on for someone who deliberately turned it **off**. Instead:

- `onInstalled(reason="install")` marks the chat hosts (`claude`, `pi`) *pending* a default. Extension **updates never get the marker** → existing users are never touched (grandfathering).
- `getVoice` adopts the `recommended` voice once per pending host (once signed in, so `/voices` is populated), then drains it.
- **Any explicit `setVoice` OR `unsetVoice` ("Voice off") drains the host** → a deliberate off is never re-defaulted.

Server-driven + additive-optional: **inert until the server nominates a `recommended` voice**, and reversible — reverting just stops seeding future installs; already-adopted users keep a normal, changeable preference. No 1-way door.

## Adversarial review found + fixed a race

A reviewer caught a TOCTOU: `maybeAdoptDefaultVoice` checked pending once, then did a real `/voices` fetch, then wrote — so a "Voice off" in another tab *during that network window* could be clobbered (silent swap). Fixed by re-validating pending immediately before the terminal write; fail-first test interleaves an in-flight adoption with `unsetVoice`.

## Files

`src/onboarding/voiceDefaults.ts` (new, DI-tested like `firstRun.ts`) · `src/prefs/PreferenceModule.ts` (adopt/drain) · `src/svc/background.ts` (onInstalled seed).

## Testing

Fail-first across `voiceDefaults.spec.ts` + `VoicePreferences.spec.ts`: adopt-on-fresh-install, no-adopt (signed-out / no-recommended / existing-user / voice-off-then-drain / explicit-choice-drains), and the TOCTOU race. Full gate green (tsc + Jest + 1821 Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WmjGuAUmFGQBZukitHp4L