### PR TITLE
fix(api): don't hang callApi on 204/304 background responses

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -31,6 +31,14 @@ export async function callApi(
 }
 
 /**
+ * Statuses the Fetch spec defines as carrying no body — constructing a Response with
+ * any body for one of these throws a TypeError.
+ */
+function isNullBodyStatus(status: number): boolean {
+  return status === 204 || status === 205 || status === 304;
+}
+
+/**
  * Routes API request through background service worker to bypass CSP restrictions
  */
 async function callApiViaBackground(
@@ -52,49 +60,59 @@ async function callApiViaBackground(
         ...serializedRequest
       },
       (response) => {
-        if (chrome.runtime.lastError) {
-          reject(new Error(chrome.runtime.lastError.message));
-          return;
-        }
+        // Anything thrown in here escapes the Promise executor, leaving the caller
+        // hung forever rather than failing — so the whole body is guarded (#557).
+        try {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
 
-        if (!response.success) {
-          const error = new Error(response.error || 'Background API request failed');
-          error.name = response.name || 'ApiError';
-          reject(error);
-          return;
-        }
+          if (!response.success) {
+            const error = new Error(response.error || 'Background API request failed');
+            error.name = response.name || 'ApiError';
+            reject(error);
+            return;
+          }
 
-        // Reconstruct Response object from background response
-        const responseData = response.response;
-        const responseHeaders = new Headers(responseData.headers);
+          // Reconstruct Response object from background response
+          const responseData = response.response;
+          const responseHeaders = new Headers(responseData.headers);
 
-        // Respect desired responseType when reconstructing the Response body
-        const desiredType = (options as any)?.responseType as ('json'|'text'|'arrayBuffer'|undefined);
-        let bodyInit: BodyInit | null = null;
-        if (desiredType === 'json') {
-          if (typeof responseData.body === 'string') {
-            bodyInit = responseData.body as string;
+          // Respect desired responseType when reconstructing the Response body
+          const desiredType = (options as any)?.responseType as ('json'|'text'|'arrayBuffer'|undefined);
+          let bodyInit: BodyInit | null = null;
+          if (isNullBodyStatus(responseData.status)) {
+            // 204/205/304 carry no body by definition, and the Response constructor
+            // rejects ANY body for them — including "" and "null" (#557).
+            bodyInit = null;
+          } else if (desiredType === 'json') {
+            if (typeof responseData.body === 'string') {
+              bodyInit = responseData.body as string;
+            } else {
+              bodyInit = JSON.stringify(responseData.body ?? null);
+            }
+            if (!responseHeaders.has('content-type')) {
+              responseHeaders.set('content-type', 'application/json');
+            }
+          } else if (desiredType === 'arrayBuffer') {
+            bodyInit = responseData.body as ArrayBuffer;
           } else {
-            bodyInit = JSON.stringify(responseData.body ?? null);
+            bodyInit = typeof responseData.body === 'string'
+              ? (responseData.body as string)
+              : String(responseData.body ?? '');
           }
-          if (!responseHeaders.has('content-type')) {
-            responseHeaders.set('content-type', 'application/json');
-          }
-        } else if (desiredType === 'arrayBuffer') {
-          bodyInit = responseData.body as ArrayBuffer;
-        } else {
-          bodyInit = typeof responseData.body === 'string'
-            ? (responseData.body as string)
-            : String(responseData.body ?? '');
+
+          const reconstructedResponse = new Response(bodyInit, {
+            status: responseData.status,
+            statusText: responseData.statusText,
+            headers: responseHeaders
+          });
+
+          resolve(reconstructedResponse);
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
         }
-
-        const reconstructedResponse = new Response(bodyInit, {
-          status: responseData.status,
-          statusText: responseData.statusText,
-          headers: responseHeaders
-        });
-
-        resolve(reconstructedResponse);
       }
     );
   });

