### PR TITLE
feat(voices): pin store + curateShortlist pin membership (Phase 2a foundation)

### DIFF
--- a/src/tts/VoiceCuration.ts
+++ b/src/tts/VoiceCuration.ts
@@ -152,11 +152,20 @@ function pickHdFeatured(
  * featured pair + value voices by popularity rank — then fill any spare
  * capacity in server order (covers single-tier catalogs and short featured
  * sets). Deprecated voices are dropped first, except the current one.
+ *
+ * `pinnedIds` (Phase-2 user pins) overrides shortlist membership when the user
+ * has curated their own: membership IS the pinned set, in catalog order, with
+ * the current voice still pinned first. In that mode there is NO fill-to-cap
+ * padding — an empty pinned set legitimately yields just the current voice, and
+ * the "More voices…" door (added by the menu, not here) keeps it non-empty. A
+ * null/absent `pinnedIds` leaves every existing path exactly as it was, so a
+ * user who has never pinned sees the unchanged server-featured behaviour.
  */
 export function curateShortlist(
   voices: SpeechSynthesisVoiceRemote[],
   currentVoiceId: string | null,
-  cap: number
+  cap: number,
+  pinnedIds?: ReadonlySet<string> | null
 ): CuratedShortlist {
   const catalog = visibleCatalog(voices, currentVoiceId);
   // Once the server serves `featured`, it drives shortlist membership; until
@@ -181,25 +190,34 @@ export function curateShortlist(
     : undefined;
   if (current) take(current);
 
-  if (serverCurated) {
-    catalog.filter((voice) => voice.featured).forEach(take);
+  if (pinnedIds) {
+    // User-curated membership: the pinned set in catalog order, current-first
+    // (already taken above). Deliberately NOT filled to the cap — the pins
+    // ARE the shortlist.
+    catalog.filter((voice) => pinnedIds.has(voice.id)).forEach(take);
   } else {
-    pickHdFeatured(catalog.filter((v) => getVoiceTier(v) === "hd")).forEach(
-      take
-    );
+    if (serverCurated) {
+      catalog.filter((voice) => voice.featured).forEach(take);
+    } else {
+      pickHdFeatured(catalog.filter((v) => getVoiceTier(v) === "hd")).forEach(
+        take
+      );
 
-    catalog
-      .map((voice, serverIndex) => ({ voice, serverIndex }))
-      .filter(({ voice }) => getVoiceTier(voice) === "everyday")
-      .sort(
-        (a, b) =>
-          everydayRank(a.voice) - everydayRank(b.voice) ||
-          a.serverIndex - b.serverIndex
-      )
-      .forEach(({ voice }) => take(voice));
+      catalog
+        .map((voice, serverIndex) => ({ voice, serverIndex }))
+        .filter(({ voice }) => getVoiceTier(voice) === "everyday")
+        .sort(
+          (a, b) =>
+            everydayRank(a.voice) - everydayRank(b.voice) ||
+            a.serverIndex - b.serverIndex
+        )
+        .forEach(({ voice }) => take(voice));
+    }
+
+    // Fill any spare capacity in server order (server-featured + heuristic
+    // paths only; pin mode owns its own membership).
+    catalog.forEach(take);
   }
-
-  catalog.forEach(take);
 
   return {
     voices: shortlist,

--- a/src/tts/VoicePins.ts
+++ b/src/tts/VoicePins.ts
@@ -1,0 +1,206 @@
+import type { SpeechSynthesisVoiceRemote } from "./SpeechModel";
+
+/**
+ * Per-host voice pins (doc/plans/2026-07-05-voice-shortlist-pins-design.md).
+ *
+ * A "pin" marks a voice for the short in-app menu of a host. The server's
+ * `featured` set is the DEFAULT pin set; this module stores only the user's
+ * explicit deltas on top — an *overlay*, not a snapshot — so a user who has
+ * curated their own shortlist still receives future server curation for the
+ * voices they never touched. (An emptied shortlist is therefore not a permanent
+ * block: a brand-new featured voice, absent from the user's `unpinned` list,
+ * still surfaces. That is intentional.)
+ *
+ * Storage is host-generic and local-first: one chrome.storage.local key holds
+ * `{ [hostId]: { pinned: string[]; unpinned: string[] } }`. A third host is a
+ * config line at the call site, not a schema change here.
+ *
+ * The pure helpers below are the whole model; the async helpers only add a
+ * (dependency-injected) storage layer on top, mirroring src/onboarding/voiceDefaults.ts.
+ */
+
+export const VOICE_PINS_KEY = "voicePins";
+
+export interface HostPinOverlay {
+  /** Voice ids the user pinned on top of the server defaults (non-defaults). */
+  pinned: string[];
+  /** Server-default voice ids the user removed. */
+  unpinned: string[];
+}
+
+/** hostId → overlay. A host absent from the map is un-customized (default pins). */
+export type VoicePinStore = Record<string, HostPinOverlay>;
+
+/** The slice of chrome.storage.local this module needs (injectable for tests). */
+export interface PinStorage {
+  get(key: string): Promise<unknown>;
+  set(key: string, value: unknown): Promise<void>;
+}
+
+// --- pure helpers ---------------------------------------------------------
+
+function toStringArray(raw: unknown): string[] {
+  return Array.isArray(raw)
+    ? raw.filter((x): x is string => typeof x === "string")
+    : [];
+}
+
+/** Coerce any stored value to a safe overlay — the storage boundary is untrusted. */
+export function toOverlay(raw: unknown): HostPinOverlay {
+  const obj = (raw && typeof raw === "object" ? raw : {}) as Record<
+    string,
+    unknown
+  >;
+  return { pinned: toStringArray(obj.pinned), unpinned: toStringArray(obj.unpinned) };
+}
+
+/** An overlay carrying no deltas is equivalent to un-customized (default pins). */
+export function isHostOverlayEmpty(overlay: HostPinOverlay | null): boolean {
+  return !overlay || (overlay.pinned.length === 0 && overlay.unpinned.length === 0);
+}
+
+/** The host's overlay, or null when the host was never customized. */
+export function getHostOverlay(
+  store: VoicePinStore,
+  hostId: string
+): HostPinOverlay | null {
+  const raw = (store as Record<string, unknown>)[hostId];
+  return raw === undefined ? null : toOverlay(raw);
+}
+
+/** The ids the server marks `featured` (its default pin set), in catalog order. */
+export function serverFeaturedIds(
+  voices: Array<Pick<SpeechSynthesisVoiceRemote, "id" | "featured">>
+): string[] {
+  return voices.filter((v) => v.featured).map((v) => v.id);
+}
+
+/**
+ * The resolved pinned set = server defaults, minus the user's removals, plus
+ * the user's additions. A null overlay is the identity (just the defaults), so
+ * this doubles as "what would be pinned for an un-customized host".
+ */
+export function resolvePinnedIds(
+  featuredIds: Iterable<string>,
+  overlay: HostPinOverlay | null
+): Set<string> {
+  const resolved = new Set<string>(featuredIds);
+  if (overlay) {
+    for (const id of overlay.unpinned) resolved.delete(id);
+    for (const id of overlay.pinned) resolved.add(id);
+  }
+  return resolved;
+}
+
+/**
+ * Apply a pin/unpin to an overlay, keeping it minimal: `pinned` only ever holds
+ * non-default additions, `unpinned` only ever holds default removals, so an
+ * overlay that has drifted back to the defaults normalizes to empty (and the
+ * storage layer then drops the host key).
+ */
+export function togglePin(
+  overlay: HostPinOverlay | null,
+  voiceId: string,
+  featuredIds: Iterable<string>,
+  pin: boolean
+): HostPinOverlay {
+  const isDefault = new Set(featuredIds).has(voiceId);
+  const base = toOverlay(overlay);
+  const pinned = new Set(base.pinned);
+  const unpinned = new Set(base.unpinned);
+
+  if (pin) {
+    unpinned.delete(voiceId);
+    // A default is already pinned, so it needs no addition entry.
+    if (isDefault) pinned.delete(voiceId);
+    else pinned.add(voiceId);
+  } else {
+    pinned.delete(voiceId);
+    // Only a default needs a removal entry; a non-default just leaves `pinned`.
+    if (isDefault) unpinned.add(voiceId);
+    else unpinned.delete(voiceId);
+  }
+  return { pinned: [...pinned], unpinned: [...unpinned] };
+}
+
+// --- storage-backed helpers (dependency-injected) -------------------------
+
+/** chrome.storage.local wrapper matching PreferenceModule's guarded idiom. */
+export function defaultPinStorage(): PinStorage {
+  return {
+    get: (key) =>
+      new Promise((resolve) => {
+        if (typeof chrome === "undefined" || !chrome.storage || !chrome.storage.local) {
+          resolve(undefined);
+          return;
+        }
+        chrome.storage.local.get([key], (result) => {
+          resolve(
+            chrome.runtime && chrome.runtime.lastError ? undefined : result?.[key]
+          );
+        });
+      }),
+    set: (key, value) =>
+      new Promise((resolve, reject) => {
+        if (typeof chrome === "undefined" || !chrome.storage || !chrome.storage.local) {
+          resolve();
+          return;
+        }
+        chrome.storage.local.set({ [key]: value }, () => {
+          const err = chrome.runtime && chrome.runtime.lastError;
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+  };
+}
+
+async function loadStore(storage: PinStorage): Promise<VoicePinStore> {
+  const raw = await storage.get(VOICE_PINS_KEY);
+  return raw && typeof raw === "object" ? (raw as VoicePinStore) : {};
+}
+
+/** The host's overlay from storage, or null when the host was never customized. */
+export async function loadHostOverlay(
+  hostId: string,
+  storage: PinStorage = defaultPinStorage()
+): Promise<HostPinOverlay | null> {
+  return getHostOverlay(await loadStore(storage), hostId);
+}
+
+/**
+ * Persist a pin/unpin for one voice on one host. When the resulting overlay is
+ * empty (the user reverted to the defaults) the host key is dropped, so an
+ * un-customized host and a reverted-to-default host are indistinguishable —
+ * both fall back to the server-featured default path.
+ */
+export async function setVoicePinned(
+  hostId: string,
+  voiceId: string,
+  featuredIds: Iterable<string>,
+  pin: boolean,
+  storage: PinStorage = defaultPinStorage()
+): Promise<void> {
+  const store = await loadStore(storage);
+  const next = togglePin(getHostOverlay(store, hostId), voiceId, featuredIds, pin);
+  const updated: VoicePinStore = { ...store };
+  if (isHostOverlayEmpty(next)) delete updated[hostId];
+  else updated[hostId] = next;
+  await storage.set(VOICE_PINS_KEY, updated);
+}
+
+/**
+ * The in-host menu's entry point: the resolved pinned ids for a host, or null
+ * when the user has NOT customized that host. Null is meaningful — the menu
+ * then keeps its default (server-featured, fill-to-cap) path untouched; only a
+ * real overlay switches the menu to pin-defined membership.
+ */
+export async function resolvePinnedIdsForHost(
+  hostId: string,
+  voices: Array<Pick<SpeechSynthesisVoiceRemote, "id" | "featured">>,
+  storage: PinStorage = defaultPinStorage()
+): Promise<Set<string> | null> {
+  const overlay = await loadHostOverlay(hostId, storage);
+  if (!overlay) return null;
+  return resolvePinnedIds(serverFeaturedIds(voices), overlay);
+}

--- a/test/tts/VoiceCuration.spec.ts
+++ b/test/tts/VoiceCuration.spec.ts
@@ -341,6 +341,92 @@ describe("curateShortlist with a server-curated catalog", () => {
   });
 });
 
+// --- §Phase-2 user pins (doc/plans/2026-07-05-voice-shortlist-pins-design.md) --
+// When the user has curated their own shortlist by pinning, the resolved
+// pinned set drives menu membership DIRECTLY: current voice first
+// (grandfathering), then pinned voices in catalog order, capped — and with NO
+// fill-to-cap padding, which is what makes the "empty-pin floor" real (0 pins →
+// current + door only). Omitting pinnedIds must leave every existing path
+// (server-featured + heuristic) untouched.
+
+describe("curateShortlist with user pins (pinnedIds)", () => {
+  it("draws membership from the pinned set, current-first, with no padding", () => {
+    const pinned = new Set(["onyx", "sage"]); // two pins
+    const result = curateShortlist(curated, "alloy", CLAUDE_MENU_CAP, pinned);
+    // current (Alloy, grandfathered) + the two pins in catalog order — NOT padded to 4.
+    expect(result.voices.map((v) => v.id)).toEqual(["alloy", "onyx", "sage"]);
+  });
+
+  it("pins the current voice first even when it is not in the pinned set (grandfathering)", () => {
+    const pinned = new Set(["onyx"]);
+    const result = curateShortlist(curated, "nova", CLAUDE_MENU_CAP, pinned);
+    expect(result.voices[0].id).toBe("nova");
+    expect(result.voices.map((v) => v.id)).toContain("onyx");
+  });
+
+  it("does not duplicate the current voice when it is also pinned", () => {
+    const pinned = new Set(["alloy", "onyx"]);
+    const result = curateShortlist(curated, "alloy", CLAUDE_MENU_CAP, pinned);
+    expect(result.voices.filter((v) => v.id === "alloy").length).toBe(1);
+  });
+
+  it("caps a large pinned set at the menu cap (the menu never scales)", () => {
+    const pinned = new Set([
+      "ig1TeITnnNlsJtfHxJlW",
+      "bWJPewAagbymiJXZcxnh",
+      "coral",
+      "onyx",
+      "sage",
+      "shimmer",
+    ]); // six pins
+    const result = curateShortlist(curated, null, CLAUDE_MENU_CAP, pinned);
+    expect(result.voices.length).toBe(CLAUDE_MENU_CAP);
+  });
+
+  it("orders pinned voices by catalog (server) order, not by pinned-set order", () => {
+    const pinned = new Set(["shimmer", "onyx"]); // deliberately reversed
+    const result = curateShortlist(curated, null, PI_MENU_CAP, pinned);
+    const onyxIdx = result.voices.findIndex((v) => v.id === "onyx");
+    const shimmerIdx = result.voices.findIndex((v) => v.id === "shimmer");
+    expect(onyxIdx).toBeGreaterThanOrEqual(0);
+    expect(onyxIdx).toBeLessThan(shimmerIdx); // onyx precedes shimmer in server order
+  });
+
+  it("yields the current voice only when the pinned set is empty (empty-pin floor)", () => {
+    const result = curateShortlist(curated, "alloy", CLAUDE_MENU_CAP, new Set());
+    // The "More voices…" door is added by the menu, not curation — curation
+    // legitimately returns just the grandfathered current voice.
+    expect(result.voices.map((v) => v.id)).toEqual(["alloy"]);
+  });
+
+  it("can be empty when pins are empty and there is no current voice (menu shows just the door)", () => {
+    const result = curateShortlist(curated, null, CLAUDE_MENU_CAP, new Set());
+    expect(result.voices).toEqual([]);
+    expect(result.hiddenCount).toBe(curated.length);
+  });
+
+  it("excludes a deprecated pinned voice unless it is the current voice", () => {
+    const withDeprecated = curated.map((v) =>
+      v.id === "onyx" ? withManifest(v, { deprecated: true }) : v
+    );
+    const pinned = new Set(["onyx", "sage"]);
+    const result = curateShortlist(withDeprecated, null, CLAUDE_MENU_CAP, pinned);
+    expect(result.voices.map((v) => v.id)).not.toContain("onyx");
+    expect(result.voices.map((v) => v.id)).toContain("sage");
+  });
+
+  it("leaves the un-pinned path (undefined pinnedIds) exactly as before", () => {
+    // Regression guard: omitting pinnedIds reproduces the server-featured path.
+    const result = curateShortlist(curated, null, PI_MENU_CAP);
+    expect(result.voices.map((v) => v.name)).toEqual([
+      "Paola",
+      "Joey",
+      "Onyx",
+      "Sage",
+    ]);
+  });
+});
+
 describe("curateShortlist grandfathering (deprecated voices)", () => {
   it("excludes a deprecated voice even when the server featured it", () => {
     const withDeprecated = curated.map((v) =>

--- a/test/tts/VoicePins.spec.ts
+++ b/test/tts/VoicePins.spec.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from "vitest";
+import {
+  toOverlay,
+  serverFeaturedIds,
+  resolvePinnedIds,
+  togglePin,
+  isHostOverlayEmpty,
+  getHostOverlay,
+  loadHostOverlay,
+  setVoicePinned,
+  resolvePinnedIdsForHost,
+  VOICE_PINS_KEY,
+  type HostPinOverlay,
+  type PinStorage,
+} from "../../src/tts/VoicePins";
+
+// A voice pin overlay records only the user's explicit *deltas* on top of the
+// server's `featured` set (the default pins): ids they added (`pinned`) and
+// server-default ids they removed (`unpinned`). The pure helpers below are the
+// whole model — everything else layers storage on top.
+
+describe("toOverlay (null-safety at the storage boundary)", () => {
+  it("passes a well-formed overlay through", () => {
+    expect(toOverlay({ pinned: ["a"], unpinned: ["b"] })).toEqual({
+      pinned: ["a"],
+      unpinned: ["b"],
+    });
+  });
+
+  it("coerces missing / garbage fields to empty string arrays", () => {
+    expect(toOverlay(null)).toEqual({ pinned: [], unpinned: [] });
+    expect(toOverlay(undefined)).toEqual({ pinned: [], unpinned: [] });
+    expect(toOverlay({})).toEqual({ pinned: [], unpinned: [] });
+    expect(toOverlay({ pinned: "x", unpinned: 3 })).toEqual({
+      pinned: [],
+      unpinned: [],
+    });
+    expect(toOverlay({ pinned: ["a", 1, null, "b"] })).toEqual({
+      pinned: ["a", "b"],
+      unpinned: [],
+    });
+  });
+});
+
+describe("serverFeaturedIds", () => {
+  it("returns the ids of featured voices only, in order", () => {
+    expect(
+      serverFeaturedIds([
+        { id: "a", featured: true },
+        { id: "b", featured: false },
+        { id: "c" },
+        { id: "d", featured: true },
+      ] as any)
+    ).toEqual(["a", "d"]);
+  });
+});
+
+describe("resolvePinnedIds (defaults overlaid with user deltas)", () => {
+  const featured = ["a", "b", "c", "d"];
+
+  it("is the server featured set when the overlay is null (identity — un-customized)", () => {
+    expect([...resolvePinnedIds(featured, null)]).toEqual(featured);
+  });
+
+  it("adds user-pinned ids on top of the defaults", () => {
+    expect(resolvePinnedIds(featured, { pinned: ["z"], unpinned: [] })).toEqual(
+      new Set(["a", "b", "c", "d", "z"])
+    );
+  });
+
+  it("removes user-unpinned defaults", () => {
+    expect(resolvePinnedIds(featured, { pinned: [], unpinned: ["b"] })).toEqual(
+      new Set(["a", "c", "d"])
+    );
+  });
+
+  it("resolves to an empty set when every default is unpinned", () => {
+    expect(
+      resolvePinnedIds(featured, { pinned: [], unpinned: featured }).size
+    ).toBe(0);
+  });
+});
+
+describe("togglePin (minimal, normalized deltas)", () => {
+  const featured = ["a", "b", "c", "d"];
+
+  it("records an unpinned server default in `unpinned`", () => {
+    expect(togglePin(null, "b", featured, false)).toEqual({
+      pinned: [],
+      unpinned: ["b"],
+    });
+  });
+
+  it("records a pinned non-default voice in `pinned`", () => {
+    expect(togglePin(null, "z", featured, true)).toEqual({
+      pinned: ["z"],
+      unpinned: [],
+    });
+  });
+
+  it("re-pinning a previously-unpinned default clears the removal (reverts to default)", () => {
+    const removed = togglePin(null, "b", featured, false);
+    expect(togglePin(removed, "b", featured, true)).toEqual({
+      pinned: [],
+      unpinned: [],
+    });
+  });
+
+  it("unpinning a user-added voice just drops it from `pinned`", () => {
+    const added = togglePin(null, "z", featured, true);
+    expect(togglePin(added, "z", featured, false)).toEqual({
+      pinned: [],
+      unpinned: [],
+    });
+  });
+
+  it("pinning a voice that is already a server default is a no-op (already pinned)", () => {
+    expect(togglePin(null, "a", featured, true)).toEqual({
+      pinned: [],
+      unpinned: [],
+    });
+  });
+
+  it("does not duplicate an id already recorded", () => {
+    const added = togglePin(null, "z", featured, true);
+    expect(togglePin(added, "z", featured, true)).toEqual({
+      pinned: ["z"],
+      unpinned: [],
+    });
+  });
+});
+
+describe("isHostOverlayEmpty", () => {
+  it("is true only when both arrays are empty (or the overlay is null)", () => {
+    expect(isHostOverlayEmpty({ pinned: [], unpinned: [] })).toBe(true);
+    expect(isHostOverlayEmpty(null)).toBe(true);
+    expect(isHostOverlayEmpty({ pinned: ["a"], unpinned: [] })).toBe(false);
+    expect(isHostOverlayEmpty({ pinned: [], unpinned: ["b"] })).toBe(false);
+  });
+});
+
+describe("getHostOverlay", () => {
+  it("returns null for a host the user never customized", () => {
+    expect(getHostOverlay({}, "pi")).toBeNull();
+  });
+
+  it("returns the normalized overlay for a customized host", () => {
+    expect(
+      getHostOverlay({ pi: { pinned: ["z"], unpinned: [] } } as any, "pi")
+    ).toEqual({ pinned: ["z"], unpinned: [] });
+  });
+
+  it("normalizes a garbage stored value defensively", () => {
+    expect(
+      getHostOverlay({ pi: { pinned: "nope" } } as any, "pi")
+    ).toEqual({ pinned: [], unpinned: [] });
+  });
+});
+
+// --- storage-backed helpers (dependency-injected, like voiceDefaults.ts) ---
+
+function memoryStorage(
+  seed: Record<string, unknown> = {}
+): PinStorage & { store: Record<string, unknown> } {
+  const store: Record<string, unknown> = { ...seed };
+  return {
+    store,
+    get: async (key: string) => store[key],
+    set: async (key: string, value: unknown) => {
+      store[key] = value;
+    },
+  };
+}
+
+describe("loadHostOverlay", () => {
+  it("returns null when nothing is stored", async () => {
+    expect(await loadHostOverlay("pi", memoryStorage())).toBeNull();
+  });
+
+  it("returns the stored overlay for the host", async () => {
+    const s = memoryStorage({
+      [VOICE_PINS_KEY]: { pi: { pinned: ["z"], unpinned: [] } },
+    });
+    expect(await loadHostOverlay("pi", s)).toEqual({ pinned: ["z"], unpinned: [] });
+  });
+
+  it("returns null for a host absent from a populated store", async () => {
+    const s = memoryStorage({
+      [VOICE_PINS_KEY]: { claude: { pinned: ["z"], unpinned: [] } },
+    });
+    expect(await loadHostOverlay("pi", s)).toBeNull();
+  });
+});
+
+describe("setVoicePinned", () => {
+  const featured = ["a", "b", "c", "d"];
+
+  it("persists an unpin as a host overlay", async () => {
+    const s = memoryStorage();
+    await setVoicePinned("pi", "b", featured, false, s);
+    expect((s.store[VOICE_PINS_KEY] as any).pi).toEqual({
+      pinned: [],
+      unpinned: ["b"],
+    });
+  });
+
+  it("drains the host key when the overlay reverts to empty (back to defaults)", async () => {
+    const s = memoryStorage();
+    await setVoicePinned("pi", "b", featured, false, s); // customize
+    await setVoicePinned("pi", "b", featured, true, s); // revert
+    expect((s.store[VOICE_PINS_KEY] as any)?.pi).toBeUndefined();
+  });
+
+  it("never disturbs another host's overlay", async () => {
+    const s = memoryStorage({
+      [VOICE_PINS_KEY]: { claude: { pinned: ["x"], unpinned: [] } },
+    });
+    await setVoicePinned("pi", "z", featured, true, s);
+    expect((s.store[VOICE_PINS_KEY] as any).claude).toEqual({
+      pinned: ["x"],
+      unpinned: [],
+    });
+    expect((s.store[VOICE_PINS_KEY] as any).pi).toEqual({
+      pinned: ["z"],
+      unpinned: [],
+    });
+  });
+});
+
+describe("resolvePinnedIdsForHost (the menu-consumer entry point)", () => {
+  const voices = [
+    { id: "a", featured: true },
+    { id: "b", featured: true },
+    { id: "z" },
+  ] as any;
+
+  it("returns null for an un-customized host — the menu keeps its default (padded) path", async () => {
+    expect(await resolvePinnedIdsForHost("pi", voices, memoryStorage())).toBeNull();
+  });
+
+  it("returns the resolved pinned set for a customized host", async () => {
+    const s = memoryStorage({
+      [VOICE_PINS_KEY]: { pi: { pinned: ["z"], unpinned: ["b"] } },
+    });
+    expect(await resolvePinnedIdsForHost("pi", voices, s)).toEqual(
+      new Set(["a", "z"])
+    );
+  });
+});
+
+describe("the overlay is a delta, not a snapshot", () => {
+  it("a NEW server-featured voice reaches a user who had emptied their shortlist", () => {
+    // The user unpinned every voice they had seen...
+    const originalFeatured = ["a", "b"];
+    let overlay: HostPinOverlay | null = null;
+    overlay = togglePin(overlay, "a", originalFeatured, false);
+    overlay = togglePin(overlay, "b", originalFeatured, false);
+    expect(resolvePinnedIds(originalFeatured, overlay).size).toBe(0); // emptied
+
+    // ...then the server later features a brand-new voice "c". Because the
+    // overlay only records removals of voices the user actually saw, "c" is not
+    // in `unpinned`, so it surfaces. This is intended: server curation keeps
+    // introducing new voices; an emptied shortlist is not a permanent block.
+    const laterFeatured = ["a", "b", "c"];
+    expect(resolvePinnedIds(laterFeatured, overlay)).toEqual(new Set(["c"]));
+  });
+});


### PR DESCRIPTION
## What & why

Phase 2 of the [voice-shortlist redesign](../blob/main/doc/plans/2026-07-05-voice-shortlist-pins-design.md) lets users curate their own **short in-host voice menu** by *pinning favourites*. This PR is the pure, fully-tested **foundation** — it is **inert** (nothing calls it yet); the menu wiring + unified settings UI land in a follow-up (Phase 2b).

Shipping the foundation on its own keeps the eventual integration PR small and lets the pin model + curation change be reviewed as isolated, well-tested logic.

## Changes

**`src/tts/VoicePins.ts` (new)** — a host-generic, local-first pin store.
- Pins are an **overlay** on the server's `featured` set (the default pins), **not a snapshot**: we persist only the user's explicit adds/removals. This is the deliberate choice — a snapshot would freeze a customizing user out of *all* future server curation; the overlay keeps server defaults flowing for voices the user never touched. One `chrome.storage.local` key, shaped `{ [hostId]: { pinned, unpinned } }`; a third host is a config line, not a schema change. DI storage, mirroring `src/onboarding/voiceDefaults.ts`.
- One documented consequence (tested): if a user empties their shortlist and the server *later* features a brand-new voice, it surfaces (it isn't in their `unpinned` list). Intended — server curation keeps introducing voices; an empty state isn't a permanent block.

**`curateShortlist` gains an optional `pinnedIds`.**
- When present, the pinned set drives menu membership (current voice first for grandfathering, then pins in catalog order, capped) with **no fill-to-cap padding** — that is what makes the design's *empty-pin floor* real (0 pins → current + door only).
- When **absent/null**, every existing path (server-`featured` and the local heuristic) is left **byte-for-byte unchanged**, so users who never pin — i.e. everyone today — are untouched. The menu wiring will pass `pinnedIds` **only when a real overlay exists** for the host.

## Tests
- 26 pin-store cases (normalisation at the storage boundary, minimal-delta toggling, drain-to-default, per-host isolation, the delta-not-snapshot wrinkle above).
- 8 `curateShortlist` pin-mode cases (membership-from-pins, current-first grandfathering, no padding, cap still applies, empty-pin floor, deprecated-pin exclusion, and a regression guard that the un-pinned path is unchanged).
- Full gate green (`tsc` + Jest + Vitest, 1858 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)