### PR TITLE
fix(endpointing): spend the submission wait where the model says the user is NOT finished

### DIFF
--- a/doc/voice-endpointing.md
+++ b/doc/voice-endpointing.md
@@ -10,11 +10,17 @@ Signals
 
 Timing Model
 - File: src/TimerModule.ts:1
-  - `initialDelay = maxDelay * pFinishedSpeaking * (1 - tempo)`
+  - `initialDelay = max(maxDelay * (1 - pFinishedSpeaking) * (1 - tempo), MIN_INITIAL_DELAY_MS)`
   - `finalDelay = max(initialDelay - elapsedSinceStop, 0)`
-- `maxDelay` currently 7000 ms.
-  - `pFinishedSpeaking` defaults to 1 when absent.
-  - `tempo` defaults to 0 (neutral) and is clamped to [0,1].
+- The wait is patience, spent where the model says the user may NOT be finished: a low
+  `pFinishedSpeaking` ("probably mid-sentence") holds the turn open; a high score submits
+  promptly. (#521 — the original formula was proportional to p, which the server-side
+  endpointing eval (#519) showed cut users off on exactly the utterances the model had
+  flagged as unfinished.)
+- `maxDelay` currently 7000 ms; `MIN_INITIAL_DELAY_MS` currently 500 ms (a grace window
+  against an overconfident score when transcription returns faster than the floor).
+  - `pFinishedSpeaking` absent means no signal → treated as 0 (maximum patience).
+  - `tempo` defaults to 0 (neutral); both inputs are clamped to [0,1] inside calculateDelay.
 
 Where It Runs
 - File: src/state-machines/ConversationMachine.ts:1522
@@ -32,12 +38,16 @@ Submission Gate (crucial)
 
 Design Philosophy
 - “Always be listening.” Defer the response to give the user every chance to continue.
-- Be conservative with short or high‑tempo utterances (small `initialDelay`), but do not add needless fixed latency.
+- Spend patience where the model is unsure the user finished (low `pFinishedSpeaking` → long
+  wait); submit promptly when it is confident, but never add needless fixed latency — the
+  floor is measured from speech end, so transcription latency usually consumes it.
+- High‑tempo speakers get shorter waits: their pauses are shorter, so a fast speaker who
+  hasn’t resumed is likely done.
 - Fall back after silence: if the user has stopped long enough (`USER_STOPPED_TIMEOUT_MS = 10s`), submit regardless of scores.
 
 Telemetry and Debugging
 - File: src/state-machines/ConversationMachine.ts:1578
-  - Logs `submissionDelay` details: `pFinished`, `tempo`, `initialDelay`, `finalDelay`, `scheduledAt`, `nextSubmissionTime`.
+  - Logs `submissionDelay` details: `pFinished`, `tempo`, `finalDelay`, `scheduledAt`, `nextSubmissionTime`.
 - File: src/state-machines/ConversationMachine.ts:1429
   - Logs `submissionTiming` on submit: planned vs. actual wait (jitter).
 - Guard logging includes `{ noStopYet: true }` when `timeUserStoppedSpeaking` is 0 to explain skips.
@@ -46,8 +56,10 @@ Telemetry and Debugging
 
 Tuning Knobs
 - `maxDelay` (ConversationMachine) — global cap.
-- `pFinishedSpeaking` and `tempo` — upstream features; client clamps tempo and uses neutral default (0) when absent.
-- Optional future floor: a tiny minimum delay for near‑instant cases if desired (not enabled by default).
+- `MIN_INITIAL_DELAY_MS` (TimerModule) — grace floor on the initial delay; empirical,
+  tune against the server-side endpointing eval (#519).
+- `pFinishedSpeaking` and `tempo` — upstream features; calculateDelay clamps both and
+  defaults absent p to 0 (maximum patience) and absent tempo to 0 (neutral).
 - `USER_STOPPED_TIMEOUT_MS` — submit regardless after prolonged silence.
 
 Tests
@@ -56,6 +68,6 @@ Tests
 - test/state-machines/ConversationMachine-submissionDelay.spec.ts — proves that accumulating holds until the delay elapses and that merges don’t preempt the timer.
 
 Practical Guidance
-- If you see premature submits, check logs for `noStopYet: true` (guard blocked) or `finalDelay: 0` with very small `initialDelay`.
-- If a provider stops returning `tempo`, the default remains patient (no zeroing due to `(1 - tempo)`), so behavior degrades gracefully.
+- If you see premature submits, check logs for `noStopYet: true` (guard blocked) or `finalDelay: 0` with a high `pFinished` (the elapsed transcription time consumed the wait).
+- If a provider stops returning `pFinishedSpeaking` or `tempo`, the defaults remain patient (absent p → 0, absent tempo → 0), so behavior degrades gracefully.
 

--- a/src/TimerModule.ts
+++ b/src/TimerModule.ts
@@ -1,34 +1,56 @@
 /**
- * Calculate the delay before submitting a message to Pi.
+ * Minimum initial delay (measured from when the user stopped speaking) before an
+ * auto-submit, even when the endpointing model is certain the user has finished.
+ * Guards against an overconfident score cutting the user off when transcription
+ * returns unusually fast; in the typical case transcription latency already
+ * exceeds this, so it adds no perceptible latency. Empirical knob — tune against
+ * the server-side endpointing eval (see #519/#521).
+ */
+export const MIN_INITIAL_DELAY_MS = 500;
+
+/**
+ * Calculate the delay before submitting a message to the chatbot.
  *
- * @param timeUserStoppedSpeaking - The time the user stopped speaking.
- * @param probabilityFinished - The probability that the user has finished speaking. Expected to be between 0 and 1.
- * @param tempo - The tempo of the user's speech. Expected to be between 0 and 1.
+ * The wait is patience, spent where the endpointing model says the user may NOT
+ * be finished: `maxDelay · (1 − pFinishedSpeaking) · (1 − tempo)`, floored at
+ * MIN_INITIAL_DELAY_MS, minus the time already elapsed since the user stopped
+ * speaking. A low score ("probably mid-sentence") holds the turn open; a high
+ * score submits promptly. (#521 — the original formula was proportional to p,
+ * which spent the patience exactly where it was least needed.)
+ *
+ * @param timeUserStoppedSpeaking - The time the user stopped speaking (ms epoch).
+ * @param probabilityFinished - P(user has finished their turn), in [0, 1].
+ *   Absent means no signal: treated as 0 → maximum patience.
+ * @param tempo - Speech tempo in [0, 1]; faster speech shortens the wait
+ *   (a fast speaker who hasn't resumed is likely done). Absent means neutral (0).
  * @param maxDelay - The maximum delay.
- * @returns The calculated delay.
+ * @returns The remaining delay in milliseconds.
  */
 export function calculateDelay(
   timeUserStoppedSpeaking: number,
-  probabilityFinished: number,
-  tempo: number,
+  probabilityFinished: number | undefined,
+  tempo: number | undefined,
   maxDelay: number
 ): number {
-  // Get the current time (in milliseconds)
   const currentTime = new Date().getTime();
 
-  // Calculate the time elapsed since the user stopped speaking (in milliseconds)
+  // Time elapsed since the user stopped speaking (in milliseconds)
   const timeElapsed = currentTime - timeUserStoppedSpeaking;
 
-  // We invert the tempo because a faster speech (tempo approaching 1) should reduce the delay
-  let tempoFactor = 1 - tempo;
+  const pFinished = clamp01(probabilityFinished ?? 0);
+  const tempoFactor = 1 - clamp01(tempo ?? 0);
 
-  // Calculate the combined probability factor
-  let combinedProbability = probabilityFinished * tempoFactor;
+  // Patience is proportional to how UNfinished the model thinks the user is
+  const initialDelay = Math.max(
+    maxDelay * (1 - pFinished) * tempoFactor,
+    MIN_INITIAL_DELAY_MS
+  );
 
-  // The combined factor influences the initial delay
-  const initialDelay = combinedProbability * maxDelay;
-
-  // Calculate the final delay after accounting for the time already elapsed
+  // Account for the time already elapsed (e.g. transcription latency)
   const finalDelay = Math.max(initialDelay - timeElapsed, 0);
   return finalDelay;
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
 }

--- a/src/state-machines/ConversationMachine.ts
+++ b/src/state-machines/ConversationMachine.ts
@@ -736,26 +736,14 @@ const machine = setup({
 
       const maxDelay = 7000; // 7 second max submission delay (lowered from 8s in v1.6.0)
 
-      // Calculate the initial delay based on pFinishedSpeaking
-      let probabilityFinished = 1;
-      if (e.pFinishedSpeaking !== undefined) {
-        probabilityFinished = e.pFinishedSpeaking;
-      }
-
-      // Incorporate the tempo into the delay. If undefined, treat as 0 (neutral)
-      // so we do not zero‑out the delay. In calculateDelay we use (1 - tempo)
-      // as a factor; a default of 1 would make the factor 0 and eliminate
-      // any waiting, which is not desired when tempo is unavailable.
-      let tempo = e.tempo !== undefined ? e.tempo : 0;
-      // Clamp to [0, 1] to avoid unexpected values from upstream
-      tempo = Math.max(0, Math.min(1, tempo));
-
+      // Defaulting and clamping of pFinishedSpeaking/tempo live in calculateDelay
+      // (absent score → maximum patience; absent tempo → neutral).
       const scheduledAt = Date.now();
       const timeElapsed = scheduledAt - context.timeUserStoppedSpeaking;
       const finalDelay = calculateDelay(
         context.timeUserStoppedSpeaking,
-        probabilityFinished,
-        tempo,
+        e.pFinishedSpeaking,
+        e.tempo,
         maxDelay
       );
 
@@ -781,21 +769,17 @@ const machine = setup({
       lastSubmissionScheduledAt = scheduledAt;
 
       // Detailed debug to correlate measured vs expected
-      const tempoFactor = 1 - tempo;
-      const initialDelay = Math.max(maxDelay * probabilityFinished * tempoFactor, 0);
       try {
         logger.debug(
           "[ConversationMachine] submissionDelay:",
           JSON.stringify({
             seq: (e as any).sequenceNumber,
-            pFinished: probabilityFinished,
-            tempo,
-            tempoFactor,
+            pFinished: e.pFinishedSpeaking,
+            tempo: e.tempo,
             maxDelay,
             timeUserStoppedSpeaking: context.timeUserStoppedSpeaking,
             scheduledAt,
             timeElapsed,
-            initialDelay,
             finalDelay,
             nextSubmissionTime,
           })

--- a/src/state-machines/DictationMachine.ts
+++ b/src/state-machines/DictationMachine.ts
@@ -1724,20 +1724,14 @@ export const machine = setup({
         // Use configured max delay for dictation endpoint detection
         const maxDelay = REFINEMENT_MAX_DELAY_MS;
 
-        // Use pFinishedSpeaking from API, default to 1 if not provided
-        let probabilityFinished = transcriptionEvent.pFinishedSpeaking ?? 1;
-
-        // Use tempo from API, default to 0 if not provided (neutral)
-        let tempo = transcriptionEvent.tempo ?? 0;
-        // Clamp tempo to [0, 1]
-        tempo = Math.max(0, Math.min(1, tempo));
-
+        // Defaulting and clamping of pFinishedSpeaking/tempo live in calculateDelay
+        // (absent score → maximum patience; absent tempo → neutral).
         const scheduledAt = Date.now();
         const timeElapsed = scheduledAt - context.timeLastTranscriptionReceived;
         const finalDelay = calculateDelay(
           context.timeLastTranscriptionReceived,
-          probabilityFinished,
-          tempo,
+          transcriptionEvent.pFinishedSpeaking,
+          transcriptionEvent.tempo,
           maxDelay
         );
 
@@ -1745,8 +1739,8 @@ export const machine = setup({
           "[DictationMachine] refinementDelay:",
           JSON.stringify({
             seq: transcriptionEvent.sequenceNumber,
-            pFinished: probabilityFinished,
-            tempo,
+            pFinished: transcriptionEvent.pFinishedSpeaking,
+            tempo: transcriptionEvent.tempo,
             maxDelay,
             timeElapsed,
             finalDelay,

--- a/test/timers/calculateDelay.spec.ts
+++ b/test/timers/calculateDelay.spec.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { calculateDelay } from '../../src/TimerModule';
+import { calculateDelay, MIN_INITIAL_DELAY_MS } from '../../src/TimerModule';
 
+// Policy under test (#521): the endpointing wait is patience — spend it where the
+// model says the user may NOT be finished. initialDelay = maxDelay · (1 − p) · (1 − tempo),
+// floored at MIN_INITIAL_DELAY_MS, then reduced by the time already elapsed since the
+// user stopped speaking. The pre-#521 formula was proportional to p (patience spent
+// where it was least needed); these tests pin the corrected direction.
 describe('TimerModule.calculateDelay', () => {
   const BASE_TIME = 1_000_000; // ms
+  const MAX_DELAY = 7000;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -13,26 +19,63 @@ describe('TimerModule.calculateDelay', () => {
     vi.useRealTimers();
   });
 
-  it('respects pFinished and tempo when both provided', () => {
-    const pFinished = 0.2;
-    const tempo = 0.8611111111111112; // ~fast speaking
-    const maxDelay = 7000;
-    const timeUserStoppedSpeaking = BASE_TIME; // elapsed=0
+  it('waits longer when the model says the user is NOT finished (low p) than when finished (high p)', () => {
+    const tempo = 0.5;
+    const stoppedAt = BASE_TIME; // elapsed = 0
 
-    const delay = calculateDelay(timeUserStoppedSpeaking, pFinished, tempo, maxDelay);
-    // expected ≈ 7000 * 0.2 * (1 - 0.861111...) = ~194.44ms
-    expect(delay).toBeGreaterThan(190);
-    expect(delay).toBeLessThan(200);
+    const waitWhenUnfinished = calculateDelay(stoppedAt, 0.2, tempo, MAX_DELAY);
+    const waitWhenFinished = calculateDelay(stoppedAt, 0.9, tempo, MAX_DELAY);
+
+    expect(waitWhenUnfinished).toBeGreaterThan(waitWhenFinished);
   });
 
-  it('yields zero delay when tempo=1 (factor becomes 0)', () => {
-    const pFinished = 0.5;
-    const tempo = 1;
-    const maxDelay = 7000;
-    const timeUserStoppedSpeaking = BASE_TIME;
+  it('computes maxDelay · (1 − p) · (1 − tempo) when above the floor', () => {
+    // 7000 · (1 − 0.2) · (1 − 0.5) = 2800ms
+    const delay = calculateDelay(BASE_TIME, 0.2, 0.5, MAX_DELAY);
+    expect(delay).toBe(2800);
+  });
 
-    const delay = calculateDelay(timeUserStoppedSpeaking, pFinished, tempo, maxDelay);
+  it('subtracts time already elapsed since the user stopped speaking', () => {
+    const stoppedAt = BASE_TIME - 1000; // 1s ago (e.g. transcription latency)
+    // 7000 · 0.8 · 1 − 1000 = 4600ms
+    const delay = calculateDelay(stoppedAt, 0.2, 0, MAX_DELAY);
+    expect(delay).toBe(4600);
+  });
+
+  it('floors the initial delay when the model is confident the user finished', () => {
+    // p = 1 → raw initial delay 0; the floor keeps a grace window against an
+    // overconfident score when transcription returns faster than the floor.
+    const delay = calculateDelay(BASE_TIME, 1, 0, MAX_DELAY);
+    expect(delay).toBe(MIN_INITIAL_DELAY_MS);
+  });
+
+  it('floors the initial delay when tempo = 1 zeroes the tempo factor', () => {
+    const delay = calculateDelay(BASE_TIME, 0.2, 1, MAX_DELAY);
+    expect(delay).toBe(MIN_INITIAL_DELAY_MS);
+  });
+
+  it('lets elapsed time consume the floor (no fixed latency after transcription)', () => {
+    const stoppedAt = BASE_TIME - (MIN_INITIAL_DELAY_MS + 100);
+    const delay = calculateDelay(stoppedAt, 1, 0, MAX_DELAY);
     expect(delay).toBe(0);
   });
-});
 
+  it('treats an absent pFinishedSpeaking as no signal → maximum patience', () => {
+    // Same effective wait as the pre-#521 default (p ?? 1 under the proportional
+    // formula): a provider that stops sending the score degrades to patient, not twitchy.
+    const delay = calculateDelay(BASE_TIME, undefined, 0, MAX_DELAY);
+    expect(delay).toBe(MAX_DELAY);
+  });
+
+  it('treats an absent tempo as neutral (no reduction)', () => {
+    const delay = calculateDelay(BASE_TIME, 0.5, undefined, MAX_DELAY);
+    expect(delay).toBe(3500);
+  });
+
+  it('clamps out-of-range inputs to [0, 1]', () => {
+    // p > 1 clamps to 1 → floor; tempo < 0 clamps to 0 → neutral
+    expect(calculateDelay(BASE_TIME, 1.5, -0.5, MAX_DELAY)).toBe(MIN_INITIAL_DELAY_MS);
+    // p < 0 clamps to 0 → maximum patience
+    expect(calculateDelay(BASE_TIME, -1, 0, MAX_DELAY)).toBe(MAX_DELAY);
+  });
+});


### PR DESCRIPTION
## What & why

Resolves #521 — the endpointing auto-submit delay used `pFinishedSpeaking` with the **inverted sign**. The formula (`src/TimerModule.ts`, unchanged since Nov 2023) was

```
initialDelay = maxDelay · p · (1 − tempo)
```

so the model's "probably mid-sentence" utterances got the *shortest* waits. The server-side endpointing eval built on the #505 turn-outcome events caught this in live data (#519): 48% of auto-submits rode a `p ≤ 0.4` score — mid-sentence fragments the model correctly flagged as unfinished, submitted anyway, after which the user resumed speaking. The patience was being spent exactly where it was useless (user already finished → pure latency) and removed exactly where it was needed.

## The corrected policy

```
initialDelay = max(maxDelay · (1 − p) · (1 − tempo), MIN_INITIAL_DELAY_MS)
finalDelay   = max(initialDelay − elapsedSinceStop, 0)
```

- **Sign flipped**: low p ("not finished") now holds the turn open; high p submits promptly. This is what `doc/voice-endpointing.md`'s own "patient listener" philosophy always described.
- **New `MIN_INITIAL_DELAY_MS` (500 ms) grace floor**, measured from speech end: guards against an overconfident score when transcription returns unusually fast. In the typical case STT latency (~1 s) consumes it, so it adds no perceptible latency — confirmed live (below). It's an empirical knob; the #519 eval gives us the data to tune it.
- **Defaulting/clamping centralized in `calculateDelay`**: absent p → 0 (maximum patience — same effective wait as the old `p ?? 1` default under the proportional formula, so a provider that stops sending the score degrades to patient, not twitchy); absent tempo → neutral; both clamped to [0,1]. The duplicated call-site defaulting in `ConversationMachine`/`DictationMachine` — whose `?? 1` would now mean "assume finished" — is collapsed, along with the ConversationMachine debug log that recomputed the old formula (it would now log lies).

`DictationMachine`'s refinement delay shares the formula and benefits the same way: refine promptly when the user is done, hold off while they're mid-thought (fewer wasted refinement calls).

## TDD

Fail-first per the repo protocol: `test/timers/calculateDelay.spec.ts` rewritten to pin the corrected direction (9 cases: monotonicity, exact values, floor, floor-consumed-by-elapsed, absent-score/tempo defaults, clamping) — all 9 confirmed failing against the old implementation for the expected reasons before the fix, all green after. Full suite: typecheck + Jest + Vitest, 212 files / 1900 tests green.

## Real-host verification (Layer 4 CDP, per the caution map — endpointing is reserve-zone)

Branch build overlaid on the seeded CDP profile, live pi.ai, debug logging on, one synthetic voice turn:

```
submissionDelay: {"seq":1,"pFinished":0.9,"tempo":0.813,"timeElapsed":996,"finalDelay":0,...}
AUTO-SUBMIT CONFIRMED: message count 0 → 1
```

Real `/transcribe` scores (p=0.9, tempo=0.81) → grace floor 500 ms already consumed by 996 ms STT latency → submit with zero added wait, message posted, no console errors. The happy path is unchanged in feel; the behavioral change (longer waits) applies to low-p fragments, which the unit tests pin and the #519 eval will measure before/after in production.

## Follow-up

The saypi-api side holds off on recalibrating `pFinishedSpeaking` until this ships and the eval re-baselines (see #519 discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3UAKZvwnqeCi3QFb44vxv
