### PR TITLE
process: awaiting-founder marker — label + notification workflow + convention (#524)

### DIFF
--- a/.github/workflows/awaiting-founder-notify.yaml
+++ b/.github/workflows/awaiting-founder-notify.yaml
@@ -29,6 +29,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          ACTOR: ${{ github.actor }}
         run: |
           gh api "repos/${{ github.repository }}/issues/${NUMBER}/comments" \
-            -f body="@rosscado — this is now **awaiting a founder decision or sign-off** (\`awaiting-founder\` applied by @${{ github.actor }}). See the latest comment/description for what's being asked. Standing queue: [open items with this label](https://github.com/${{ github.repository }}/issues?q=is%3Aopen+label%3Aawaiting-founder)."
+            -f body="@rosscado — this is now **awaiting a founder decision or sign-off** (\`awaiting-founder\` applied by @${ACTOR}). See the latest comment/description for what's being asked. Standing queue: [open items with this label](https://github.com/${{ github.repository }}/issues?q=is%3Aopen+label%3Aawaiting-founder)."

--- a/.github/workflows/awaiting-founder-notify.yaml
+++ b/.github/workflows/awaiting-founder-notify.yaml
@@ -1,0 +1,34 @@
+# Notifies the founder when something is marked as blocked on their decision.
+#
+# Applying the `awaiting-founder` label to an issue or PR posts a comment that
+# @-mentions the founder, which generates a GitHub notification. This is the
+# mechanical half of the "awaiting-founder marker" convention documented in
+# AGENTS.md (issue #524): agents apply the label whenever a high-blast-radius
+# PR needs sign-off or a governance proposal needs a decision.
+#
+# pull_request_target (not pull_request) so the job has a write token for
+# commenting; it never checks out PR code, so there is no execution risk.
+name: awaiting-founder-notify
+
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  notify:
+    if: github.event.label.name == 'awaiting-founder'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment to notify the founder
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${NUMBER}/comments" \
+            -f body="@rosscado — this is now **awaiting a founder decision or sign-off** (\`awaiting-founder\` applied by @${{ github.actor }}). See the latest comment/description for what's being asked. Standing queue: [open items with this label](https://github.com/${{ github.repository }}/issues?q=is%3Aopen+label%3Aawaiting-founder)."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Beyond this founder-gated set, **`doc/codebase-caution-map.md`** maps the wider 
 
 **Escalate to the founder only for:** product/UX taste calls (what/whether to build), credentials/resources you lack, **store releases**, contract changes that require the server side to change, gate-weakening or release-machinery edits, irreversible actions, or anything risking customer trust. Otherwise proceed. Escalate **immediately — not in the handoff —** anything that looks like a live user-facing failure of a *shipped* version (see `doc/release/incident-response.md`); everything else batches. End every session with a handoff: shipped / in-flight / waiting-on-human / built-but-unreleased.
 
+**Founder-attention marker (`awaiting-founder`).** Anything blocked on a founder decision or sign-off — a high-blast-radius PR awaiting approval, a governance proposal awaiting a verdict — must carry the **`awaiting-founder` label** (works on issues and PRs alike). Applying it fires `.github/workflows/awaiting-founder-notify.yaml`, which @-mentions the founder so a GitHub notification lands; state *what is being asked* in a comment when you apply it, and remove the label once the founder has decided. Standing queue (check it rather than assuming nothing waits): `gh issue list -R Pedal-Intelligence/saypi-userscript --label awaiting-founder` and `gh pr list -R Pedal-Intelligence/saypi-userscript --label awaiting-founder`, or [the label view](https://github.com/Pedal-Intelligence/saypi-userscript/issues?q=is%3Aopen+label%3Aawaiting-founder).
+
 ### Issue Authoring Standard
 - **Problem:** one-sentence summary of what's wrong.
 - **Scope:** which surfaces/flows are affected (and what's explicitly out of scope).

--- a/test/workflows/awaiting-founder-notify.spec.ts
+++ b/test/workflows/awaiting-founder-notify.spec.ts
@@ -15,9 +15,11 @@ const workflowPath = resolve(
 describe("awaiting-founder marker convention", () => {
   it("notification workflow exists and fires on the labeled event for issues and PRs", () => {
     const workflow = readFileSync(workflowPath, "utf8");
-    expect(workflow).toContain("issues:");
-    expect(workflow).toContain("pull_request_target:");
-    expect(workflow).toMatch(/types:\s*\[labeled\]/);
+    // Pin the actual `on:` block shape (a permissions `issues: write` line
+    // must not satisfy this) — both event sources, each with [labeled].
+    expect(workflow).toMatch(
+      /on:\s*\n\s+issues:\s*\n\s+types:\s*\[labeled\]\s*\n\s+pull_request_target:\s*\n\s+types:\s*\[labeled\]/
+    );
   });
 
   it("workflow matches exactly the awaiting-founder label and mentions the founder", () => {
@@ -30,6 +32,10 @@ describe("awaiting-founder marker convention", () => {
 
   it("AGENTS.md documents the label so future sessions use the convention", () => {
     const agentsMd = readFileSync(resolve(repoRoot, "AGENTS.md"), "utf8");
-    expect(agentsMd).toContain("awaiting-founder");
+    // Load-bearing phrases, not a bare substring — the convention paragraph
+    // must keep saying when to apply the marker and when to take it off.
+    expect(agentsMd).toContain("Founder-attention marker (`awaiting-founder`)");
+    expect(agentsMd).toContain("must carry the **`awaiting-founder` label**");
+    expect(agentsMd).toContain("remove the label once the founder has decided");
   });
 });

--- a/test/workflows/awaiting-founder-notify.spec.ts
+++ b/test/workflows/awaiting-founder-notify.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Guards the awaiting-founder marker convention (#524): the notification
+// workflow, the label it matches, and the AGENTS.md documentation must not
+// drift apart, or the founder silently stops being notified.
+
+const repoRoot = resolve(__dirname, "../..");
+const workflowPath = resolve(
+  repoRoot,
+  ".github/workflows/awaiting-founder-notify.yaml"
+);
+
+describe("awaiting-founder marker convention", () => {
+  it("notification workflow exists and fires on the labeled event for issues and PRs", () => {
+    const workflow = readFileSync(workflowPath, "utf8");
+    expect(workflow).toContain("issues:");
+    expect(workflow).toContain("pull_request_target:");
+    expect(workflow).toMatch(/types:\s*\[labeled\]/);
+  });
+
+  it("workflow matches exactly the awaiting-founder label and mentions the founder", () => {
+    const workflow = readFileSync(workflowPath, "utf8");
+    expect(workflow).toContain(
+      "github.event.label.name == 'awaiting-founder'"
+    );
+    expect(workflow).toContain("@rosscado");
+  });
+
+  it("AGENTS.md documents the label so future sessions use the convention", () => {
+    const agentsMd = readFileSync(resolve(repoRoot, "AGENTS.md"), "utf8");
+    expect(agentsMd).toContain("awaiting-founder");
+  });
+});


### PR DESCRIPTION
## Why

High-blast-radius PRs and governance proposals block on founder sign-off with no signal that anything is waiting — latency is "whenever the founder next looks". Issue #524 (from the 2026-07-07 agent-improvement batch) asks for a mechanical marker + notification so sign-off latency drops without weakening any gate.

## What

- **`awaiting-founder` label** (created on the repo) — the required marker for anything blocked on a founder decision, on issues and PRs alike.
- **`.github/workflows/awaiting-founder-notify.yaml`** — fires on the `labeled` event (issues + `pull_request_target`), and when the label is `awaiting-founder` posts a comment @-mentioning @rosscado, generating a GitHub notification. `pull_request_target` is used for the write-scoped token; the job never checks out PR code, so no execution risk. Additive CI — no existing gate touched.
- **AGENTS.md** — documents the convention (apply + state the ask + remove on decision) and the standing queue queries (`gh issue list`/`gh pr list --label awaiting-founder`).
- **Guard spec** `test/workflows/awaiting-founder-notify.spec.ts` — keeps the workflow triggers, the exact label name, the founder mention, and the AGENTS.md documentation from drifting apart (fail-first: red on the missing AGENTS.md doc before the edit).

## Verification

- Fail-first: spec red pre-AGENTS.md edit (AGENTS.md assertion), green after.
- Full gate green locally: `npm test` — typecheck + Jest + Vitest, 213 files / 1896 passed.
- Live workflow verification post-merge: apply the label to this PR (or #523) and confirm the notification comment lands — will do as part of closing #524.

Fixes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMWq5NUKDpZJtsehkGpt8u