### PR TITLE
fix(voices): studio fits its window — adaptive sizing + i18n substitution fix + fresh stage voice

### DIFF
--- a/entrypoints/settings/index.ts
+++ b/entrypoints/settings/index.ts
@@ -15,6 +15,7 @@ import {
   SETTINGS_DEEP_LINK_KEY,
   parseSettingsDeepLink,
 } from "../../src/popup/popupopener";
+import { settingsWindowGrowthFor } from "../../src/popup/settingsWindowSize";
 
 // Styles
 import "./styles/base.css"; // reset + utilities (replaces the 2.9 MB Tailwind v2 dump)
@@ -148,7 +149,32 @@ class SettingsApp {
 
   private async switchToTab(tabId: string): Promise<void> {
     // Load tab on-demand when user switches to it
+    void this.ensureRoomFor(tabId);
     await this.loadTab(tabId);
+  }
+
+  /**
+   * Adaptive window sizing (macOS System Settings pattern): the compact popup
+   * grows — never shrinks — when a roomy pane (the Voices studio) is shown.
+   * Only applies to the popup window the extension created; when settings
+   * lives in a normal browser tab, the tab manages itself.
+   */
+  private async ensureRoomFor(tabId: string): Promise<void> {
+    try {
+      const win = await browser.windows.getCurrent();
+      if (win.type !== 'popup' || win.id === undefined) return;
+      const growth = settingsWindowGrowthFor(
+        tabId,
+        { width: win.width ?? 0, height: win.height ?? 0 },
+        {
+          availWidth: window.screen.availWidth,
+          availHeight: window.screen.availHeight,
+        }
+      );
+      if (growth) await browser.windows.update(win.id, growth);
+    } catch (e) {
+      // Sizing is a nicety — never let it break the settings page.
+    }
   }
 }
 

