### PR TITLE
fix(sweep): stop the ChatGPT diagnostic manufacturing false drift

### DIFF
--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -127,3 +127,47 @@ export function summarize(evidence = {}) {
     netFailures: Array.isArray(evidence.requestFailed) ? evidence.requestFailed.length : 0,
   };
 }
+
+/**
+ * The chat-history selector chatgpt.com's adapter uses (src/chatbots/ChatGPT.ts
+ * getChatHistorySelector()). Tag-agnostic on purpose: ChatGPT swapped the turn
+ * container from <article> to <section> in 2026-06 while keeping the
+ * data-testid (#362). Kept in sync by test/scripts/e2e-host-sweep-diags.spec.ts.
+ */
+export const CHATGPT_TURN_SELECTOR = '[data-testid^="conversation-turn"]';
+export const CHATGPT_CHAT_HISTORY_SELECTOR = `div:has(> ${CHATGPT_TURN_SELECTOR})`;
+
+/**
+ * Per-host DOM/selector diagnostics, evaluated in page context by the harness.
+ * These mirror the selectors SayPi's adapters depend on, so a sweep surfaces real
+ * drift — and, just as importantly, does NOT manufacture drift by probing a
+ * selector the adapter has already moved off (#560). Each is a self-contained
+ * function: it is stringified and evaluated in the page, so it may not close over
+ * anything from this module.
+ */
+export const DIAGS = {
+  pi: () => ({
+    voiceMenus: document.querySelectorAll("#saypi-voice-menu").length,
+    chatHistory: document.querySelectorAll("#saypi-chat-history").length,
+    presentMsgsDecorated: document.querySelectorAll(".present-messages [id*='saypi'], .present-messages [class*='saypi']").length,
+    callButtons: document.querySelectorAll("#saypi-callButton").length,
+  }),
+  claude: () => ({
+    voiceSelectors: document.querySelectorAll("#claude-voice-selector").length,
+    assistantMsgs: document.querySelectorAll(".font-claude-message, [data-testid='assistant-turn']").length,
+    customPlaceholders: document.querySelectorAll(".custom-placeholder, #claude-placeholder").length,
+    nativePlaceholders: [...document.querySelectorAll("p[data-placeholder]")].map((p) => p.getAttribute("data-placeholder")).slice(0, 4),
+    callButtons: document.querySelectorAll("#saypi-callButton").length,
+  }),
+  chatgpt: () => ({
+    // Tag-agnostic, matching the adapter. The per-tag census below still exposes a
+    // future tag change instead of silently absorbing it.
+    turnsByTestid: document.querySelectorAll('[data-testid^="conversation-turn"]').length,
+    turnTags: [...new Set([...document.querySelectorAll('[data-testid^="conversation-turn"]')].map((t) => t.tagName.toLowerCase()))],
+    assistantByDataTurn: document.querySelectorAll('[data-turn="assistant"]').length,
+    assistantByRole: document.querySelectorAll('[data-message-author-role="assistant"]').length,
+    chatHistorySelMatch: document.querySelectorAll('div:has(> [data-testid^="conversation-turn"])').length,
+    saypiChatHistory: document.querySelectorAll("#saypi-chat-history").length,
+    callButtons: document.querySelectorAll("#saypi-callButton").length,
+  }),
+};

--- a/scripts/e2e-host-sweep.mjs
+++ b/scripts/e2e-host-sweep.mjs
@@ -39,7 +39,7 @@ import { createServer } from "node:net";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveCdpProfileDir, buildCdpChromeArgs, isCloudflareChallenge } from "./layer4cdp-lib.mjs";
-import { HOSTS, parseSweepArgs, summarize, ttsCoverage, SAYPI_TTS_PROVIDER } from "./e2e-host-sweep-lib.mjs";
+import { HOSTS, DIAGS, parseSweepArgs, summarize, ttsCoverage, SAYPI_TTS_PROVIDER } from "./e2e-host-sweep-lib.mjs";
 import { enforceSpendCap } from "./l4-ledger.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -84,31 +84,6 @@ function markCleanExit(profileDir) {
   }
 }
 
