### PR TITLE
safety: secret scanning in CI — gitleaks with clean baseline (#531)

### DIFF
--- a/.github/workflows/secret-scan.yaml
+++ b/.github/workflows/secret-scan.yaml
@@ -1,0 +1,56 @@
+name: Secret Scan
+
+# Advisory secret-scanning gate (gitleaks) — see doc/secret-scanning.md.
+# Scans PR commit ranges and the main tree for committed credentials.
+# Promotion to a *required* check is a founder-gated follow-up (#531).
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Pinned gitleaks release. Bump deliberately: update BOTH values together
+  # (checksum from gitleaks_<ver>_checksums.txt on the GitHub release) and
+  # keep the drift-guard spec (test/scripts/secret-scan.spec.ts) in sync.
+  GITLEAKS_VERSION: "8.30.1"
+  GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the PR base..head commit range is resolvable.
+          fetch-depth: 0
+
+      - name: Install gitleaks (pinned, checksum-verified)
+        run: |
+          curl -sSfL -o "$RUNNER_TEMP/gitleaks.tar.gz" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  $RUNNER_TEMP/gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP" gitleaks
+          "$RUNNER_TEMP/gitleaks" version
+
+      # PRs: scan every commit in the PR range, so a secret that is added and
+      # then removed within the same PR still fails the check.
+      - name: Scan PR commits (gitleaks git)
+        if: github.event_name == 'pull_request'
+        run: |
+          "$RUNNER_TEMP/gitleaks" git . \
+            --config .gitleaks.toml --no-banner --redact --verbose \
+            --log-opts "--no-merges ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
+      # Pushes to main (and manual runs): scan the checked-out tree — the
+      # clean-baseline invariant from doc/secret-scanning.md.
+      - name: Scan working tree (gitleaks dir)
+        if: github.event_name != 'pull_request'
+        run: |
+          "$RUNNER_TEMP/gitleaks" dir . \
+            --config .gitleaks.toml --no-banner --redact

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,57 @@
+# Gitleaks configuration for saypi-userscript.
+# Used by CI (.github/workflows/secret-scan.yaml) and local runs — see
+# doc/secret-scanning.md.
+#
+# Discipline: the baseline is CLEAN — `gitleaks dir . --config .gitleaks.toml`
+# must exit 0 on the tree. Every allowlist entry must be as narrow as it can
+# be while staying effective, and MUST carry a comment saying what it matches,
+# why it is safe, and how it was verified. Never allowlist a real credential:
+# if the scan fires on something real, rotate it first, then remove it from
+# the tree (doc/secret-scanning.md, "When the scan fires").
+
+title = "saypi-userscript"
+
+[extend]
+# Start from gitleaks' built-in default ruleset; entries below only narrow it.
+useDefault = true
+
+# --- Scrubbed-fixture placeholder JWT ---------------------------------------
+# The recorded ChatGPT DOM fixtures (doc/dom/chatgpt/*.html) originally
+# captured real session tokens; PR #541 replaced them with one exact fake JWT:
+#   header    {"alg":"none"}
+#   payload   {"sub":"REDACTED","note":"scrubbed-fixture"}
+#   signature the literal string "SCRUBBED"
+# It cannot authenticate anything, but it still trips the `jwt` rule. We
+# allowlist the exact placeholder string (regexTarget "line" so the match is
+# independent of which fragment a rule captures as the secret). A future
+# fixture capture that embeds a REAL token does not contain this string and
+# still fails the scan.
+[[allowlists]]
+description = "Scrubbed-fixture placeholder JWT (alg:none / sub REDACTED / sig SCRUBBED) from PR #541"
+regexTarget = "line"
+regexes = [
+  '''eyJhbGciOiJub25lIn0\.eyJzdWIiOiJSRURBQ1RFRCIsIm5vdGUiOiJzY3J1YmJlZC1maXh0dXJlIn0\.SCRUBBED''',
+]
+
+# --- generic-api-key inside recorded host-page DOM fixtures ------------------
+# doc/dom/**/*.html are verbatim captures of third-party host pages (ChatGPT,
+# Claude, Pi). Their serialized client-side app state contains many
+# high-entropy PUBLIC client-delivered values — A/B experiment variant hashes,
+# feature-gate ids — sitting next to credential-ish keyword names (one flag is
+# literally called "..._leaked_credential_check"), which is exactly what the
+# keyword+entropy `generic-api-key` heuristic fires on. Verified 2026-07-07:
+# each such finding decoded to a public experiment-variant id in a
+# '"..._variant",[...]' list, not a credential; and gitleaks shadows
+# overlapping findings, so suppressing one exact string just surfaces the next
+# candidate in the same 94k-char blob — exact-string allowlisting is unbounded
+# here. Scope: ONLY the generic-api-key rule, ONLY these fixture paths. Every
+# specific rule (jwt, openai-api-key, aws-*, github-*, private-key, ...) still
+# applies to these files, so a real captured token still fails the scan.
+# Belt-and-braces: the DOM capture recorder is to redact tokens/PII at capture
+# time (doc/secret-scanning.md, "Fixture hygiene").
+[[allowlists]]
+description = "generic-api-key keyword+entropy false positives in recorded third-party DOM fixtures (public experiment/gate ids)"
+targetRules = ["generic-api-key"]
+paths = [
+  '''doc/dom/.*\.html$''',
+]

--- a/doc/secret-scanning.md
+++ b/doc/secret-scanning.md
@@ -1,0 +1,141 @@
+# Secret scanning (gitleaks)
+
+The never-commit-secrets rule (AGENTS.md, "Credentials") is enforced
+mechanically by [gitleaks](https://github.com/gitleaks/gitleaks) in CI
+(issue #531). This page is the operating manual: what runs, the
+clean-baseline discipline, how to run it locally, and what to do when it
+fires.
+
+## What runs
+
+`.github/workflows/secret-scan.yaml` — on **every pull request** and on
+**pushes to `main`** (plus manual `workflow_dispatch`), with read-only
+permissions:
+
+- **PRs** run `gitleaks git` over the PR's commit range
+  (`base.sha..head.sha`), so a secret that is added and then removed within
+  the same PR still fails the check.
+- **Pushes to `main`** run `gitleaks dir .` over the checked-out tree — a
+  standing assertion that the baseline stays clean.
+
+The binary is a **pinned release** (not `latest`, not a third-party action):
+the workflow downloads the exact `GITLEAKS_VERSION`, verifies the release
+tarball against the pinned `GITLEAKS_SHA256`, and only then runs it. We do
+not use `gitleaks/gitleaks-action`, which requires a `GITLEAKS_LICENSE` key
+for organization-owned repos. All scans run with `--redact` so a detected
+secret is never echoed into Actions logs.
+
+A Vitest drift guard (`test/scripts/secret-scan.spec.ts`) asserts the
+workflow's triggers, the version/checksum pin, `--redact`, and the config
+discipline below — so a quiet weakening edit fails the normal test gate.
+
+**Status: advisory.** The job runs on every PR but is not yet a *required*
+check. Promotion to required is a branch-protection change and, per
+AGENTS.md, a founder-gated gate change — tracked as the follow-up on #531.
+
+## The clean-baseline discipline
+
+`gitleaks dir . --config .gitleaks.toml` on the tree **must exit 0**. That
+invariant is what makes the check meaningful: any finding is a new problem,
+never ambient noise to be waved off.
+
+Consequences:
+
+- **No standing suppressions without rationale.** Every `[[allowlists]]`
+  entry in `.gitleaks.toml` must carry a comment saying what it matches, why
+  it is safe, and how that was verified. (The drift-guard spec enforces the
+  comment's existence; review enforces its honesty.)
+- **Allowlist entries are as narrow as they can be while staying
+  effective.** Prefer an exact known-fake string; scope by rule *and* path
+  when an exact string can't work (see the fixture entry below); never
+  suppress a whole rule or a whole directory unscoped.
+- **Never allowlist anything real.** If the scan fires on a genuine
+  credential, allowlisting it is the one forbidden move — see "When the scan
+  fires".
+
+### Current allowlist (2 entries)
+
+1. **The scrubbed-fixture placeholder JWT** — PR #541 replaced real captured
+   session tokens in the ChatGPT DOM fixtures with one exact fake JWT
+   (`{"alg":"none"}` header, `{"sub":"REDACTED","note":"scrubbed-fixture"}`
+   payload, literal `SCRUBBED` signature). The exact string is allowlisted;
+   a real token would not match it.
+2. **`generic-api-key` in `doc/dom/**/*.html`** — recorded third-party host
+   pages serialize the host's client-side state, which is full of
+   high-entropy *public* values (A/B experiment variant hashes, feature-gate
+   ids) sitting next to credential-ish keyword names (one ChatGPT flag is
+   literally named `..._leaked_credential_check`). That keyword+entropy
+   coincidence is exactly what the generic heuristic fires on, and gitleaks
+   surfaces the next overlapping candidate once one is suppressed — so
+   exact-string allowlisting is unbounded there. The entry is scoped to that
+   one heuristic rule on those paths only; every specific rule (`jwt`,
+   vendor API keys, `private-key`, …) still applies to the fixtures, so a
+   future capture embedding a real token still fails.
+
+### Fixture hygiene (capture-time redaction — follow-up)
+
+The durable fix for fixture noise is upstream of the scanner: the DOM
+capture recorder (`scripts/dom-capture/`) should **redact at capture time**
+— strip or placeholder session tokens, cookies, JWTs, email addresses, and
+account/org/device identifiers before a fixture is ever written to disk (the
+#541 review recommendation). Until that lands, treat any newly recorded
+fixture as suspect: run the local scan before committing it, and scrub with
+the #541 placeholder convention (`REDACTED` scalars, the `alg:none`
+placeholder JWT) rather than adding allowlist entries.
+
+## Running locally
+
+Use the same pinned version as CI (macOS arm64 shown; checksums are in
+`gitleaks_<ver>_checksums.txt` on the release page):
+
+```sh
+VER=8.30.1
+curl -sSfL -O "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_darwin_arm64.tar.gz"
+curl -sSfL -O "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_checksums.txt"
+shasum -a 256 -c <(grep darwin_arm64 "gitleaks_${VER}_checksums.txt")
+tar xzf "gitleaks_${VER}_darwin_arm64.tar.gz" gitleaks
+```
+
+Then, from the repo root:
+
+```sh
+./gitleaks dir . --config .gitleaks.toml --no-banner --redact          # tree scan (the baseline invariant)
+./gitleaks git . --config .gitleaks.toml --log-opts "main..HEAD"       # scan your branch's commits, like CI does for PRs
+```
+
+Don't commit the binary; keep it outside the repo or delete it after use.
+
+### Optional pre-commit hook
+
+To catch a secret before it ever reaches a commit:
+
+```sh
+# .git/hooks/pre-commit (chmod +x)
+#!/bin/sh
+exec gitleaks git . --config .gitleaks.toml --staged --pre-commit --redact --no-banner
+```
+
+This is offered, not mandated — CI remains the backstop.
+
+## When the scan fires
+
+1. **Assume it's real until proven fake.** Verify without printing the
+   value (check whether it's a placeholder, decode JWT claims only, check
+   expiry).
+2. **If it's real: rotate first.** The credential is compromised the moment
+   it is pushed anywhere (this repo is public) — revoke/rotate it at the
+   provider *before* touching the tree, then remove it from the tree.
+   History rewrite is optional once the credential is dead; rotation is not.
+   Escalate to the founder per AGENTS.md.
+3. **If it's verifiably fake:** prefer scrubbing the file over allowlisting;
+   if it must stay (e.g. a deliberate placeholder), add the narrowest
+   possible allowlist entry with a rationale comment, and make sure the
+   drift-guard spec still passes.
+
+## Bumping the pinned gitleaks version
+
+Update together, in one PR: `GITLEAKS_VERSION` + `GITLEAKS_SHA256` in the
+workflow (linux_x64 checksum from the release's checksums file), the
+assertions in `test/scripts/secret-scan.spec.ts`, and the version in this
+doc's local-run snippet. Re-run the local tree scan to confirm the baseline
+is still clean under the new ruleset before merging.

--- a/test/scripts/secret-scan.spec.ts
+++ b/test/scripts/secret-scan.spec.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+// Drift guard for the secret-scanning CI gate (#531).
+//
+// The workflow and the gitleaks config are load-bearing safety plumbing: a
+// silent edit that drops a trigger, unpins the binary, or adds an
+// unexplained allowlist entry would quietly weaken the credentials boundary.
+// These checks assert the invariants doc/secret-scanning.md promises.
+
+const workflowPath = resolve(__dirname, "../../.github/workflows/secret-scan.yaml");
+const configPath = resolve(__dirname, "../../.gitleaks.toml");
+
+const workflow = readFileSync(workflowPath, "utf8");
+const config = readFileSync(configPath, "utf8");
+
+describe("secret-scan workflow (.github/workflows/secret-scan.yaml)", () => {
+  it("triggers on pull_request and push to main", () => {
+    expect(workflow).toMatch(/^on:/m);
+    expect(workflow).toMatch(/^\s*pull_request:/m);
+    // push scoped to main (not all branches)
+    expect(workflow).toMatch(/push:\s*\n\s*branches:\s*\[\s*main\s*\]/);
+  });
+
+  it("runs with read-only permissions", () => {
+    expect(workflow).toMatch(/^permissions:\s*\n\s*contents:\s*read/m);
+    expect(workflow).not.toMatch(/:\s*write/);
+  });
+
+  it("pins the exact gitleaks version and its release checksum", () => {
+    // Bumping gitleaks is fine — do it deliberately: update the workflow's
+    // version + sha256 pair AND these assertions together.
+    expect(workflow).toContain('GITLEAKS_VERSION: "8.30.1"');
+    expect(workflow).toContain(
+      'GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"'
+    );
+    // ...and actually verifies the checksum before running the binary.
+    expect(workflow).toMatch(/sha256sum -c/);
+  });
+
+  it("uses the repo gitleaks config for every scan step", () => {
+    const scanInvocations = workflow.match(/gitleaks" (git|dir) /g) ?? [];
+    expect(scanInvocations.length).toBeGreaterThanOrEqual(2); // PR-range + tree scan
+    const configFlags = workflow.match(/--config \.gitleaks\.toml/g) ?? [];
+    expect(configFlags.length).toBe(scanInvocations.length);
+  });
+
+  it("redacts secrets from CI logs", () => {
+    // Every scan invocation must carry --redact so a detected secret is
+    // never echoed into public Actions logs.
+    const scanBlocks = workflow.split(/gitleaks" (?:git|dir) /).slice(1);
+    for (const block of scanBlocks) {
+      expect(block.slice(0, 200)).toContain("--redact");
+    }
+  });
+});
+
+describe("gitleaks config (.gitleaks.toml)", () => {
+  it("extends the default ruleset", () => {
+    expect(config).toMatch(/\[extend\]/);
+    expect(config).toMatch(/useDefault\s*=\s*true/);
+  });
+
+  it("parses as sane TOML (light checks)", () => {
+    // Balanced triple-quoted literals and no stray unclosed tables.
+    const tripleQuotes = config.match(/'''/g) ?? [];
+    expect(tripleQuotes.length % 2).toBe(0);
+    // Only known top-level tables are declared.
+    const tables = config.match(/^\[+[^\]]+\]+$/gm) ?? [];
+    for (const table of tables) {
+      expect(["[extend]", "[[allowlists]]"]).toContain(table.trim());
+    }
+  });
+
+  it("gives every allowlist entry a description", () => {
+    const lines = config.split("\n");
+    const entryCount = lines.filter((l) => l.trim() === "[[allowlists]]").length;
+    expect(entryCount).toBeGreaterThan(0);
+    const descriptions = config.match(/^description\s*=\s*".+"/gm) ?? [];
+    expect(descriptions.length).toBe(entryCount);
+  });
+
+  it("precedes every allowlist entry with a rationale comment", () => {
+    // Clean-baseline discipline (doc/secret-scanning.md): no standing
+    // suppression without a comment explaining what it matches and why it
+    // is safe. The nearest non-blank line above each [[allowlists]] header
+    // must be a comment.
+    const lines = config.split("\n");
+    lines.forEach((line, i) => {
+      if (line.trim() !== "[[allowlists]]") return;
+      let j = i - 1;
+      while (j >= 0 && lines[j].trim() === "") j--;
+      expect(
+        lines[j]?.trim().startsWith("#"),
+        `allowlist entry at line ${i + 1} lacks a rationale comment`
+      ).toBe(true);
+    });
+  });
+
+  it("keeps the fixture allowlist scoped to the generic rule, not whole files", () => {
+    // The doc/dom fixture entry must stay rule-scoped: specific rules (jwt,
+    // vendor keys, private-key) must keep applying to recorded fixtures so a
+    // future capture embedding a real token still fails the scan.
+    // Note: rationale comments precede each [[allowlists]] header, so they
+    // belong to the previous split chunk — match on the entry's paths value.
+    const fixtureEntry = config
+      .split("[[allowlists]]")
+      .slice(1)
+      .find((block) => block.includes("'''doc/dom"));
+    expect(fixtureEntry).toBeDefined();
+    expect(fixtureEntry).toMatch(/targetRules\s*=\s*\[\s*"generic-api-key"\s*\]/);
+  });
+});


### PR DESCRIPTION
## Why

The never-commit-secrets boundary (AGENTS.md, Credentials) has been prompt-enforced only — nothing in CI would catch a credential landing in a PR. #531 asks for a mechanical gate. The need is not hypothetical: the baseline scan for this very PR found a real committed ngrok authtoken and captured session JWTs in recorded fixtures, remediated in #541 (token rotation escalated separately).

## What

- **`.github/workflows/secret-scan.yaml`** — advisory gitleaks job on every `pull_request` and on `push` to `main` (+ `workflow_dispatch`), `permissions: contents: read`.
  - PRs: `gitleaks git` over the PR commit range (`base.sha..head.sha`) — a secret added then removed within the PR still fails.
  - Pushes to main: `gitleaks dir .` over the tree — the standing clean-baseline invariant.
  - **Pinned binary, not the action**: `gitleaks/gitleaks-action` requires a `GITLEAKS_LICENSE` key for org-owned repos, so the workflow downloads the exact v8.30.1 release, verifies the tarball against its published sha256, then runs it. All scans use `--redact` so a hit never reaches public Actions logs.
- **`.gitleaks.toml`** — default ruleset + two narrow allowlist entries, each with a verified rationale comment (details below).
- **`test/scripts/secret-scan.spec.ts`** — Vitest drift guard: triggers, read-only permissions, the exact version+checksum pin, `--config`/`--redact` on every scan step, and the config discipline (every allowlist entry described + commented; the fixture entry stays rule-scoped).
- **`doc/secret-scanning.md`** — operating manual: what runs, clean-baseline discipline, local run with the pinned version, optional pre-commit hook, the rotate-first when-it-fires runbook, and the capture-time-redaction follow-up for the DOM recorder (from the #541 review: future fixture captures must redact tokens, emails, account/org/device ids at capture time).

## Baseline & allowlist (2 entries, both verified)

Post-#541 the tree was *nearly* clean. What still fired, and why each entry is safe:

1. **The scrubbed-fixture placeholder JWT** (`jwt` + `generic-api-key` rules): #541's exact placeholder — header `{"alg":"none"}`, payload `{"sub":"REDACTED","note":"scrubbed-fixture"}`, signature literal `SCRUBBED` (verified by decoding). Allowlisted as the exact string; a real token can't match it.
2. **`generic-api-key` scoped off `doc/dom/**/*.html`**: the recorded ChatGPT pages serialize client-side app state full of high-entropy *public* values (A/B experiment variant hashes) adjacent to credential-ish keyword names — one flag is literally named `..._leaked_credential_check`. Each finding was decoded/inspected: public experiment-variant ids, not credentials. Exact-string allowlisting is unbounded here (gitleaks surfaces the next overlapping candidate once one is suppressed — verified empirically), so the entry is scoped to that one heuristic rule on those paths only. Every specific rule (`jwt`, vendor keys, `private-key`, …) still applies to the fixtures — proven by the seeded run below. The durable fix (capture-time redaction in the recorder) is documented as the follow-up.

## Verification

Local runs with the same pinned v8.30.1 (checksum-verified):

**(a) clean baseline — exit 0**
```
$ gitleaks dir . --config .gitleaks.toml --no-banner --redact
INF scanned ~15850381 bytes (15.85 MB) in 235ms
INF no leaks found
exit code: 0
```

**(b) seeded fake secrets — detected, exit 1** (uncommitted scratch files; a synthetic GitHub-PAT-shaped string, seeded both at repo root and *inside the allowlisted fixture dir* to prove specific rules still fire there; AWS's documented example key wasn't usable — the default ruleset allowlists it as a known example)
```
$ gitleaks dir . --config .gitleaks.toml --no-banner --redact --verbose   # with 2 seeded fakes
Finding:     <script>var t = "REDACTED";</script>
Secret:      REDACTED
RuleID:      github-pat
File:        doc/dom/chatgpt/seeded-scratch.html
Fingerprint: doc/dom/chatgpt/seeded-scratch.html:github-pat:1

Finding:     github_token = "REDACTED
Secret:      REDACTED
RuleID:      github-pat
File:        seeded-scratch.tmp
Fingerprint: seeded-scratch.tmp:github-pat:1

WRN leaks found: 2
exit code: 1
```

Also verified: the CI PR-range form (`gitleaks git . --log-opts "<range>"`) runs clean over recent main including the #541 scrub commit (deletions aren't flagged; 3 commits scanned, no leaks).

`npm test` green in the worktree: typecheck + Jest + Vitest — 214 Vitest files, 1913 passed / 1 skipped (includes the new drift guard).

## Follow-ups (out of scope here)

- **Promotion to a required check** — branch-protection change, founder-gated (#531 stays open for it).
- **Capture-time redaction in the DOM recorder** — documented in `doc/secret-scanning.md`.

Addresses #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMWq5NUKDpZJtsehkGpt8u