### PR TITLE
release: credential rotation runbook + freshness check (#534)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ ngrok.yml
 # Layer-4 real-host spend ledger (#533) — personal operational data, never committed
 .l4-ledger.json
 .l4-ledger.json.corrupt-*
+
+# Credential-freshness state (timestamps only — release:freshness, #534)
+.credential-freshness.json

--- a/doc/release/README.md
+++ b/doc/release/README.md
@@ -28,8 +28,10 @@ auto-update**, and store-submission plumbing is founder-gated.
 - `scripts/release-lib.mjs` — pure, unit-tested logic (version decision, payload
   categorization, changelog digest, packet rendering). Tests: `test/scripts/release-lib.spec.ts`.
 - `scripts/store-status.mjs` / `scripts/store-status-lib.mjs` — read-only per-store review
-  status check (`npm run release:status`, #529; see "Checking review status" below).
-  Tests: `test/scripts/store-status-lib.spec.ts`.
+  status check (`npm run release:status`, #529; see "Checking review status" below) and the
+  credential-freshness check (`npm run release:freshness`, #534; rotation runbook in
+  [`publishing-credentials.md`](publishing-credentials.md) § "Rotation & lifetimes").
+  Tests: `test/scripts/store-status-lib.spec.ts`, `test/scripts/credential-freshness.spec.ts`.
 - `doc/release/stores.json` — single source of truth for store identity + per-store facts.
   Consumed by the packet generator and any future browser-driver / API path.
 - `doc/release/{chrome-web-store,edge-addons,firefox-amo}.md` — per-store submission detail.
@@ -65,6 +67,7 @@ npm run release:finalize -- <version> --yes  # = … finalize <version> --yes
 npm run release:submit -- <store> --dry-run  # ⛔ #412: auth-check a store's publishing API
 npm run release:submit -- <store> --yes      # ⛔ #412: headless API submission (founder-only)
 npm run release:status                       # read-only: review/publish status per store (#529)
+npm run release:freshness                    # read-only: publishing-credential health per store (#534)
 ```
 
 Run from the **main checkout on `main`** — a real release is cut from main and the build

--- a/doc/release/publishing-credentials.md
+++ b/doc/release/publishing-credentials.md
@@ -15,10 +15,11 @@ time. The easiest way: drop them in a local, gitignored **`.env.publish`** at th
 file. The tool reads only `process.env` and `.env.publish`; it **never** reads `.env.production`,
 and it logs only the *names* of the keys it loaded — never their values.
 
-The same credentials (same env var names, same `.env.publish` auto-load) also power the
-**read-only** review-status check `npm run release:status` (#529) — see "Checking review
-status" in [`README.md`](README.md). That command never uploads or publishes; a store whose
-vars are absent is simply reported SKIPPED.
+The same credentials (same env var names, same `.env.publish` auto-load) also power two
+**read-only** checks: the review-status check `npm run release:status` (#529 — see "Checking
+review status" in [`README.md`](README.md)) and the credential-freshness check
+`npm run release:freshness` (#534 — see "Rotation & lifetimes" below). Neither ever uploads
+or publishes; a store whose vars are absent is simply reported SKIPPED.
 
 ## Usage
 
@@ -88,6 +89,7 @@ change visibility (fine — Say, Pi exists).
 | `EDGE_PRODUCT_ID` | `824c36fe-fd03-4656-8d32-67b0ae2cbdad` |
 | `EDGE_API_KEY` | API key — Partner Center → Edge → **Publish API** → Create API credentials |
 | `EDGE_CLIENT_ID` | Client ID (same page) |
+| `EDGE_KEY_ISSUED` | *(optional)* the date the current API key was created, e.g. `2026-07-07` — the API can't report a key's expiry, so `release:freshness` computes the 72-day countdown from this. Update it every rotation. |
 
 **Auth is v1.1** (header `Authorization: ApiKey <key>`, `X-ClientID: <id>`); the old v1 Entra/OAuth
 model ended 2024-12-31. ⚠️ **API keys expire every ~72 days** — a `401` means "rotate the key in
@@ -106,6 +108,78 @@ Create both at `https://addons.mozilla.org/developers/addon/api/key/`. Submissio
 `--upload-source-code=source-code.zip` satisfies the minified-build source requirement; build steps
 go into the reviewer notes automatically. Listed submissions enter the AMO review queue (not
 instantly public). Ensure `.output/firefox-mv2/manifest.json` carries `gecko@saypi.ai`.
+
+## Rotation & lifetimes (#534)
+
+**Ownership:** the **founder rotates** every publishing credential (each rotation needs a
+dashboard login only the founder holds); the **freshness check reminds**. The scheduled
+weekly maintenance routine (#525) runs `npm run release:freshness -- --json` and pings the
+founder via the awaiting-founder notification pattern when anything comes back `EXPIRED` or
+`EXPIRING_SOON` — so an expiring token becomes a calm heads-up, not a release-day surprise.
+
+```bash
+npm run release:freshness            # human table: per-store credential health
+npm run release:freshness -- --json  # machine-readable, for the #525 routine
+```
+
+The check reuses the exact read-only probes `release:status` already performs — a real CWS
+refresh-token exchange, the Edge dummy-UUID poll probe, a JWT-authed AMO request — and adds
+a **days-since-last-verified** column (state in the gitignored `.credential-freshness.json`;
+timestamps only, never values) plus, for Edge, an **expiry countdown** computed from
+`EDGE_KEY_ISSUED` (see the env-var table above — the Edge API cannot report a key's expiry
+date, so the issued date is recorded manually at each rotation). Exit code: `1` only on
+`EXPIRED`/`ERROR`; `SKIPPED` (no creds available, e.g. an agent checkout) and
+`EXPIRING_SOON` exit `0`.
+
+### 🟢 Chrome — `CWS_REFRESH_TOKEN` (OAuth refresh token)
+
+- **Lifetime hinges on the OAuth app's publishing status** (verified against
+  [Google's OAuth 2.0 docs](https://developers.google.com/identity/protocols/oauth2#expiration),
+  2026-07): an app left in **"Testing"** gets refresh tokens that **expire in 7 days**; an
+  app **"In production"** gets long-lived tokens with **no scheduled expiry**. This runbook's
+  setup (above) directs a self-owned publishing client to be **published to production**, so
+  the intended steady state is long-lived — but a working exchange today can't prove which
+  status the app has. Confirm it in **Google Auth Platform → Audience → Publishing status**;
+  if it still says Testing, publish to production once and remint.
+- **Even a production token dies on:** 6 months of non-use (the weekly freshness run itself
+  keeps it warm), revocation at https://myaccount.google.com/permissions, or the
+  **100-refresh-tokens-per-client-per-account cap** (minting the 101st silently invalidates
+  the oldest — don't script token minting).
+- **Rotation steps:** § "Minting `CWS_REFRESH_TOKEN`" above (Google Cloud Console → OAuth
+  Playground with your own client → exchange → paste into `.env.publish`). ~5 minutes.
+- **Failure signature:** `release:status` / `release:submit --dry-run` → chrome `ERROR:
+  auth failed: Token has been expired or revoked` (`invalid_grant`);
+  `release:freshness` → chrome `EXPIRED` with the remint pointer. A
+  `401 unauthorized_client` instead means the token was presented with a *different*
+  client's id/secret — remint with the current client, don't hunt for an expiry.
+
+### 🔵 Edge — `EDGE_API_KEY` (Publish-API key)
+
+- **Lifetime: 72 days, fixed** — Microsoft cut keys from 2 years to 72 days with the v1.1
+  API-key model ([Edge blog, 2025-01](https://blogs.windows.com/msedgedev/2025/01/08/enhanced-security-for-extensions-with-publish-api-next-steps/):
+  *"The API key is valid for 72 days"*). There is **no programmatic renewal**; Microsoft
+  emails reminders before expiry, and Partner Center shows each key's expiry date.
+- **Rotation steps:** [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/publishapi)
+  → Microsoft Edge → **Publish API** → create a new API key → update `EDGE_API_KEY` **and
+  `EDGE_KEY_ISSUED`** in `.env.publish`. ~2 minutes, every ~10 weeks.
+- **Failure signature:** any API call (including the read-only probe) returns **HTTP 401**
+  — `release:status` → edge `ERROR: publish-API credentials rejected (401)…`;
+  `release:freshness` → edge `EXPIRED`. With `EDGE_KEY_ISSUED` set, the freshness check
+  flags `EXPIRING_SOON` from 14 days out — i.e. *before* the 401 ever happens.
+
+### 🟠 Firefox — `WEB_EXT_API_KEY` / `WEB_EXT_API_SECRET` (AMO JWT issuer + secret)
+
+- **Lifetime: long-lived.** Mozilla documents **no expiry** for the issuer/secret pair
+  ([AMO API auth docs](https://mozilla.github.io/addons-server/topics/api/auth.html)) —
+  they stay valid until regenerated/revoked at
+  https://addons.mozilla.org/developers/addon/api/key/. (Each *request* signs a fresh JWT
+  from the secret, capped at 5 minutes — that's per-call, not a credential lifetime.)
+- **Rotation steps:** none on a schedule; regenerate at the key-management page above only
+  on suspected exposure, then update both vars in `.env.publish`.
+- **Failure signature:** authenticated AMO requests return **HTTP 401** —
+  `release:freshness` → firefox `EXPIRED` with the regenerate pointer. (`release:status`
+  can partially mask a bad secret because the addon-detail endpoint is public; the
+  freshness probe deliberately uses an auth-*required* endpoint.)
 
 ## How `--dry-run` checks each store
 - **Chrome:** real OAuth token exchange + a read-only `fetchStatus` (prints the current published version).

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "release:finalize": "node scripts/release.mjs finalize",
     "release:submit": "node scripts/release.mjs submit",
     "release:status": "node scripts/store-status.mjs",
+    "release:freshness": "node scripts/store-status.mjs --freshness",
     "prebuild:firefox": "node scripts/validate-env.js --file .env.production --env production && npm run copy-onnx",
     "build:firefox": "wxt build -b firefox",
     "source-archive": "git archive --format=zip -o source-code.zip HEAD",

--- a/scripts/store-status-lib.mjs
+++ b/scripts/store-status-lib.mjs
@@ -16,7 +16,7 @@
  * Credential env-var sets are reused from release-lib.mjs — same names `release:submit` uses.
  */
 import { createHmac, randomUUID } from "node:crypto";
-import { CWS_ENV, EDGE_ENV, AMO_ENV, compareSemver } from "./release-lib.mjs";
+import { CWS_ENV, EDGE_ENV, AMO_ENV, compareSemver, cwsErrorMessage } from "./release-lib.mjs";
 
 export const STATUS_STORES = ["chrome", "edge", "firefox"];
 
@@ -256,4 +256,273 @@ export function amoAuthHeader({ issuer, secret, now = new Date(), jti = randomUU
 export function edgeCrxIdFromListingUrl(url = "") {
   const seg = String(url).split("?")[0].split("/").filter(Boolean).pop() || "";
   return /^[a-p]{32}$/.test(seg) ? seg : null;
+}
+
+// ── Credential freshness (#534) ──────────────────────────────────────────────────────
+//
+// Pure classification for `store-status.mjs --freshness` (npm run release:freshness):
+// per-store credential health from the SAME read-only probes the status check already
+// performs (CWS refresh-token exchange, Edge dummy-UUID probe, AMO JWT-authed GET),
+// plus a computed Edge key-expiry countdown from the founder-recorded EDGE_KEY_ISSUED
+// (the Edge API exposes no way to read a key's expiry date). Lifetime facts + rotation
+// steps live in doc/release/publishing-credentials.md ("Rotation & lifetimes").
+
+/** Edge Publish-API keys expire every 72 days (MS Edge blog, 2025-01-08; was 2 years). */
+export const EDGE_KEY_LIFETIME_DAYS = 72;
+
+/** The credential that actually rotates, per store — what a freshness verdict is about. */
+export const FRESHNESS_CREDENTIAL = {
+  chrome: "CWS_REFRESH_TOKEN",
+  edge: "EDGE_API_KEY",
+  firefox: "WEB_EXT_API_KEY/SECRET",
+};
+
+/**
+ * @typedef {Object} FreshnessRecord
+ * @property {"chrome"|"edge"|"firefox"} store
+ * @property {string} credential        The rotating credential this verdict is about
+ * @property {"OK"|"EXPIRING_SOON"|"EXPIRED"|"SKIPPED"|"ERROR"} status
+ * @property {boolean} skipped          true when credentials were missing (no request made)
+ * @property {string|null} reason       why the credential is not simply OK
+ * @property {string[]} notes
+ * @property {string|null} expiresAt        (Edge only) computed from EDGE_KEY_ISSUED
+ * @property {number|null} daysUntilExpiry  (Edge only) computed from EDGE_KEY_ISSUED
+ * @property {string|null} lastVerifiedAt   from the freshness state file (applyFreshnessHistory)
+ * @property {number|null} daysSinceVerified
+ */
+
+/** @returns {FreshnessRecord} */
+function baseFreshness(store) {
+  return {
+    store,
+    credential: FRESHNESS_CREDENTIAL[store] || store,
+    status: "OK",
+    skipped: false,
+    reason: null,
+    notes: [],
+    expiresAt: null,
+    daysUntilExpiry: null,
+    lastVerifiedAt: null,
+    daysSinceVerified: null,
+  };
+}
+
+/**
+ * Record for a store we did NOT probe because its credentials are missing. Not an error.
+ * @returns {FreshnessRecord}
+ */
+export function freshnessSkipped(store, missing = []) {
+  return {
+    ...baseFreshness(store),
+    skipped: true,
+    status: "SKIPPED",
+    reason: `missing env: ${missing.join(", ")} (see doc/release/publishing-credentials.md)`,
+  };
+}
+
+/**
+ * Record for a probe that failed for a non-credential reason (network, unexpected shape).
+ * @returns {FreshnessRecord}
+ */
+export function freshnessError(store, message) {
+  return { ...baseFreshness(store), status: "ERROR", reason: message };
+}
+
+/**
+ * Classify the Chrome OAuth refresh-token exchange (the POST to CWS_TOKEN_URL).
+ * A success proves the token works TODAY — it cannot distinguish a long-lived
+ * "In production" token from a "Testing" one that dies in 7 days, so an OK carries
+ * that caveat as a note. Never copies token values into the record.
+ * @param {object} json     token-endpoint response body
+ * @param {boolean} httpOk  res.ok
+ * @returns {FreshnessRecord}
+ */
+export function classifyCwsTokenFreshness(json = {}, httpOk = false) {
+  const r = baseFreshness("chrome");
+  if (httpOk && json.access_token) {
+    r.notes.push(
+      "exchange succeeded — does NOT prove the token is long-lived: confirm the OAuth app is " +
+        '"In production" (Google Auth Platform → Audience), else the token expires in 7 days',
+    );
+    return r;
+  }
+  if (json.error === "invalid_grant") {
+    r.status = "EXPIRED";
+    r.reason =
+      "refresh token expired or revoked (invalid_grant) — remint via the OAuth Playground " +
+      '(publishing-credentials.md § "Minting CWS_REFRESH_TOKEN")';
+    return r;
+  }
+  if (json.error === "unauthorized_client") {
+    r.status = "EXPIRED";
+    r.reason =
+      "token/client mismatch (unauthorized_client) — id, secret, and refresh token must all come " +
+      "from the same OAuth client; remint the token with the current client";
+    return r;
+  }
+  r.status = "ERROR";
+  r.reason = `token exchange failed: ${cwsErrorMessage(json)}`;
+  return r;
+}
+
+/**
+ * Classify the Edge dummy-UUID probe (GET on a poll URL — the same probe `release:status`
+ * and `release:submit --dry-run` use). 401/403 = key rejected; any other response (404 for
+ * the dummy operation id is normal) means the key was accepted.
+ * @param {number} httpStatus
+ * @returns {FreshnessRecord}
+ */
+export function classifyEdgeProbeFreshness(httpStatus) {
+  const r = baseFreshness("edge");
+  if (httpStatus === 401 || httpStatus === 403) {
+    r.status = "EXPIRED";
+    r.reason = `key rejected (HTTP ${httpStatus}) — EDGE_API_KEY expires every ~${EDGE_KEY_LIFETIME_DAYS} days; create a new key in Partner Center → Edge → Publish API (then update EDGE_KEY_ISSUED)`;
+    return r;
+  }
+  if (httpStatus >= 500) {
+    r.status = "ERROR";
+    r.reason = `probe failed server-side (HTTP ${httpStatus}) — no credential verdict`;
+    return r;
+  }
+  r.notes.push(`probe accepted (HTTP ${httpStatus})`);
+  return r;
+}
+
+/**
+ * Classify an AMO request that REQUIRES developer auth (the versions list with
+ * filter=all_with_unlisted). 2xx proves the JWT issuer/secret work; 401/403 = rejected.
+ * @param {number} httpStatus
+ * @returns {FreshnessRecord}
+ */
+export function classifyAmoProbeFreshness(httpStatus) {
+  const r = baseFreshness("firefox");
+  if (httpStatus >= 200 && httpStatus < 300) return r;
+  if (httpStatus === 401 || httpStatus === 403) {
+    r.status = "EXPIRED";
+    r.reason = `JWT credentials rejected (HTTP ${httpStatus}) — regenerate at https://addons.mozilla.org/developers/addon/api/key/`;
+    return r;
+  }
+  r.status = "ERROR";
+  r.reason = `authenticated probe failed (HTTP ${httpStatus}) — no credential verdict`;
+  return r;
+}
+
+/**
+ * Compute the Edge key expiry countdown from the founder-recorded issue date
+ * (EDGE_KEY_ISSUED in .env.publish) — the API can't report it. Null when absent/invalid.
+ * @param {{issued?: string, now?: Date, lifetimeDays?: number}} args
+ * @returns {{issuedAt: string, expiresAt: string, daysUntilExpiry: number, expired: boolean}|null}
+ */
+export function edgeKeyCountdown({ issued, now = new Date(), lifetimeDays = EDGE_KEY_LIFETIME_DAYS } = {}) {
+  const issuedMs = Date.parse(issued ?? "");
+  if (!Number.isFinite(issuedMs)) return null;
+  const expiresMs = issuedMs + lifetimeDays * DAY_MS;
+  return {
+    issuedAt: new Date(issuedMs).toISOString(),
+    expiresAt: new Date(expiresMs).toISOString(),
+    daysUntilExpiry: Math.floor((expiresMs - now.getTime()) / DAY_MS),
+    expired: now.getTime() >= expiresMs,
+  };
+}
+
+/**
+ * Merge the Edge countdown into a probe record. An expired countdown escalates to
+ * EXPIRED even when the probe passed (the probe can lag the actual cutoff); a countdown
+ * inside the warn window escalates OK → EXPIRING_SOON. A probe-EXPIRED verdict is never
+ * downgraded. Without a countdown the record stays probe-result-only, with a note.
+ * @param {FreshnessRecord} record
+ * @param {ReturnType<typeof edgeKeyCountdown>} countdown
+ * @param {{warnDays?: number}} [opts]
+ * @returns {FreshnessRecord}
+ */
+export function applyEdgeCountdown(record, countdown, { warnDays = 14 } = {}) {
+  const out = { ...record, notes: [...record.notes] };
+  if (!countdown) {
+    out.notes.push("EDGE_KEY_ISSUED not set — expiry countdown unavailable (probe result only)");
+    return out;
+  }
+  out.expiresAt = countdown.expiresAt;
+  out.daysUntilExpiry = countdown.daysUntilExpiry;
+  if (out.status !== "OK") return out;
+  if (countdown.expired) {
+    out.status = "EXPIRED";
+    out.reason = `key issued ${countdown.issuedAt.slice(0, 10)} is past its ${EDGE_KEY_LIFETIME_DAYS}-day lifetime — rotate in Partner Center (then update EDGE_KEY_ISSUED)`;
+  } else if (countdown.daysUntilExpiry <= warnDays) {
+    out.status = "EXPIRING_SOON";
+    out.reason = `key expires in ${countdown.daysUntilExpiry} day(s) (${countdown.expiresAt.slice(0, 10)}) — rotate in Partner Center soon`;
+  }
+  return out;
+}
+
+/** A record whose probe actually verified the credential works today. */
+function isVerified(record) {
+  return record.status === "OK" || record.status === "EXPIRING_SOON";
+}
+
+/**
+ * Annotate records with last-verified history from the freshness state file
+ * ({store: {lastVerifiedAt}}). A store verified THIS run reads as verified now;
+ * anything else carries the previous timestamp (or null — never invented).
+ * @param {FreshnessRecord[]} records
+ * @param {Record<string, {lastVerifiedAt?: string}>} [state]
+ * @param {Date} [now]
+ * @returns {FreshnessRecord[]}
+ */
+export function applyFreshnessHistory(records, state = {}, now = new Date()) {
+  return records.map((r) => {
+    const prev = state[r.store]?.lastVerifiedAt ?? null;
+    const at = isVerified(r) ? now.toISOString() : prev;
+    return {
+      ...r,
+      lastVerifiedAt: at,
+      daysSinceVerified: at ? Math.floor((now.getTime() - Date.parse(at)) / DAY_MS) : null,
+    };
+  });
+}
+
+/**
+ * Next contents for the freshness state file: verified-this-run stores stamped `now`,
+ * everything else keeps its previous entry.
+ * @param {Record<string, {lastVerifiedAt?: string}>} state
+ * @param {FreshnessRecord[]} records
+ * @param {Date} [now]
+ */
+export function nextFreshnessState(state = {}, records = [], now = new Date()) {
+  const next = { ...state };
+  for (const r of records) {
+    if (isVerified(r)) next[r.store] = { lastVerifiedAt: now.toISOString() };
+  }
+  return next;
+}
+
+/** Compact fixed-width freshness table: store, credential, status, verified age, expiry. */
+export function renderFreshnessTable(records = []) {
+  const headers = ["store", "credential", "status", "last verified", "expires"];
+  const rows = records.map((r) => [
+    r.store,
+    r.credential,
+    r.status,
+    r.lastVerifiedAt
+      ? `${r.lastVerifiedAt.slice(0, 10)}${r.daysSinceVerified ? ` (${r.daysSinceVerified}d ago)` : " (today)"}`
+      : "never",
+    r.expiresAt
+      ? `${r.expiresAt.slice(0, 10)}${r.daysUntilExpiry != null ? ` (${r.daysUntilExpiry}d)` : ""}`
+      : "—",
+  ]);
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((row) => row[i].length)));
+  const line = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join("  ");
+  const out = [line(headers), line(widths.map((w) => "─".repeat(w))), ...rows.map(line)];
+
+  const details = records
+    .flatMap((r) => [
+      ...(r.reason ? [`${r.store}: ${r.reason}`] : []),
+      ...(r.notes || []).map((n) => `${r.store}: ${n}`),
+    ])
+    .map((d) => `  · ${d}`);
+  return [...out, ...(details.length ? ["", ...details] : [])].join("\n");
+}
+
+/** 1 when any credential is EXPIRED or a probe ERRORed; SKIPPED/EXPIRING_SOON stay 0. */
+export function freshnessExitCode(records = []) {
+  return records.some((r) => r.status === "EXPIRED" || r.status === "ERROR") ? 1 : 0;
 }

--- a/scripts/store-status.mjs
+++ b/scripts/store-status.mjs
@@ -3,6 +3,15 @@
  * store-status — READ-ONLY store-review status check for all three web stores (#529).
  *
  *   node scripts/store-status.mjs [--json] [--stall-days N]     (npm run release:status)
+ *   node scripts/store-status.mjs --freshness [--json]          (npm run release:freshness, #534)
+ *
+ * `--freshness` reuses the same per-store credential probes but reports CREDENTIAL
+ * health instead of review state: does each publishing credential still work, when was
+ * it last verified (state kept in the gitignored .credential-freshness.json), and — for
+ * Edge, whose ~72-day API-key expiry the API can't report — a countdown computed from
+ * the founder-recorded EDGE_KEY_ISSUED. Rotation runbook: doc/release/publishing-
+ * credentials.md ("Rotation & lifetimes"). Exit 1 only on EXPIRED/ERROR; SKIPPED and
+ * EXPIRING_SOON exit 0 (the #525 weekly routine consumes --json and pings the founder).
  *
  * For each store in doc/release/stores.json it hits read-only status endpoints with the
  * SAME credentials `release:submit` uses (env vars / .env.publish — see
@@ -18,7 +27,7 @@
  * It reads only process.env / .env.publish (never .env.production) and logs only the
  * NAMES of env vars, never values.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve as resolvePath } from "node:path";
@@ -50,6 +59,17 @@ import {
   amoAuthHeader,
   edgeCrxIdFromListingUrl,
   isFinalSemver,
+  freshnessSkipped,
+  freshnessError,
+  classifyCwsTokenFreshness,
+  classifyEdgeProbeFreshness,
+  classifyAmoProbeFreshness,
+  edgeKeyCountdown,
+  applyEdgeCountdown,
+  applyFreshnessHistory,
+  nextFreshnessState,
+  renderFreshnessTable,
+  freshnessExitCode,
 } from "./store-status-lib.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -165,11 +185,106 @@ async function checkFirefox(env, stores) {
 
 const CHECKS = { chrome: checkChrome, edge: checkEdge, firefox: checkFirefox };
 
+// ── Per-store credential-freshness probes (#534 — all read-only) ─────────────────────
+
+async function probeChromeFreshness(env) {
+  const e = requireEnv(CWS_ENV, env);
+  const { res, json } = await getJson(CWS_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: cwsTokenBody({ clientId: e.CWS_CLIENT_ID, clientSecret: e.CWS_CLIENT_SECRET, refreshToken: e.CWS_REFRESH_TOKEN }),
+  });
+  return classifyCwsTokenFreshness(json, res.ok);
+}
+
+async function probeEdgeFreshness(env) {
+  const e = requireEnv(EDGE_ENV, env);
+  const probe = await fetch(edgeUploadPollUrl(e.EDGE_PRODUCT_ID, "00000000-0000-0000-0000-000000000000"), {
+    headers: edgeHeaders({ apiKey: e.EDGE_API_KEY, clientId: e.EDGE_CLIENT_ID }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  // EDGE_KEY_ISSUED (optional, .env.publish): the day the key was created in Partner
+  // Center — the API cannot report a key's expiry date, so the countdown is manual.
+  return applyEdgeCountdown(classifyEdgeProbeFreshness(probe.status), edgeKeyCountdown({ issued: env.EDGE_KEY_ISSUED }));
+}
+
+async function probeFirefoxFreshness(env, stores) {
+  const e = requireEnv(AMO_ENV, env);
+  const guid = stores?.stores?.firefox?.id || "gecko@saypi.ai";
+  // The unlisted-inclusive versions list REQUIRES developer auth, so it's a true
+  // credential probe (the public addon detail would succeed with a missing header).
+  const url = `https://addons.mozilla.org/api/v5/addons/addon/${encodeURIComponent(guid)}/versions/?filter=all_with_unlisted&page_size=1`;
+  const res = await fetch(url, {
+    headers: { Authorization: amoAuthHeader({ issuer: e.WEB_EXT_API_KEY, secret: e.WEB_EXT_API_SECRET }) },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  return classifyAmoProbeFreshness(res.status);
+}
+
+const FRESHNESS_PROBES = { chrome: probeChromeFreshness, edge: probeEdgeFreshness, firefox: probeFirefoxFreshness };
+
+// Last-verified history — timestamps only, no secrets; gitignored local state.
+const FRESHNESS_STATE_PATH = join(repoRoot, ".credential-freshness.json");
+
+function loadFreshnessState() {
+  try {
+    return existsSync(FRESHNESS_STATE_PATH) ? JSON.parse(readFileSync(FRESHNESS_STATE_PATH, "utf8")) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function runFreshness(asJson) {
+  const now = new Date();
+  const stores = existsSync(STORES_PATH) ? JSON.parse(readFileSync(STORES_PATH, "utf8")) : null;
+
+  const records = [];
+  for (const store of STATUS_STORES) {
+    const missing = missingCreds(store, process.env);
+    if (missing.length) {
+      info(`${store}: SKIPPED (missing env: ${missing.join(", ")})`);
+      records.push(freshnessSkipped(store, missing));
+      continue;
+    }
+    try {
+      info(`${store}: probing credentials…`);
+      records.push(await FRESHNESS_PROBES[store](process.env, stores));
+    } catch (e) {
+      records.push(freshnessError(store, e?.message || String(e)));
+    }
+  }
+
+  const state = loadFreshnessState();
+  const annotated = applyFreshnessHistory(records, state, now);
+  writeFileSync(FRESHNESS_STATE_PATH, JSON.stringify(nextFreshnessState(state, records, now), null, 2) + "\n");
+
+  if (asJson) {
+    console.log(JSON.stringify({ generatedAt: now.toISOString(), mode: "freshness", stores: annotated }, null, 2));
+  } else {
+    console.log("");
+    console.log(renderFreshnessTable(annotated));
+  }
+
+  const attention = annotated.filter((r) => r.status === "EXPIRED" || r.status === "EXPIRING_SOON");
+  if (attention.length) {
+    info(
+      `\n⚠ ${attention.length} credential(s) need rotation — founder action; see ` +
+        `doc/release/publishing-credentials.md ("Rotation & lifetimes").`,
+    );
+  }
+  process.exit(freshnessExitCode(annotated));
+}
+
 // ── Entry ───────────────────────────────────────────────────────────────────────────
 
 async function main() {
   const argv = process.argv.slice(2);
   const asJson = argv.includes("--json");
+  if (argv.includes("--freshness")) {
+    loadPublishEnv();
+    await runFreshness(asJson);
+    return;
+  }
   const stallDaysArg = argv[argv.indexOf("--stall-days") + 1];
   const stallDays = argv.includes("--stall-days") ? Number(stallDaysArg) : 14;
   if (!Number.isFinite(stallDays) || stallDays <= 0) {

--- a/test/scripts/credential-freshness.spec.ts
+++ b/test/scripts/credential-freshness.spec.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from "vitest";
+import {
+  EDGE_KEY_LIFETIME_DAYS,
+  FRESHNESS_CREDENTIAL,
+  freshnessSkipped,
+  freshnessError,
+  classifyCwsTokenFreshness,
+  classifyEdgeProbeFreshness,
+  classifyAmoProbeFreshness,
+  edgeKeyCountdown,
+  applyEdgeCountdown,
+  applyFreshnessHistory,
+  nextFreshnessState,
+  renderFreshnessTable,
+  freshnessExitCode,
+} from "../../scripts/store-status-lib.mjs";
+
+const NOW = new Date("2026-07-07T12:00:00Z");
+const DAY = 24 * 60 * 60 * 1000;
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * DAY).toISOString();
+
+// ── Per-store credential naming (what the check is actually about) ─────────────────
+
+describe("FRESHNESS_CREDENTIAL", () => {
+  it("names the rotating credential per store", () => {
+    expect(FRESHNESS_CREDENTIAL.chrome).toBe("CWS_REFRESH_TOKEN");
+    expect(FRESHNESS_CREDENTIAL.edge).toBe("EDGE_API_KEY");
+    expect(FRESHNESS_CREDENTIAL.firefox).toBe("WEB_EXT_API_KEY/SECRET");
+  });
+});
+
+// ── Skipped / error records ─────────────────────────────────────────────────────────
+
+describe("freshnessSkipped / freshnessError", () => {
+  it("skipped: SKIPPED status, names missing vars (never values), exit-code neutral", () => {
+    const r = freshnessSkipped("edge", ["EDGE_API_KEY", "EDGE_CLIENT_ID"]);
+    expect(r.store).toBe("edge");
+    expect(r.skipped).toBe(true);
+    expect(r.status).toBe("SKIPPED");
+    expect(r.reason).toMatch(/EDGE_API_KEY/);
+    expect(r.reason).toMatch(/EDGE_CLIENT_ID/);
+  });
+
+  it("error: ERROR status with the message as reason", () => {
+    const r = freshnessError("chrome", "network timeout");
+    expect(r.status).toBe("ERROR");
+    expect(r.reason).toBe("network timeout");
+  });
+});
+
+// ── Chrome: OAuth refresh-token exchange classification ─────────────────────────────
+
+describe("classifyCwsTokenFreshness", () => {
+  it("a successful exchange is OK — but notes that it does not prove long-lived (Testing vs In production)", () => {
+    const r = classifyCwsTokenFreshness({ access_token: "ya29.SECRET-VALUE", expires_in: 3599 }, true);
+    expect(r.store).toBe("chrome");
+    expect(r.status).toBe("OK");
+    expect(r.notes.join(" ")).toMatch(/in production/i);
+    // The access token value must never leak into the record.
+    expect(JSON.stringify(r)).not.toContain("ya29.SECRET-VALUE");
+  });
+
+  it("invalid_grant means the refresh token is expired/revoked — EXPIRED with the remint pointer", () => {
+    const r = classifyCwsTokenFreshness(
+      { error: "invalid_grant", error_description: "Token has been expired or revoked." },
+      false,
+    );
+    expect(r.status).toBe("EXPIRED");
+    expect(r.reason).toMatch(/invalid_grant/);
+    expect(r.reason).toMatch(/remint|OAuth Playground/i);
+  });
+
+  it("unauthorized_client means client/token mismatch — EXPIRED with the same-client rule", () => {
+    const r = classifyCwsTokenFreshness({ error: "unauthorized_client" }, false);
+    expect(r.status).toBe("EXPIRED");
+    expect(r.reason).toMatch(/same OAuth client/i);
+  });
+
+  it("any other failure is ERROR (carries the description)", () => {
+    const r = classifyCwsTokenFreshness({ error: "internal_failure", error_description: "boom" }, false);
+    expect(r.status).toBe("ERROR");
+    expect(r.reason).toMatch(/boom/);
+  });
+});
+
+// ── Edge: dummy-UUID probe classification ────────────────────────────────────────────
+
+describe("classifyEdgeProbeFreshness", () => {
+  it("a non-401 probe response means the key was accepted (404 for the dummy id is normal)", () => {
+    const r = classifyEdgeProbeFreshness(404);
+    expect(r.store).toBe("edge");
+    expect(r.status).toBe("OK");
+  });
+
+  it("401 means the ~72-day key has expired — EXPIRED pointing at Partner Center", () => {
+    const r = classifyEdgeProbeFreshness(401);
+    expect(r.status).toBe("EXPIRED");
+    expect(r.reason).toMatch(/72/);
+    expect(r.reason).toMatch(/Partner Center/i);
+  });
+
+  it("5xx is an ERROR, not a credential verdict", () => {
+    expect(classifyEdgeProbeFreshness(503).status).toBe("ERROR");
+  });
+});
+
+// ── Firefox: authenticated AMO request classification ───────────────────────────────
+
+describe("classifyAmoProbeFreshness", () => {
+  it("2xx on the auth-required endpoint verifies the JWT credentials", () => {
+    const r = classifyAmoProbeFreshness(200);
+    expect(r.store).toBe("firefox");
+    expect(r.status).toBe("OK");
+  });
+
+  it("401/403 means the JWT credentials were rejected — EXPIRED with the regenerate pointer", () => {
+    for (const code of [401, 403]) {
+      const r = classifyAmoProbeFreshness(code);
+      expect(r.status).toBe("EXPIRED");
+      expect(r.reason).toMatch(/addons\.mozilla\.org/);
+    }
+  });
+
+  it("5xx is an ERROR, not a credential verdict", () => {
+    expect(classifyAmoProbeFreshness(500).status).toBe("ERROR");
+  });
+});
+
+// ── Edge key expiry countdown from EDGE_KEY_ISSUED (manual issued date) ──────────────
+
+describe("edgeKeyCountdown", () => {
+  it("computes expiresAt = issued + 72 days and the remaining days", () => {
+    const c = edgeKeyCountdown({ issued: daysAgo(10), now: NOW })!;
+    expect(c.expired).toBe(false);
+    expect(c.daysUntilExpiry).toBe(EDGE_KEY_LIFETIME_DAYS - 10);
+    expect(c.expiresAt).toBe(new Date(Date.parse(daysAgo(10)) + EDGE_KEY_LIFETIME_DAYS * DAY).toISOString());
+  });
+
+  it("a key older than the lifetime is expired (negative countdown)", () => {
+    const c = edgeKeyCountdown({ issued: daysAgo(80), now: NOW })!;
+    expect(c.expired).toBe(true);
+    expect(c.daysUntilExpiry).toBeLessThan(0);
+  });
+
+  it("exactly at the lifetime boundary counts as expired", () => {
+    const c = edgeKeyCountdown({ issued: daysAgo(EDGE_KEY_LIFETIME_DAYS), now: NOW })!;
+    expect(c.expired).toBe(true);
+    expect(c.daysUntilExpiry).toBe(0);
+  });
+
+  it("returns null for an absent or unparseable issued date", () => {
+    expect(edgeKeyCountdown({ issued: undefined, now: NOW })).toBeNull();
+    expect(edgeKeyCountdown({ issued: "not-a-date", now: NOW })).toBeNull();
+  });
+});
+
+describe("applyEdgeCountdown", () => {
+  const okEdge = () => classifyEdgeProbeFreshness(404);
+
+  it("merges the countdown into an OK record", () => {
+    const r = applyEdgeCountdown(okEdge(), edgeKeyCountdown({ issued: daysAgo(10), now: NOW }));
+    expect(r.status).toBe("OK");
+    expect(r.daysUntilExpiry).toBe(62);
+    expect(r.expiresAt).toBeTruthy();
+  });
+
+  it("flags EXPIRING_SOON inside the warn window", () => {
+    const r = applyEdgeCountdown(okEdge(), edgeKeyCountdown({ issued: daysAgo(60), now: NOW }), { warnDays: 14 });
+    expect(r.status).toBe("EXPIRING_SOON");
+    expect(r.reason).toMatch(/12 day/);
+  });
+
+  it("an expired countdown wins even when the probe still passed", () => {
+    const r = applyEdgeCountdown(okEdge(), edgeKeyCountdown({ issued: daysAgo(80), now: NOW }));
+    expect(r.status).toBe("EXPIRED");
+  });
+
+  it("no countdown (EDGE_KEY_ISSUED unset) → probe-result-only, with a note saying so", () => {
+    const r = applyEdgeCountdown(okEdge(), null);
+    expect(r.status).toBe("OK");
+    expect(r.notes.join(" ")).toMatch(/EDGE_KEY_ISSUED/);
+  });
+
+  it("never downgrades an EXPIRED probe verdict", () => {
+    const r = applyEdgeCountdown(classifyEdgeProbeFreshness(401), edgeKeyCountdown({ issued: daysAgo(10), now: NOW }));
+    expect(r.status).toBe("EXPIRED");
+  });
+});
+
+// ── last-verified history (state file round-trip, injected clock) ───────────────────
+
+describe("applyFreshnessHistory / nextFreshnessState", () => {
+  it("a record verified OK now reads 0 days since verified", () => {
+    const [r] = applyFreshnessHistory([classifyAmoProbeFreshness(200)], {}, NOW);
+    expect(r.lastVerifiedAt).toBe(NOW.toISOString());
+    expect(r.daysSinceVerified).toBe(0);
+  });
+
+  it("a skipped record carries the previous verification age from state", () => {
+    const state = { edge: { lastVerifiedAt: daysAgo(5) } };
+    const [r] = applyFreshnessHistory([freshnessSkipped("edge", ["EDGE_API_KEY"])], state, NOW);
+    expect(r.lastVerifiedAt).toBe(daysAgo(5));
+    expect(r.daysSinceVerified).toBe(5);
+  });
+
+  it("no history at all → null (never invents a verification)", () => {
+    const [r] = applyFreshnessHistory([freshnessSkipped("chrome", ["CWS_CLIENT_ID"])], {}, NOW);
+    expect(r.lastVerifiedAt).toBeNull();
+    expect(r.daysSinceVerified).toBeNull();
+  });
+
+  it("nextFreshnessState records now for verified stores and keeps prior entries for the rest", () => {
+    const state = { chrome: { lastVerifiedAt: daysAgo(9) } };
+    const records = [
+      freshnessSkipped("chrome", ["CWS_CLIENT_ID"]), // not verified this run
+      classifyEdgeProbeFreshness(404), // verified
+      classifyAmoProbeFreshness(401), // rejected — must NOT count as verified
+    ];
+    const next = nextFreshnessState(state, records, NOW);
+    expect(next.chrome).toEqual({ lastVerifiedAt: daysAgo(9) });
+    expect(next.edge).toEqual({ lastVerifiedAt: NOW.toISOString() });
+    expect(next.firefox).toBeUndefined();
+  });
+
+  it("EXPIRING_SOON still counts as a successful verification (the credential works today)", () => {
+    const soon = applyEdgeCountdown(classifyEdgeProbeFreshness(404), edgeKeyCountdown({ issued: daysAgo(60), now: NOW }));
+    const next = nextFreshnessState({}, [soon], NOW);
+    expect(next.edge).toEqual({ lastVerifiedAt: NOW.toISOString() });
+  });
+});
+
+// ── Rendering + exit code ────────────────────────────────────────────────────────────
+
+describe("renderFreshnessTable", () => {
+  it("renders one row per store with credential, status, verified age, and expiry", () => {
+    const records = applyFreshnessHistory(
+      [
+        classifyCwsTokenFreshness({ access_token: "t" }, true),
+        applyEdgeCountdown(classifyEdgeProbeFreshness(404), edgeKeyCountdown({ issued: daysAgo(60), now: NOW })),
+        freshnessSkipped("firefox", ["WEB_EXT_API_KEY", "WEB_EXT_API_SECRET"]),
+      ],
+      {},
+      NOW,
+    );
+    const table = renderFreshnessTable(records);
+    expect(table).toMatch(/chrome/);
+    expect(table).toMatch(/CWS_REFRESH_TOKEN/);
+    expect(table).toMatch(/EDGE_API_KEY/);
+    expect(table).toMatch(/EXPIRING_SOON/);
+    expect(table).toMatch(/SKIPPED/);
+    expect(table).toMatch(/2026-07-19/); // edge expiresAt: issued 2026-05-08 + 72-day lifetime
+  });
+});
+
+describe("freshnessExitCode", () => {
+  it("0 when everything is OK, SKIPPED, or merely EXPIRING_SOON", () => {
+    const records = [
+      classifyAmoProbeFreshness(200),
+      freshnessSkipped("chrome", ["CWS_CLIENT_ID"]),
+      applyEdgeCountdown(classifyEdgeProbeFreshness(404), edgeKeyCountdown({ issued: daysAgo(60), now: NOW })),
+    ];
+    expect(freshnessExitCode(records)).toBe(0);
+  });
+
+  it("1 when any credential is EXPIRED or a check ERRORed", () => {
+    expect(freshnessExitCode([classifyEdgeProbeFreshness(401)])).toBe(1);
+    expect(freshnessExitCode([freshnessError("chrome", "boom")])).toBe(1);
+  });
+});

--- a/test/scripts/credential-freshness.spec.ts
+++ b/test/scripts/credential-freshness.spec.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   EDGE_KEY_LIFETIME_DAYS,
   FRESHNESS_CREDENTIAL,
@@ -265,5 +267,12 @@ describe("freshnessExitCode", () => {
   it("1 when any credential is EXPIRED or a check ERRORed", () => {
     expect(freshnessExitCode([classifyEdgeProbeFreshness(401)])).toBe(1);
     expect(freshnessExitCode([freshnessError("chrome", "boom")])).toBe(1);
+  });
+});
+
+describe("freshness state file hygiene", () => {
+  it(".credential-freshness.json is gitignored (timestamps-only state must never be committed)", () => {
+    const gitignore = readFileSync(resolve(__dirname, "../../.gitignore"), "utf8");
+    expect(gitignore.split("\n")).toContain(".credential-freshness.json");
   });
 });


### PR DESCRIPTION
Addresses #534 — credential-rotation ownership + freshness monitoring for the store publishing tokens. (The third acceptance criterion — the *scheduled* weekly run that pings the founder — lands with #525; this PR provides the machine-readable check it will consume and documents that wiring in the runbook.)

## What's here

**1. Rotation runbook** — `doc/release/publishing-credentials.md` gains a **"Rotation & lifetimes"** section (on top of the just-merged #540 state), with per-store: credential type, verified lifetime, exact rotation steps (dashboard URLs), the failure signature when expired, and explicit ownership (**founder rotates, the freshness check reminds**).

Verified lifetime facts (sources checked 2026-07-07):
- **Chrome `CWS_REFRESH_TOKEN`**: lifetime hinges on the OAuth app's publishing status — **"Testing" → expires in 7 days**, **"In production" → no scheduled expiry** ([Google OAuth 2.0 docs § refresh-token expiration](https://developers.google.com/identity/protocols/oauth2#expiration)). The runbook's existing setup directs the client to be published to production, so the intended steady state is long-lived; the section tells the founder to confirm the status field (a working exchange can't prove it) and lists the residual killers: 6-month non-use (the weekly run keeps it warm), revocation, and the 100-tokens-per-client cap.
- **Edge `EDGE_API_KEY`**: **72 days, fixed**, no programmatic renewal ([MS Edge blog, 2025-01-08](https://blogs.windows.com/msedgedev/2025/01/08/enhanced-security-for-extensions-with-publish-api-next-steps/): "The API key is valid for 72 days"); manual regeneration in Partner Center.
- **Firefox `WEB_EXT_API_KEY/SECRET`**: **long-lived** — Mozilla documents no expiry for the JWT issuer/secret ([AMO API auth docs](https://mozilla.github.io/addons-server/topics/api/auth.html)); each *request* signs a ≤5-minute JWT, which is per-call, not a credential lifetime.

**2. Freshness check** — `npm run release:freshness` (= `store-status.mjs --freshness`, `--json` supported). No second prober: it **reuses the existing #529 credential probes** (real CWS refresh-token exchange, Edge dummy-UUID poll probe, JWT-authed AMO request — the AMO probe deliberately hits the auth-*required* versions endpoint, since the public addon detail can mask a bad secret). It reports per-store credential health, **days-since-last-verified** (state in the gitignored `.credential-freshness.json`, timestamps only), and — because the Edge API can't report a key's expiry date — a **countdown from the new optional `EDGE_KEY_ISSUED`** env var (documented in the env-var table; `EXPIRING_SOON` from 14 days out, i.e. before the 401 ever happens). Exit 1 only on `EXPIRED`/`ERROR`; `SKIPPED` and `EXPIRING_SOON` exit 0.

**3. Reminder path** — documented in the runbook: the #525 weekly routine runs `release:freshness -- --json` and pings the founder via the awaiting-founder notification pattern on `EXPIRED`/`EXPIRING_SOON`.

Pure logic (classification, countdown, verified-history, rendering, exit code) lives in `scripts/store-status-lib.mjs`; the CLI adds only the three probe calls + state-file I/O.

## Verification

- **Fail-first TDD**: `test/scripts/credential-freshness.spec.ts` written first — 30/30 failed (exports absent), then implementation → **30/30 pass**; existing `store-status-lib.spec.ts` (29) untouched and green.
- **Full suite green** in the worktree: typecheck + Jest + Vitest (215 files, 1962 passed / 1 skipped).
- **No-creds dry run** (this environment holds no publishing credentials — the live credentialed run is the founder's):

```
store    credential              status   last verified  expires
───────  ──────────────────────  ───────  ─────────────  ───────
chrome   CWS_REFRESH_TOKEN       SKIPPED  never          —
edge     EDGE_API_KEY            SKIPPED  never          —
firefox  WEB_EXT_API_KEY/SECRET  SKIPPED  never          —

  · chrome: missing env: CWS_CLIENT_ID, CWS_CLIENT_SECRET, CWS_REFRESH_TOKEN, CWS_PUBLISHER_ID, CWS_EXTENSION_ID (see doc/release/publishing-credentials.md)
  · edge: missing env: EDGE_PRODUCT_ID, EDGE_API_KEY, EDGE_CLIENT_ID (see doc/release/publishing-credentials.md)
  · firefox: missing env: WEB_EXT_API_KEY, WEB_EXT_API_SECRET (see doc/release/publishing-credentials.md)
exit=0
```

`--json` emits `{generatedAt, mode: "freshness", stores: [...]}` for #525.

Safety unchanged: read-only probes only, never touches `.env.production`, logs env var **names** only, state file holds timestamps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMWq5NUKDpZJtsehkGpt8u