### PR TITLE
feat(voices): unified cross-host catalog with per-host pins (Phase 2c)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -996,13 +996,33 @@
     "message": "Great quality — your monthly allowance lasts about 20× longer.",
     "description": "One-line note under the Everyday voices group heading in the settings voice catalog"
   },
-  "voicesUse": {
-    "message": "Use this voice",
-    "description": "Button that selects a voice from the settings voice catalog"
-  },
   "voicesCurrent": {
     "message": "In use",
     "description": "Badge marking the currently selected voice in the settings voice catalog"
+  },
+  "voicesUseShort": {
+    "message": "Use",
+    "description": "Short label on the per-host 'use this voice' button in the unified settings voice catalog (the host is shown alongside it)."
+  },
+  "voicesUseOnHost": {
+    "message": "Use $name$ on $host$",
+    "description": "Accessible label for the per-host 'use this voice' button in the settings voice catalog; $name$ is the voice, $host$ is the assistant (e.g. Pi, Claude).",
+    "placeholders": {
+      "name": { "content": "$1", "example": "Marin" },
+      "host": { "content": "$2", "example": "Claude" }
+    }
+  },
+  "voicesPinToHost": {
+    "message": "Pin $name$ to the $host$ menu",
+    "description": "Accessible label for the per-host pin toggle in the settings voice catalog; pinning shows the voice in that assistant's short in-app voice menu. $name$ is the voice, $host$ is the assistant.",
+    "placeholders": {
+      "name": { "content": "$1", "example": "Marin" },
+      "host": { "content": "$2", "example": "Pi" }
+    }
+  },
+  "voicesPinExplainer": {
+    "message": "Pin your favourite voices to keep each site's in-app menu short. Pinned voices show in the menu; the full catalogue stays here.",
+    "description": "One-line explanation above the unified settings voice catalog describing what the per-host pin toggles do."
   },
   "voicesPreview": {
     "message": "Play a sample of $name$",

--- a/entrypoints/settings/tabs/voices/VoicesPanel.tsx
+++ b/entrypoints/settings/tabs/voices/VoicesPanel.tsx
@@ -1,10 +1,11 @@
 /**
  * Voices-tab panel (Preact).
  *
- * Static skeleton only — VoicesController renders the per-host catalog into
- * #voice-catalog after mount and wires the host pills by id, so the ids and
- * classes here (`#voices-preference`, `#voice-host-pills`, `#voice-host-pi`,
- * `#voice-host-claude`, `.voice-host-pill`, `#voice-catalog`) are load-bearing.
+ * Static skeleton only — VoicesController renders ONE unified cross-host
+ * catalog into #voice-catalog after mount, so that id is load-bearing. There
+ * are no per-host pills any more: the catalog is a single list and each row
+ * carries its own per-host pin toggles + Use action (the 2026-07-05 shortlist
+ * redesign — doc/plans/2026-07-05-voice-shortlist-pins-design.md).
  *
  * This tab sits alongside Dictation deliberately: Dictation is voice-in,
  * Voices is voice-out (#471). It is also the destination of the in-page voice
@@ -21,42 +22,11 @@ export function VoicesPanel() {
         <div class="description" data-i18n="voicesSectionDescription">
           Choose the voice that reads replies aloud on each site.
         </div>
-        {/* Each pill wears its assistant's logo and brand color (#473) so
-            users orient at a glance — matching the platform cards on
-            saypi.ai/features/sites-supported. Logos are decorative (the pill
-            text is the accessible label), hence alt="" + aria-hidden; the
-            active state is also carried by aria-selected and font weight, so
-            color is never the only signal. Assets live in public/icons/logos/,
-            served from the extension root. */}
-        <div id="voice-host-pills" role="tablist">
-          <button
-            type="button"
-            id="voice-host-pi"
-            class="voice-host-pill"
-            role="tab"
-          >
-            <img
-              class="voice-host-logo"
-              src="/icons/logos/pi.png"
-              alt=""
-              aria-hidden="true"
-            />
-            Pi
-          </button>
-          <button
-            type="button"
-            id="voice-host-claude"
-            class="voice-host-pill"
-            role="tab"
-          >
-            <img
-              class="voice-host-logo"
-              src="/icons/logos/claude.png"
-              alt=""
-              aria-hidden="true"
-            />
-            Claude
-          </button>
+        {/* What the per-host pin toggles on each row do — the catalog is one
+            unified list; pinning curates each site's short in-app menu. */}
+        <div class="description voices-pin-explainer" data-i18n="voicesPinExplainer">
+          Pin your favourite voices to keep each site's in-app menu short.
+          Pinned voices show in the menu; the full catalogue stays here.
         </div>
         <div id="voice-catalog" aria-live="polite"></div>
       </div>

--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -1,16 +1,41 @@
 import getMessage from "../../../../src/i18n";
 import { SpeechSynthesisVoiceRemote } from "../../../../src/tts/SpeechModel";
-import { getVoiceTier, visibleCatalog } from "../../../../src/tts/VoiceCuration";
 import { SpeechSynthesisModule } from "../../../../src/tts/SpeechSynthesisModule";
 import { UserPreferenceModule } from "../../../../src/prefs/PreferenceModule";
 import { getJwtManagerSync } from "../../../../src/JwtManager";
 import type { ChatbotId } from "../../../../src/chatbots/ChatbotIdentifier";
+import {
+  HostPinOverlay,
+  loadHostOverlay,
+  serverFeaturedIds,
+  setVoicePinned,
+} from "../../../../src/tts/VoicePins";
+import {
+  HostCatalog,
+  HostVoiceState,
+  UnifiedVoiceRow,
+  unifyHostCatalogs,
+} from "../../../../src/tts/VoiceCatalogUnify";
 
 /**
  * The hosts with a SayPi voice picker. ChatGPT is a deliberate non-goal (it
  * uses OpenAI's native read-aloud — doc/plans/2026-07-02-voice-selection-ux.md §3).
  */
 export type VoiceHostId = Extract<ChatbotId, "pi" | "claude">;
