### PR TITLE
fix(dictation): show the button when a field is decorated while already focused

### DIFF
--- a/src/UniversalDictationModule.ts
+++ b/src/UniversalDictationModule.ts
@@ -117,25 +117,9 @@ export class UniversalDictationModule {
   }
 
   private decorateExistingElements(): void {
+    // A field that is already focused gets its button shown by decorateInput(),
+    // whichever path decorates it — the initial scan or the observer (#558).
     this.findAndDecorateInputs(document.body);
-    // Check if any input is already focused and show its dictation button
-    this.checkInitialFocusState();
-  }
-
-  private checkInitialFocusState(): void {
-    // Check if there's an already focused element that we just decorated
-    const activeElement = document.activeElement;
-    if (activeElement && activeElement instanceof HTMLElement) {
-      // Find if this active element has been decorated by us
-      for (const target of this.decoratedElements.values()) {
-        if (target.element === activeElement && target.button) {
-          // Show the button for the pre-focused element
-          target.button.style.display = "flex";
-          console.log("Universal Dictation: Showing button for pre-focused element:", activeElement);
-          break;
-        }
-      }
-    }
   }
 
   private findAndDecorateInputs(searchRoot: Element): void {
@@ -190,6 +174,15 @@ export class UniversalDictationModule {
       this.decoratedElements.set(inputElement, target);
       this.positionButton(inputElement, dictationButton);
       this.setupInputEventListeners(target);
+
+      // A field the host focused before we decorated it will never emit another
+      // `focus` event, so the listener just wired up can't reveal the button —
+      // check at decoration time instead (#558). Deliberately not routed through
+      // the listener's showButton(), which would also switch an active dictation
+      // target; decoration is not a user focus gesture.
+      if (document.activeElement === inputElement) {
+        dictationButton.style.display = "flex";
+      }
 
       console.debug("Decorated input element with dictation button:", inputElement);
     } catch (error) {

--- a/test/UniversalDictationModule-PreFocusedDecoration.spec.ts
+++ b/test/UniversalDictationModule-PreFocusedDecoration.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Regression test for issue #558 (residual of #502): a field that is ALREADY the
+ * focused element when it gets decorated never shows its dictation button.
+ *
+ * `checkInitialFocusState()` ran once, at `initialize()`. A field decorated later —
+ * via the MutationObserver, which is exactly how Mistral Le Chat's ProseMirror
+ * composer arrives (#502) — gets no further `focus` event if the host focused it
+ * first, so neither visibility path fires and the button stays `display: none`
+ * until the user clicks away and back.
+ *
+ * These tests drive the *real* module through the real MutationObserver, mirroring
+ * UniversalDictationModule-RootNodeDecoration.spec.ts.
+ */
+
+const makeSvg = () =>
+  document.createElementNS("http://www.w3.org/2000/svg", "svg") as SVGElement;
+
+vi.mock("../src/state-machines/DictationMachine", () => ({
+  createDictationMachine: vi.fn(),
+}));
+
+vi.mock("../src/events/EventBus.js", () => ({
+  default: { emit: vi.fn(), on: vi.fn() },
+}));
+
+vi.mock("../src/icons/IconModule", () => ({
+  IconModule: {
+    bubbleBw: { cloneNode: vi.fn(() => makeSvg()) },
+    bubble: vi.fn(() => makeSvg()),
+  },
+}));
+
+vi.mock("../src/i18n", () => ({
+  default: vi.fn((key: string) => `mocked-${key}`),
+}));
+
+import { UniversalDictationModule } from "../src/UniversalDictationModule";
+
+class NoopObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const flushMutations = () => new Promise((resolve) => setTimeout(resolve, 0));
+const buttonDisplay = () =>
+  (document.querySelector(".saypi-dictation-button") as HTMLElement | null)?.style.display;
+
+describe("UniversalDictationModule — decoration of an already-focused field (issue #558)", () => {
+  let module: UniversalDictationModule;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+
+    (global as any).ResizeObserver = NoopObserver;
+    (global as any).IntersectionObserver = NoopObserver;
+    (document as any).elementsFromPoint = () => [];
+
+    (UniversalDictationModule as any).instance = undefined;
+    module = UniversalDictationModule.getInstance();
+  });
+
+  afterEach(() => {
+    module.destroy();
+    (UniversalDictationModule as any).instance = undefined;
+    document.body.innerHTML = "";
+  });
+
+  it("shows the button when a focused element BECOMES contenteditable after init (Mistral's mechanism)", async () => {
+    const composer = document.createElement("div");
+    composer.className = "ProseMirror";
+    composer.tabIndex = 0; // jsdom needs an explicit focusable hook; contenteditable alone isn't one
+    document.body.appendChild(composer);
+    module.initialize();
+
+    // ProseMirror turns the node into an editor and focuses it, in that order — the
+    // focus event fires before we have a button to show, and never fires again.
+    composer.setAttribute("contenteditable", "true");
+    composer.focus();
+    expect(document.activeElement).toBe(composer);
+
+    await flushMutations();
+
+    expect(document.querySelectorAll(".saypi-dictation-button").length).toBe(1);
+    expect(buttonDisplay()).toBe("flex");
+  });
+
+  it("shows the button when an already-focused field is decorated on insertion", async () => {
+    module.initialize();
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+
+    await flushMutations();
+
+    expect(buttonDisplay()).toBe("flex");
+  });
+
+  it("still covers the pre-existing focused field found by the initial scan", async () => {
+    const input = document.createElement("input");
+    input.type = "text";
+    document.body.appendChild(input);
+    input.focus();
+
+    module.initialize();
+    await flushMutations();
+
+    expect(buttonDisplay()).toBe("flex");
+  });
+
+  it("leaves the button hidden for a field that is not focused", async () => {
+    module.initialize();
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+
+    await flushMutations();
+
+    expect(document.querySelectorAll(".saypi-dictation-button").length).toBe(1);
+    expect(buttonDisplay()).toBe("none");
+  });
+});


### PR DESCRIPTION
## Why

Universal dictation has two independent races between SayPi and the host page: *when the field gets decorated*, and *when the field gets focused*. #502 fixed the first one (decoration now catches root nodes and `contenteditable` attribute mutations). This is the second one, and it produces the same user-visible symptom — no dictation button on Mistral Le Chat's composer — which is why it survived #502's fix.

`checkInitialFocusState()` ran exactly once, at `initialize()`. It could only ever catch a field that was both focused *and* already decorated at that instant. A field decorated later, by the MutationObserver, that the host had *already* focused gets no further `focus` event — so the listener wired up during decoration never fires, and the button stays `display: none` until the user clicks away and back.

The `/sweep` run on `f52a1cf` caught it intermittently: 1 of 2 `e2e-dictation-sweep mistral` runs reported `button=false transcriptLanded=false`. The only difference between the two console captures is one line — the failing run logs `Decorated input element with dictation button` **without** the matching `Universal Dictation: Showing button for pre-focused element`.

## What

- Move the already-focused check into `decorateInput()`, so it covers every decoration path: the initial scan, childList insertion, and the `contenteditable` attribute mutation.
- Set `display` directly rather than calling the focus listener's `showButton()` — that helper also calls `switchDictationTarget()`, and decoration is not a user focus gesture.
- Delete `checkInitialFocusState()`: the per-decoration check strictly subsumes it (the initial scan decorates through the same function), so leaving it would be vestigial.

## Verification

Fail-first. `test/UniversalDictationModule-PreFocusedDecoration.spec.ts` drives the real module through the real MutationObserver, mirroring the #502 spec next to it. Before the fix, exactly the two late-decoration cases fail and the two control cases pass:

```
× shows the button when a focused element BECOMES contenteditable after init → expected 'none' to be 'flex'
× shows the button when an already-focused field is decorated on insertion    → expected 'none' to be 'flex'
✓ still covers the pre-existing focused field found by the initial scan
✓ leaves the button hidden for a field that is not focused
```

That last control matters: it pins the behaviour that an *unfocused* field's button stays hidden, so the fix can't degrade into "always visible".

After: all 4 pass, the three existing `UniversalDictationModule-*` specs stay green, and the full suite is clean — **219 files, 2025 passed, 1 skipped**, type-check included.

Fixes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5tDjPqe75yTHjCKavhrFx