--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -137,6 +137,13 @@ interface StudioViewModel {
   /** Host-owned built-ins exist (e.g. Pi's) — they get a note, not cards. */
   hasBuiltins: boolean;
   currentId: string | null;
+  /**
+   * The voice the stage announces: the FRESH catalog entry for the current
+   * id when one exists (the stored preference can be a stale snapshot from
+   * before sample_url/languages existed), else the stored voice itself
+   * (built-ins and grandfathered voices aren't in the catalog).
+   */
+  stagedCurrent: SpeechSynthesisVoiceRemote | null;
   featuredIds: string[];
   /** The resolved pin set (server defaults ⊕ user overlay). */
   pinned: Set<string>;
@@ -289,6 +296,9 @@ export class VoicesController {
     // host's menu and never pinnable — the studio notes them, not cards them.
     const catalog = visible.filter((voice) => !voice.default);
     const hasBuiltins = visible.length > catalog.length;
+    const stagedCurrent = currentId
+      ? visible.find((voice) => voice.id === currentId) ?? data.current
+      : null;
 
     const featuredIds = serverFeaturedIds(catalog);
     const customized = data.overlay !== null;
@@ -327,6 +337,7 @@ export class VoicesController {
       catalog,
       hasBuiltins,
       currentId,
+      stagedCurrent,
       featuredIds,
       pinned,
       seated: shortlist.voices,
@@ -352,7 +363,7 @@ export class VoicesController {
       return;
     }
 
-    body.appendChild(this.renderStage(data.current, vm));
+    body.appendChild(this.renderStage(vm.stagedCurrent, vm));
     body.appendChild(this.renderSlotsSection(vm));
     body.appendChild(this.renderShelves(vm));
   }
@@ -376,7 +387,10 @@ export class VoicesController {
     } else {
       key = "voicesNoneAvailable";
     }
-    empty.setAttribute("data-i18n", key);
+    // data-i18n ONLY on substitution-free text: the bootstrap's replaceI18n()
+    // rewrites [data-i18n] textContent from the bare key, which would wipe
+    // the host name out of substituted strings (the "In 's menu" defect).
+    if (!substitutions) empty.setAttribute("data-i18n", key);
     empty.textContent = getMessage(key, substitutions);
     return empty;
   }
@@ -412,7 +426,7 @@ export class VoicesController {
 
     const eyebrow = document.createElement("div");
     eyebrow.classList.add("voice-stage-eyebrow");
-    eyebrow.setAttribute("data-i18n", "voicesSpeaksWith");
+    // No data-i18n: substituted text (replaceI18n would strip the host name).
     eyebrow.textContent = getMessage("voicesSpeaksWith", [vm.host.label]);
     meta.appendChild(eyebrow);
 
@@ -473,7 +487,7 @@ export class VoicesController {
     head.classList.add("voice-slots-head");
     const title = document.createElement("span");
     title.classList.add("voice-slots-title");
-    title.setAttribute("data-i18n", "voicesInHostMenu");
+    // No data-i18n on substituted text (replaceI18n clobber — see renderEmptyState).
     title.textContent = getMessage("voicesInHostMenu", [vm.host.label]);
     head.appendChild(title);
     const hint = document.createElement("span");
@@ -493,7 +507,6 @@ export class VoicesController {
     if (vm.overflowCount > 0) {
       const overflow = document.createElement("div");
       overflow.classList.add("voice-slots-overflow");
-      overflow.setAttribute("data-i18n", "voicesMenuOverflow");
       overflow.textContent = getMessage("voicesMenuOverflow", [
         String(vm.overflowCount),
         String(vm.host.menuCap),
@@ -504,7 +517,6 @@ export class VoicesController {
     if (vm.hasBuiltins) {
       const builtins = document.createElement("div");
       builtins.classList.add("voice-slots-builtins");
-      builtins.setAttribute("data-i18n", "voicesBuiltinsNote");
       builtins.textContent = getMessage("voicesBuiltinsNote", [vm.host.label]);
       section.appendChild(builtins);
     }

--- a/src/popup/settingsWindowSize.ts
+++ b/src/popup/settingsWindowSize.ts
@@ -1,0 +1,59 @@
+/**
+ * Adaptive settings-window sizing (macOS System Settings pattern): the popup
+ * opens compact — right for the form-style tabs — and grows when a pane needs
+ * a full page. Today that's only the Voices studio (Host Studio redesign,
+ * doc/plans/2026-07-07-voices-host-studio-design.md); a future roomy tab is
+ * one more entry in LARGE_TABS.
+ *
+ * Pure: the caller (settings bootstrap) supplies current window + screen
+ * bounds and applies the result via browser.windows.update.
+ */
+
+/** Tabs that need a full page rather than the compact popup. */
+const LARGE_TABS = new Set(["voices"]);
+
+/**
+ * Whether a settings tab wants the full-size window — used by the background
+ * to open deep-linked windows at full size directly (no visible grow-jolt).
+ */
+export function isRoomySettingsTab(tab: string): boolean {
+  return LARGE_TABS.has(tab);
+}
+
+/**
+ * Roomy target for the studio: 1120 fits the 940px content column + sidebar
+ * with breathing room; 900 shows stage + slots + a full shelf row.
+ */
+export const STUDIO_WINDOW = { width: 1120, height: 900 };
+
+export interface WindowBounds {
+  width: number;
+  height: number;
+}
+export interface ScreenBounds {
+  availWidth: number;
+  availHeight: number;
+}
+
+/**
+ * The window growth needed so `tab` fits, or null when none is needed.
+ * Grow-only, per dimension: switching back to a compact tab never shrinks
+ * the window, and a user's own larger sizing is always respected (no yo-yo).
+ */
+export function settingsWindowGrowthFor(
+  tab: string,
+  current: WindowBounds,
+  screen: ScreenBounds
+): WindowBounds | null {
+  if (!LARGE_TABS.has(tab)) return null;
+  const width = Math.max(
+    current.width,
+    Math.min(STUDIO_WINDOW.width, screen.availWidth)
+  );
+  const height = Math.max(
+    current.height,
+    Math.min(STUDIO_WINDOW.height, screen.availHeight)
+  );
+  if (width === current.width && height === current.height) return null;
+  return { width, height };
+}

--- a/src/svc/background.ts
+++ b/src/svc/background.ts
@@ -8,6 +8,8 @@ import { pickSyntheticSpeechClip } from "../offscreen/syntheticSpeechPool";
 import { maybeOpenFirstRunTab } from "../onboarding/firstRun";
 import { seedVoiceDefaultsOnFreshInstall } from "../onboarding/voiceDefaults";
 import { detectPermissionLoss, buildPermissionsUrl, MIC_GRANTED_FLAG } from "../permissions/permissionLossDetection";
+import { SETTINGS_DEEP_LINK_KEY, parseSettingsDeepLink } from "../popup/popupopener";
+import { STUDIO_WINDOW, isRoomySettingsTab } from "../popup/settingsWindowSize";
 
 // Track when PKCE authentication is in progress to prevent cookie listener interference
 let isPKCEAuthInProgress = false;
@@ -54,7 +56,24 @@ async function openSettingsWindow() {
     // We check local storage flag 'shareData'. If it's undefined, consent will show.
     const { shareData } = await browser.storage.local.get('shareData');
     const needsConsent = typeof shareData === 'undefined';
-    const height = needsConsent ? 640 : 512; // taller for consent (640px to match illustration), compact for settings (512px)
+    let width = POPUP_DESKTOP_WIDTH;
+    let height = needsConsent ? 640 : 512; // taller for consent (640px to match illustration), compact for settings (512px)
+
+    // A deep link into a roomy pane (the Voices studio) opens at full size
+    // directly, so the user never sees a compact window jolt larger. The
+    // page-side ensureRoomFor covers every other path (e.g. clicking the
+    // Voices tab later); Chrome clamps oversized windows to the screen.
+    try {
+      const stored = await browser.storage.local.get(SETTINGS_DEEP_LINK_KEY);
+      const link = parseSettingsDeepLink(stored?.[SETTINGS_DEEP_LINK_KEY]);
+      if (link && isRoomySettingsTab(link.tab)) {
+        width = STUDIO_WINDOW.width;
+        height = STUDIO_WINDOW.height;
+      }
+    } catch (e) {
+      // Best-effort sizing; the compact default is always safe.
+    }
+
     // Firefox on Android does not support opening popup windows; open a tab instead
     if (isFirefox() && isMobileDevice()) {
       await browser.tabs.create({ url: popupURL, active: true });
@@ -64,7 +83,7 @@ async function openSettingsWindow() {
     await browser.windows.create({
       url: popupURL,
       type: 'popup',
-      width: POPUP_DESKTOP_WIDTH,
+      width,
       height,
       focused: true
     });

--- a/test/popup/settingsWindowSize.spec.ts
+++ b/test/popup/settingsWindowSize.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  settingsWindowGrowthFor,
+  STUDIO_WINDOW,
+} from "../../src/popup/settingsWindowSize";
+
+// The settings popup opens compact (right for the form tabs) and grows —
+// macOS System Settings style — when the Voices studio needs the room.
+
+const SCREEN = { availWidth: 1728, availHeight: 1079 };
+
+describe("settingsWindowGrowthFor", () => {
+  it("grows the compact popup to the studio size for the voices tab", () => {
+    const growth = settingsWindowGrowthFor(
+      "voices",
+      { width: 742, height: 512 },
+      SCREEN
+    );
+    expect(growth).toEqual({
+      width: STUDIO_WINDOW.width,
+      height: STUDIO_WINDOW.height,
+    });
+  });
+
+  it("asks nothing for the compact tabs", () => {
+    for (const tab of ["general", "chat", "dictation", "about"]) {
+      expect(
+        settingsWindowGrowthFor(tab, { width: 742, height: 512 }, SCREEN)
+      ).toBeNull();
+    }
+  });
+
+  it("clamps to the available screen", () => {
+    const growth = settingsWindowGrowthFor(
+      "voices",
+      { width: 742, height: 512 },
+      { availWidth: 1024, availHeight: 700 }
+    );
+    expect(growth).toEqual({ width: 1024, height: 700 });
+  });
+
+  it("never shrinks a window the user has made larger", () => {
+    expect(
+      settingsWindowGrowthFor(
+        "voices",
+        { width: 1500, height: 1000 },
+        SCREEN
+      )
+    ).toBeNull();
+  });
+
+  it("grows only the deficient dimension", () => {
+    const growth = settingsWindowGrowthFor(
+      "voices",
+      { width: 1500, height: 512 },
+      SCREEN
+    );
+    expect(growth).toEqual({ width: 1500, height: STUDIO_WINDOW.height });
+  });
+});

--- a/test/settings/tabs/voices-controller.spec.tsx
+++ b/test/settings/tabs/voices-controller.spec.tsx
@@ -210,9 +210,10 @@ describe("VoicesController — stage", () => {
     const stage = q(container, ".voice-stage")!;
     expect(stage.style.getPropertyValue("--stage-from")).toBe("#2DD4BF");
     expect(stage.style.getPropertyValue("--stage-to")).toBe("#0E7490");
-    expect(q(container, ".voice-stage-eyebrow")!.dataset.i18n).toBe(
-      "voicesSpeaksWith"
-    );
+    // Substituted text must NOT carry data-i18n (replaceI18n clobber guard).
+    const eyebrow = q(container, ".voice-stage-eyebrow")!;
+    expect(eyebrow.textContent).toBe("voicesSpeaksWith");
+    expect(eyebrow.dataset.i18n).toBeUndefined();
     expect(q(container, ".voice-stage-name")!.textContent).toBe("Marin");
     expect(q(container, ".voice-stage-tagline")!.dataset.i18n).toBe(
       "voiceTagline_marin"
@@ -235,9 +236,9 @@ describe("VoicesController — stage", () => {
     expect(q(container, ".voice-stage-name")!.textContent).toBe("Aria");
     // built-ins are host-owned: never a card, but the note explains the menu
     expect(cardOf(container, "voice1")).toBeNull();
-    expect(q(container, ".voice-slots-builtins")!.dataset.i18n).toBe(
-      "voicesBuiltinsNote"
-    );
+    const builtins = q(container, ".voice-slots-builtins")!;
+    expect(builtins.textContent).toBe("voicesBuiltinsNote");
+    expect(builtins.dataset.i18n).toBeUndefined();
   });
 });
 
@@ -313,7 +314,8 @@ describe("VoicesController — menu slots (curateShortlist truth)", () => {
     // cap 4: onyx + alloy, coral, marin seated; nova pinned but waiting
     expect(slotIds(container)).toEqual(["onyx", "alloy", "coral", "marin"]);
     const overflow = q(container, ".voice-slots-overflow")!;
-    expect(overflow.dataset.i18n).toBe("voicesMenuOverflow");
+    expect(overflow.textContent).toBe("voicesMenuOverflow");
+    expect(overflow.dataset.i18n).toBeUndefined();
   });
 });
 
@@ -505,11 +507,116 @@ describe("VoicesController — states", () => {
       },
     });
     const { container } = await mount(deps);
-    expect(q(container, ".voice-studio-empty")!.dataset.i18n).toBe(
-      "voicesLoadError"
-    );
+    const error = q(container, ".voice-studio-empty")!;
+    expect(error.textContent).toBe("voicesLoadError");
+    expect(error.dataset.i18n).toBeUndefined(); // substituted → no data-i18n
     hostTab(container, "claude")!.click();
     await flushAsync();
     expect(cardOf(container, "cedar")).toBeTruthy();
+  });
+});
+
+// --- regression: replaceI18n() (settings bootstrap) rewrites every
+// [data-i18n] element's text WITHOUT substitutions. Any studio element whose
+// text carries substitutions must therefore NOT declare data-i18n, or a boot
+// race wipes the host name ("SPEAKS WITH", "In 's menu") and the overflow
+// numbers — the founder-observed defect after #520.
+import { replaceI18n } from "../../../entrypoints/settings/shared/i18n";
+
+describe("VoicesController — replaceI18n clobber immunity", () => {
+  // The global chrome.i18n mock ignores substitutions, which would make a
+  // clobber invisible (same text either way). Interpolate here so a
+  // substitution-less re-render produces observably different text.
+  let originalGetMessage: any;
+  beforeEach(() => {
+    const i18n = (globalThis as any).chrome.i18n;
+    originalGetMessage = i18n.getMessage.getMockImplementation();
+    i18n.getMessage.mockImplementation((key: string, subs?: string | string[]) => {
+      const list = subs === undefined ? [] : Array.isArray(subs) ? subs : [subs];
+      return list.length ? `${key}:${list.join(",")}` : key;
+    });
+  });
+  afterEach(() => {
+    (globalThis as any).chrome.i18n.getMessage.mockImplementation(
+      originalGetMessage
+    );
+  });
+
+  it("keeps substituted text intact when replaceI18n runs after the studio paints", async () => {
+    const deps = makeDeps({
+      pi: [
+        mkVoice("alloy"),
+        mkVoice("coral"),
+        mkVoice("marin"),
+        mkVoice("nova"),
+        mkVoice("onyx"),
+      ],
+      piCurrent: mkVoice("onyx"),
+      piOverlay: { pinned: ["alloy", "coral", "marin", "nova"], unpinned: [] },
+    });
+    const { container } = await mount(deps);
+    const textOf = (sel: string) => q(container, sel)!.textContent;
+    const before = {
+      eyebrow: textOf(".voice-stage-eyebrow"),
+      slotsTitle: textOf(".voice-slots-title"),
+      overflow: textOf(".voice-slots-overflow"),
+    };
+    replaceI18n();
+    expect(textOf(".voice-stage-eyebrow")).toBe(before.eyebrow);
+    expect(textOf(".voice-slots-title")).toBe(before.slotsTitle);
+    expect(textOf(".voice-slots-overflow")).toBe(before.overflow);
+  });
+
+  it("keeps the built-ins note and load-error text intact too", async () => {
+    const withBuiltins = makeDeps({
+      pi: [mkVoice("voice1", { default: true }), mkVoice("marin")],
+    });
+    const { container } = await mount(withBuiltins);
+    const builtinsBefore = q(container, ".voice-slots-builtins")!.textContent;
+    replaceI18n();
+    expect(q(container, ".voice-slots-builtins")!.textContent).toBe(builtinsBefore);
+
+    document.body.innerHTML = "";
+    const failing = makeDeps({
+      overrides: {
+        getVoices: vi.fn(async () => {
+          throw new Error("network");
+        }),
+      },
+    });
+    const { container: c2 } = await mount(failing);
+    const errBefore = q(c2, ".voice-studio-empty")!.textContent;
+    replaceI18n();
+    expect(q(c2, ".voice-studio-empty")!.textContent).toBe(errBefore);
+  });
+});
+
+describe("VoicesController — stale stored voice snapshot (stage freshness)", () => {
+  it("resolves the current voice through the catalog so the stage gets fresh metadata", async () => {
+    // The stored preference can be an old serialized snapshot (no sample_url,
+    // no languages); the catalog entry with the same id is authoritative.
+    const staleAsh = mkVoice("ash", {
+      sample_url: undefined,
+      languages: undefined,
+    });
+    const freshAsh = mkVoice("ash", { languages: ["en", "fr", "de"] });
+    const deps = makeDeps({
+      pi: [freshAsh, mkVoice("marin")],
+      piCurrent: staleAsh,
+    });
+    const { container } = await mount(deps);
+    // stage orb is playable (fresh sample_url), not a static mark
+    expect(q(container, ".voice-stage button[data-orb-voice='ash']")).toBeTruthy();
+    expect(q(container, ".voice-stage-play")).toBeTruthy();
+    expect(q(container, ".voice-stage-lang")).toBeTruthy();
+  });
+
+  it("still stages a stored voice absent from the catalog (built-in / grandfathered)", async () => {
+    const deps = makeDeps({
+      pi: [mkVoice("marin")],
+      piCurrent: mkVoice("voice1", { default: true, name: "Aria" }),
+    });
+    const { container } = await mount(deps);
+    expect(q(container, ".voice-stage-name")!.textContent).toBe("Aria");
   });
 });


### PR DESCRIPTION
## What & why

Founder feedback on the shipped Host Studio (#520): the settings chrome opens as a deliberately compact popup (742×512) and the studio — a full-page experience — spilled far outside it. Two visible defects came along for the ride: substituted i18n strings rendered without their substitutions (\"SPEAKS WITH\", \"In 's menu\", an overflow note with no numbers), and the stage lost its play button/chips for some users.

## Fixes (fail-first TDD)

- **i18n substitution clobber**: the settings bootstrap's `replaceI18n()` rewrites every `[data-i18n]` element's text from the bare key — no substitutions — and it runs on *every* tab load. Any studio text carrying substitutions no longer declares `data-i18n`. Repro test mounts the studio, runs the real `replaceI18n()`, and asserts the host name survives (with an interpolating i18n mock so the clobber is observable). Incidentally this explains why 2c's pin explainer never rendered: `.description` is display:none *and* the mechanism would have eaten its text anyway.
- **Stale stage voice**: the stage rendered the stored preference object — a snapshot serialized whenever the user last picked a voice, possibly predating `sample_url`/`languages`. It now resolves the fresh catalog entry by id, keeping the snapshot fallback for built-ins and grandfathered voices.

## Adaptive window (founder-chosen direction)

macOS System Settings pattern: compact popup for the form tabs; grows to **1120×900** (screen-clamped, grow-only — never shrinks back, respects user resizing) when the Voices studio is shown. Door deep links (`voices/<host>`) open at full size directly, so the common path has no visible resize jolt. Popup-type windows only — settings in a normal tab manages itself. Sizing math is a pure module (`src/popup/settingsWindowSize.ts`, 5 unit tests) shared by the background (create-time) and the page (switch-time).

## Verified

- Gate: tsc + Jest + Vitest (1893, +9 new) + i18n-validate.
- Headless drive: i18n substitutions survive full boot; wiring no-ops harmlessly where the screen is smaller than the target (clamping).
- **Headed on real Chrome (seeded CDP profile): plain open 742×512 → click Voices → exactly 1120×900 → back to General → unchanged; deep-linked open lands at 1120×900 immediately.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126wHo7dAjNhpyKUGvoa5r3