+
+/**
+ * The pinnable hosts, in display order. Host-generic: a third host (once SayPi
+ * TTS reaches it) is one more line here, not a schema change — pins, unify, and
+ * the row model all key on the host id.
+ */
+const VOICE_HOSTS: ReadonlyArray<{
+  id: VoiceHostId;
+  label: string;
+  logo: string;
+}> = [
+  { id: "pi", label: "Pi", logo: "/icons/logos/pi.png" },
+  { id: "claude", label: "Claude", logo: "/icons/logos/claude.png" },
+];
 
 export interface VoiceCatalogDeps {
   getVoices(host: VoiceHostId): Promise<SpeechSynthesisVoiceRemote[]>;
@@ -19,6 +44,15 @@ export interface VoiceCatalogDeps {
   isAuthenticated(): boolean;
   /** Play the voice's free canned sample clip (design §4). No-op without one. */
   playPreview(voice: SpeechSynthesisVoiceRemote): void;
+  /** The user's pin overlay for a host, or null when un-customized. */
+  loadPins(host: VoiceHostId): Promise<HostPinOverlay | null>;
+  /** Pin/unpin a voice for a host (featuredIds = that host's default pins). */
+  setPinned(
+    host: VoiceHostId,
+    voiceId: string,
+    featuredIds: string[],
+    pin: boolean
+  ): Promise<void>;
 }
 
 // The settings page is its own document — no content-script audio-output
@@ -42,85 +76,76 @@ function defaultDeps(): VoiceCatalogDeps {
   const prefs = UserPreferenceModule.getInstance();
   return {
     getVoices: (host) => speech.getVoices(host),
-    getVoice: (host) => prefs.getVoice(host) as Promise<SpeechSynthesisVoiceRemote | null>,
+    getVoice: (host) =>
+      prefs.getVoice(host) as Promise<SpeechSynthesisVoiceRemote | null>,
     setVoice: (voice, host) => prefs.setVoice(voice, host).then(() => {}),
     isAuthenticated: () => getJwtManagerSync().isAuthenticated(),
     playPreview: (voice) => {
       if (voice.sample_url) playPreviewClip(voice.sample_url);
     },
+    loadPins: (host) => loadHostOverlay(host),
+    setPinned: (host, voiceId, featuredIds, pin) =>
+      setVoicePinned(host, voiceId, featuredIds, pin),
   };
 }
 
 /**
- * Renders the full per-host voice catalog in the settings Voices tab — the
- * "shelf" layer of the voice-selection architecture: HD and Everyday groups,
- * every catalog voice listed, selection per host. The in-page menus stay
- * capped; this surface absorbs the catalog's growth.
+ * Renders ONE unified cross-host voice catalog in the settings Voices tab. Each
+ * row carries per-host pin toggles (which define the in-host shortlist) and a
+ * per-host Use action; host-serveability is derived from catalog membership.
+ * The in-page menus stay short; this surface absorbs the catalog's growth.
  */
 export class VoicesController {
   private deps!: VoiceCatalogDeps;
   private readonly injectedDeps?: VoiceCatalogDeps;
-  private host: VoiceHostId = "pi";
   private renderToken = 0;
+  /** host id → that host's default pin set (server `featured`), for toggles. */
+  private featuredByHost = new Map<string, string[]>();
 
   constructor(private container: HTMLElement, deps?: VoiceCatalogDeps) {
     this.injectedDeps = deps;
   }
 
   async init(): Promise<void> {
-    // Resolved lazily so constructing the controller is side-effect-free —
-    // the default deps touch app config, and any failure lands in init()'s
-    // rejection (which the tab catches) rather than tab construction.
+    // Resolved lazily so constructing the controller is side-effect-free.
     this.deps = this.injectedDeps ?? defaultDeps();
-    const pills: Array<[string, VoiceHostId]> = [
-      ["#voice-host-pi", "pi"],
-      ["#voice-host-claude", "claude"],
-    ];
-    for (const [selector, host] of pills) {
-      this.container
-        .querySelector<HTMLButtonElement>(selector)
-        ?.addEventListener("click", () => {
-          void this.selectHost(host);
-        });
-    }
-    await this.selectHost(this.host);
+    await this.render();
   }
 
-  private async selectHost(host: VoiceHostId): Promise<void> {
-    this.host = host;
+  /**
+   * Gather every host's catalog + current voice + pin overlay, unify them, and
+   * paint. Per-host resilient: one host's fetch failing degrades to that host
+   * contributing nothing, never blanking the other.
+   */
+  private async render(): Promise<void> {
     const token = ++this.renderToken;
-    this.container
-      .querySelectorAll<HTMLButtonElement>(".voice-host-pill")
-      .forEach((pill) => {
-        const isActive = pill.id === `voice-host-${host}`;
-        pill.classList.toggle("active", isActive);
-        // The pills are a tablist; state must be programmatic too, not just
-        // the brand-color accent (#473).
-        pill.setAttribute("aria-selected", String(isActive));
-      });
+    const catalogs = await Promise.all(
+      VOICE_HOSTS.map(async ({ id }): Promise<HostCatalog> => {
+        const [voices, current, overlay] = await Promise.all([
+          this.deps.getVoices(id).catch(() => []),
+          this.deps.getVoice(id).catch(() => null),
+          this.deps.loadPins(id).catch(() => null),
+        ]);
+        return { hostId: id, voices, currentId: current?.id ?? null, overlay };
+      })
+    );
+    if (token !== this.renderToken) return; // a newer render superseded us
 
-    const [voices, current] = await Promise.all([
-      this.deps.getVoices(host),
-      this.deps.getVoice(host),
-    ]);
-    if (token !== this.renderToken) return; // a newer selection superseded us
-    this.renderCatalog(voices, current);
+    this.featuredByHost = new Map(
+      catalogs.map((c) => [c.hostId, serverFeaturedIds(c.voices)])
+    );
+    this.renderCatalog(unifyHostCatalogs(catalogs));
   }
 
-  private renderCatalog(
-    voices: SpeechSynthesisVoiceRemote[],
-    current: SpeechSynthesisVoiceRemote | null
-  ): void {
+  private renderCatalog(rows: UnifiedVoiceRow[]): void {
     const catalog = this.container.querySelector<HTMLElement>("#voice-catalog");
     if (!catalog) return;
     catalog.innerHTML = "";
 
-    if (voices.length === 0) {
-      // Signed out → /voices legitimately returns [] (401): prompt sign-in.
-      // Signed in with an empty catalog means the fetch failed — telling an
-      // authenticated user to sign in would be wrong and confusing. This runs
-      // on the RAW catalog (before the deprecated filter) so the signed-out vs
-      // fetch-failure distinction is never masked by retirement.
+    if (rows.length === 0) {
+      // Signed out → both /voices calls 401 → []: prompt sign-in. Signed in
+      // with nothing selectable means the fetch failed (or the whole catalog
+      // retired) — telling an authenticated user to sign in would be wrong.
       const emptyKey = this.deps.isAuthenticated()
         ? "voicesNoneAvailable"
         : "signInForTTS";
@@ -132,31 +157,24 @@ export class VoicesController {
       return;
     }
 
-    // Retirement (design §5): deprecated voices drop out of the catalog for new
-    // selectors, but the user's current voice always survives (grandfathering).
-    const shown = visibleCatalog(voices, current?.id ?? null);
-
-    const hd = shown.filter((voice) => getVoiceTier(voice) === "hd");
-    const everyday = shown.filter(
-      (voice) => getVoiceTier(voice) === "everyday"
-    );
+    const hd = rows.filter((row) => row.tier === "hd");
+    const everyday = rows.filter((row) => row.tier === "everyday");
 
     if (hd.length > 0 && everyday.length > 0) {
       catalog.appendChild(
-        this.renderShelf("hd", "voicesShelfHd", "hdVoicesAllowanceNote", hd, current)
+        this.renderShelf("hd", "voicesShelfHd", "hdVoicesAllowanceNote", hd)
       );
       catalog.appendChild(
         this.renderShelf(
           "everyday",
           "voicesShelfEveryday",
           "voicesShelfEverydayBlurb",
-          everyday,
-          current
+          everyday
         )
       );
     } else {
       // Single-tier catalog (today's state): a flat list, no shelf chrome.
-      catalog.appendChild(this.renderList(shown, current));
+      catalog.appendChild(this.renderList(rows));
     }
   }
 
@@ -164,8 +182,7 @@ export class VoicesController {
     tierKey: string,
     titleKey: string,
     blurbKey: string,
-    voices: SpeechSynthesisVoiceRemote[],
-    current: SpeechSynthesisVoiceRemote | null
+    rows: UnifiedVoiceRow[]
   ): HTMLElement {
     const shelf = document.createElement("div");
     shelf.classList.add("voice-shelf", `voice-shelf-${tierKey}`);
@@ -184,29 +201,22 @@ export class VoicesController {
     header.appendChild(blurb);
     shelf.appendChild(header);
 
-    shelf.appendChild(this.renderList(voices, current));
+    shelf.appendChild(this.renderList(rows));
     return shelf;
   }
 
-  private renderList(
-    voices: SpeechSynthesisVoiceRemote[],
-    current: SpeechSynthesisVoiceRemote | null
-  ): HTMLElement {
+  private renderList(rows: UnifiedVoiceRow[]): HTMLElement {
     const list = document.createElement("ul");
     list.classList.add("voice-list");
-    voices.forEach((voice) => {
-      list.appendChild(this.renderRow(voice, current?.id === voice.id));
-    });
+    rows.forEach((row) => list.appendChild(this.renderRow(row)));
     return list;
   }
 
-  private renderRow(
-    voice: SpeechSynthesisVoiceRemote,
-    isCurrent: boolean
-  ): HTMLElement {
-    const row = document.createElement("li");
-    row.classList.add("voice-row");
-    row.dataset.voiceId = voice.id;
+  private renderRow(row: UnifiedVoiceRow): HTMLElement {
+    const voice = row.voice;
+    const li = document.createElement("li");
+    li.classList.add("voice-row");
+    li.dataset.voiceId = voice.id;
 
     const main = document.createElement("div");
     main.classList.add("voice-row-main");
@@ -221,12 +231,10 @@ export class VoicesController {
       description.textContent = subtitle;
       main.appendChild(description);
     }
-    row.appendChild(main);
+    li.appendChild(main);
 
     // Choice by ear (design §4): a free ▶ preview, its own target separate from
-    // "Use this voice", rendered only when the server serves a sample clip. It
-    // rides on both current and selectable rows so the "Your voice" card can be
-    // auditioned too.
+    // "Use this voice", rendered only when the server serves a sample clip.
     if (voice.sample_url) {
       const preview = document.createElement("button");
       preview.type = "button";
@@ -234,38 +242,88 @@ export class VoicesController {
       preview.setAttribute("aria-label", getMessage("voicesPreview", [voice.name]));
       preview.innerHTML =
         '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 5v14l11-7z"></path></svg>';
-      preview.addEventListener("click", () => {
-        this.deps.playPreview(voice);
-      });
-      row.appendChild(preview);
+      preview.addEventListener("click", () => this.deps.playPreview(voice));
+      li.appendChild(preview);
     }
 
-    if (isCurrent) {
-      row.classList.add("current");
+    const hosts = document.createElement("div");
+    hosts.classList.add("voice-row-hosts");
+    row.hosts.forEach((state) => {
+      if (state.serveable) hosts.appendChild(this.renderHostControls(voice, state));
+    });
+    li.appendChild(hosts);
+
+    return li;
+  }
+
+  /**
+   * Per-host controls for one voice: a pin toggle (defines the in-host
+   * shortlist for that host) plus a Use action — or an "in use" badge when the
+   * voice is already that host's current selection. Grouped and labelled by
+   * host so the two hosts stay legible on one row.
+   */
+  private renderHostControls(
+    voice: SpeechSynthesisVoiceRemote,
+    state: HostVoiceState
+  ): HTMLElement {
+    const meta = VOICE_HOSTS.find((h) => h.id === state.hostId)!;
+    const group = document.createElement("div");
+    group.classList.add("voice-host-controls");
+    group.dataset.host = state.hostId;
+
+    const label = document.createElement("span");
+    label.classList.add("voice-host-label");
+    const logo = document.createElement("img");
+    logo.classList.add("voice-host-logo");
+    logo.src = meta.logo;
+    logo.alt = "";
+    logo.setAttribute("aria-hidden", "true");
+    label.appendChild(logo);
+    label.appendChild(document.createTextNode(meta.label));
+    group.appendChild(label);
+
+    const pin = document.createElement("button");
+    pin.type = "button";
+    pin.classList.add("voice-pin");
+    pin.classList.toggle("pinned", state.pinned);
+    pin.setAttribute("aria-pressed", String(state.pinned));
+    pin.setAttribute(
+      "aria-label",
+      getMessage("voicesPinToHost", [voice.name, meta.label])
+    );
+    pin.innerHTML =
+      '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true" focusable="false"><path fill="currentColor" d="M14 4v5l2 3v2h-5v5l-1 1-1-1v-5H4v-2l2-3V4a2 2 0 0 1-1-2h10a2 2 0 0 1-1 2z"></path></svg>';
+    pin.addEventListener("click", () =>
+      this.togglePin(pin, voice, meta.id, state.hostId)
+    );
+    group.appendChild(pin);
+
+    if (state.isCurrent) {
       const badge = document.createElement("span");
       badge.classList.add("voice-current-badge");
       badge.setAttribute("data-i18n", "voicesCurrent");
       badge.textContent = getMessage("voicesCurrent");
-      row.appendChild(badge);
+      group.appendChild(badge);
     } else {
       const use = document.createElement("button");
       use.type = "button";
       use.classList.add("voice-use");
-      use.setAttribute("data-i18n", "voicesUse");
-      use.textContent = getMessage("voicesUse");
-      use.addEventListener("click", () => {
-        void this.useVoice(voice);
-      });
-      row.appendChild(use);
+      use.setAttribute(
+        "aria-label",
+        getMessage("voicesUseOnHost", [voice.name, meta.label])
+      );
+      use.setAttribute("data-i18n", "voicesUseShort");
+      use.textContent = getMessage("voicesUseShort");
+      use.addEventListener("click", () => this.useVoice(voice, meta.id));
+      group.appendChild(use);
     }
-    return row;
+    return group;
   }
 
   /**
    * Metadata fallback for rows whose voice carries no server description.
    * Language coverage is what genuinely separates otherwise identically-named
-   * variants — the pi catalog serves two "Paola"s (#474) — and it is honest,
-   * useful copy on any description-less row.
+   * variants — the pi catalog serves two "Paola"s (#474).
    */
   private languagesSubtitle(voice: SpeechSynthesisVoiceRemote): string {
     const count = voice.languages?.length ?? 0;
@@ -274,10 +332,43 @@ export class VoicesController {
       : "";
   }
 
-  private async useVoice(voice: SpeechSynthesisVoiceRemote): Promise<void> {
-    const host = this.host;
+  /**
+   * Pinning has no cross-row effect and never regroups the shelves, so the
+   * toggle flips IN PLACE — no re-render, so keyboard focus and scroll survive
+   * the interaction. Optimistic: revert the visual if the write fails.
+   */
+  private async togglePin(
+    pinBtn: HTMLButtonElement,
+    voice: SpeechSynthesisVoiceRemote,
+    host: VoiceHostId,
+    hostId: string
+  ): Promise<void> {
+    const nowPinned = pinBtn.getAttribute("aria-pressed") !== "true";
+    pinBtn.setAttribute("aria-pressed", String(nowPinned));
+    pinBtn.classList.toggle("pinned", nowPinned);
+    try {
+      await this.deps.setPinned(
+        host,
+        voice.id,
+        this.featuredByHost.get(hostId) ?? [],
+        nowPinned
+      );
+    } catch (error) {
+      pinBtn.setAttribute("aria-pressed", String(!nowPinned));
+      pinBtn.classList.toggle("pinned", !nowPinned);
+      console.error("Failed to update voice pin", error);
+    }
+  }
+
+  /**
+   * Selecting a voice moves the "in use" badge between two rows, so this one
+   * re-renders (re-reading the stored voice) rather than patching in place.
+   */
+  private async useVoice(
+    voice: SpeechSynthesisVoiceRemote,
+    host: VoiceHostId
+  ): Promise<void> {
     await this.deps.setVoice(voice, host);
-    if (host !== this.host) return; // host switched while persisting
-    await this.selectHost(host); // one render path; re-reads the stored voice
+    await this.render();
   }
 }

--- a/entrypoints/settings/tabs/voices/voices.css
+++ b/entrypoints/settings/tabs/voices/voices.css
@@ -1,43 +1,16 @@
-/* Voices tab — the full per-host catalog behind the in-page menus'
-   "More voices…" door */
-#voice-host-pills {
-  display: flex;
-  gap: 0.5rem;
-  margin: 0.5rem 0 0.75rem;
+/* Voices tab — ONE unified cross-host catalog behind the in-page menus'
+   "More voices…" door. Each row curates its own per-host shortlist via pin
+   toggles (2026-07-05 shortlist redesign). */
+
+.voices-pin-explainer {
+  margin: 0.35rem 0 0.75rem;
 }
-.voice-host-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  border: 1px solid #d1d5db;
-  border-radius: 9999px;
-  background: transparent;
-  padding: 0.25rem 0.9rem;
-  font-size: 0.85rem;
-  cursor: pointer;
-}
+
 .voice-host-logo {
   width: 16px;
   height: 16px;
   border-radius: 4px;
   object-fit: contain;
-}
-/* The active pill takes on its assistant's brand palette (#473): Pi's forest
-   green on cream, Claude's terracotta on ivory. Weight + border + aria-selected
-   carry the state too — color is an accent, never the only signal. */
-.voice-host-pill.active {
-  background: #e5e7eb;
-  font-weight: 600;
-}
-#voice-host-pi.active {
-  background: #f5efe1;
-  border-color: #12805c;
-  color: #0b5c41;
-}
-#voice-host-claude.active {
-  background: #f8f0e9;
-  border-color: #d97757;
-  color: #ae5630;
 }
 .voice-shelf {
   margin-bottom: 0.75rem;
@@ -62,9 +35,9 @@
 .voice-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.4rem 0.25rem;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  padding: 0.45rem 0.25rem;
   border-bottom: 1px solid rgba(0, 0, 0, 0.06);
 }
 .voice-row:last-child {
@@ -74,8 +47,7 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  /* Push the trailing controls (▶ preview + Use/badge) together to the right,
-     regardless of how many there are. */
+  /* Push the trailing controls (▶ preview + per-host groups) to the right. */
   margin-right: auto;
 }
 .voice-preview {
@@ -103,6 +75,53 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Per-host controls: one group per host that serves the voice. */
+.voice-row-hosts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.9rem;
+  flex-shrink: 0;
+}
+.voice-host-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.voice-host-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+/* Pin toggle — outline when off, brand-tinted fill when pinned. aria-pressed
+   carries the state to assistive tech; colour is an accent, never the only
+   signal (the filled pin icon + border weight read without colour). */
+.voice-pin {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border: 1px solid #d1d5db;
+  border-radius: 9999px;
+  background: transparent;
+  color: #9ca3af;
+  cursor: pointer;
+}
+.voice-pin:hover {
+  background: #f3f4f6;
+  color: #6b7280;
+}
+.voice-pin.pinned {
+  color: #ae5630;
+  border-color: #d97757;
+  background: #f8f0e9;
+}
+
 .voice-use {
   flex-shrink: 0;
   border: 1px solid #d1d5db;

--- a/src/tts/VoiceCatalogUnify.ts
+++ b/src/tts/VoiceCatalogUnify.ts
@@ -1,0 +1,101 @@
+import { SpeechSynthesisVoiceRemote } from "./SpeechModel";
+import { getVoiceTier, visibleCatalog, VoiceTier } from "./VoiceCuration";
+import {
+  HostPinOverlay,
+  resolvePinnedIds,
+  serverFeaturedIds,
+} from "./VoicePins";
+
+/**
+ * Collapse the per-host voice catalogs into ONE cross-host catalog for the
+ * settings Voices tab (doc/plans/2026-07-05-voice-shortlist-pins-design.md).
+ *
+ * Every SayPi-served voice works on any host, so the catalog is host-generic;
+ * host-specificity survives only as per-voice state (serveable / pinned /
+ * current) so the UI can show per-host pin toggles + a per-host Use action on
+ * one row. Host-serveability is DERIVED from catalog membership — no new server
+ * field — and Pi's native voices (`default: true`, host-owned) are excluded:
+ * they are always shown in Pi's own menu and are not part of any shortlist,
+ * matching the in-host menu, which curates only non-default voices.
+ */
+
+export interface HostCatalog {
+  hostId: string;
+  voices: SpeechSynthesisVoiceRemote[];
+  currentId: string | null;
+  overlay: HostPinOverlay | null;
+}
+
+export interface HostVoiceState {
+  hostId: string;
+  /** The voice is in this host's (non-deprecated, non-default) catalog. */
+  serveable: boolean;
+  /** Resolved pin state for this host (only ever true when serveable). */
+  pinned: boolean;
+  /** This voice is this host's current selection. */
+  isCurrent: boolean;
+}
+
+export interface UnifiedVoiceRow {
+  voice: SpeechSynthesisVoiceRemote;
+  tier: VoiceTier;
+  /** One entry per input host, in input order. */
+  hosts: HostVoiceState[];
+}
+
+interface HostView {
+  hostId: string;
+  currentId: string | null;
+  byId: Map<string, SpeechSynthesisVoiceRemote>;
+  order: SpeechSynthesisVoiceRemote[];
+  pinned: Set<string>;
+}
+
+function deriveHostView(catalog: HostCatalog): HostView {
+  // Deprecated voices drop out (except the current one — grandfathering); Pi's
+  // native default voices are host-owned and never pinnable.
+  const visible = visibleCatalog(catalog.voices, catalog.currentId).filter(
+    (voice) => !voice.default
+  );
+  return {
+    hostId: catalog.hostId,
+    currentId: catalog.currentId,
+    byId: new Map(visible.map((voice) => [voice.id, voice])),
+    order: visible,
+    // Featured ids come from the full catalog; featured voices are non-default,
+    // so this matches the visible set. resolvePinnedIds treats a null overlay as
+    // the identity (just the server defaults).
+    pinned: resolvePinnedIds(serverFeaturedIds(catalog.voices), catalog.overlay),
+  };
+}
+
+export function unifyHostCatalogs(catalogs: HostCatalog[]): UnifiedVoiceRow[] {
+  const views = catalogs.map(deriveHostView);
+
+  // Union the voices in a stable order: first host's catalog order, then each
+  // later host's not-yet-seen voices appended.
+  const seen = new Set<string>();
+  const ordered: SpeechSynthesisVoiceRemote[] = [];
+  for (const view of views) {
+    for (const voice of view.order) {
+      if (!seen.has(voice.id)) {
+        seen.add(voice.id);
+        ordered.push(voice);
+      }
+    }
+  }
+
+  return ordered.map((voice) => ({
+    voice,
+    tier: getVoiceTier(voice),
+    hosts: views.map((view) => {
+      const serveable = view.byId.has(voice.id);
+      return {
+        hostId: view.hostId,
+        serveable,
+        pinned: serveable && view.pinned.has(voice.id),
+        isCurrent: view.currentId === voice.id,
+      };
+    }),
+  }));
+}

--- a/test/settings/tabs/VoicesPanel.spec.tsx
+++ b/test/settings/tabs/VoicesPanel.spec.tsx
@@ -17,34 +17,20 @@ describe("VoicesPanel", () => {
     ).toBeTruthy();
   });
 
-  it("renders the host pills and catalog container VoicesController targets", () => {
+  it("explains the per-host pin toggles", () => {
     const { container } = render(<VoicesPanel />);
-    const pills = [
-      ...container.querySelectorAll("#voice-host-pills button.voice-host-pill"),
-    ];
-    expect(pills.map((p) => p.id)).toEqual([
-      "voice-host-pi",
-      "voice-host-claude",
-    ]);
-    expect(container.querySelector("#voice-catalog")).toBeTruthy();
+    expect(
+      container.querySelector(
+        "#voices-preference [data-i18n='voicesPinExplainer']",
+      ),
+    ).toBeTruthy();
   });
 
-  it("brands each pill with its assistant's logo while keeping the text label (#473)", () => {
+  it("renders the unified catalog container VoicesController targets, with no host pills", () => {
     const { container } = render(<VoicesPanel />);
-    const piLogo = container.querySelector<HTMLImageElement>(
-      "#voice-host-pi img.voice-host-logo"
-    );
-    const claudeLogo = container.querySelector<HTMLImageElement>(
-      "#voice-host-claude img.voice-host-logo"
-    );
-    expect(piLogo?.getAttribute("src")).toBe("/icons/logos/pi.png");
-    expect(claudeLogo?.getAttribute("src")).toBe("/icons/logos/claude.png");
-    // Decorative images: the pill text stays the accessible label.
-    expect(piLogo?.getAttribute("alt")).toBe("");
-    expect(claudeLogo?.getAttribute("aria-hidden")).toBe("true");
-    expect(container.querySelector("#voice-host-pi")?.textContent?.trim()).toBe("Pi");
-    expect(
-      container.querySelector("#voice-host-claude")?.textContent?.trim()
-    ).toBe("Claude");
+    expect(container.querySelector("#voice-catalog")).toBeTruthy();
+    // The per-host pill tablist is gone — the catalog is one unified list.
+    expect(container.querySelector("#voice-host-pills")).toBeNull();
+    expect(container.querySelector(".voice-host-pill")).toBeNull();
   });
 });

--- a/test/settings/tabs/voices-controller.spec.tsx
+++ b/test/settings/tabs/voices-controller.spec.tsx
@@ -2,40 +2,64 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, cleanup } from "@testing-library/preact";
 import { VoicesPanel } from "../../../entrypoints/settings/tabs/voices/VoicesPanel";
 import { VoicesController } from "../../../entrypoints/settings/tabs/voices/voices-controller";
-import {
-  ElevenLabsVoice,
-  claudeMockVoices,
-  openAiMockVoices,
-  mockVoices,
-} from "../../data/Voices";
 import { SpeechSynthesisVoiceRemote } from "../../../src/tts/SpeechModel";
+import type { HostPinOverlay } from "../../../src/tts/VoicePins";
 
-const flipDayClaude: SpeechSynthesisVoiceRemote[] = [
-  ...claudeMockVoices,
-  ...openAiMockVoices,
-];
+// The Voices tab is now ONE unified cross-host catalog (no per-host pills):
+// each row carries per-host pin toggles + a per-host Use action. These tests
+// drive the controller through injected deps and assert the unified DOM.
 
-function makeDeps(overrides: Partial<Record<string, any>> = {}) {
+function mkVoice(
+  id: string,
+  over: Partial<SpeechSynthesisVoiceRemote> = {}
+): SpeechSynthesisVoiceRemote {
   return {
-    getVoices: vi.fn(async (host: string) =>
-      host === "claude" ? flipDayClaude : mockVoices
-    ),
-    getVoice: vi.fn(async () => null as SpeechSynthesisVoiceRemote | null),
-    setVoice: vi.fn(async () => {}),
-    isAuthenticated: vi.fn(() => true),
-    playPreview: vi.fn((_voice: SpeechSynthesisVoiceRemote) => {}),
-    ...overrides,
-  };
+    id,
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+    powered_by: "OpenAI",
+    price_per_thousand_chars_in_credits: 50,
+    default: false,
+    lang: "en",
+    localService: false,
+    voiceURI: `https://api.saypi.ai/voices/${id}`,
+    ...over,
+  } as SpeechSynthesisVoiceRemote;
 }
 
-function voiceWithSample(
-  id: string,
-  name: string,
-  sampleUrl?: string
-): SpeechSynthesisVoiceRemote {
-  const v = new ElevenLabsVoice(id, name);
-  v.sample_url = sampleUrl;
-  return v;
+interface DepsConfig {
+  pi?: SpeechSynthesisVoiceRemote[];
+  claude?: SpeechSynthesisVoiceRemote[];
+  piCurrent?: SpeechSynthesisVoiceRemote | null;
+  claudeCurrent?: SpeechSynthesisVoiceRemote | null;
+  piOverlay?: HostPinOverlay | null;
+  claudeOverlay?: HostPinOverlay | null;
+  authenticated?: boolean;
+  overrides?: Record<string, any>;
+}
+
+function makeDeps(cfg: DepsConfig = {}) {
+  const byHost: Record<string, SpeechSynthesisVoiceRemote[]> = {
+    pi: cfg.pi ?? [],
+    claude: cfg.claude ?? [],
+  };
+  const currentByHost: Record<string, SpeechSynthesisVoiceRemote | null> = {
+    pi: cfg.piCurrent ?? null,
+    claude: cfg.claudeCurrent ?? null,
+  };
+  const overlayByHost: Record<string, HostPinOverlay | null> = {
+    pi: cfg.piOverlay ?? null,
+    claude: cfg.claudeOverlay ?? null,
+  };
+  return {
+    getVoices: vi.fn(async (host: string) => byHost[host]),
+    getVoice: vi.fn(async (host: string) => currentByHost[host]),
+    setVoice: vi.fn(async () => {}),
+    isAuthenticated: vi.fn(() => cfg.authenticated ?? true),
+    playPreview: vi.fn((_v: SpeechSynthesisVoiceRemote) => {}),
+    loadPins: vi.fn(async (host: string) => overlayByHost[host]),
+    setPinned: vi.fn(async () => {}),
+    ...cfg.overrides,
+  };
 }
 
 async function mount(deps = makeDeps()) {
@@ -49,259 +73,292 @@ function flushAsync(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+const q = (c: HTMLElement, sel: string) =>
+  c.querySelector(sel) as HTMLElement | null;
+const rowOf = (c: HTMLElement, id: string) =>
+  q(c, `#voice-catalog [data-voice-id='${id}']`);
+const hostGroup = (c: HTMLElement, id: string, host: string) =>
+  q(
+    c,
+    `#voice-catalog [data-voice-id='${id}'] .voice-host-controls[data-host='${host}']`
+  );
+
 beforeEach(() => {
   document.body.innerHTML = "";
 });
 afterEach(() => cleanup());
 
-describe("VoicesController", () => {
-  it("loads the Pi catalog by default and renders a row per voice", async () => {
-    const { container, deps } = await mount();
+describe("VoicesController — unified catalog", () => {
+  it("fetches every host and renders one row per unioned voice", async () => {
+    const deps = makeDeps({
+      pi: [mkVoice("marin"), mkVoice("paola")],
+      claude: [mkVoice("marin"), mkVoice("jarnathan")],
+    });
+    const { container } = await mount(deps);
     expect(deps.getVoices).toHaveBeenCalledWith("pi");
-    const rows = container.querySelectorAll("#voice-catalog .voice-row");
-    expect(rows.length).toBe(mockVoices.length);
-  });
-
-  it("switches host when the Claude pill is clicked", async () => {
-    const { container, deps } = await mount();
-    (container.querySelector("#voice-host-claude") as HTMLElement).click();
-    await flushAsync();
     expect(deps.getVoices).toHaveBeenCalledWith("claude");
-    const rows = container.querySelectorAll("#voice-catalog .voice-row");
-    expect(rows.length).toBe(flipDayClaude.length);
+    const ids = [...container.querySelectorAll("#voice-catalog .voice-row")].map(
+      (r) => (r as HTMLElement).dataset.voiceId
+    );
+    // union: pi order first (marin, paola), then claude-only (jarnathan)
+    expect(ids).toEqual(["marin", "paola", "jarnathan"]);
   });
 
-  it("mirrors the active pill into aria-selected, not just the color accent (#473)", async () => {
-    const { container } = await mount();
-    const pi = container.querySelector("#voice-host-pi")!;
-    const claude = container.querySelector("#voice-host-claude")!;
-    expect(pi.getAttribute("aria-selected")).toBe("true");
-    expect(claude.getAttribute("aria-selected")).toBe("false");
-    (claude as HTMLElement).click();
-    await flushAsync();
-    expect(pi.getAttribute("aria-selected")).toBe("false");
-    expect(claude.getAttribute("aria-selected")).toBe("true");
+  it("keeps rendering the other host when one host's fetch fails (no all-or-nothing)", async () => {
+    const deps = makeDeps({
+      overrides: {
+        getVoices: vi.fn(async (host: string) => {
+          if (host === "pi") throw new Error("network");
+          return [mkVoice("marin")];
+        }),
+      },
+    });
+    const { container } = await mount(deps);
+    expect(rowOf(container, "marin")).toBeTruthy();
+    expect(hostGroup(container, "marin", "claude")).toBeTruthy();
+    expect(hostGroup(container, "marin", "pi")).toBeNull();
   });
 
   it("groups a mixed-tier catalog into HD and Everyday shelves", async () => {
-    const { container } = await mount();
-    (container.querySelector("#voice-host-claude") as HTMLElement).click();
-    await flushAsync();
+    const deps = makeDeps({
+      claude: [
+        mkVoice("jarnathan", {
+          powered_by: "ElevenLabs",
+          price_per_thousand_chars_in_credits: 1000,
+        }),
+        mkVoice("nova"),
+      ],
+    });
+    const { container } = await mount(deps);
     const shelves = [
       ...container.querySelectorAll("#voice-catalog .voice-shelf-title"),
     ].map((el) => el.getAttribute("data-i18n"));
     expect(shelves).toEqual(["voicesShelfHd", "voicesShelfEveryday"]);
-    const hdShelf = container.querySelector("#voice-catalog .voice-shelf-hd")!;
-    expect(hdShelf.querySelector("[data-voice-id='c6SfcYrb2t09NHXiT80T']")).toBeTruthy();
-    const everydayShelf = container.querySelector(
-      "#voice-catalog .voice-shelf-everyday"
-    )!;
-    expect(everydayShelf.querySelector("[data-voice-id='coral']")).toBeTruthy();
-  });
-
-  it("renders a flat list without shelf headers for a single-tier catalog", async () => {
-    const { container } = await mount();
     expect(
-      container.querySelector("#voice-catalog .voice-shelf-title")
-    ).toBeNull();
+      q(container, "#voice-catalog .voice-shelf-hd [data-voice-id='jarnathan']")
+    ).toBeTruthy();
     expect(
-      container.querySelector("#voice-catalog .voice-row")
+      q(
+        container,
+        "#voice-catalog .voice-shelf-everyday [data-voice-id='nova']"
+      )
     ).toBeTruthy();
   });
 
-  it("selects a voice for the active host when its Use button is clicked", async () => {
-    const { container, deps } = await mount();
-    (container.querySelector("#voice-host-claude") as HTMLElement).click();
-    await flushAsync();
-    const coralRow = container.querySelector(
-      "#voice-catalog [data-voice-id='coral']"
-    ) as HTMLElement;
-    (coralRow.querySelector("button.voice-use") as HTMLElement).click();
-    await flushAsync();
-    expect(deps.setVoice).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "coral" }),
-      "claude"
-    );
-  });
-
-  it("marks the stored voice's row as current instead of offering Use", async () => {
-    const jessica = claudeMockVoices.find((v) => v.name === "Jessica")!;
-    const deps = makeDeps({ getVoice: vi.fn(async () => jessica) });
+  it("renders a flat list without shelf headers for a single-tier catalog", async () => {
+    const deps = makeDeps({ pi: [mkVoice("marin"), mkVoice("nova")] });
     const { container } = await mount(deps);
-    (container.querySelector("#voice-host-claude") as HTMLElement).click();
-    await flushAsync();
-    const row = container.querySelector(
-      "#voice-catalog [data-voice-id='g6xIsTj2HwM6VR4iXFCw']"
-    ) as HTMLElement;
-    expect(row.classList.contains("current")).toBe(true);
-    expect(row.querySelector("button.voice-use")).toBeNull();
+    expect(q(container, "#voice-catalog .voice-shelf-title")).toBeNull();
+    expect(q(container, "#voice-catalog .voice-row")).toBeTruthy();
   });
+});
 
-  it("shows a sign-in prompt when the catalog comes back empty while signed out", async () => {
+describe("VoicesController — per-host Use / current (Record<host,voice> preserved)", () => {
+  it("selects a voice for the RIGHT host when that host's Use button is clicked", async () => {
     const deps = makeDeps({
-      getVoices: vi.fn(async () => []),
-      isAuthenticated: vi.fn(() => false),
+      pi: [mkVoice("marin")],
+      claude: [mkVoice("marin")],
     });
     const { container } = await mount(deps);
-    const empty = container.querySelector("#voice-catalog .voice-catalog-empty");
-    expect(empty).toBeTruthy();
-    expect(empty?.getAttribute("data-i18n")).toBe("signInForTTS");
+    const use = q(
+      container,
+      "[data-voice-id='marin'] .voice-host-controls[data-host='claude'] button.voice-use"
+    );
+    use!.click();
+    await flushAsync();
+    expect(deps.setVoice).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "marin" }),
+      "claude"
+    );
+    expect(deps.setVoice).not.toHaveBeenCalledWith(expect.anything(), "pi");
+  });
+
+  it("marks the host's current voice with a badge instead of a Use button, per host", async () => {
+    const marin = mkVoice("marin");
+    const deps = makeDeps({
+      pi: [marin, mkVoice("nova")],
+      claude: [mkVoice("marin"), mkVoice("nova")],
+      piCurrent: marin, // current on pi only
+    });
+    const { container } = await mount(deps);
+    const piGroup = hostGroup(container, "marin", "pi")!;
+    const claudeGroup = hostGroup(container, "marin", "claude")!;
+    expect(piGroup.querySelector(".voice-current-badge")).toBeTruthy();
+    expect(piGroup.querySelector("button.voice-use")).toBeNull();
+    expect(claudeGroup.querySelector("button.voice-use")).toBeTruthy();
+    expect(claudeGroup.querySelector(".voice-current-badge")).toBeNull();
+  });
+});
+
+describe("VoicesController — pins", () => {
+  it("renders a pin toggle per serveable host, pressed for server-featured voices", async () => {
+    const deps = makeDeps({
+      pi: [mkVoice("marin", { featured: true }), mkVoice("ash")],
+    });
+    const { container } = await mount(deps);
+    expect(
+      q(
+        container,
+        "[data-voice-id='marin'] [data-host='pi'] button.voice-pin"
+      )?.getAttribute("aria-pressed")
+    ).toBe("true");
+    expect(
+      q(
+        container,
+        "[data-voice-id='ash'] [data-host='pi'] button.voice-pin"
+      )?.getAttribute("aria-pressed")
+    ).toBe("false");
+  });
+
+  it("shows a pin toggle only for the hosts that serve the voice", async () => {
+    const deps = makeDeps({
+      pi: [mkVoice("paola")], // Pi-only
+      claude: [mkVoice("jarnathan")],
+    });
+    const { container } = await mount(deps);
+    expect(
+      q(container, "[data-voice-id='paola'] [data-host='pi'] button.voice-pin")
+    ).toBeTruthy();
+    expect(q(container, "[data-voice-id='paola'] [data-host='claude']")).toBeNull();
+  });
+
+  it("flips the pin in place (aria-pressed) and persists — without re-fetching the catalog", async () => {
+    const deps = makeDeps({ pi: [mkVoice("marin", { featured: true })] });
+    const { container } = await mount(deps);
+    const getVoicesCallsBefore = deps.getVoices.mock.calls.length;
+    const pin = q(
+      container,
+      "[data-voice-id='marin'] [data-host='pi'] button.voice-pin"
+    )!;
+    expect(pin.getAttribute("aria-pressed")).toBe("true");
+    pin.click();
+    await flushAsync();
+    expect(pin.getAttribute("aria-pressed")).toBe("false");
+    expect(deps.setPinned).toHaveBeenCalledWith("pi", "marin", ["marin"], false);
+    // no re-render (a full re-render would re-call getVoices)
+    expect(deps.getVoices.mock.calls.length).toBe(getVoicesCallsBefore);
+  });
+
+  it("pins a non-featured voice on click", async () => {
+    const deps = makeDeps({
+      pi: [mkVoice("marin", { featured: true }), mkVoice("ash")],
+    });
+    const { container } = await mount(deps);
+    const pin = q(
+      container,
+      "[data-voice-id='ash'] [data-host='pi'] button.voice-pin"
+    )!;
+    pin.click();
+    await flushAsync();
+    expect(pin.getAttribute("aria-pressed")).toBe("true");
+    expect(deps.setPinned).toHaveBeenCalledWith("pi", "ash", ["marin"], true);
+  });
+
+  it("reflects the user's stored overlay in the initial pin state", async () => {
+    const deps = makeDeps({
+      pi: [mkVoice("marin", { featured: true }), mkVoice("ash")],
+      piOverlay: { pinned: ["ash"], unpinned: ["marin"] },
+    });
+    const { container } = await mount(deps);
+    expect(
+      q(
+        container,
+        "[data-voice-id='marin'] [data-host='pi'] button.voice-pin"
+      )?.getAttribute("aria-pressed")
+    ).toBe("false");
+    expect(
+      q(
+        container,
+        "[data-voice-id='ash'] [data-host='pi'] button.voice-pin"
+      )?.getAttribute("aria-pressed")
+    ).toBe("true");
+  });
+});
+
+describe("VoicesController — empty states", () => {
+  it("prompts sign-in when both catalogs come back empty while signed out", async () => {
+    const deps = makeDeps({ authenticated: false });
+    const { container } = await mount(deps);
+    expect(
+      q(container, "#voice-catalog .voice-catalog-empty")?.getAttribute("data-i18n")
+    ).toBe("signInForTTS");
   });
 
   it("does NOT tell a signed-in user to sign in when the catalog is empty (fetch failure)", async () => {
-    const deps = makeDeps({ getVoices: vi.fn(async () => []) }); // authenticated
+    const deps = makeDeps({ authenticated: true });
     const { container } = await mount(deps);
-    const empty = container.querySelector("#voice-catalog .voice-catalog-empty");
-    expect(empty).toBeTruthy();
-    expect(empty?.getAttribute("data-i18n")).toBe("voicesNoneAvailable");
+    expect(
+      q(container, "#voice-catalog .voice-catalog-empty")?.getAttribute("data-i18n")
+    ).toBe("voicesNoneAvailable");
   });
+});
 
-  // The live pi catalog carries two distinct voices both named "Paola"
-  // (classic + eleven_v3). Only one has a server description, so rows
-  // without one must fall back to language-coverage metadata — otherwise the
-  // user sees two identical bare rows (#474).
-  describe("identically-named voices (#474)", () => {
-    const paolaClassic = new ElevenLabsVoice(
-      "ig1TeITnnNlsJtfHxJlW",
-      "Paola",
-      undefined,
-      undefined,
-      undefined,
-      ["en", "ja", "zh"]
+describe("VoicesController — preview (▶) and subtitles (ported)", () => {
+  it("renders a ▶ only on rows whose voice has a sample_url, and previews without selecting", async () => {
+    const withClip = mkVoice("nova", {
+      sample_url: "https://api.saypi.ai/voices/nova/sample.mp3",
+    } as any);
+    const noClip = mkVoice("ash");
+    const deps = makeDeps({ pi: [withClip, noClip] });
+    const { container } = await mount(deps);
+    const previewBtn = q(container, "[data-voice-id='nova'] button.voice-preview");
+    expect(previewBtn).toBeTruthy();
+    expect(q(container, "[data-voice-id='ash'] button.voice-preview")).toBeNull();
+    previewBtn!.click();
+    await flushAsync();
+    expect(deps.playPreview).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "nova" })
     );
-    const paolaV3 = new ElevenLabsVoice(
-      "paola-v3",
-      "Paola",
-      "F",
-      undefined,
-      "Paola on ElevenLabs' most expressive model, with expanded language coverage.",
-      ["en", "ja", "zh", "is"]
-    );
-
-    it("falls back to a languages subtitle so twin names stay distinguishable", async () => {
-      const deps = makeDeps({
-        getVoices: vi.fn(async () => [paolaClassic, paolaV3]),
-      });
-      const { container } = await mount(deps);
-      const subtitleOf = (id: string) =>
-        container.querySelector(
-          `#voice-catalog [data-voice-id='${id}'] .voice-row-desc`
-        )?.textContent ?? "";
-      expect(subtitleOf("paola-v3")).toContain("most expressive");
-      expect(subtitleOf("ig1TeITnnNlsJtfHxJlW")).not.toBe("");
-      expect(subtitleOf("ig1TeITnnNlsJtfHxJlW")).not.toBe(
-        subtitleOf("paola-v3")
-      );
-    });
-
-    it("shows no subtitle when there is neither description nor language data", async () => {
-      const bare = new ElevenLabsVoice("v1", "Solo");
-      const deps = makeDeps({ getVoices: vi.fn(async () => [bare]) });
-      const { container } = await mount(deps);
-      expect(
-        container.querySelector(
-          "#voice-catalog [data-voice-id='v1'] .voice-row-desc"
-        )
-      ).toBeNull();
-    });
+    expect(deps.setVoice).not.toHaveBeenCalled();
   });
 
-  // Choice by ear (design §4): a free canned preview clip, rendered only when
-  // the server serves a sample_url — a separate target from "Use this voice".
-  describe("voice preview (▶)", () => {
-    it("renders a ▶ button only on rows whose voice has a sample_url", async () => {
-      const withClip = voiceWithSample(
-        "withclip",
-        "Nova",
-        "https://api.saypi.ai/voices/nova/sample.mp3"
-      );
-      const noClip = voiceWithSample("noclip", "Ash", undefined);
-      const deps = makeDeps({ getVoices: vi.fn(async () => [withClip, noClip]) });
-      const { container } = await mount(deps);
-      const previewOf = (id: string) =>
-        container.querySelector(
-          `#voice-catalog [data-voice-id='${id}'] button.voice-preview`
-        );
-      expect(previewOf("withclip")).toBeTruthy();
-      expect(previewOf("noclip")).toBeNull();
-    });
-
-    it("plays the sample without selecting the voice when ▶ is clicked", async () => {
-      const withClip = voiceWithSample(
-        "withclip",
-        "Nova",
-        "https://api.saypi.ai/voices/nova/sample.mp3"
-      );
-      const deps = makeDeps({ getVoices: vi.fn(async () => [withClip]) });
-      const { container } = await mount(deps);
-      const btn = container.querySelector(
-        "#voice-catalog [data-voice-id='withclip'] button.voice-preview"
-      ) as HTMLElement;
-      btn.click();
-      await flushAsync();
-      expect(deps.playPreview).toHaveBeenCalledTimes(1);
-      expect(deps.playPreview).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "withclip" })
-      );
-      // Preview must not select — that is the "Use this voice" button's job.
-      expect(deps.setVoice).not.toHaveBeenCalled();
-    });
-
-    it("offers ▶ on the current voice's row too (the 'Your voice' card previews)", async () => {
-      const current = voiceWithSample(
-        "withclip",
-        "Nova",
-        "https://api.saypi.ai/voices/nova/sample.mp3"
-      );
-      const deps = makeDeps({
-        getVoices: vi.fn(async () => [current]),
-        getVoice: vi.fn(async () => current),
-      });
-      const { container } = await mount(deps);
-      const row = container.querySelector(
-        "#voice-catalog [data-voice-id='withclip']"
-      ) as HTMLElement;
-      expect(row.classList.contains("current")).toBe(true);
-      expect(row.querySelector("button.voice-preview")).toBeTruthy();
-    });
+  it("falls back to a languages subtitle when a voice has no description (#474 twin names)", async () => {
+    const bare = mkVoice("paola", { languages: ["en", "ja", "zh"] } as any);
+    const deps = makeDeps({ pi: [bare] });
+    const { container } = await mount(deps);
+    const desc = q(container, "[data-voice-id='paola'] .voice-row-desc");
+    expect(desc?.textContent ?? "").not.toBe("");
   });
 
-  // Retirement (design §5): a deprecated voice drops out of the catalog for new
-  // selectors, but a user already on one keeps seeing and using it forever
-  // (grandfathering — never a silent swap).
-  describe("deprecated voices (grandfathering)", () => {
-    function deprecate(
-      v: SpeechSynthesisVoiceRemote
-    ): SpeechSynthesisVoiceRemote {
-      v.deprecated = true;
-      return v;
-    }
+  it("shows no subtitle when a voice has neither description nor language data", async () => {
+    const solo = mkVoice("solo"); // no description, no languages
+    const deps = makeDeps({ pi: [solo] });
+    const { container } = await mount(deps);
+    expect(q(container, "[data-voice-id='solo'] .voice-row-desc")).toBeNull();
+  });
 
-    it("hides a deprecated voice from the catalog", async () => {
-      const live = new ElevenLabsVoice("live", "Live");
-      const retired = deprecate(new ElevenLabsVoice("retired", "Retired"));
-      const deps = makeDeps({ getVoices: vi.fn(async () => [live, retired]) });
-      const { container } = await mount(deps);
-      expect(
-        container.querySelector("#voice-catalog [data-voice-id='live']")
-      ).toBeTruthy();
-      expect(
-        container.querySelector("#voice-catalog [data-voice-id='retired']")
-      ).toBeNull();
-    });
+  it("offers ▶ on a row whose voice is a host's current selection (the card previews too)", async () => {
+    const current = mkVoice("nova", {
+      sample_url: "https://api.saypi.ai/voices/nova/sample.mp3",
+    } as any);
+    const deps = makeDeps({ pi: [current], piCurrent: current });
+    const { container } = await mount(deps);
+    expect(
+      hostGroup(container, "nova", "pi")?.querySelector(".voice-current-badge")
+    ).toBeTruthy();
+    expect(
+      rowOf(container, "nova")?.querySelector("button.voice-preview")
+    ).toBeTruthy();
+  });
+});
 
-    it("keeps rendering a deprecated voice that is the user's current selection", async () => {
-      const retired = deprecate(new ElevenLabsVoice("retired", "Retired"));
-      const deps = makeDeps({
-        getVoices: vi.fn(async () => [retired]),
-        getVoice: vi.fn(async () => retired),
-      });
-      const { container } = await mount(deps);
-      const row = container.querySelector(
-        "#voice-catalog [data-voice-id='retired']"
-      ) as HTMLElement;
-      expect(row).toBeTruthy();
-      expect(row.classList.contains("current")).toBe(true);
+describe("VoicesController — deprecated grandfathering (ported)", () => {
+  it("hides a deprecated voice from the catalog", async () => {
+    const deps = makeDeps({
+      pi: [mkVoice("live"), mkVoice("retired", { deprecated: true })],
     });
+    const { container } = await mount(deps);
+    expect(rowOf(container, "live")).toBeTruthy();
+    expect(rowOf(container, "retired")).toBeNull();
+  });
+
+  it("keeps rendering a deprecated voice that is the host's current selection", async () => {
+    const retired = mkVoice("retired", { deprecated: true });
+    const deps = makeDeps({ pi: [retired], piCurrent: retired });
+    const { container } = await mount(deps);
+    expect(rowOf(container, "retired")).toBeTruthy();
+    expect(
+      hostGroup(container, "retired", "pi")?.querySelector(".voice-current-badge")
+    ).toBeTruthy();
   });
 });

--- a/test/tts/VoiceCatalogUnify.spec.ts
+++ b/test/tts/VoiceCatalogUnify.spec.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import {
+  unifyHostCatalogs,
+  type HostCatalog,
+  type UnifiedVoiceRow,
+} from "../../src/tts/VoiceCatalogUnify";
+import { SpeechSynthesisVoiceRemote } from "../../src/tts/SpeechModel";
+
+// Minimal voice factory — only the fields unify/tier read.
+function v(
+  id: string,
+  over: Partial<SpeechSynthesisVoiceRemote> = {}
+): SpeechSynthesisVoiceRemote {
+  return {
+    id,
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+    powered_by: "OpenAI",
+    price_per_thousand_chars_in_credits: 50,
+    default: false,
+    lang: "en",
+    localService: false,
+    voiceURI: `https://api.saypi.ai/voices/${id}`,
+    ...over,
+  } as SpeechSynthesisVoiceRemote;
+}
+
+function host(
+  hostId: string,
+  voices: SpeechSynthesisVoiceRemote[],
+  over: Partial<HostCatalog> = {}
+): HostCatalog {
+  return { hostId, voices, currentId: null, overlay: null, ...over };
+}
+
+function rowFor(rows: UnifiedVoiceRow[], id: string): UnifiedVoiceRow {
+  const row = rows.find((r) => r.voice.id === id);
+  if (!row) throw new Error(`no row for ${id}`);
+  return row;
+}
+
+function stateFor(row: UnifiedVoiceRow, hostId: string) {
+  const s = row.hosts.find((h) => h.hostId === hostId);
+  if (!s) throw new Error(`no ${hostId} state`);
+  return s;
+}
+
+describe("unifyHostCatalogs — union & serveability", () => {
+  it("collapses a voice served by both hosts into a single row with both host states", () => {
+    const shared = v("marin");
+    const rows = unifyHostCatalogs([
+      host("pi", [shared]),
+      host("claude", [v("marin")]),
+    ]);
+    expect(rows.length).toBe(1);
+    expect(rows[0].hosts.map((h) => h.hostId)).toEqual(["pi", "claude"]);
+    expect(stateFor(rows[0], "pi").serveable).toBe(true);
+    expect(stateFor(rows[0], "claude").serveable).toBe(true);
+  });
+
+  it("marks a host-specific voice serveable on that host only", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("paola")]),
+      host("claude", [v("jarnathan")]),
+    ]);
+    expect(stateFor(rowFor(rows, "paola"), "pi").serveable).toBe(true);
+    expect(stateFor(rowFor(rows, "paola"), "claude").serveable).toBe(false);
+    expect(stateFor(rowFor(rows, "jarnathan"), "claude").serveable).toBe(true);
+    expect(stateFor(rowFor(rows, "jarnathan"), "pi").serveable).toBe(false);
+  });
+
+  it("orders the union first-host-first, then appends later-host-only voices", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("paola"), v("marin")]),
+      host("claude", [v("marin"), v("jarnathan")]),
+    ]);
+    expect(rows.map((r) => r.voice.id)).toEqual(["paola", "marin", "jarnathan"]);
+  });
+
+  it("contributes nothing for a host whose catalog is empty (e.g. a failed fetch)", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("marin")]),
+      host("claude", []),
+    ]);
+    expect(rows.length).toBe(1);
+    expect(stateFor(rows[0], "claude").serveable).toBe(false);
+    expect(stateFor(rows[0], "pi").serveable).toBe(true);
+  });
+});
+
+describe("unifyHostCatalogs — pin state", () => {
+  it("treats a server-featured voice as pinned by default (no overlay)", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("marin", { featured: true }), v("ash", { featured: false })]),
+    ]);
+    expect(stateFor(rowFor(rows, "marin"), "pi").pinned).toBe(true);
+    expect(stateFor(rowFor(rows, "ash"), "pi").pinned).toBe(false);
+  });
+
+  it("applies the user's overlay: removes an unpinned default, adds a pinned non-default", () => {
+    const rows = unifyHostCatalogs([
+      host(
+        "pi",
+        [v("marin", { featured: true }), v("ash")],
+        { overlay: { pinned: ["ash"], unpinned: ["marin"] } }
+      ),
+    ]);
+    expect(stateFor(rowFor(rows, "marin"), "pi").pinned).toBe(false);
+    expect(stateFor(rowFor(rows, "ash"), "pi").pinned).toBe(true);
+  });
+
+  it("keeps pin state independent per host", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("marin", { featured: true })]),
+      host("claude", [v("marin", { featured: false })]),
+    ]);
+    expect(stateFor(rowFor(rows, "marin"), "pi").pinned).toBe(true);
+    expect(stateFor(rowFor(rows, "marin"), "claude").pinned).toBe(false);
+  });
+
+  it("never reports a voice pinned on a host that does not serve it", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("paola", { featured: true })]),
+      host("claude", []),
+    ]);
+    expect(stateFor(rowFor(rows, "paola"), "claude").pinned).toBe(false);
+  });
+});
+
+describe("unifyHostCatalogs — current voice", () => {
+  it("marks the host's current voice", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("marin"), v("ash")], { currentId: "ash" }),
+      host("claude", [v("marin"), v("ash")], { currentId: "marin" }),
+    ]);
+    expect(stateFor(rowFor(rows, "ash"), "pi").isCurrent).toBe(true);
+    expect(stateFor(rowFor(rows, "ash"), "claude").isCurrent).toBe(false);
+    expect(stateFor(rowFor(rows, "marin"), "claude").isCurrent).toBe(true);
+  });
+});
+
+describe("unifyHostCatalogs — exclusions", () => {
+  it("excludes host-native default voices (Pi 1-8) from the pin catalog", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("pi-1", { default: true }), v("marin")]),
+    ]);
+    expect(rows.map((r) => r.voice.id)).toEqual(["marin"]);
+  });
+
+  it("excludes a deprecated voice from the catalog", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("marin"), v("retired", { deprecated: true })]),
+    ]);
+    expect(rows.map((r) => r.voice.id)).toEqual(["marin"]);
+  });
+
+  it("keeps a deprecated voice that is the host's current selection (grandfathering)", () => {
+    const rows = unifyHostCatalogs([
+      host("pi", [v("retired", { deprecated: true })], { currentId: "retired" }),
+    ]);
+    expect(rows.map((r) => r.voice.id)).toEqual(["retired"]);
+    expect(stateFor(rows[0], "pi").isCurrent).toBe(true);
+  });
+});
+
+describe("unifyHostCatalogs — tier", () => {
+  it("classifies each row's tier from the voice", () => {
+    const rows = unifyHostCatalogs([
+      host("claude", [
+        v("jarnathan", { powered_by: "ElevenLabs", price_per_thousand_chars_in_credits: 1000 }),
+        v("nova"),
+      ]),
+    ]);
+    expect(rowFor(rows, "jarnathan").tier).toBe("hd");
+    expect(rowFor(rows, "nova").tier).toBe("everyday");
+  });
+});