-// Per-host DOM/selector diagnostics, evaluated in page context. These mirror the
-// selectors SayPi's adapters depend on, so a sweep surfaces drift directly.
-const DIAGS = {
-  pi: () => ({
-    voiceMenus: document.querySelectorAll("#saypi-voice-menu").length,
-    chatHistory: document.querySelectorAll("#saypi-chat-history").length,
-    presentMsgsDecorated: document.querySelectorAll(".present-messages [id*='saypi'], .present-messages [class*='saypi']").length,
-    callButtons: document.querySelectorAll("#saypi-callButton").length,
-  }),
-  claude: () => ({
-    voiceSelectors: document.querySelectorAll("#claude-voice-selector").length,
-    assistantMsgs: document.querySelectorAll(".font-claude-message, [data-testid='assistant-turn']").length,
-    customPlaceholders: document.querySelectorAll(".custom-placeholder, #claude-placeholder").length,
-    nativePlaceholders: [...document.querySelectorAll("p[data-placeholder]")].map((p) => p.getAttribute("data-placeholder")).slice(0, 4),
-    callButtons: document.querySelectorAll("#saypi-callButton").length,
-  }),
-  chatgpt: () => ({
-    turnsByTestid: document.querySelectorAll('article[data-testid^="conversation-turn"]').length,
-    assistantByDataTurn: document.querySelectorAll('article[data-turn="assistant"]').length,
-    assistantByRole: document.querySelectorAll('[data-message-author-role="assistant"]').length,
-    chatHistorySelMatch: document.querySelectorAll('div:has(> article[data-testid^="conversation-turn"])').length,
-    articleCount: document.querySelectorAll("article").length,
-    callButtons: document.querySelectorAll("#saypi-callButton").length,
-  }),
-};
 
 /**
  * Select a faster claude.ai model (Claude-native UI) before the turn so the reply +

--- a/test/scripts/e2e-host-sweep-diags.spec.ts
+++ b/test/scripts/e2e-host-sweep-diags.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Avoid the VoiceMenu->Pi->PiVoiceMenu->VoiceMenu circular import (same shim the
+// other ChatGPT specs use).
+vi.mock("../../src/chatbots/Pi", () => ({ PiAIChatbot: class {} }));
+
+import ChatGPTChatbot from "../../src/chatbots/ChatGPT";
+import {
+  DIAGS,
+  CHATGPT_CHAT_HISTORY_SELECTOR,
+  CHATGPT_TURN_SELECTOR,
+} from "../../scripts/e2e-host-sweep-lib.mjs";
+
+/**
+ * The host sweep's DOM diagnostics exist to surface real selector drift. When a
+ * diagnostic probes a selector the adapter has already moved off, it does the
+ * opposite: it reports 0 on a perfectly healthy host and manufactures a false
+ * drift finding on every run (#560).
+ *
+ * chatgpt.com swapped the turn container from <article> to <section> in 2026-06
+ * while keeping data-testid="conversation-turn-N" (#362). The adapter went
+ * tag-agnostic then; the diagnostic did not.
+ */
+
+/** The live structure: #thread > main > list > [wrapper > turn]. Mirrors ChatGPTChatHistoryDrift.spec.ts. */
+function buildThread(turnTag: "article" | "section") {
+  document.body.innerHTML = "";
+  const thread = document.createElement("div");
+  thread.id = "thread";
+  const main = document.createElement("main");
+  const list = document.createElement("div");
+  main.appendChild(list);
+  thread.appendChild(main);
+  document.body.appendChild(thread);
+
+  for (const [n, role] of [[1, "user"], [2, "assistant"]] as const) {
+    const wrapper = document.createElement("div");
+    const turn = document.createElement(turnTag);
+    turn.setAttribute("data-testid", `conversation-turn-${n}`);
+    turn.setAttribute("data-turn", role);
+    const roleEl = document.createElement("div");
+    roleEl.setAttribute("data-message-author-role", role);
+    turn.appendChild(roleEl);
+    wrapper.appendChild(turn);
+    list.appendChild(wrapper);
+  }
+}
+
+describe("e2e-host-sweep ChatGPT diagnostic (#560)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("counts turns on the live <section> DOM chatgpt.com serves today", () => {
+    buildThread("section");
+    const d = DIAGS.chatgpt();
+
+    expect(d.turnsByTestid).toBe(2);
+    expect(d.assistantByDataTurn).toBe(1);
+    expect(d.assistantByRole).toBe(1);
+    expect(d.chatHistorySelMatch).toBeGreaterThan(0);
+  });
+
+  it("still counts turns if ChatGPT reverts to <article>, and names the tag either way", () => {
+    buildThread("article");
+    expect(DIAGS.chatgpt().turnsByTestid).toBe(2);
+    expect(DIAGS.chatgpt().turnTags).toEqual(["article"]);
+
+    buildThread("section");
+    expect(DIAGS.chatgpt().turnTags).toEqual(["section"]);
+  });
+
+  it("reports zeroes when the turn markers really are gone (genuine drift still visible)", () => {
+    document.body.innerHTML = `<div id="thread"><main><div><div><p>hi</p></div></div></main></div>`;
+    const d = DIAGS.chatgpt();
+
+    expect(d.turnsByTestid).toBe(0);
+    expect(d.chatHistorySelMatch).toBe(0);
+    expect(d.turnTags).toEqual([]);
+  });
+
+  it("probes the same chat-history selector the adapter queries", () => {
+    // getChatHistorySelector() returns "#thread <sel>, <sel>" — the diagnostic uses
+    // the unscoped half, so drift in either one fails this test.
+    expect(new ChatGPTChatbot().getChatHistorySelector()).toContain(CHATGPT_CHAT_HISTORY_SELECTOR);
+    expect(CHATGPT_CHAT_HISTORY_SELECTOR).toContain(CHATGPT_TURN_SELECTOR);
+  });
+});


