### PR TITLE
release: read-only store-review status checks (#529)

### DIFF
--- a/doc/release/README.md
+++ b/doc/release/README.md
@@ -27,6 +27,9 @@ auto-update**, and store-submission plumbing is founder-gated.
   `package-extension.sh` / `npm run source-archive`; does not reimplement the build.
 - `scripts/release-lib.mjs` — pure, unit-tested logic (version decision, payload
   categorization, changelog digest, packet rendering). Tests: `test/scripts/release-lib.spec.ts`.
+- `scripts/store-status.mjs` / `scripts/store-status-lib.mjs` — read-only per-store review
+  status check (`npm run release:status`, #529; see "Checking review status" below).
+  Tests: `test/scripts/store-status-lib.spec.ts`.
 - `doc/release/stores.json` — single source of truth for store identity + per-store facts.
   Consumed by the packet generator and any future browser-driver / API path.
 - `doc/release/{chrome-web-store,edge-addons,firefox-amo}.md` — per-store submission detail.
@@ -61,6 +64,7 @@ npm run release:tag -- <version> --yes     # = … tag <version> --yes
 npm run release:finalize -- <version> --yes  # = … finalize <version> --yes
 npm run release:submit -- <store> --dry-run  # ⛔ #412: auth-check a store's publishing API
 npm run release:submit -- <store> --yes      # ⛔ #412: headless API submission (founder-only)
+npm run release:status                       # read-only: review/publish status per store (#529)
 ```
 
 Run from the **main checkout on `main`** — a real release is cut from main and the build
@@ -127,6 +131,33 @@ to v<x>` commit whose package.json matches) and tags *that* — not `HEAD`, whic
 merges may have moved past — and refuses if it can't find a matching commit. `finalize` pushes
 origin/main + the tag, then **cuts the GitHub release** from `_locales/en/release_notes.txt`
 (pass `--no-gh-release` to skip; refine the release title/body on GitHub afterward).
+
+## Checking review status (read-only, any time) — #529
+
+`npm run release:status` (= `node scripts/store-status.mjs [--json] [--stall-days N]`)
+reports where each store actually stands, so a stalled review is noticed on purpose rather
+than incidentally. For every store in `stores.json` it hits **read-only** endpoints with the
+same credentials `release:submit` uses (env vars / `.env.publish`,
+per [`publishing-credentials.md`](publishing-credentials.md)) and prints a compact table:
+live version · review state · last update · a **stall flag**.
+
+- **Chrome:** OAuth token + CWS V2 `:fetchStatus` — published version and any
+  `PENDING_REVIEW`/`REJECTED` submitted revision.
+- **Edge:** the publish-API credentials probe (catches the ~72-day key expiry) + the public
+  product-details endpoint for the live version. Edge's API exposes **no review state**, so
+  stalls there are inferred from release lag (below).
+- **Firefox (AMO):** JWT-authed v5 addon detail + versions list — live version plus any
+  listed version still `unreviewed` in the queue, with its submission date.
+
+**Stall flag** (default threshold 14 days, `--stall-days N`): a submission in review longer
+than the threshold, **or** a store whose live version is still behind the latest release tag
+even though that release is older than the threshold — the second rule is what catches Edge,
+which offers no review-state visibility at all.
+
+Degrades gracefully: a store whose credential env vars are absent is reported **SKIPPED**
+(exit 0, no request made) — only a failed check (bad auth/network) exits 1. The tool never
+uploads/publishes anything, never reads `.env.production`, and logs env var **names** only.
+Intended future use: a scheduled routine that runs this and files an issue on a stall (#525).
 
 ## Future: one-click automation via publishing APIs (#412)
 The 1.11.0 wet run established that **browser-driving is a dead end for releases:**

--- a/doc/release/publishing-credentials.md
+++ b/doc/release/publishing-credentials.md
@@ -15,6 +15,11 @@ time. The easiest way: drop them in a local, gitignored **`.env.publish`** at th
 file. The tool reads only `process.env` and `.env.publish`; it **never** reads `.env.production`,
 and it logs only the *names* of the keys it loaded — never their values.
 
+The same credentials (same env var names, same `.env.publish` auto-load) also power the
+**read-only** review-status check `npm run release:status` (#529) — see "Checking review
+status" in [`README.md`](README.md). That command never uploads or publishes; a store whose
+vars are absent is simply reported SKIPPED.
+
 ## Usage
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "release:tag": "node scripts/release.mjs tag",
     "release:finalize": "node scripts/release.mjs finalize",
     "release:submit": "node scripts/release.mjs submit",
+    "release:status": "node scripts/store-status.mjs",
     "prebuild:firefox": "node scripts/validate-env.js --file .env.production --env production && npm run copy-onnx",
     "build:firefox": "wxt build -b firefox",
     "source-archive": "git archive --format=zip -o source-code.zip HEAD",

--- a/scripts/store-status-lib.mjs
+++ b/scripts/store-status-lib.mjs
@@ -16,9 +16,18 @@
  * Credential env-var sets are reused from release-lib.mjs — same names `release:submit` uses.
  */
 import { createHmac, randomUUID } from "node:crypto";
-import { CWS_ENV, EDGE_ENV, AMO_ENV, compareSemver, parseSemver } from "./release-lib.mjs";
+import { CWS_ENV, EDGE_ENV, AMO_ENV, compareSemver } from "./release-lib.mjs";
 
 export const STATUS_STORES = ["chrome", "edge", "firefox"];
+
+/**
+ * Strictly-final X.Y.Z (optionally v-prefixed). release-lib's parseSemver has no end
+ * anchor, so a prerelease tag like v1.14.0-rc.1 would parse as final 1.14.0 and could
+ * false-flag every store in the lag heuristic — versions must pass this guard first.
+ */
+export function isFinalSemver(v) {
+  return /^v?\d+\.\d+\.\d+$/.test(String(v ?? "").trim());
+}
 
 /** Required env var NAMES per store (values are never logged anywhere in this tool). */
 export const STORE_ENV = { chrome: CWS_ENV, edge: EDGE_ENV, firefox: AMO_ENV };
@@ -181,9 +190,9 @@ export function computeStalls(records, { now = new Date(), stallDays = 14, lates
 
     if (
       latestRelease &&
-      parseSemver(latestRelease.version) &&
+      isFinalSemver(latestRelease.version) &&
       r.liveVersion &&
-      parseSemver(r.liveVersion) &&
+      isFinalSemver(r.liveVersion) &&
       compareSemver(r.liveVersion, latestRelease.version) < 0 &&
       days(latestRelease.date) > stallDays
     ) {
@@ -207,7 +216,7 @@ export function renderStatusTable(records = []) {
     r.state,
     r.submittedVersion ? `${r.submittedVersion}${r.submittedAt ? ` @ ${r.submittedAt.slice(0, 10)}` : ""}` : "—",
     r.updatedAt ? r.updatedAt.slice(0, 10) : "—",
-    r.stalled ? "⚠ STALLED" : r.skipped ? "—" : "ok",
+    r.stalled ? "⚠ STALLED" : r.skipped || r.state === "ERROR" ? "—" : "ok",
   ]);
   const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((row) => row[i].length)));
   const line = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join("  ");
@@ -228,12 +237,13 @@ export function renderStatusTable(records = []) {
 /**
  * Build the `Authorization: JWT <token>` header value for AMO API requests.
  * Deterministic given {now, jti} so it's testable; the secret is only used to sign
- * (never embedded). AMO requires exp ≤ iat + 5 minutes.
+ * (never embedded). AMO requires exp ≤ iat + 5 minutes and rejects tokens whose iat is
+ * in the future, so iat is backdated 30s to absorb local clock skew.
  * @param {{issuer: string, secret: string, now?: Date, jti?: string}} args
  */
 export function amoAuthHeader({ issuer, secret, now = new Date(), jti = randomUUID() }) {
   const b64 = (obj) => Buffer.from(JSON.stringify(obj)).toString("base64url");
-  const iat = Math.floor(now.getTime() / 1000);
+  const iat = Math.floor(now.getTime() / 1000) - 30;
   const head = b64({ alg: "HS256", typ: "JWT" });
   const payload = b64({ iss: issuer, jti, iat, exp: iat + 300 });
   const sig = createHmac("sha256", secret).update(`${head}.${payload}`).digest("base64url");

--- a/scripts/store-status-lib.mjs
+++ b/scripts/store-status-lib.mjs
@@ -1,0 +1,249 @@
+/**
+ * store-status-lib — pure logic for the read-only store-review status check (#529).
+ *
+ * No network, no fs, no clock: response→record normalizers per store, stall computation
+ * with an injected `now`, and table rendering — all unit-tested in
+ * test/scripts/store-status-lib.spec.ts. The I/O (fetch, credentials, git) lives in
+ * scripts/store-status.mjs.
+ *
+ * Response shapes:
+ *  - Chrome: CWS API V2 `items:fetchStatus` (developer.chrome.com/docs/webstore/api/reference/rest/v2).
+ *  - Edge:   the public product-details endpoint (the credentialed publish API exposes NO
+ *            read-only review state — see doc/release/publishing-credentials.md).
+ *  - AMO:    v5 addon detail + versions list (mozilla.org/api/v5); an "unreviewed" listed
+ *            file marks a version still in the review queue.
+ *
+ * Credential env-var sets are reused from release-lib.mjs — same names `release:submit` uses.
+ */
+import { createHmac, randomUUID } from "node:crypto";
+import { CWS_ENV, EDGE_ENV, AMO_ENV, compareSemver, parseSemver } from "./release-lib.mjs";
+
+export const STATUS_STORES = ["chrome", "edge", "firefox"];
+
+/** Required env var NAMES per store (values are never logged anywhere in this tool). */
+export const STORE_ENV = { chrome: CWS_ENV, edge: EDGE_ENV, firefox: AMO_ENV };
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * @typedef {Object} StatusRecord
+ * @property {"chrome"|"edge"|"firefox"} store
+ * @property {boolean} skipped        true when credentials were missing (no request made)
+ * @property {string} [reason]        why the store was skipped / errored
+ * @property {string|null} liveVersion
+ * @property {string} state           PUBLISHED | IN_REVIEW | REJECTED | SKIPPED | ERROR | UNKNOWN | …
+ * @property {string|null} submittedVersion
+ * @property {string|null} submittedAt  ISO timestamp of the in-review submission (when the API exposes one)
+ * @property {string|null} updatedAt    ISO timestamp of the last store-side update
+ * @property {boolean} inReview
+ * @property {string[]} notes
+ * @property {boolean} [stalled]
+ * @property {string|null} [stallReason]
+ */
+
+function baseRecord(store) {
+  return {
+    store,
+    skipped: false,
+    liveVersion: null,
+    state: "UNKNOWN",
+    submittedVersion: null,
+    submittedAt: null,
+    updatedAt: null,
+    inReview: false,
+    notes: [],
+  };
+}
+
+/** Names of the store's required env vars that are absent from `env`. */
+export function missingCreds(store, env = {}) {
+  return (STORE_ENV[store] || []).filter((name) => !env[name]);
+}
+
+/** Record for a store we did NOT query because its credentials are missing. Not an error. */
+export function skippedRecord(store, missing = []) {
+  return {
+    ...baseRecord(store),
+    skipped: true,
+    state: "SKIPPED",
+    reason: `missing env: ${missing.join(", ")} (see doc/release/publishing-credentials.md)`,
+  };
+}
+
+/** Record for a store whose check failed (auth/network/shape) — reported, never thrown. */
+export function errorRecord(store, message) {
+  return { ...baseRecord(store), state: "ERROR", reason: message };
+}
+
+// ── Chrome Web Store (API V2 :fetchStatus) ──────────────────────────────────────────
+
+/**
+ * Normalize a CWS V2 fetchStatus response. ItemState enum:
+ * PENDING_REVIEW | STAGED | PUBLISHED | PUBLISHED_TO_TESTERS | REJECTED | CANCELLED.
+ * fetchStatus carries NO timestamps, so submittedAt stays null (stall detection then
+ * falls back to the release-lag heuristic in computeStalls).
+ * @returns {StatusRecord}
+ */
+export function normalizeChromeStatus(json = {}) {
+  const r = baseRecord("chrome");
+  const published = json.publishedItemRevisionStatus;
+  const submitted = json.submittedItemRevisionStatus;
+  r.liveVersion = published?.distributionChannels?.[0]?.crxVersion ?? null;
+  if (submitted) {
+    r.submittedVersion = submitted.distributionChannels?.[0]?.crxVersion ?? null;
+    r.inReview = submitted.state === "PENDING_REVIEW";
+    r.state = r.inReview ? "IN_REVIEW" : submitted.state || "UNKNOWN";
+  } else if (r.liveVersion) {
+    r.state = published?.state || "PUBLISHED";
+  }
+  if (json.takenDown) r.notes.push("item is TAKEN DOWN");
+  if (json.warned) r.notes.push("item has been warned by the store");
+  return r;
+}
+
+// ── Microsoft Edge Add-ons (public product details) ─────────────────────────────────
+
+/**
+ * Normalize the public getproductdetailsbycrxid response ({version, lastUpdateDate in
+ * epoch SECONDS}). Edge's publish API has no read-only review-state endpoint, so review
+ * visibility is limited to "which version is live, since when".
+ * @returns {StatusRecord}
+ */
+export function normalizeEdgeStatus(json = {}) {
+  const r = baseRecord("edge");
+  r.liveVersion = json.version ?? null;
+  if (typeof json.lastUpdateDate === "number") {
+    r.updatedAt = new Date(json.lastUpdateDate * 1000).toISOString();
+  }
+  if (r.liveVersion) r.state = "PUBLISHED";
+  r.notes.push("Edge exposes no review state via API — stall detection uses release lag");
+  return r;
+}
+
+// ── Firefox AMO (v5 addon detail + versions list) ───────────────────────────────────
+
+/**
+ * Normalize the AMO addon detail (public) plus, when available, the authenticated
+ * versions list (?filter=all_with_unlisted). A listed version whose file.status is
+ * neither "public" nor "disabled" (i.e. "unreviewed") is still in the review queue.
+ * @param {object} [addon]
+ * @param {{results?: Array<{version?: string, channel?: string, file?: {status?: string, created?: string}}>}|null} [versions]
+ * @returns {StatusRecord}
+ */
+export function normalizeAmoStatus(addon = {}, versions = null) {
+  const r = baseRecord("firefox");
+  const current = addon.current_version;
+  r.liveVersion = current?.version ?? null;
+  r.updatedAt = current?.reviewed ?? current?.file?.created ?? addon.last_updated ?? null;
+  if (r.liveVersion) r.state = addon.status === "public" || !addon.status ? "PUBLISHED" : String(addon.status).toUpperCase();
+
+  const pending = (versions?.results || []).filter(
+    (v) => v.channel === "listed" && v.file && !["public", "disabled"].includes(v.file.status),
+  );
+  if (pending.length) {
+    // Newest submission first (by file.created).
+    pending.sort((a, b) => String(b.file.created).localeCompare(String(a.file.created)));
+    r.inReview = true;
+    r.state = "IN_REVIEW";
+    r.submittedVersion = pending[0].version ?? null;
+    r.submittedAt = pending[0].file.created ?? null;
+  }
+  return r;
+}
+
+// ── Stall computation (injected clock) ──────────────────────────────────────────────
+
+/**
+ * Flag stalled stores. Two signals, in priority order:
+ *  1. In-review age: a submission has sat in review for MORE than `stallDays`
+ *     (only when the store's API exposes the submission timestamp — AMO does).
+ *  2. Release lag: the store's live version is behind `latestRelease.version` even though
+ *     that release is older than `stallDays` — catches stores with no review visibility
+ *     (Edge) or no timestamps (Chrome).
+ * Skipped/unknown records are never flagged.
+ *
+ * @param {StatusRecord[]} records
+ * @param {{now?: Date, stallDays?: number, latestRelease?: {version: string, date: string}|null}} opts
+ * @returns {StatusRecord[]} new records with {stalled, stallReason}
+ */
+export function computeStalls(records, { now = new Date(), stallDays = 14, latestRelease = null } = {}) {
+  const nowMs = now.getTime();
+  const days = (iso) => (nowMs - Date.parse(iso)) / DAY_MS;
+  return records.map((r) => {
+    const out = { ...r, stalled: false, stallReason: null };
+    if (r.skipped || r.state === "ERROR") return out;
+
+    if (r.inReview && r.submittedAt && days(r.submittedAt) > stallDays) {
+      out.stalled = true;
+      out.stallReason = `${r.submittedVersion || "a submission"} in review for ${Math.floor(days(r.submittedAt))} days (threshold ${stallDays})`;
+      return out;
+    }
+
+    if (
+      latestRelease &&
+      parseSemver(latestRelease.version) &&
+      r.liveVersion &&
+      parseSemver(r.liveVersion) &&
+      compareSemver(r.liveVersion, latestRelease.version) < 0 &&
+      days(latestRelease.date) > stallDays
+    ) {
+      out.stalled = true;
+      out.stallReason =
+        `live ${r.liveVersion} is behind v${latestRelease.version}, released ` +
+        `${Math.floor(days(latestRelease.date))} days ago (threshold ${stallDays})`;
+    }
+    return out;
+  });
+}
+
+// ── Rendering ───────────────────────────────────────────────────────────────────────
+
+/** Compact fixed-width table: store, live version, state, submitted, updated, stall flag. */
+export function renderStatusTable(records = []) {
+  const headers = ["store", "live", "state", "submitted", "updated", "stall"];
+  const rows = records.map((r) => [
+    r.store,
+    r.liveVersion || "—",
+    r.state,
+    r.submittedVersion ? `${r.submittedVersion}${r.submittedAt ? ` @ ${r.submittedAt.slice(0, 10)}` : ""}` : "—",
+    r.updatedAt ? r.updatedAt.slice(0, 10) : "—",
+    r.stalled ? "⚠ STALLED" : r.skipped ? "—" : "ok",
+  ]);
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((row) => row[i].length)));
+  const line = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join("  ");
+  const out = [line(headers), line(widths.map((w) => "─".repeat(w))), ...rows.map(line)];
+
+  const details = records
+    .flatMap((r) => [
+      ...(r.reason ? [`${r.store}: ${r.reason}`] : []),
+      ...(r.stallReason ? [`${r.store}: ${r.stallReason}`] : []),
+      ...(r.notes || []).map((n) => `${r.store}: ${n}`),
+    ])
+    .map((d) => `  · ${d}`);
+  return [...out, ...(details.length ? ["", ...details] : [])].join("\n");
+}
+
+// ── AMO JWT auth (HS256, per addons-server API v5 auth docs) ────────────────────────
+
+/**
+ * Build the `Authorization: JWT <token>` header value for AMO API requests.
+ * Deterministic given {now, jti} so it's testable; the secret is only used to sign
+ * (never embedded). AMO requires exp ≤ iat + 5 minutes.
+ * @param {{issuer: string, secret: string, now?: Date, jti?: string}} args
+ */
+export function amoAuthHeader({ issuer, secret, now = new Date(), jti = randomUUID() }) {
+  const b64 = (obj) => Buffer.from(JSON.stringify(obj)).toString("base64url");
+  const iat = Math.floor(now.getTime() / 1000);
+  const head = b64({ alg: "HS256", typ: "JWT" });
+  const payload = b64({ iss: issuer, jti, iat, exp: iat + 300 });
+  const sig = createHmac("sha256", secret).update(`${head}.${payload}`).digest("base64url");
+  return `JWT ${head}.${payload}.${sig}`;
+}
+
+// ── stores.json helpers ─────────────────────────────────────────────────────────────
+
+/** The Edge LISTING id (crx id) is the last path segment of stores.json's listingUrl. */
+export function edgeCrxIdFromListingUrl(url = "") {
+  const seg = String(url).split("?")[0].split("/").filter(Boolean).pop() || "";
+  return /^[a-p]{32}$/.test(seg) ? seg : null;
+}

--- a/scripts/store-status.mjs
+++ b/scripts/store-status.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * store-status — READ-ONLY store-review status check for all three web stores (#529).
+ *
+ *   node scripts/store-status.mjs [--json] [--stall-days N]     (npm run release:status)
+ *
+ * For each store in doc/release/stores.json it hits read-only status endpoints with the
+ * SAME credentials `release:submit` uses (env vars / .env.publish — see
+ * doc/release/publishing-credentials.md) and prints a compact table: live version,
+ * review state, last update, and a stall flag when a submission has been in review —
+ * or a store has lagged the latest release tag — longer than the threshold (default 14
+ * days). A store whose credentials are absent is reported as SKIPPED (exit 0), so the
+ * command degrades gracefully; only a failed check (bad auth, network, unexpected
+ * response) exits 1.
+ *
+ * SAFETY: this command never uploads, publishes, or mutates anything — every request is
+ * a GET (plus the OAuth token POST for Chrome and a GET credentials probe for Edge).
+ * It reads only process.env / .env.publish (never .env.production) and logs only the
+ * NAMES of env vars, never values.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve as resolvePath } from "node:path";
+import {
+  requireEnv,
+  CWS_ENV,
+  CWS_TOKEN_URL,
+  cwsTokenBody,
+  cwsStatusUrl,
+  cwsErrorMessage,
+  EDGE_ENV,
+  edgeHeaders,
+  edgeUploadPollUrl,
+  AMO_ENV,
+  parseSemver,
+  formatSemver,
+  compareSemver,
+} from "./release-lib.mjs";
+import {
+  STATUS_STORES,
+  missingCreds,
+  skippedRecord,
+  errorRecord,
+  normalizeChromeStatus,
+  normalizeEdgeStatus,
+  normalizeAmoStatus,
+  computeStalls,
+  renderStatusTable,
+  amoAuthHeader,
+  edgeCrxIdFromListingUrl,
+} from "./store-status-lib.mjs";
+
+const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
+const STORES_PATH = join(repoRoot, "doc", "release", "stores.json");
+// Gitignored, founder-provided publishing credentials — the same file `release:submit`
+// auto-loads (scripts/release.mjs loadPublishEnv; parser mirrored here so release.mjs
+// stays untouched). Never .env.production.
+const ENV_PUBLISH_PATH = join(repoRoot, ".env.publish");
+const FETCH_TIMEOUT_MS = 15_000;
+
+const info = (m) => console.error(m); // status/log lines → stderr; report → stdout
+
+function loadPublishEnv() {
+  if (!existsSync(ENV_PUBLISH_PATH)) return 0;
+  const loaded = [];
+  for (const raw of readFileSync(ENV_PUBLISH_PATH, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^(?:export\s+)?([A-Z0-9_]+)\s*=\s*(.*)$/);
+    if (!m) continue;
+    const [, key, rawVal] = m;
+    if (key in process.env) continue; // explicit shell env takes precedence
+    process.env[key] = rawVal.replace(/^(['"])(.*)\1$/, "$2");
+    loaded.push(key);
+  }
+  if (loaded.length) info(`Loaded ${loaded.length} credential(s) from .env.publish: ${loaded.join(", ")}`);
+  return loaded.length;
+}
+
+async function getJson(url, init = {}) {
+  const res = await fetch(url, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  const json = await res.json().catch(() => ({}));
+  return { res, json };
+}
+
+/** Latest release tag (vX.Y.Z) + its commit date, for the release-lag stall heuristic. */
+function latestReleaseFromGit() {
+  try {
+    const tags = execFileSync("git", ["tag", "-l", "v*"], { cwd: repoRoot, encoding: "utf8" })
+      .split("\n")
+      .map((t) => parseSemver(t))
+      .filter(Boolean)
+      .map(formatSemver);
+    if (!tags.length) return null;
+    const version = tags.sort(compareSemver).at(-1);
+    const date = execFileSync("git", ["log", "-1", "--format=%cI", `v${version}`], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }).trim();
+    return date ? { version, date } : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Per-store checks (all read-only) ───────────────────────────────────────────────
+
+async function checkChrome(env) {
+  const e = requireEnv(CWS_ENV, env);
+  const { res: tokRes, json: tok } = await getJson(CWS_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: cwsTokenBody({ clientId: e.CWS_CLIENT_ID, clientSecret: e.CWS_CLIENT_SECRET, refreshToken: e.CWS_REFRESH_TOKEN }),
+  });
+  if (!tokRes.ok || !tok.access_token) throw new Error(`auth failed: ${cwsErrorMessage(tok)}`);
+  const { res, json } = await getJson(cwsStatusUrl(e.CWS_PUBLISHER_ID, e.CWS_EXTENSION_ID), {
+    headers: { Authorization: `Bearer ${tok.access_token}` },
+  });
+  if (!res.ok) throw new Error(`fetchStatus failed: ${cwsErrorMessage(json)}`);
+  return normalizeChromeStatus(json);
+}
+
+async function checkEdge(env, stores) {
+  const e = requireEnv(EDGE_ENV, env);
+  // 1. Credentials probe (same read-only probe `release:submit --dry-run` uses): a GET on a
+  //    poll URL with a dummy operation id — 401 = key rejected/expired (~72-day expiry).
+  const probe = await fetch(edgeUploadPollUrl(e.EDGE_PRODUCT_ID, "00000000-0000-0000-0000-000000000000"), {
+    headers: edgeHeaders({ apiKey: e.EDGE_API_KEY, clientId: e.EDGE_CLIENT_ID }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (probe.status === 401) {
+    throw new Error("publish-API credentials rejected (401) — EDGE_API_KEY expires every ~72 days; rotate in Partner Center.");
+  }
+  // 2. Live listing state from the public product-details endpoint (the publish API has no
+  //    read-only status endpoint). The listing crx id comes from stores.json's listingUrl.
+  const crxId = edgeCrxIdFromListingUrl(stores?.stores?.edge?.listingUrl);
+  if (!crxId) throw new Error("could not derive the Edge listing crx id from stores.json listingUrl");
+  const { res, json } = await getJson(`https://microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/${crxId}`);
+  if (!res.ok) throw new Error(`product details failed (HTTP ${res.status})`);
+  const record = normalizeEdgeStatus(json);
+  record.notes.unshift(`publish-API credentials accepted (probe HTTP ${probe.status})`);
+  return record;
+}
+
+async function checkFirefox(env, stores) {
+  const e = requireEnv(AMO_ENV, env);
+  const guid = stores?.stores?.firefox?.id || "gecko@saypi.ai";
+  const auth = () => ({ Authorization: amoAuthHeader({ issuer: e.WEB_EXT_API_KEY, secret: e.WEB_EXT_API_SECRET }) });
+  const base = `https://addons.mozilla.org/api/v5/addons/addon/${encodeURIComponent(guid)}`;
+  const { res, json: addon } = await getJson(`${base}/`, { headers: auth() });
+  if (!res.ok) throw new Error(`addon detail failed (HTTP ${res.status}${addon.detail ? `: ${addon.detail}` : ""})`);
+  // The versions list (with unlisted/unreviewed entries) needs developer auth; tolerate
+  // failure so a scope problem degrades to detail-only rather than an ERROR record.
+  let versions = null;
+  const v = await getJson(`${base}/versions/?filter=all_with_unlisted&page_size=25`, { headers: auth() }).catch(() => null);
+  if (v?.res?.ok) versions = v.json;
+  const record = normalizeAmoStatus(addon, versions);
+  if (!versions) record.notes.push("versions list unavailable — review-queue visibility limited to the public listing");
+  return record;
+}
+
+const CHECKS = { chrome: checkChrome, edge: checkEdge, firefox: checkFirefox };
+
+// ── Entry ───────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const asJson = argv.includes("--json");
+  const stallDaysArg = argv[argv.indexOf("--stall-days") + 1];
+  const stallDays = argv.includes("--stall-days") ? Number(stallDaysArg) : 14;
+  if (!Number.isFinite(stallDays) || stallDays <= 0) {
+    console.error(`Invalid --stall-days "${stallDaysArg}" — expected a positive number.`);
+    process.exit(2);
+  }
+
+  loadPublishEnv();
+  const stores = existsSync(STORES_PATH) ? JSON.parse(readFileSync(STORES_PATH, "utf8")) : null;
+  const latestRelease = latestReleaseFromGit();
+
+  const records = [];
+  for (const store of STATUS_STORES) {
+    const missing = missingCreds(store, process.env);
+    if (missing.length) {
+      info(`${store}: SKIPPED (missing env: ${missing.join(", ")})`);
+      records.push(skippedRecord(store, missing));
+      continue;
+    }
+    try {
+      info(`${store}: checking…`);
+      records.push(await CHECKS[store](process.env, stores));
+    } catch (e) {
+      records.push(errorRecord(store, e?.message || String(e)));
+    }
+  }
+
+  const flagged = computeStalls(records, { now: new Date(), stallDays, latestRelease });
+
+  if (asJson) {
+    console.log(JSON.stringify({ generatedAt: new Date().toISOString(), stallDays, latestRelease, stores: flagged }, null, 2));
+  } else {
+    console.log("");
+    console.log(renderStatusTable(flagged));
+    if (latestRelease) console.log(`\n  latest release tag: v${latestRelease.version} (${latestRelease.date.slice(0, 10)})`);
+  }
+
+  const errored = flagged.filter((r) => r.state === "ERROR");
+  const stalled = flagged.filter((r) => r.stalled);
+  if (stalled.length) info(`\n⚠ ${stalled.length} store(s) look STALLED — see doc/release/README.md ("Checking review status").`);
+  process.exit(errored.length ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e?.message || String(e));
+  process.exit(1);
+});

--- a/scripts/store-status.mjs
+++ b/scripts/store-status.mjs
@@ -49,6 +49,7 @@ import {
   renderStatusTable,
   amoAuthHeader,
   edgeCrxIdFromListingUrl,
+  isFinalSemver,
 } from "./store-status-lib.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -87,11 +88,13 @@ async function getJson(url, init = {}) {
 /** Latest release tag (vX.Y.Z) + its commit date, for the release-lag stall heuristic. */
 function latestReleaseFromGit() {
   try {
+    // Final release tags only — prerelease tags (v1.14.0-rc.1) must not become the
+    // lag-heuristic baseline (parseSemver alone would truncate them to a final).
     const tags = execFileSync("git", ["tag", "-l", "v*"], { cwd: repoRoot, encoding: "utf8" })
       .split("\n")
-      .map((t) => parseSemver(t))
-      .filter(Boolean)
-      .map(formatSemver);
+      .map((t) => t.trim())
+      .filter(isFinalSemver)
+      .map((t) => formatSemver(parseSemver(t)));
     if (!tags.length) return null;
     const version = tags.sort(compareSemver).at(-1);
     const date = execFileSync("git", ["log", "-1", "--format=%cI", `v${version}`], {

--- a/test/scripts/store-status-lib.spec.ts
+++ b/test/scripts/store-status-lib.spec.ts
@@ -9,6 +9,8 @@ import {
   renderStatusTable,
   amoAuthHeader,
   edgeCrxIdFromListingUrl,
+  errorRecord,
+  isFinalSemver,
   STATUS_STORES,
 } from "../../scripts/store-status-lib.mjs";
 
@@ -299,6 +301,18 @@ describe("computeStalls", () => {
     expect(out.map((r) => r.stalled)).toEqual([false, false, false]);
   });
 
+  it("ignores a prerelease latest tag in the lag heuristic (never masquerades as a final)", () => {
+    // release-lib's parseSemver has no end anchor, so "1.14.0-rc.1" would parse as 1.14.0;
+    // the lag rule must reject prerelease versions outright.
+    const latestRelease = { version: "1.14.0-rc.1", date: new Date(NOW.getTime() - 20 * DAY).toISOString() };
+    const [r] = computeStalls([base({ store: "edge", liveVersion: "1.11.0" })], {
+      now: NOW,
+      stallDays: 14,
+      latestRelease,
+    });
+    expect(r.stalled).toBe(false);
+  });
+
   it("respects a custom --stall-days threshold", () => {
     const submittedAt = new Date(NOW.getTime() - 5 * DAY).toISOString();
     const [strict] = computeStalls([base({ inReview: true, submittedAt })], { now: NOW, stallDays: 3 });
@@ -330,6 +344,27 @@ describe("renderStatusTable", () => {
     expect(table).toMatch(/SKIPPED/);
     expect(table).toMatch(/STALLED/); // edge lags 1.13.0 released 22 days before NOW
   });
+
+  it("ERROR rows show — (not ok) in the stall column", () => {
+    const table = renderStatusTable(computeStalls([errorRecord("chrome", "auth failed")], { now: NOW }));
+    const row = table.split("\n").find((l) => l.startsWith("chrome"))!;
+    expect(row).toMatch(/ERROR/);
+    expect(row).not.toMatch(/\bok\b/);
+  });
+});
+
+// ── Final-version guard ────────────────────────────────────────────────────────────
+
+describe("isFinalSemver", () => {
+  it("accepts only strictly-final X.Y.Z (optionally v-prefixed)", () => {
+    expect(isFinalSemver("1.13.0")).toBe(true);
+    expect(isFinalSemver("v1.13.0")).toBe(true);
+    expect(isFinalSemver("1.14.0-rc.1")).toBe(false);
+    expect(isFinalSemver("v1.14.0-beta")).toBe(false);
+    expect(isFinalSemver("1.13")).toBe(false);
+    expect(isFinalSemver("")).toBe(false);
+    expect(isFinalSemver(null as unknown as string)).toBe(false);
+  });
 });
 
 // ── AMO JWT (deterministic with injected clock + nonce) ────────────────────────────
@@ -344,7 +379,8 @@ describe("amoAuthHeader", () => {
     const payload = dec(p);
     expect(payload.iss).toBe("user:123:45");
     expect(payload.jti).toBe("nonce-1");
-    expect(payload.iat).toBe(Math.floor(NOW.getTime() / 1000));
+    // iat is backdated 30s so a fast local clock can't put it in AMO's future (401s).
+    expect(payload.iat).toBe(Math.floor(NOW.getTime() / 1000) - 30);
     expect(payload.exp).toBe(payload.iat + 300);
   });
 

--- a/test/scripts/store-status-lib.spec.ts
+++ b/test/scripts/store-status-lib.spec.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect } from "vitest";
+import {
+  missingCreds,
+  skippedRecord,
+  normalizeChromeStatus,
+  normalizeEdgeStatus,
+  normalizeAmoStatus,
+  computeStalls,
+  renderStatusTable,
+  amoAuthHeader,
+  edgeCrxIdFromListingUrl,
+  STATUS_STORES,
+} from "../../scripts/store-status-lib.mjs";
+
+// ── Fixtures (shapes derived from each store's documented/observed API responses) ──
+
+// CWS V2 :fetchStatus — schema per developer.chrome.com/docs/webstore/api/reference/rest/v2
+// (publishedItemRevisionStatus/submittedItemRevisionStatus are ItemRevisionStatus objects;
+// ItemState enum: PENDING_REVIEW | STAGED | PUBLISHED | PUBLISHED_TO_TESTERS | REJECTED | CANCELLED).
+const CWS_PUBLISHED_ONLY = {
+  name: "publishers/123/items/glhhgglpalmjjkoiigojligncepccdei",
+  itemId: "glhhgglpalmjjkoiigojligncepccdei",
+  publishedItemRevisionStatus: {
+    state: "PUBLISHED",
+    distributionChannels: [{ deployPercentage: 100, crxVersion: "1.12.0" }],
+  },
+  lastAsyncUploadState: "SUCCEEDED",
+  takenDown: false,
+  warned: false,
+};
+
+const CWS_IN_REVIEW = {
+  ...CWS_PUBLISHED_ONLY,
+  submittedItemRevisionStatus: {
+    state: "PENDING_REVIEW",
+    distributionChannels: [{ deployPercentage: 100, crxVersion: "1.13.0" }],
+  },
+};
+
+const CWS_REJECTED = {
+  ...CWS_PUBLISHED_ONLY,
+  submittedItemRevisionStatus: {
+    state: "REJECTED",
+    distributionChannels: [{ deployPercentage: 100, crxVersion: "1.13.0" }],
+  },
+};
+
+// Edge public product details (microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/<crxid>)
+// — observed live 2026-07-07: version is a string, lastUpdateDate is epoch SECONDS (float).
+const EDGE_DETAILS = {
+  crxId: "jabjanmkommeachipnbiggdohahbfgpj",
+  name: "Say, Pi: Hands-Free AI Voice Chat",
+  version: "1.11.0",
+  lastUpdateDate: 1782086063.6782613, // 2026-06-21T23:54:23Z
+};
+
+// AMO v5 addon detail (addons.mozilla.org/api/v5/addons/addon/<guid>/) — observed live 2026-07-07.
+const AMO_ADDON = {
+  guid: "gecko@saypi.ai",
+  slug: "say-pi",
+  status: "public",
+  current_version: {
+    version: "1.13.0",
+    reviewed: "2026-07-01T06:36:03Z",
+    file: { status: "public", created: "2026-07-01T06:31:42Z" },
+  },
+  last_updated: "2026-07-01T06:36:03Z",
+};
+
+// AMO v5 versions list (…/versions/?filter=all_with_unlisted) — file.status "unreviewed"
+// marks a version still in the review queue.
+const AMO_VERSIONS_IN_REVIEW = {
+  results: [
+    {
+      version: "1.14.0",
+      channel: "listed",
+      file: { status: "unreviewed", created: "2026-07-05T10:00:00Z" },
+    },
+    {
+      version: "1.13.0",
+      channel: "listed",
+      file: { status: "public", created: "2026-07-01T06:31:42Z" },
+    },
+    {
+      version: "0.9.0",
+      channel: "listed",
+      file: { status: "disabled", created: "2024-01-01T00:00:00Z" },
+    },
+  ],
+};
+
+const NOW = new Date("2026-07-07T12:00:00Z");
+const DAY = 24 * 60 * 60 * 1000;
+
+// ── Credentials gating ─────────────────────────────────────────────────────────────
+
+describe("missingCreds / skippedRecord", () => {
+  it("reports every required env var name per store when env is empty", () => {
+    expect(missingCreds("chrome", {})).toEqual([
+      "CWS_CLIENT_ID",
+      "CWS_CLIENT_SECRET",
+      "CWS_REFRESH_TOKEN",
+      "CWS_PUBLISHER_ID",
+      "CWS_EXTENSION_ID",
+    ]);
+    expect(missingCreds("edge", {})).toEqual(["EDGE_PRODUCT_ID", "EDGE_API_KEY", "EDGE_CLIENT_ID"]);
+    expect(missingCreds("firefox", {})).toEqual(["WEB_EXT_API_KEY", "WEB_EXT_API_SECRET"]);
+  });
+
+  it("reports nothing when all vars are present", () => {
+    const env = {
+      EDGE_PRODUCT_ID: "p",
+      EDGE_API_KEY: "k",
+      EDGE_CLIENT_ID: "c",
+    };
+    expect(missingCreds("edge", env)).toEqual([]);
+  });
+
+  it("skippedRecord is marked SKIPPED and names the missing vars (never values)", () => {
+    const r = skippedRecord("edge", ["EDGE_API_KEY", "EDGE_CLIENT_ID"]);
+    expect(r.store).toBe("edge");
+    expect(r.skipped).toBe(true);
+    expect(r.state).toBe("SKIPPED");
+    expect(r.reason).toMatch(/EDGE_API_KEY/);
+    expect(r.reason).toMatch(/EDGE_CLIENT_ID/);
+  });
+
+  it("STATUS_STORES covers all three stores in submission order", () => {
+    expect(STATUS_STORES).toEqual(["chrome", "edge", "firefox"]);
+  });
+});
+
+// ── Chrome normalizer ──────────────────────────────────────────────────────────────
+
+describe("normalizeChromeStatus", () => {
+  it("published-only: live version, PUBLISHED, nothing in review", () => {
+    const r = normalizeChromeStatus(CWS_PUBLISHED_ONLY);
+    expect(r.store).toBe("chrome");
+    expect(r.liveVersion).toBe("1.12.0");
+    expect(r.state).toBe("PUBLISHED");
+    expect(r.inReview).toBe(false);
+    expect(r.submittedVersion).toBeNull();
+  });
+
+  it("pending review: surfaces the submitted version and IN_REVIEW state", () => {
+    const r = normalizeChromeStatus(CWS_IN_REVIEW);
+    expect(r.liveVersion).toBe("1.12.0");
+    expect(r.state).toBe("IN_REVIEW");
+    expect(r.inReview).toBe(true);
+    expect(r.submittedVersion).toBe("1.13.0");
+    // CWS fetchStatus carries no timestamps — stall detection falls back to release lag.
+    expect(r.submittedAt).toBeNull();
+  });
+
+  it("rejected submission is surfaced as REJECTED (not in review)", () => {
+    const r = normalizeChromeStatus(CWS_REJECTED);
+    expect(r.state).toBe("REJECTED");
+    expect(r.inReview).toBe(false);
+    expect(r.submittedVersion).toBe("1.13.0");
+  });
+
+  it("takenDown/warned flags land in notes", () => {
+    const r = normalizeChromeStatus({ ...CWS_PUBLISHED_ONLY, takenDown: true, warned: true });
+    expect(r.notes.join(" ")).toMatch(/taken down/i);
+    expect(r.notes.join(" ")).toMatch(/warned/i);
+  });
+
+  it("tolerates an empty response", () => {
+    const r = normalizeChromeStatus({});
+    expect(r.liveVersion).toBeNull();
+    expect(r.state).toBe("UNKNOWN");
+  });
+});
+
+// ── Edge normalizer ────────────────────────────────────────────────────────────────
+
+describe("normalizeEdgeStatus", () => {
+  it("maps version + epoch-seconds lastUpdateDate to an ISO timestamp", () => {
+    const r = normalizeEdgeStatus(EDGE_DETAILS);
+    expect(r.store).toBe("edge");
+    expect(r.liveVersion).toBe("1.11.0");
+    expect(r.state).toBe("PUBLISHED");
+    expect(r.updatedAt).toMatch(/^2026-06-21T/);
+    // Edge's publish API exposes no review state — the record says so.
+    expect(r.notes.join(" ")).toMatch(/review state/i);
+  });
+
+  it("tolerates an empty response", () => {
+    const r = normalizeEdgeStatus({});
+    expect(r.liveVersion).toBeNull();
+    expect(r.updatedAt).toBeNull();
+    expect(r.state).toBe("UNKNOWN");
+  });
+});
+
+// ── AMO normalizer ─────────────────────────────────────────────────────────────────
+
+describe("normalizeAmoStatus", () => {
+  it("public addon detail alone: live version + PUBLISHED", () => {
+    const r = normalizeAmoStatus(AMO_ADDON);
+    expect(r.store).toBe("firefox");
+    expect(r.liveVersion).toBe("1.13.0");
+    expect(r.state).toBe("PUBLISHED");
+    expect(r.updatedAt).toBe("2026-07-01T06:36:03Z");
+    expect(r.inReview).toBe(false);
+  });
+
+  it("an unreviewed listed version marks the record IN_REVIEW with its submission time", () => {
+    const r = normalizeAmoStatus(AMO_ADDON, AMO_VERSIONS_IN_REVIEW);
+    expect(r.state).toBe("IN_REVIEW");
+    expect(r.inReview).toBe(true);
+    expect(r.submittedVersion).toBe("1.14.0");
+    expect(r.submittedAt).toBe("2026-07-05T10:00:00Z");
+    expect(r.liveVersion).toBe("1.13.0"); // live version unchanged while in review
+  });
+
+  it("disabled/public versions never count as in-review", () => {
+    const r = normalizeAmoStatus(AMO_ADDON, {
+      results: AMO_VERSIONS_IN_REVIEW.results.filter((v) => v.file.status !== "unreviewed"),
+    });
+    expect(r.inReview).toBe(false);
+    expect(r.state).toBe("PUBLISHED");
+  });
+
+  it("tolerates empty responses", () => {
+    const r = normalizeAmoStatus({});
+    expect(r.liveVersion).toBeNull();
+    expect(r.state).toBe("UNKNOWN");
+  });
+});
+
+// ── Stall computation (injected clock) ─────────────────────────────────────────────
+
+describe("computeStalls", () => {
+  // `any` because the lib's StatusRecord typedef narrows `store` to the union; the loose
+  // fixture builder is fine for tests.
+  const base = (over: Record<string, unknown>): any => ({
+    store: "firefox",
+    skipped: false,
+    liveVersion: "1.13.0",
+    state: "PUBLISHED",
+    submittedVersion: null,
+    submittedAt: null,
+    updatedAt: null,
+    inReview: false,
+    notes: [],
+    ...over,
+  });
+
+  it("flags an in-review submission older than the threshold", () => {
+    const submittedAt = new Date(NOW.getTime() - 15 * DAY).toISOString();
+    const [r] = computeStalls([base({ inReview: true, state: "IN_REVIEW", submittedVersion: "1.14.0", submittedAt })], {
+      now: NOW,
+      stallDays: 14,
+    });
+    expect(r.stalled).toBe(true);
+    expect(r.stallReason).toMatch(/15 day/);
+  });
+
+  it("boundary: exactly at the threshold is NOT stalled; just over is", () => {
+    const atThreshold = new Date(NOW.getTime() - 14 * DAY).toISOString();
+    const justOver = new Date(NOW.getTime() - 14 * DAY - 60 * 1000).toISOString();
+    const mk = (submittedAt: string) =>
+      computeStalls([base({ inReview: true, state: "IN_REVIEW", submittedAt })], { now: NOW, stallDays: 14 })[0];
+    expect(mk(atThreshold).stalled).toBe(false);
+    expect(mk(justOver).stalled).toBe(true);
+  });
+
+  it("flags a store whose live version lags a release older than the threshold (the Edge scenario)", () => {
+    const latestRelease = { version: "1.13.0", date: new Date(NOW.getTime() - 20 * DAY).toISOString() };
+    const [r] = computeStalls([base({ store: "edge", liveVersion: "1.11.0" })], {
+      now: NOW,
+      stallDays: 14,
+      latestRelease,
+    });
+    expect(r.stalled).toBe(true);
+    expect(r.stallReason).toMatch(/1\.11\.0/);
+    expect(r.stallReason).toMatch(/1\.13\.0/);
+  });
+
+  it("does not flag a lagging store while the release is younger than the threshold", () => {
+    const latestRelease = { version: "1.13.0", date: new Date(NOW.getTime() - 3 * DAY).toISOString() };
+    const [r] = computeStalls([base({ store: "edge", liveVersion: "1.11.0" })], {
+      now: NOW,
+      stallDays: 14,
+      latestRelease,
+    });
+    expect(r.stalled).toBe(false);
+  });
+
+  it("does not flag up-to-date stores, skipped records, or unknown versions", () => {
+    const latestRelease = { version: "1.13.0", date: new Date(NOW.getTime() - 20 * DAY).toISOString() };
+    const records = [
+      base({}), // live == latest
+      base({ store: "edge", skipped: true, state: "SKIPPED", liveVersion: null }),
+      base({ store: "chrome", liveVersion: null, state: "UNKNOWN" }),
+    ];
+    const out = computeStalls(records, { now: NOW, stallDays: 14, latestRelease });
+    expect(out.map((r) => r.stalled)).toEqual([false, false, false]);
+  });
+
+  it("respects a custom --stall-days threshold", () => {
+    const submittedAt = new Date(NOW.getTime() - 5 * DAY).toISOString();
+    const [strict] = computeStalls([base({ inReview: true, submittedAt })], { now: NOW, stallDays: 3 });
+    const [lax] = computeStalls([base({ inReview: true, submittedAt })], { now: NOW, stallDays: 14 });
+    expect(strict.stalled).toBe(true);
+    expect(lax.stalled).toBe(false);
+  });
+});
+
+// ── Table rendering ────────────────────────────────────────────────────────────────
+
+describe("renderStatusTable", () => {
+  it("renders one row per store with version, state, and a stall marker", () => {
+    const records = computeStalls(
+      [
+        normalizeChromeStatus(CWS_IN_REVIEW),
+        normalizeEdgeStatus(EDGE_DETAILS),
+        skippedRecord("firefox", ["WEB_EXT_API_KEY", "WEB_EXT_API_SECRET"]),
+      ],
+      { now: NOW, stallDays: 14, latestRelease: { version: "1.13.0", date: "2026-06-15T00:00:00Z" } },
+    );
+    const table = renderStatusTable(records);
+    expect(table).toMatch(/chrome/);
+    expect(table).toMatch(/edge/);
+    expect(table).toMatch(/firefox/);
+    expect(table).toMatch(/1\.12\.0/);
+    expect(table).toMatch(/1\.11\.0/);
+    expect(table).toMatch(/IN_REVIEW/);
+    expect(table).toMatch(/SKIPPED/);
+    expect(table).toMatch(/STALLED/); // edge lags 1.13.0 released 22 days before NOW
+  });
+});
+
+// ── AMO JWT (deterministic with injected clock + nonce) ────────────────────────────
+
+describe("amoAuthHeader", () => {
+  it("builds an HS256 JWT with iss/jti/iat/exp and a 5-minute lifetime", () => {
+    const header = amoAuthHeader({ issuer: "user:123:45", secret: "s3cret", now: NOW, jti: "nonce-1" });
+    expect(header).toMatch(/^JWT [A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    const [h, p] = header.slice(4).split(".");
+    const dec = (s: string) => JSON.parse(Buffer.from(s, "base64url").toString("utf8"));
+    expect(dec(h)).toEqual({ alg: "HS256", typ: "JWT" });
+    const payload = dec(p);
+    expect(payload.iss).toBe("user:123:45");
+    expect(payload.jti).toBe("nonce-1");
+    expect(payload.iat).toBe(Math.floor(NOW.getTime() / 1000));
+    expect(payload.exp).toBe(payload.iat + 300);
+  });
+
+  it("is deterministic for the same inputs and never embeds the secret", () => {
+    const a = amoAuthHeader({ issuer: "i", secret: "topsecret", now: NOW, jti: "j" });
+    const b = amoAuthHeader({ issuer: "i", secret: "topsecret", now: NOW, jti: "j" });
+    expect(a).toBe(b);
+    expect(a).not.toContain("topsecret");
+  });
+});
+
+// ── stores.json helpers ────────────────────────────────────────────────────────────
+
+describe("edgeCrxIdFromListingUrl", () => {
+  it("extracts the crx id from the Edge listing URL in stores.json", () => {
+    expect(edgeCrxIdFromListingUrl("https://microsoftedge.microsoft.com/addons/detail/jabjanmkommeachipnbiggdohahbfgpj")).toBe(
+      "jabjanmkommeachipnbiggdohahbfgpj",
+    );
+  });
+  it("returns null for a malformed URL", () => {
+    expect(edgeCrxIdFromListingUrl("")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Store review status has been unmonitored: the Edge Add-ons review sat stalled for weeks and was only noticed incidentally (Edge is live at **1.11.0** today while AMO already serves **1.13.0** — the exact lag this tool exists to surface). #529 asks for a read-only, credentialed status check per store, with a stall alert, documented alongside `doc/release/`.

## What

**`npm run release:status`** (= `node scripts/store-status.mjs [--json] [--stall-days N]`) — a strictly **read-only** check that reuses the exact credential model of `release:submit` (same env var names from `release-lib.mjs`, same gitignored `.env.publish` auto-load, values never logged, `.env.production` never touched):

- **Chrome** — OAuth token exchange + CWS V2 `:fetchStatus` (the same read-only call `release:submit --dry-run` already makes): published `crxVersion` plus any submitted revision (`PENDING_REVIEW` → `IN_REVIEW`, `REJECTED` surfaced; `takenDown`/`warned` land in notes).
- **Edge** — the existing credentials probe (catches the ~72-day API-key expiry) + the public product-details endpoint for the live version/date. Edge's publish API exposes **no review state**, so Edge stalls are inferred from release lag (below).
- **Firefox (AMO)** — HS256-JWT-authed v5 addon detail + versions list (`?filter=all_with_unlisted`): live version, plus any listed version still `unreviewed` in the queue with its submission date.

**Stall flag** (default 14 days, `--stall-days N`), two signals in the pure lib with an injected clock:
1. a submission in review longer than the threshold (AMO exposes timestamps), or
2. a store whose live version is behind the latest `v*` release tag even though that release is older than the threshold — this is the rule that catches Edge (and Chrome, whose `fetchStatus` has no timestamps).

Architecture mirrors the release tooling: `scripts/store-status-lib.mjs` is pure (normalizers, stall computation, table render, AMO JWT builder — no network/fs/clock), `scripts/store-status.mjs` does the I/O. `release.mjs`/`release-lib.mjs`/`release-publish.mjs` are **untouched** (only pure helpers imported); no CI wiring here — the scheduled invocation belongs to #525. Docs: a "Checking review status" section in `doc/release/README.md` + a pointer in `publishing-credentials.md`.

## Verification

- **Fail-first TDD:** `test/scripts/store-status-lib.spec.ts` written first and run red (module missing), then the lib brought it green — 26 cases: per-store normalizers from fixtures derived from each store's documented/observed API shapes (CWS V2 reference schema + ItemState enum; live public Edge/AMO responses observed 2026-07-07), stall boundary cases with an injected `now` (exactly-at-threshold not stalled, just-over stalled), release-lag scenario, SKIPPED-when-no-creds, table render smoke, deterministic AMO JWT.
- **Full suite green** in the worktree: `npm test` exit 0 (tsc, Jest 2, Vitest 1929 passed / 1 skipped). Layer 0 caught two typing issues in the first pass; fixed.
- **No-creds `--json` dry run** (required contract — exit 0, all stores SKIPPED, no network):

```
$ node scripts/store-status.mjs --json
{
  "generatedAt": "2026-07-07T20:30:35.127Z",
  "stallDays": 14,
  "latestRelease": { "version": "1.13.0", "date": "2026-07-01T07:23:59+01:00" },
  "stores": [
    { "store": "chrome", "skipped": true, "state": "SKIPPED",
      "reason": "missing env: CWS_CLIENT_ID, CWS_CLIENT_SECRET, CWS_REFRESH_TOKEN, CWS_PUBLISHER_ID, CWS_EXTENSION_ID (see doc/release/publishing-credentials.md)", "stalled": false, ... },
    { "store": "edge", "skipped": true, "state": "SKIPPED",
      "reason": "missing env: EDGE_PRODUCT_ID, EDGE_API_KEY, EDGE_CLIENT_ID (see doc/release/publishing-credentials.md)", "stalled": false, ... },
    { "store": "firefox", "skipped": true, "state": "SKIPPED",
      "reason": "missing env: WEB_EXT_API_KEY, WEB_EXT_API_SECRET (see doc/release/publishing-credentials.md)", "stalled": false, ... }
  ]
}
exit=0
```

## Not done here (deliberately)

**The first live credentialed run is deferred.** Per the credentials boundary, this session implemented and unit-tested only. Before #529 closes, the founder (or an explicitly authorized session) should run `npm run release:status` once with real credentials and paste the (secret-free) output on #529 — that run should immediately flag Edge (live 1.11.0 vs v1.13.0 released 2026-07-01, once >14 days old; use `--stall-days 5` today to see it fire).

Addresses #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMWq5NUKDpZJtsehkGpt8u