### PR DESCRIPTION
## What & why

Phase 2c — the payoff of the [voice-shortlist redesign](../blob/main/doc/plans/2026-07-05-voice-shortlist-pins-design.md). The settings **Voices** tab is now **one unified cross-host catalog** instead of a per-host pill-switched list. Each row shows the voice once with a per-host control group: a **pin toggle** (which curates that host's short in-app menu) + a **Use** action, or an "in use" badge. This lights the pin feature up end-to-end — pins set here drive the in-host menus (via the Phase 2a store + 2b wiring, both merged) on their next open.

Builds on #515 (2a foundation) and #516 (2b menu wiring).

## Changes
- **`src/tts/VoiceCatalogUnify.ts`** (new, pure + 13 tests): unifies the per-host catalogs into one, deriving host-serveability from catalog membership (no new server field) and per-voice pin/current state. Handles per-host divergence (a voice featured/deprecated on one host only). Pi's native `default:true` voices are excluded — host-owned, always shown in Pi's menu, never pinnable — consistent with the in-host menu, which curates only non-default voices.
- **`voices-controller.ts`** (rewritten): fetches every host **resiliently** (each fetch wrapped in `.catch` — one host failing degrades to it contributing nothing, never blanking the other), unifies, and renders. **Pin toggles flip in place** (no re-render → keyboard focus + scroll survive the headline interaction); **Use re-renders** (the "in use" badge moves between two rows). Per-host Use preserves the existing `Record<chatbotId,voiceId>` model — no cross-host selection.
- **`VoicesPanel.tsx` / `voices.css`**: drop the host pills; one catalog, a pin explainer, per-host control styling.
- **i18n**: `voicesPinToHost`, `voicesUseOnHost`, `voicesUseShort`, `voicesPinExplainer` (dead `voicesUse` removed).

## Invariants held (adversarially reviewed)
Grandfathering (current voice always renders, even deprecated) · **never a silent swap** (pinning never touches the current voice; only Use does) · per-host selection preserved · the right host's `featuredIds` reach `setVoicePinned`. A `feature-dev:code-reviewer` pass found no high-confidence defects against these; its two flagged follow-ups (spec-coverage parity, dead i18n key) are addressed in this PR.

## Known v1 scope (conscious)
A pin set in settings reaches an **already-open** host tab on the menu's **next open** — voice *selection* live-propagates (via #475) but pins have no cross-tab event yet. Fine for v1.

## Tests
13 unify + 19 controller + 3 panel; ported forward all prior catalog coverage (per-host Use targeting, current vs Use, deprecated grandfathering, ▶ preview incl. on the current row, #474 twin-name + no-data subtitle). Full gate green (`tsc` + Jest + Vitest, 1882 tests); `i18n-validate` passes.

> After merge: one Layer-4 real-host check of the full loop (pin in settings → reopen the in-host menu → membership changed) — the settings-write → `chrome.storage` → content-script-read seam that unit tests can't exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)