### PR TITLE
feat(voices): in-host menus honour user pins (Phase 2b wiring)

### DIFF
--- a/src/chatbots/ClaudeVoiceMenu.ts
+++ b/src/chatbots/ClaudeVoiceMenu.ts
@@ -741,7 +741,8 @@ export class ClaudeVoiceMenu extends VoiceSelector {
    */
   protected override renderMenu(
     voices: SpeechSynthesisVoiceRemote[],
-    storedVoice: SpeechSynthesisVoiceRemote | null
+    storedVoice: SpeechSynthesisVoiceRemote | null,
+    pinnedIds?: ReadonlySet<string> | null
   ): void {
     const voiceSelector = this.element;
     // Compute heuristics to decide what to show across this dataset
@@ -765,7 +766,8 @@ export class ClaudeVoiceMenu extends VoiceSelector {
     const curated = curateShortlist(
       voices,
       storedVoice?.id ?? null,
-      CLAUDE_MENU_CAP
+      CLAUDE_MENU_CAP,
+      pinnedIds
     );
     this.showTier = curated.tiersCoexist;
 

--- a/src/tts/GridVoiceSelector.ts
+++ b/src/tts/GridVoiceSelector.ts
@@ -47,7 +47,8 @@ export abstract class GridVoiceSelector extends VoiceSelector {
 
   protected renderMenu(
     voices: SpeechSynthesisVoiceRemote[],
-    storedVoice: SpeechSynthesisVoiceRemote | null
+    storedVoice: SpeechSynthesisVoiceRemote | null,
+    pinnedIds?: ReadonlySet<string> | null
   ): void {
     const container = this.element;
     const defaults = voices.filter((voice) => voice.default);
@@ -63,7 +64,7 @@ export abstract class GridVoiceSelector extends VoiceSelector {
     const curated =
       cap === null
         ? { voices: customs, hiddenCount: 0, tiersCoexist: false }
-        : curateShortlist(customs, storedVoice?.id ?? null, cap);
+        : curateShortlist(customs, storedVoice?.id ?? null, cap, pinnedIds);
     this.reconcileCustomRows(
       container,
       curated.voices,

--- a/src/tts/VoiceMenu.ts
+++ b/src/tts/VoiceMenu.ts
@@ -11,6 +11,11 @@ import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { SpeechSynthesisVoiceRemote } from "./SpeechModel";
 import { SpeechSynthesisModule } from "./SpeechSynthesisModule";
 import { getJwtManagerSync } from "../JwtManager";
+import {
+  loadHostOverlay,
+  resolvePinnedIds,
+  serverFeaturedIds,
+} from "./VoicePins";
 
 /**
  * A chatbot that ships its own set of built-in voices, with introduction audio
@@ -67,7 +72,8 @@ export abstract class VoiceSelector {
    */
   protected abstract renderMenu(
     voices: SpeechSynthesisVoiceRemote[],
-    storedVoice: SpeechSynthesisVoiceRemote | null
+    storedVoice: SpeechSynthesisVoiceRemote | null,
+    pinnedIds?: ReadonlySet<string> | null
   ): void;
 
   /**
@@ -89,11 +95,22 @@ export abstract class VoiceSelector {
    */
   async refreshMenu(): Promise<void> {
     const speechSynthesis = SpeechSynthesisModule.getInstance();
-    const [voices, storedVoice] = await Promise.all([
+    const [voices, storedVoice, pinOverlay] = await Promise.all([
       speechSynthesis.getVoices(this.chatbot),
       this.userPreferences.getVoice(this.chatbot),
+      // The host's voice-pin overlay (Phase 2). Loaded alongside the catalog so
+      // pins are resolved synchronously at render — the current voice still
+      // pins first on the first paint. Pin resolution must NEVER break a menu
+      // render: any storage failure falls back to the default shortlist.
+      loadHostOverlay(this.chatbot.getID()).catch(() => null),
     ]);
-    this.renderMenu(voices ?? [], storedVoice ?? null);
+    const catalog = voices ?? [];
+    // A null overlay (un-customized host) yields a null pinned set, which keeps
+    // renderMenu on its default server-featured/heuristic path unchanged.
+    const pinnedIds = pinOverlay
+      ? resolvePinnedIds(serverFeaturedIds(catalog), pinOverlay)
+      : null;
+    this.renderMenu(catalog, storedVoice ?? null, pinnedIds);
   }
 
   /**

--- a/test/chatbots/ClaudeVoiceMenu-curation.spec.ts
+++ b/test/chatbots/ClaudeVoiceMenu-curation.spec.ts
@@ -199,3 +199,37 @@ describe("ClaudeVoiceMenu current-voice visibility (was: pinning)", () => {
     expect(openSettingsMock).toHaveBeenCalledWith("voices");
   });
 });
+
+// --- §Phase-2 user pins -----------------------------------------------------
+// The resolved pin set (from settings) is threaded into renderMenu as a third
+// argument and drives dropdown membership directly: current voice first, then
+// the pins in catalog order, no fill-to-cap padding. Absent → today's
+// behaviour (every test above passes two arguments).
+describe("ClaudeVoiceMenu with user pins", () => {
+  it("renders exactly the pinned voices (catalog order, no fill-to-cap)", () => {
+    const menu = makeMenu();
+    menu.renderMenu(flipDayCatalog, null, new Set(["onyx", "sage"]));
+    const names = voiceRows(menu).map((r) => r.dataset.voiceName);
+    expect(names).toEqual(["Onyx", "Sage"]);
+  });
+
+  it("keeps the current voice first even when it is not in the pin set (grandfathering)", () => {
+    const lucy = claudeMockVoices.find((v) => v.name === "Lucy")!;
+    const menu = makeMenu();
+    menu.renderMenu(flipDayCatalog, lucy, new Set(["onyx"]));
+    const names = voiceRows(menu).map((r) => r.dataset.voiceName);
+    expect(names[0]).toBe("Lucy");
+    expect(names).toContain("Onyx");
+  });
+
+  it("shows only the current voice — plus the ever-present door — when the pin set is empty", () => {
+    const lucy = claudeMockVoices.find((v) => v.name === "Lucy")!;
+    const menu = makeMenu();
+    menu.renderMenu(flipDayCatalog, lucy, new Set());
+    const names = voiceRows(menu).map((r) => r.dataset.voiceName);
+    expect(names).toEqual(["Lucy"]);
+    expect(
+      menu.menuContent.querySelector("[data-action='more-voices']")
+    ).not.toBeNull();
+  });
+});

--- a/test/chatbots/PiVoiceMenu-curation.spec.ts
+++ b/test/chatbots/PiVoiceMenu-curation.spec.ts
@@ -193,3 +193,36 @@ describe("PiVoiceMenu current-voice visibility", () => {
     expect(ids).toContain("coral");
   });
 });
+
+// --- §Phase-2 user pins -----------------------------------------------------
+// When the user has curated their own shortlist (in settings), the resolved
+// pin set is threaded into renderMenu as a third argument and drives menu
+// membership directly: current voice first, then the pins in catalog order,
+// with no fill-to-cap padding. An absent set keeps today's behaviour (proven
+// by every test above, which passes two arguments).
+describe("PiVoiceMenu with user pins", () => {
+  it("renders exactly the pinned voices (catalog order, no fill-to-cap)", () => {
+    const menu = makeMenu();
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], null, new Set(["onyx", "sage"]));
+    const ids = customRows(menu.element).map((r) => r.dataset.voiceId);
+    expect(ids).toEqual(["onyx", "sage"]);
+  });
+
+  it("keeps the current voice pinned first even when it is not in the pin set (grandfathering)", () => {
+    const paola = piElevenLabs.find((v) => v.id === "ig1TeITnnNlsJtfHxJlW")!;
+    const menu = makeMenu();
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], paola, new Set(["onyx"]));
+    const ids = customRows(menu.element).map((r) => r.dataset.voiceId);
+    expect(ids[0]).toBe("ig1TeITnnNlsJtfHxJlW");
+    expect(ids).toContain("onyx");
+  });
+
+  it("shows only the current voice — plus the ever-present door — when the pin set is empty", () => {
+    const paola = piElevenLabs.find((v) => v.id === "ig1TeITnnNlsJtfHxJlW")!;
+    const menu = makeMenu();
+    menu.renderMenu([...piBuiltIns, ...piFlipDay], paola, new Set());
+    const ids = customRows(menu.element).map((r) => r.dataset.voiceId);
+    expect(ids).toEqual(["ig1TeITnnNlsJtfHxJlW"]);
+    expect(menu.element.querySelector("button.saypi-more-voices")).not.toBeNull();
+  });
+});

--- a/test/tts/VoiceMenuRefresh.spec.ts
+++ b/test/tts/VoiceMenuRefresh.spec.ts
@@ -116,3 +116,59 @@ describe("refreshMenu with nested (preview) buttons present (#485 tombstone)", (
     expect(preview.hasAttribute("data-saypi-host-voice")).toBe(false);
   });
 });
+
+// refreshMenu is the gather-then-render seam. Phase 2 has it also resolve the
+// host's voice pins (from chrome.storage) alongside the catalog + stored voice,
+// and hand the resolved set to renderMenu as a third argument. When the host is
+// un-customized it hands null, so the menu keeps its default shortlist.
+describe("refreshMenu resolves user pins and forwards them to renderMenu", () => {
+  beforeEach(() => {
+    getVoicesMock.mockReset();
+    (chrome.storage.local as any)._reset();
+  });
+
+  function makeGrid(): TestGrid {
+    const grid: any = Object.create(TestGrid.prototype);
+    grid.chatbot = { getID: () => "claude", getID_: undefined };
+    grid.userPreferences = {
+      getVoice: vi.fn(async () => null),
+      setVoice: vi.fn(async () => {}),
+      unsetVoice: vi.fn(async () => {}),
+    };
+    grid.element = document.createElement("div");
+    return grid as TestGrid;
+  }
+
+  it("passes the resolved pinned set (defaults ± the user's overlay) into renderMenu", async () => {
+    getVoicesMock.mockResolvedValue([
+      { id: "a", featured: true },
+      { id: "b", featured: true },
+      { id: "z" },
+    ]);
+    (chrome.storage.local as any)._setState({
+      voicePins: { claude: { pinned: ["z"], unpinned: ["b"] } },
+    });
+    const grid = makeGrid();
+    const renderSpy = vi
+      .spyOn(grid as any, "renderMenu")
+      .mockImplementation(() => {});
+
+    await grid.refreshMenu();
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    // defaults {a,b} − unpinned {b} + pinned {z} = {a,z}
+    expect(renderSpy.mock.calls[0][2]).toEqual(new Set(["a", "z"]));
+  });
+
+  it("passes null (keep the default shortlist) when the host has no pin overlay", async () => {
+    getVoicesMock.mockResolvedValue([{ id: "a", featured: true }]);
+    const grid = makeGrid();
+    const renderSpy = vi
+      .spyOn(grid as any, "renderMenu")
+      .mockImplementation(() => {});
+
+    await grid.refreshMenu();
+
+    expect(renderSpy.mock.calls[0][2]).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

Phase 2b of the [voice-shortlist redesign](../blob/main/doc/plans/2026-07-05-voice-shortlist-pins-design.md). The in-host voice menus now source their shortlist from the user's **pins** when the user has curated their own. Builds on the Phase 2a foundation (#515).

`refreshMenu` — the single gather-then-render seam — loads the host's pin overlay from `chrome.storage` alongside the catalog + stored voice, resolves it against the server's `featured` defaults, and hands the resolved id set to `renderMenu`. Both surfaces (Pi's button grid via `GridVoiceSelector`, Claude's dropdown via `ClaudeVoiceMenu`) forward it to `curateShortlist`.

**Ships inert and safe.** Nothing creates a pin overlay yet — the Phase 2c settings UI does that. Until then every host is un-customized, `loadHostOverlay` returns `null`, `pinnedIds` is `null`, and the menus keep their **exact** server-featured/heuristic behaviour.

## Timing / safety notes
- The overlay load is **parallelised** into `refreshMenu`'s existing `Promise.all`, so there's no added serial latency. The single `renderMenu` still runs after all three resolve → **no reflow**, current voice still pins first on first paint.
- Pin resolution **can never break a render**: a storage failure falls back to the default shortlist (`.catch(() => null)`).
- The Claude **#494 open-race is unaffected**: its outside-click check runs *synchronously during event bubbling* against the stable trigger node, independent of when `refreshMenu` resolves. The added `chrome.storage` read only shifts the *visual* menu appearance (in `refreshMenu().then()`) by ~1ms. The `ClaudeVoiceMenu-open-race` guard is green.

## Tests
- Pi + Claude menu pin-membership: current-first grandfathering, no fill-to-cap padding, empty-pin floor (current + ever-present door).
- A `refreshMenu` integration test that seeds `chrome.storage` with an overlay and asserts the resolved set (`defaults ± overlay`) reaches `renderMenu`; plus the null-overlay (default shortlist) case.
- Full gate green (`tsc` + Jest + Vitest, 1866 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)