### PR DESCRIPTION
## Why

The host sweep's per-host DOM diagnostics are there to surface real selector drift. The ChatGPT one had drifted itself: it still probes `article[data-testid^="conversation-turn"]`, a tag chatgpt.com abandoned in 2026-06 (#362). The adapter went tag-agnostic then; the diagnostic didn't.

The result is a diagnostic that reads zero on a *healthy* host. In the `/sweep` run on `f52a1cf` it reported `turnsByTestid: 0, chatHistorySelMatch: 0, articleCount: 0` while SayPi was working fine — its own console logged `Chat history found on progressive search attempt 3` and `Found 1 recent assistant message(s)`. Measured live against the same conversation on 2026-07-26:

| selector | matches |
|---|---|
| `article[data-testid^="conversation-turn"]` (diagnostic) | 0 |
| `article` | 0 |
| `[data-testid^="conversation-turn"]` | 2 |
| `section[data-testid^="conversation-turn"]` | 2 |
| `div:has(> [data-testid^="conversation-turn"])` (adapter) | 2 |

A diagnostic that reports zero on a healthy host is worse than no diagnostic — it invites a drift finding that isn't there, on every future run.

## What

- The ChatGPT diagnostic now anchors on the same tag-agnostic `data-testid` the adapter uses, for turns, assistant turns, and the chat-history probe.
- `articleCount` becomes `turnTags` — a census of the tags actually in use. That keeps a genuine future tag change visible instead of silently absorbed, which was the one thing the old `article` anchor did well.
- Adds `saypiChatHistory`, so a sweep can distinguish "SayPi never found the history" from "the host has no turns yet" (the empty-new-chat case that made this run ambiguous).
- Moves `DIAGS` from the harness script into `e2e-host-sweep-lib.mjs` — the pure, unit-tested half, same split as the other helpers — and imports it back. Without that move the diagnostics simply weren't testable.

## Verification

Fail-first. Reverting just the diagnostic to its pre-fix form and running the new spec:

```
× counts turns on the live <section> DOM chatgpt.com serves today → expected +0 to be 2
× still counts turns if ChatGPT reverts to <article>, and names the tag either way → expected [] to deeply equal [ 'article' ]
✓ reports zeroes when the turn markers really are gone (genuine drift still visible)
× probes the same chat-history selector the adapter queries → '#thread div:has(> [data-testid…' does not contain 'div:has(> article[data-testid…'
```

That third case is the control that matters: it pins that the diagnostic still reads zero on *real* drift, so this fix can't degrade into "always reports something".

The last case is the durable part — it ties the diagnostic to `ChatGPTChatbot.getChatHistorySelector()`, so the next time ChatGPT's DOM moves, a test breaks instead of a sweep report quietly lying.

After: all 4 pass; full suite clean — **219 files, 2025 passed, 1 skipped**, type-check included.

Fixes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5tDjPqe75yTHjCKavhrFx