--- a/test/ApiClient.nullBodyStatus.spec.ts
+++ b/test/ApiClient.nullBodyStatus.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression cover for #557: a background-routed API call that comes back with a
+ * null-body status (204/205/304) used to throw inside the chrome.runtime.sendMessage
+ * response callback — where the throw escapes the Promise executor entirely, so the
+ * promise never settled and the caller hung forever.
+ *
+ * These tests use the REAL global Response (unlike test/BackgroundApiHandler.spec.ts,
+ * which stubs it with a plain object) — the null-body-status rule is enforced by the
+ * real constructor, so a stub cannot reproduce the defect.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const SAYPI_URL = "https://api.saypi.ai/turn-outcome";
+
+/** Fails fast and legibly instead of as an opaque suite timeout when the promise hangs. */
+async function settlesWithin<T>(promise: Promise<T>, ms = 1000): Promise<T> {
+  const hang = Symbol("hang");
+  const result = await Promise.race([
+    promise.then(
+      (value) => ({ ok: true as const, value }),
+      (error) => ({ ok: false as const, error })
+    ),
+    new Promise<typeof hang>((resolve) => setTimeout(() => resolve(hang), ms)),
+  ]);
+  if (result === hang) throw new Error(`promise did not settle within ${ms}ms`);
+  if (!result.ok) throw result.error;
+  return result.value;
+}
+
+describe("callApi() — background-routed null-body statuses (#557)", () => {
+  let sendMessage: ReturnType<typeof vi.fn>;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sendMessage = vi.fn();
+    (globalThis as any).chrome = {
+      runtime: { lastError: null, sendMessage, onMessage: { addListener: vi.fn() } },
+    };
+    // callApi falls back to a direct fetch when the background path rejects; stub it
+    // so a fallback is observable and no test ever reaches the real network.
+    fetchSpy = vi.fn().mockResolvedValue(new Response("fallback", { status: 200 }));
+    (globalThis as any).fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    delete (globalThis as any).chrome;
+    delete (globalThis as any).fetch;
+  });
+
+  /**
+   * Makes the background reply with the given status/body for the next request.
+   * The callback is invoked ASYNCHRONOUSLY, as Chrome does — that is what lets a
+   * throw inside it escape the Promise executor and hang the caller (#557).
+   */
+  const backgroundReplies = (status: number, body: unknown, statusText = "") => {
+    sendMessage.mockImplementation((_msg: unknown, callback: (r: unknown) => void) => {
+      setTimeout(() => callback({ success: true, response: { status, statusText, headers: {}, body } }), 0);
+    });
+  };
+
+  it.each([
+    [204, "No Content"],
+    [205, "Reset Content"],
+    [304, "Not Modified"],
+  ])("resolves a %i response instead of hanging", async (status, statusText) => {
+    backgroundReplies(status, undefined, statusText);
+    const { callApi } = await import("../src/ApiClient");
+
+    const response = await settlesWithin(callApi(SAYPI_URL, { method: "POST" }));
+
+    expect(response.status).toBe(status);
+    expect(await response.text()).toBe("");
+  });
+
+  it("resolves a 204 requested as JSON without inventing a body", async () => {
+    backgroundReplies(204, undefined, "No Content");
+    const { callApi } = await import("../src/ApiClient");
+
+    const response = await settlesWithin(
+      callApi(SAYPI_URL, { method: "POST", responseType: "json" } as any)
+    );
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+  });
+
+  it("still carries the body for a normal 200", async () => {
+    backgroundReplies(200, '{"ok":true}', "OK");
+    const { callApi } = await import("../src/ApiClient");
+
+    const response = await settlesWithin(callApi(SAYPI_URL, { method: "POST" }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
+  it("rejects — never hangs — when the response cannot be reconstructed", async () => {
+    // An out-of-range status is rejected by the Response constructor, standing in for
+    // any unforeseen reconstruction failure inside the sendMessage callback.
+    backgroundReplies(9999, "boom");
+    const { callApi } = await import("../src/ApiClient");
+
+    const response = await settlesWithin(callApi(SAYPI_URL, { method: "POST" }));
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(await response.text()).toBe("fallback");
+  });
+});


### PR DESCRIPTION
## Why

Every conversational turn on a background-routed host (claude.ai, chatgpt.com) was leaking a promise that can never settle, and printing an error into the user's page console while doing it.

`callApiViaBackground()` reconstructs a `Response` from what the service worker sends back. For a null-body status — 204, 205, 304 — the `Response` constructor rejects *any* body, and both existing branches always supply one (`JSON.stringify(undefined ?? null)` → `"null"`, or `String(undefined ?? '')` → `""`). So it threw. The throw happened inside the `chrome.runtime.sendMessage` response callback, which Chrome invokes asynchronously and outside the Promise executor's synchronous scope — so it wasn't caught, the promise neither resolved nor rejected, and the caller waited forever.

`postTurnOutcome()` (`POST /turn-outcome`, the #505 endpointing telemetry) is fire-and-forget, so today the damage is a dead promise per turn plus console noise. But any *awaited* caller that hits a 204/304 — `TextToSpeechService`, `TranscriptionModule`, `feedbackClient` — would hang the feature outright with no error and no timeout. That's the part worth fixing properly.

Found live on chatgpt.com during the Layer-4 CDP `/sweep` on `f52a1cf`:

```
Error handling response: TypeError: Response with null body status cannot have body
    at chrome-extension://<id>/content-scripts/saypi.js
```

## What

- **Null-body statuses pass `null` as the body.** New `isNullBodyStatus()` short-circuits ahead of the `responseType` branches, so 204/205/304 reconstruct correctly regardless of what the caller asked for.
- **The whole callback body is wrapped in try/catch → `reject`.** Converting a hang into a rejection *is* the fix, not extra caution: `callApi()` already falls back to a direct fetch on rejection, so an unforeseen reconstruction failure now degrades instead of silently stalling.

## Verification

Fail-first, per the repo protocol. The new spec (`test/ApiClient.nullBodyStatus.spec.ts`) differs from the existing `BackgroundApiHandler.spec.ts` in two ways that matter:

- it invokes the `sendMessage` callback **asynchronously**, as Chrome does — invoke it synchronously and the Promise constructor swallows the throw, hiding the bug;
- it uses the **real** global `Response` — the existing spec stubs it with a plain object, which can't enforce the null-body rule.

Each call races a 1s timer, so a regression reports "promise did not settle within 1000ms" rather than an opaque suite timeout.

Before the fix (5 of 6 failing, all with the hang signature):

```
× resolves a 204 response instead of hanging → promise did not settle within 1000ms
× resolves a 205 response instead of hanging → promise did not settle within 1000ms
× resolves a 304 response instead of hanging → promise did not settle within 1000ms
× resolves a 204 requested as JSON without inventing a body → promise did not settle within 1000ms
× rejects — never hangs — when the response cannot be reconstructed → promise did not settle within 1000ms
```

After: all 6 pass, `BackgroundApiHandler.spec.ts` still green, and the full suite is clean — **219 files, 2027 passed, 1 skipped**, type-check included.

Fixes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5tDjPqe75yTHjCKavhrFx