### PR TITLE
fix: gate chat mode on the chat-app origins, not the registrable domain (#559)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -112,7 +112,7 @@ panel left empty by a chunk/import break.
   context fixture (e2e/fixtures/extension.ts + launch-args.ts)
         │  chromium.launchPersistentContext with:
         │    --load-extension / --disable-extensions-except  -> the dev build
-        │    --host-resolver-rules  MAP pi.ai/claude.ai/api|www|app.saypi.ai/google-analytics.com
+        │    --host-resolver-rules  MAP pi.ai/hey.pi.ai/claude.ai/api|www|app.saypi.ai/google-analytics.com
         │                           -> 127.0.0.1:<port>, then MAP * ~NOTFOUND (fail closed)
         │    --ignore-certificate-errors / --allow-insecure-localhost
         │    --use-fake-device-for-media-stream / --use-fake-ui-for-media-stream
@@ -128,6 +128,10 @@ panel left empty by a chunk/import break.
                           guards the per-test reset the context fixture performs,
                           so no spec's hits/content-type assertion can be
                           satisfied by another spec's traffic (#462)
+     chat-adjacent-dictation.e2e.ts page.goto(https://hey.pi.ai/) -> the CHAT
+                          script's `https://pi.ai/*` doesn't match, so only the
+                          universal script injects -> .saypi-dictation-button
+                          appears and #saypi-callButton does NOT (#559)
      tooltip-contrast.e2e.ts page.goto(https://claude.ai/new) -> body.claude ->
                           the real built CSS renders .saypi-tooltip as an opaque
                           dark pill (guards the host-CSS-var contrast bug)
@@ -149,7 +153,9 @@ the machine — the run is hermetic, even GA beacons are absorbed by the mock AP
 catch-all. The redirect list **fails closed**: the explicit `MAP`s
 (`pi.ai`, `api`/`www`/`app.saypi.ai`, `google-analytics.com`) are followed by a
 trailing `MAP * ~NOTFOUND` sinkhole, so any host *not* explicitly mapped resolves
-to nothing — a future spec that reaches for an unmapped endpoint errors loudly
+to nothing. Note the `MAP`s are **exact-host**, not domain-wide: `MAP pi.ai`
+does not cover `hey.pi.ai`, which is why the chat-adjacent host has its own
+entry. A future spec that reaches for an unmapped endpoint errors loudly
 instead of silently calling the real internet.
 
 ### Files
@@ -165,6 +171,7 @@ instead of silently calling the real internet.
 | `support/mock-servers.ts` | self-signed HTTPS page server (Host-routed Pi/Claude pages) + saypi-api (`/transcribe`, hit/content-type diagnostics + per-test reset route, GA catch-all) |
 | `support/mock-pi-page.html` | minimal Pi.ai-shaped DOM the content script decorates |
 | `support/mock-claude-page.html` | minimal claude.ai stand-in (defines no `--black`) for the host-CSS contrast spec |
+| `support/mock-hey-pi-page.html` | Pi's logged-out marketing splash stand-in — an ordinary form field, no composer — for the chat-adjacent dictation spec (#559) |
 | `support/transcribe-response.ts` | the STT contract: shape of the `/transcribe` response |
 | `support/manifest-guard.ts` | `assertDevManifest()` — refuses a non-static / production build |
 | `support/check-servers.mjs` | standalone sanity check for the mock servers |

--- a/e2e/fixtures/launch-args.ts
+++ b/e2e/fixtures/launch-args.ts
@@ -11,6 +11,11 @@ export function buildLaunchArgs(o: LaunchArgsOptions): string[] {
     `MAP pi.ai 127.0.0.1:${o.piPort}`,
     // claude.ai shares the page server; it serves the Claude mock by Host header.
     `MAP claude.ai 127.0.0.1:${o.piPort}`,
+    // hey.pi.ai — Pi's logged-out marketing splash. A chat-ADJACENT host: the
+    // chat content script's `https://pi.ai/*` does not match it, so only the
+    // universal script injects and the page must run dictation, not chat (#559).
+    // Same page server, Host-routed to the splash mock.
+    `MAP hey.pi.ai 127.0.0.1:${o.piPort}`,
     `MAP api.saypi.ai 127.0.0.1:${o.apiPort}`,
     `MAP www.saypi.ai 127.0.0.1:${o.apiPort}`,
     `MAP app.saypi.ai 127.0.0.1:${o.apiPort}`,

--- a/e2e/specs/chat-adjacent-dictation.e2e.ts
+++ b/e2e/specs/chat-adjacent-dictation.e2e.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "../fixtures/extension";
+
+/**
+ * #559 — a chat-ADJACENT host runs universal dictation, not chat.
+ *
+ * `hey.pi.ai` is where pi.ai bounces every logged-out visitor: a marketing
+ * splash with no composer. The chat content script's match pattern is
+ * `https://pi.ai/*`, which matches the host `pi.ai` and nothing else, so the
+ * script that actually loads there is the *universal* one — and it used to take
+ * the chat branch anyway, because the mode gate was derived from
+ * `identifyChatbot()`, which collapses a hostname to its registrable domain.
+ * Result: chat machinery booting with nothing to decorate, while
+ * `UniversalDictationModule.isExcludedSite()` (literally `isInChatMode()`)
+ * suppressed dictation. The user got neither feature.
+ *
+ * The unit specs pin the two booleans against a mocked location. This is the
+ * only layer that can show the whole thing actually works: the real manifest
+ * deciding which script injects, the real bundle booting, and a real dictation
+ * button landing on a real field.
+ *
+ * `hey.pi.ai` is mapped at the DNS layer like every other host here
+ * (`fixtures/launch-args.ts`), so the page is served on the genuine
+ * `https://hey.pi.ai` origin and the manifest's match patterns are evaluated for
+ * real — not against a localhost stand-in.
+ */
+test("hey.pi.ai gets universal dictation, not the chat call button", async ({
+  context,
+}) => {
+  const page = await context.newPage();
+  page.on("console", (msg) => {
+    if (msg.type() === "error") console.log(`[page-error] ${msg.text()}`);
+  });
+  await page.goto("https://hey.pi.ai/", { waitUntil: "domcontentloaded" });
+
+  // Positive signal FIRST. The dictation button is created hidden
+  // (display:none until its field is focused), so wait on "attached", not the
+  // default "visible". This is also what makes the negative assertion below
+  // meaningful — on a page where the content script never ran, it would pass
+  // instantly and prove nothing.
+  await page.waitForSelector(".saypi-dictation-button", {
+    state: "attached",
+    timeout: 20_000,
+  });
+
+  // The regression: chat mode must NOT have booted here.
+  await expect(page.locator("#saypi-callButton")).toHaveCount(0);
+  await expect(page.locator(".saypi-prompt-container")).toHaveCount(0);
+
+  // ...and the button is a working one, not just an orphan in the DOM: focusing
+  // the field reveals it, which is the decorate -> focus -> show path users hit.
+  await page.locator("#email").focus();
+  await expect(page.locator(".saypi-dictation-button").first()).toBeVisible();
+});

--- a/e2e/support/mock-hey-pi-page.html
+++ b/e2e/support/mock-hey-pi-page.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>hey.pi.ai mock</title></head>
+  <body>
+    <!--
+      Stand-in for Pi's logged-out marketing splash (hey.pi.ai): a landing page
+      with an ordinary form field and NO chat composer — deliberately nothing
+      matching Pi's prompt selector, so a call button here could only come from
+      the mode gate misfiring.
+
+      The field is present in the initial HTML rather than mounted later: unlike
+      the chat DOMObserver, UniversalDictationModule does an initial scan
+      (decorateExistingElements) as well as observing mutations, so a static
+      field exercises the ordinary path.
+    -->
+    <main>
+      <h1>Hi, I'm Pi.</h1>
+      <p>Your personal AI.</p>
+      <form>
+        <label for="email">Get updates</label>
+        <input id="email" type="email" placeholder="you@example.com" />
+      </form>
+    </main>
+  </body>
+</html>

--- a/e2e/support/mock-servers.ts
+++ b/e2e/support/mock-servers.ts
@@ -45,6 +45,9 @@ export async function startMockServers(): Promise<MockServers> {
     const host = (req.headers.host ?? "").toLowerCase();
     // hey.pi.ai first: it is a pi.ai SUBdomain, so the fallthrough would hand it
     // the chat-shaped Pi mock and quietly weaken the chat-adjacent spec (#559).
+    // This ordering protects hey.pi.ai ONLY — the claude branch below is a
+    // substring test, so a future `hey.claude.ai` mapping would fall into the
+    // Claude chat mock and needs its own branch here (and its own MAP).
     const page = host.startsWith("hey.pi.ai")
       ? HEY_PI_PAGE
       : host.includes("claude.ai")

--- a/e2e/support/mock-servers.ts
+++ b/e2e/support/mock-servers.ts
@@ -9,6 +9,7 @@ const pems = await selfsigned.generate([{ name: "commonName", value: "saypi-e2e"
 const tls = { key: pems.private, cert: pems.cert };
 const PI_PAGE = readFileSync(resolve(import.meta.dirname, "mock-pi-page.html"), "utf8");
 const CLAUDE_PAGE = readFileSync(resolve(import.meta.dirname, "mock-claude-page.html"), "utf8");
+const HEY_PI_PAGE = readFileSync(resolve(import.meta.dirname, "mock-hey-pi-page.html"), "utf8");
 
 export interface MockServers {
   piPort: number;
@@ -42,7 +43,13 @@ export async function startMockServers(): Promise<MockServers> {
   // content script injects per the manifest match for whichever URL is loaded.
   const piServer = https.createServer(tls, (req, res) => {
     const host = (req.headers.host ?? "").toLowerCase();
-    const page = host.includes("claude.ai") ? CLAUDE_PAGE : PI_PAGE;
+    // hey.pi.ai first: it is a pi.ai SUBdomain, so the fallthrough would hand it
+    // the chat-shaped Pi mock and quietly weaken the chat-adjacent spec (#559).
+    const page = host.startsWith("hey.pi.ai")
+      ? HEY_PI_PAGE
+      : host.includes("claude.ai")
+        ? CLAUDE_PAGE
+        : PI_PAGE;
     res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     res.end(page);
   });

--- a/src/chatbots/ChatbotIdentifier.ts
+++ b/src/chatbots/ChatbotIdentifier.ts
@@ -135,9 +135,8 @@ export class ChatbotIdentifier {
    * on any non-chat subdomain — `hey.pi.ai` is Pi's marketing splash with no
    * composer, yet it is very much Pi (#559).
    *
-   * Hostname, not origin: the Layer-3 harness serves the real hostnames over a
-   * local server, so a scheme-sensitive check would silently drop the e2e
-   * fixtures out of chat mode.
+   * Hostname, not origin: the injection scope this mirrors is written as host
+   * match patterns, so a plain host list tracks it 1:1.
    */
   static isChatAppHost(hostnameOverride?: string): boolean {
     const hostname = this.resolveHostname(hostnameOverride);
@@ -152,9 +151,12 @@ export class ChatbotIdentifier {
    * hostname. Narrowing only `isInChatMode()` would have left `hey.pi.ai` in
    * NEITHER mode — chat machinery gone AND universal dictation still suppressed.
    *
-   * The one carve-out, unchanged from before: with no location at all (the
-   * service worker's own `chrome-extension://` scope) there is no page to be in a
-   * mode for, and both gates are false.
+   * The one carve-out, unchanged from before: a context with no `location`
+   * binding at all — no page, no mode, both gates false. Note this is NOT the
+   * extension service worker; as `getGlobalLocation()` says, that resolves to
+   * the worker's own `chrome-extension://<id>/` scope, so it has a hostname, it
+   * is not a chat-app host, and it lands in dictation mode exactly as it did
+   * before this change.
    */
   static isInDictationMode(): boolean {
     const hostname = this.resolveHostname();

--- a/src/chatbots/ChatbotIdentifier.ts
+++ b/src/chatbots/ChatbotIdentifier.ts
@@ -4,6 +4,30 @@
  */
 export type ChatbotId = "claude" | "pi" | "chatgpt" | "web";
 
+/**
+ * The exact hostnames of the chat apps SayPi decorates — i.e. the hosts the CHAT
+ * content script is injected into (`CHATBOT_MATCHES` in
+ * `entrypoints/saypi.content.ts`, and the mirror-image `excludeMatches` in
+ * `entrypoints/saypi-universal.content.ts`).
+ *
+ * Both entrypoints import the same `src/saypi.index.js`, so the bundle cannot ask
+ * at runtime which script loaded it; the injection scope has to be restated here
+ * for the mode gate to read. Those entrypoint files are founder-gated, so
+ * `test/chatbots/ChatbotIdentifier-injectionParity.spec.ts` reads them from disk
+ * and fails if this list drifts from them.
+ *
+ * Exact hosts, not registrable domains: a Chrome match pattern of
+ * `https://pi.ai/*` matches the host `pi.ai` and nothing else — not `hey.pi.ai`,
+ * not `www.pi.ai` (see #559).
+ */
+export const CHAT_APP_HOSTNAMES = [
+  "pi.ai",
+  "claude.ai",
+  "chatgpt.com",
+  "chat.com",
+  "chat.openai.com",
+] as const;
+
 export class ChatbotIdentifier {
   /**
    * Identifies which chatbot is being used based on the current URL
@@ -102,17 +126,46 @@ export class ChatbotIdentifier {
     return this.identifyChatbot() === type;
   }
 
+  /**
+   * True when the current page is one of the chat apps SayPi decorates.
+   *
+   * Keyed on the exact hostname rather than `identifyChatbot()`'s registrable
+   * domain: `identifyChatbot()` answers "which product is this?" (attribution),
+   * whereas mode is "does this page have a chat UI to decorate?". Those diverge
+   * on any non-chat subdomain — `hey.pi.ai` is Pi's marketing splash with no
+   * composer, yet it is very much Pi (#559).
+   *
+   * Hostname, not origin: the Layer-3 harness serves the real hostnames over a
+   * local server, so a scheme-sensitive check would silently drop the e2e
+   * fixtures out of chat mode.
+   */
+  static isChatAppHost(hostnameOverride?: string): boolean {
+    const hostname = this.resolveHostname(hostnameOverride);
+    if (!hostname) {
+      return false;
+    }
+    return (CHAT_APP_HOSTNAMES as readonly string[]).includes(hostname);
+  }
+
+  /**
+   * The two mode gates partition every page: exactly one of them is true for any
+   * hostname. Narrowing only `isInChatMode()` would have left `hey.pi.ai` in
+   * NEITHER mode — chat machinery gone AND universal dictation still suppressed.
+   *
+   * The one carve-out, unchanged from before: with no location at all (the
+   * service worker's own `chrome-extension://` scope) there is no page to be in a
+   * mode for, and both gates are false.
+   */
   static isInDictationMode(): boolean {
-    const chatbot = this.identifyChatbot();
-    return chatbot === "web";
+    const hostname = this.resolveHostname();
+    if (!hostname) {
+      return false;
+    }
+    return !this.isChatAppHost(hostname);
   }
 
   static isInChatMode(): boolean {
-    const chatbot = this.identifyChatbot();
-    if (!chatbot) {
-      return false;
-    }
-    return chatbot !== "web";
+    return this.isChatAppHost();
   }
 
 }

--- a/src/chatbots/ChatbotService.ts
+++ b/src/chatbots/ChatbotService.ts
@@ -10,20 +10,43 @@ import { ChatbotIdentifier } from "./ChatbotIdentifier";
  * All other parts of the application should use this service to get a chatbot.
  */
 export class ChatbotService {
+  /**
+   * Derived from the same predicate as the mode gate, so the two can't disagree
+   * (#559). This used to run its own SUBSTRING hostname test
+   * (`hostname.includes("pi.ai")`), which agreed with the mode gate only by
+   * accident — both were domain-shaped. Once mode narrowed to the exact chat-app
+   * hosts, a chat-adjacent page like `hey.pi.ai` ran universal dictation while
+   * holding a `PiAIChatbot`, and downstream code that reads the chatbot rather
+   * than the mode diverged with it: `constructTranscriptionFormData()` appended
+   * the user's Pi `nickname` to a dictation upload that carries no such field on
+   * any other site, and `buildUsageMetadata()` prefers `chatbot.getID()` over
+   * `ChatbotIdentifier.getAppId()`.
+   *
+   * So: not a chat-app host ⇒ the dictation chatbot, whatever product the
+   * hostname belongs to; otherwise switch on the identified chatbot. The five
+   * chat-app hosts resolve exactly as before. Attribution — `identifyChatbot()`
+   * / `getAppId()` / the `body` class — is deliberately left domain-shaped;
+   * `hey.pi.ai` is still Pi, it just isn't a chat page.
+   */
   static getChatbotSync(): Chatbot {
-    // Check if we're on a chatbot site
-    const hostname = window.location.hostname;
-    
-    // If we're on pi.ai, claude.ai, or ChatGPT sites, use the appropriate chatbot
-    if (hostname.includes("pi.ai")) {
-      return new PiAIChatbot();
-    } else if (hostname.includes("claude.ai")) {
-      return new ClaudeChatbot();
-    } else if (hostname.includes("chatgpt.com") || hostname.includes("chat.com") || hostname.includes("chat.openai.com")) {
-      return new ChatGPTChatbot();
-    } else {
-      // For all other sites (universal dictation), use the web dictation chatbot
+    if (!ChatbotIdentifier.isChatAppHost()) {
+      // Universal dictation, including on a non-chat subdomain of a chat app.
       return new WebDictationChatbot();
+    }
+
+    switch (ChatbotIdentifier.identifyChatbot()) {
+      case "pi":
+        return new PiAIChatbot();
+      case "claude":
+        return new ClaudeChatbot();
+      case "chatgpt":
+        return new ChatGPTChatbot();
+      default:
+        // Unreachable while CHAT_APP_HOSTNAMES and identifyChatbot() agree — the
+        // parity spec pins the former to the injection scope, and the mode spec
+        // pins the latter's answer for every one of those hosts. Fall back to
+        // the dictation chatbot rather than throwing on a page we can't name.
+        return new WebDictationChatbot();
     }
   }
 

--- a/test/chatbots/ChatbotIdentifier-chatOrigin.spec.ts
+++ b/test/chatbots/ChatbotIdentifier-chatOrigin.spec.ts
@@ -62,6 +62,10 @@ const DICTATION_HOSTS = [
   "example.com",
   "saypi.ai",
   "localhost",
+  // The extension service worker's own scope: `chrome-extension://<id>/`, whose
+  // hostname is the 32-char id. It has a host, so it is NOT the "no location"
+  // carve-out below — it is an ordinary non-chat host, as it was before #559.
+  "abcdefghijklmnopabcdefghijklmnop",
 ];
 
 describe("chat mode is gated on the chat-app origins (#559)", () => {
@@ -103,11 +107,13 @@ describe("chat mode is gated on the chat-app origins (#559)", () => {
   );
 
   /**
-   * Carve-out, deliberate and pre-existing: with no location at all (the
-   * extension service worker, whose own scope is `chrome-extension://…`) there
-   * is no page to be in a mode for, so BOTH gates stay false. This is not a hole
-   * in the partition above — it is the "no host" case, and today's behaviour
-   * (`identifyChatbot()` → undefined → both gates false) is preserved verbatim.
+   * Carve-out, deliberate and pre-existing: a context with no `location` binding
+   * at all has no page to be in a mode for, so BOTH gates stay false. This is
+   * not a hole in the partition above — it is the "no host" case, and today's
+   * behaviour (`identifyChatbot()` → undefined → both gates false) is preserved
+   * verbatim. It is NOT the extension service worker: that resolves to its own
+   * `chrome-extension://<id>/` scope, which has a hostname and therefore lands
+   * in dictation mode (covered by the DICTATION_HOSTS row for a dotless host).
    */
   test("no location means neither mode", () => {
     withHostname(null, () => {

--- a/test/chatbots/ChatbotIdentifier-chatOrigin.spec.ts
+++ b/test/chatbots/ChatbotIdentifier-chatOrigin.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Mode selection must follow the *chat-app origins the chat content script is
+ * actually injected into*, not the registrable domain.
+ *
+ * Background (#559): `identifyChatbot()` deliberately collapses a hostname to its
+ * registrable domain ("claude.ai" in "chat.claude.ai"), so every `*.pi.ai`
+ * subdomain answers "pi". The chat content script, however, is registered only
+ * for the exact chat-app origins (`https://pi.ai/*`, …). On a non-chat subdomain
+ * — e.g. `hey.pi.ai`, Pi's marketing splash, where every logged-out pi.ai visitor
+ * now lands — the *universal* content script is the one that loads, and it then
+ * took the chat branch: chat machinery booting on a page with no chat, while
+ * universal dictation suppressed itself (`isExcludedSite()` → `isInChatMode()`).
+ *
+ * The gates below are therefore keyed on the exact chat-app hostnames.
+ * `identifyChatbot()`/`getAppId()` are deliberately left alone — they feed the
+ * `app` field of API calls (attribution), which must keep saying "pi" on any
+ * pi.ai property.
+ */
+import { describe, expect, test, vi } from "vitest";
+import {
+  ChatbotIdentifier,
+  CHAT_APP_HOSTNAMES,
+  type ChatbotId,
+} from "../../src/chatbots/ChatbotIdentifier";
+
+/**
+ * Drive the real `window.location` path rather than a test-only argument, so
+ * these assertions exercise what the extension actually reads at runtime.
+ */
+function withHostname<T>(hostname: string | null, fn: () => T): T {
+  const spy = vi
+    .spyOn(
+      ChatbotIdentifier as unknown as { getGlobalLocation: () => Location | null },
+      "getGlobalLocation"
+    )
+    .mockReturnValue(
+      hostname === null ? null : ({ hostname } as unknown as Location)
+    );
+  try {
+    return fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+/** Every chat-app origin the chat content script is registered for. */
+const CHAT_HOSTS = [
+  "pi.ai",
+  "claude.ai",
+  "chatgpt.com",
+  "chat.com",
+  "chat.openai.com",
+];
+
+/** Hosts that must get ordinary universal dictation, not chat mode. */
+const DICTATION_HOSTS = [
+  "hey.pi.ai", // the reported bug: Pi's marketing splash, no chat UI at all
+  "www.pi.ai",
+  "help.claude.ai",
+  "www.chat.com",
+  "openai.com",
+  "example.com",
+  "saypi.ai",
+  "localhost",
+];
+
+describe("chat mode is gated on the chat-app origins (#559)", () => {
+  test("hey.pi.ai is a dictation page, not a chat page", () => {
+    withHostname("hey.pi.ai", () => {
+      expect(ChatbotIdentifier.isInChatMode()).toBe(false);
+      expect(ChatbotIdentifier.isInDictationMode()).toBe(true);
+    });
+  });
+
+  test.each(CHAT_HOSTS)("%s is a chat page", (hostname) => {
+    withHostname(hostname, () => {
+      expect(ChatbotIdentifier.isInChatMode()).toBe(true);
+      expect(ChatbotIdentifier.isInDictationMode()).toBe(false);
+    });
+  });
+
+  test.each(DICTATION_HOSTS)("%s is a dictation page", (hostname) => {
+    withHostname(hostname, () => {
+      expect(ChatbotIdentifier.isInChatMode()).toBe(false);
+      expect(ChatbotIdentifier.isInDictationMode()).toBe(true);
+    });
+  });
+
+  /**
+   * The two gates partition the web. Narrowing only one of them would drop
+   * hey.pi.ai into NEITHER mode — the extension would do nothing there, a worse
+   * bug than the one being fixed.
+   */
+  test.each([...CHAT_HOSTS, ...DICTATION_HOSTS])(
+    "%s lands in exactly one mode",
+    (hostname) => {
+      withHostname(hostname, () => {
+        expect(ChatbotIdentifier.isInChatMode()).not.toBe(
+          ChatbotIdentifier.isInDictationMode()
+        );
+      });
+    }
+  );
+
+  /**
+   * Carve-out, deliberate and pre-existing: with no location at all (the
+   * extension service worker, whose own scope is `chrome-extension://…`) there
+   * is no page to be in a mode for, so BOTH gates stay false. This is not a hole
+   * in the partition above — it is the "no host" case, and today's behaviour
+   * (`identifyChatbot()` → undefined → both gates false) is preserved verbatim.
+   */
+  test("no location means neither mode", () => {
+    withHostname(null, () => {
+      expect(ChatbotIdentifier.isInChatMode()).toBe(false);
+      expect(ChatbotIdentifier.isInDictationMode()).toBe(false);
+    });
+  });
+});
+
+describe("attribution is untouched by the mode gate (#559)", () => {
+  const expectations: Array<[string, ChatbotId]> = [
+    ["pi.ai", "pi"],
+    ["hey.pi.ai", "pi"], // still attributed to Pi — only the MODE changes
+    ["www.pi.ai", "pi"],
+    ["claude.ai", "claude"],
+    ["help.claude.ai", "claude"],
+    ["chatgpt.com", "chatgpt"],
+    ["chat.com", "chatgpt"],
+    ["www.chat.com", "chatgpt"],
+    ["chat.openai.com", "chatgpt"],
+    ["openai.com", "web"],
+    ["example.com", "web"],
+    ["saypi.ai", "web"],
+    ["localhost", "web"],
+  ];
+
+  test.each(expectations)("identifyChatbot(%s) is still %s", (hostname, id) => {
+    expect(ChatbotIdentifier.identifyChatbot(hostname)).toBe(id);
+  });
+
+  test.each(expectations)("getAppId() on %s is still %s", (hostname, id) => {
+    withHostname(hostname, () => {
+      expect(ChatbotIdentifier.getAppId()).toBe(id);
+    });
+  });
+});
+
+describe("the chat-app hostname list is exported for the parity check", () => {
+  test("it is the five chat-app origins", () => {
+    expect([...CHAT_APP_HOSTNAMES].sort()).toEqual([...CHAT_HOSTS].sort());
+  });
+});

--- a/test/chatbots/ChatbotIdentifier-injectionParity.spec.ts
+++ b/test/chatbots/ChatbotIdentifier-injectionParity.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Mechanical parity guard for #559.
+ *
+ * `CHAT_APP_HOSTNAMES` duplicates knowledge that really lives in the WXT
+ * entrypoints — `entrypoints/saypi.content.ts` decides which origins the CHAT
+ * content script is injected into, and `entrypoints/saypi-universal.content.ts`
+ * excludes exactly the same set. Both entrypoints import the same
+ * `src/saypi.index.js`, so the bundle cannot learn at runtime which script
+ * loaded it; the list has to be restated in source that the mode gate can read.
+ *
+ * Those entrypoint files are founder-gated (a CI path-guard fails any PR that
+ * edits them), so this spec reads them from disk and asserts the three lists
+ * agree. A future change to the injection scope then breaks a test instead of
+ * silently desyncing the mode gate from reality.
+ */
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { CHAT_APP_HOSTNAMES } from "../../src/chatbots/ChatbotIdentifier";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+function readEntrypoint(name: string): string {
+  return readFileSync(`${repoRoot}entrypoints/${name}`, "utf8");
+}
+
+/**
+ * Pull the string literals out of the named array declaration. Deliberately
+ * dumb: it reads the literal text so that any rewrite of the array (a spread, a
+ * computed value, a renamed const) fails loudly rather than being "handled".
+ */
+function extractArrayLiterals(source: string, constName: string): string[] {
+  const match = new RegExp(`${constName}\\s*=\\s*\\[([\\s\\S]*?)\\]`).exec(source);
+  if (!match) {
+    throw new Error(`Could not find a \`${constName} = [...]\` array literal`);
+  }
+  return Array.from(match[1].matchAll(/"([^"]+)"/g), (m) => m[1]);
+}
+
+/**
+ * `https://pi.ai/*` -> `pi.ai`. No normalisation beyond stripping the scheme and
+ * path: if someone later writes `https://*.pi.ai/*` the extracted host is the
+ * literal `*.pi.ai`, the equality assert fails, and a human decides what the
+ * mode gate should do about wildcard subdomains.
+ */
+function hostOfMatchPattern(pattern: string): string {
+  const match = /^https:\/\/([^/]+)\/\*$/.exec(pattern);
+  if (!match) {
+    throw new Error(
+      `Match pattern ${pattern} is not the plain \`https://<host>/*\` shape this guard understands`
+    );
+  }
+  return match[1];
+}
+
+describe("chat-app hostname parity with the content-script injection scope", () => {
+  const chatMatches = extractArrayLiterals(
+    readEntrypoint("saypi.content.ts"),
+    "CHATBOT_MATCHES"
+  );
+  const universalExcludes = extractArrayLiterals(
+    readEntrypoint("saypi-universal.content.ts"),
+    "CHATBOT_MATCHES"
+  );
+
+  test("the parse actually found the patterns", () => {
+    // Guards against the vacuous pass where a broken regex makes every
+    // toEqual() below compare nothing against nothing.
+    expect(chatMatches.length).toBeGreaterThan(0);
+    expect(universalExcludes.length).toBeGreaterThan(0);
+    expect(CHAT_APP_HOSTNAMES.length).toBe(chatMatches.length);
+  });
+
+  test("the chat content script is injected into exactly CHAT_APP_HOSTNAMES", () => {
+    expect(chatMatches.map(hostOfMatchPattern).sort()).toEqual(
+      [...CHAT_APP_HOSTNAMES].sort()
+    );
+  });
+
+  test("the universal content script excludes exactly CHAT_APP_HOSTNAMES", () => {
+    expect(universalExcludes.map(hostOfMatchPattern).sort()).toEqual(
+      [...CHAT_APP_HOSTNAMES].sort()
+    );
+  });
+});

--- a/test/chatbots/ChatbotIdentifier-injectionParity.spec.ts
+++ b/test/chatbots/ChatbotIdentifier-injectionParity.spec.ts
@@ -53,6 +53,30 @@ function hostOfMatchPattern(pattern: string): string {
   return match[1];
 }
 
+/**
+ * Does the content-script config field actually USE the const we just parsed?
+ *
+ * Without this the guard reads a const that nothing is obliged to consume:
+ * inline the five patterns into `matches:` (or drop a host from
+ * `excludeMatches:`) while leaving `CHATBOT_MATCHES` intact, and all three
+ * equality asserts above stay green while the built manifest injects a script
+ * somewhere the mode gate doesn't know about — e.g. the chat script running on
+ * four of five chat hosts *alongside* the universal one.
+ *
+ * Deliberately a literal, line-anchored identity check rather than anything
+ * clever: `matches: [...CHATBOT_MATCHES, "https://x/*"]` is a divergence too,
+ * and it should fail here rather than be "understood".
+ */
+function fieldReferencesConst(
+  source: string,
+  field: string,
+  constName: string
+): boolean {
+  return new RegExp(`^\\s*${field}:\\s*${constName}\\s*,?\\s*$`, "m").test(
+    source
+  );
+}
+
 describe("chat-app hostname parity with the content-script injection scope", () => {
   const chatMatches = extractArrayLiterals(
     readEntrypoint("saypi.content.ts"),
@@ -80,6 +104,104 @@ describe("chat-app hostname parity with the content-script injection scope", () 
   test("the universal content script excludes exactly CHAT_APP_HOSTNAMES", () => {
     expect(universalExcludes.map(hostOfMatchPattern).sort()).toEqual(
       [...CHAT_APP_HOSTNAMES].sort()
+    );
+  });
+
+  test("the parsed const is the one the injection config actually uses", () => {
+    // The `matches` of the chat script and the `excludeMatches` of the universal
+    // one are the two fields that must stay pinned to the parsed const; the
+    // universal script's own `matches` is the `isProduction` ternary over the
+    // http/https catch-all and is not this guard's business.
+    expect(
+      fieldReferencesConst(
+        readEntrypoint("saypi.content.ts"),
+        "matches",
+        "CHATBOT_MATCHES"
+      )
+    ).toBe(true);
+    expect(
+      fieldReferencesConst(
+        readEntrypoint("saypi-universal.content.ts"),
+        "excludeMatches",
+        "CHATBOT_MATCHES"
+      )
+    ).toBe(true);
+  });
+});
+
+/**
+ * Non-vacuity proof for the check above, run against synthetic sources.
+ *
+ * The review asked for this to be demonstrated by temporarily editing an
+ * entrypoint and watching the guard go red. `entrypoints/*.content.ts` are
+ * founder-gated (CI's path-guard fails any PR that touches them), so the
+ * divergences are reproduced here as source strings instead — which also makes
+ * the demonstration permanent coverage rather than a one-off manual experiment.
+ */
+describe("fieldReferencesConst catches the divergences the equality asserts miss", () => {
+  const inlined = `
+const CHATBOT_MATCHES = ["https://pi.ai/*"];
+export default defineContentScript({
+  matches: ["https://pi.ai/*", "https://evil.example/*"],
+});
+`;
+  const spread = `
+const CHATBOT_MATCHES = ["https://pi.ai/*"];
+export default defineContentScript({
+  matches: [...CHATBOT_MATCHES, "https://evil.example/*"],
+});
+`;
+  const renamed = `
+const CHATBOT_MATCHES = ["https://pi.ai/*"];
+const ACTUAL_MATCHES = ["https://pi.ai/*"];
+export default defineContentScript({
+  matches: ACTUAL_MATCHES,
+});
+`;
+  const dropped = `
+const CHATBOT_MATCHES = ["https://pi.ai/*"];
+export default defineContentScript({
+  matches: BASE_MATCHES,
+});
+`;
+  const faithful = `
+const CHATBOT_MATCHES = ["https://pi.ai/*"];
+export default defineContentScript({
+  matches: CHATBOT_MATCHES,
+  excludeMatches: CHATBOT_MATCHES,
+});
+`;
+
+  test.each([
+    ["patterns inlined into the field", inlined],
+    ["const spread into a wider array", spread],
+    ["field pointed at a different const", renamed],
+    ["field no longer references it at all", dropped],
+  ])("rejects: %s", (_label, source) => {
+    expect(fieldReferencesConst(source, "matches", "CHATBOT_MATCHES")).toBe(
+      false
+    );
+  });
+
+  test("accepts the faithful shape, for both fields", () => {
+    expect(fieldReferencesConst(faithful, "matches", "CHATBOT_MATCHES")).toBe(
+      true
+    );
+    expect(
+      fieldReferencesConst(faithful, "excludeMatches", "CHATBOT_MATCHES")
+    ).toBe(true);
+  });
+
+  test("`matches` does not accidentally satisfy `excludeMatches`", () => {
+    // The field name is a substring of the other, so an unanchored pattern would
+    // let a file that only declares `excludeMatches` pass the `matches` check.
+    const excludeOnly = `
+export default defineContentScript({
+  excludeMatches: CHATBOT_MATCHES,
+});
+`;
+    expect(fieldReferencesConst(excludeOnly, "matches", "CHATBOT_MATCHES")).toBe(
+      false
     );
   });
 });

--- a/test/chatbots/ChatbotService-modeAgreement.spec.ts
+++ b/test/chatbots/ChatbotService-modeAgreement.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * The concrete chatbot and the mode gate must never disagree (#559).
+ *
+ * `getChatbotSync()` used to pick the implementation with its own SUBSTRING
+ * hostname test (`hostname.includes("pi.ai")`), derived from nothing the mode
+ * gate could see. That was harmless only while `isInChatMode()` was *also*
+ * domain-shaped — both said "pi" on `hey.pi.ai`, so they agreed by accident.
+ * Narrowing the mode gate to the exact chat-app hosts removed that accident: the
+ * page ran universal dictation while holding a `PiAIChatbot`, and the two
+ * disagreed about what the page was.
+ *
+ * That is not cosmetic. `constructTranscriptionFormData()` appends a `nickname`
+ * field whenever `chatbot.getNickname()` differs from `chatbot.getName()` — with
+ * a `PiAIChatbot` that is the user's configured Pi nickname, so the *same*
+ * dictation carried a field on `hey.pi.ai` that it does not carry on any other
+ * dictation site. `buildUsageMetadata()` likewise prefers `chatbot.getID()` over
+ * `ChatbotIdentifier.getAppId()`.
+ *
+ * So the implementation is now derived from the same predicate as the mode: not
+ * a chat-app host ⇒ `WebDictationChatbot`, otherwise switch on the identified
+ * chatbot. This spec pins both halves — the five real chat hosts resolve exactly
+ * as they did before, and every other host (chat-adjacent subdomains included)
+ * agrees with `isInDictationMode()`.
+ */
+import { describe, expect, test, vi } from "vitest";
+import { ChatbotService } from "../../src/chatbots/ChatbotService";
+import { ChatbotIdentifier } from "../../src/chatbots/ChatbotIdentifier";
+import { PiAIChatbot } from "../../src/chatbots/Pi";
+import { ClaudeChatbot } from "../../src/chatbots/Claude";
+import ChatGPTChatbot from "../../src/chatbots/ChatGPT";
+import { WebDictationChatbot } from "../../src/chatbots/Web";
+
+/**
+ * Drive the hostname through the one seam both the mode gate and the service
+ * read. Note what this canNOT do: stub `window.location.hostname` itself —
+ * jsdom defines it as a non-configurable own accessor, so it is `localhost` for
+ * the whole run. That unstubbability is precisely why the old
+ * `window.location.hostname` routing had no unit coverage; routing through
+ * `ChatbotIdentifier` is what makes this assertable at Layer 1 at all.
+ */
+function withHostname<T>(hostname: string, fn: () => T): T {
+  const spy = vi
+    .spyOn(
+      ChatbotIdentifier as unknown as {
+        getGlobalLocation: () => Location | null;
+      },
+      "getGlobalLocation"
+    )
+    .mockReturnValue({ hostname } as unknown as Location);
+  try {
+    return fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+/** The five chat-app hosts — these must resolve exactly as they did before. */
+const CHAT_HOST_EXPECTATIONS: Array<[string, new () => unknown]> = [
+  ["pi.ai", PiAIChatbot],
+  ["claude.ai", ClaudeChatbot],
+  ["chatgpt.com", ChatGPTChatbot],
+  ["chat.com", ChatGPTChatbot],
+  ["chat.openai.com", ChatGPTChatbot],
+];
+
+/**
+ * Hosts that must get the dictation chatbot. The first four are the regression:
+ * every one of them contains a chat-host substring, so the old routing handed
+ * them a chat implementation while the mode gate said dictation.
+ */
+const DICTATION_HOSTS = [
+  "hey.pi.ai", // the reported bug
+  "www.pi.ai",
+  "help.claude.ai",
+  "www.chat.com",
+  "openai.com",
+  "example.com",
+  "localhost",
+];
+
+describe("the chatbot implementation follows the mode gate (#559)", () => {
+  test("hey.pi.ai gets the dictation chatbot, not Pi's", () => {
+    withHostname("hey.pi.ai", () => {
+      const chatbot = ChatbotService.getChatbotSync();
+      expect(chatbot).toBeInstanceOf(WebDictationChatbot);
+      expect(chatbot.getID()).toBe("web");
+    });
+  });
+
+  test.each(CHAT_HOST_EXPECTATIONS)(
+    "%s still gets its own chatbot implementation",
+    (hostname, expected) => {
+      withHostname(hostname, () => {
+        expect(ChatbotService.getChatbotSync()).toBeInstanceOf(expected);
+      });
+    }
+  );
+
+  test.each(DICTATION_HOSTS)("%s gets the dictation chatbot", (hostname) => {
+    withHostname(hostname, () => {
+      expect(ChatbotService.getChatbotSync()).toBeInstanceOf(
+        WebDictationChatbot
+      );
+    });
+  });
+
+  /**
+   * The invariant the whole finding is about: whatever the host, "am I in
+   * dictation mode?" and "am I holding the dictation chatbot?" are the same
+   * question. A future host added to one list but not the other breaks here.
+   */
+  test.each([...CHAT_HOST_EXPECTATIONS.map(([h]) => h), ...DICTATION_HOSTS])(
+    "%s cannot disagree with its own mode",
+    (hostname) => {
+      withHostname(hostname, () => {
+        const isDictationChatbot =
+          ChatbotService.getChatbotSync() instanceof WebDictationChatbot;
+        expect(isDictationChatbot).toBe(ChatbotIdentifier.isInDictationMode());
+      });
+    }
+  );
+});
+
+describe("nickname leakage on a chat-adjacent host (#559)", () => {
+  /**
+   * The concrete consequence, asserted at the seam `constructTranscriptionFormData()`
+   * reads: on `hey.pi.ai` the chatbot's nickname must equal its name, so the
+   * `nickname` form field is never appended — identical to dictation anywhere
+   * else. With a `PiAIChatbot` the two differ as soon as the user has set a Pi
+   * nickname, and the field rides along.
+   */
+  test("nickname equals the default name, so no nickname field is sent", async () => {
+    const chatbot = withHostname("hey.pi.ai", () =>
+      ChatbotService.getChatbotSync()
+    );
+    await expect(chatbot.getNickname()).resolves.toBe(chatbot.getName());
+    await expect(chatbot.hasNickname()).resolves.toBe(false);
+  });
+});

--- a/test/chatbots/ChatbotService-modeAgreement.spec.ts
+++ b/test/chatbots/ChatbotService-modeAgreement.spec.ts
@@ -29,6 +29,7 @@ import { PiAIChatbot } from "../../src/chatbots/Pi";
 import { ClaudeChatbot } from "../../src/chatbots/Claude";
 import ChatGPTChatbot from "../../src/chatbots/ChatGPT";
 import { WebDictationChatbot } from "../../src/chatbots/Web";
+import { UserPreferenceModule } from "../../src/prefs/PreferenceModule";
 
 /**
  * Drive the hostname through the one seam both the mode gate and the service
@@ -130,10 +131,31 @@ describe("nickname leakage on a chat-adjacent host (#559)", () => {
    * nickname, and the field rides along.
    */
   test("nickname equals the default name, so no nickname field is sent", async () => {
-    const chatbot = withHostname("hey.pi.ai", () =>
-      ChatbotService.getChatbotSync()
-    );
-    await expect(chatbot.getNickname()).resolves.toBe(chatbot.getName());
-    await expect(chatbot.hasNickname()).resolves.toBe(false);
+    // A STORED nickname is what makes this discriminating. Without one,
+    // AbstractChatbots.getNickname() falls back to getName() for every
+    // implementation, so a PiAIChatbot would satisfy these assertions too and the
+    // test would pass with the fix reverted. WebDictationChatbot overrides
+    // getNickname() to ignore preferences entirely — that is the difference being
+    // pinned here.
+    const prefs = UserPreferenceModule.getInstance();
+    const stored = vi
+      .spyOn(prefs, "getNickname")
+      .mockResolvedValue("Piper" as never);
+    try {
+      const chatbot = withHostname("hey.pi.ai", () =>
+        ChatbotService.getChatbotSync()
+      );
+      await expect(chatbot.getNickname()).resolves.toBe(chatbot.getName());
+      await expect(chatbot.hasNickname()).resolves.toBe(false);
+
+      // Guard against the assertions above going vacuous again: with the chat-host
+      // implementation the stored nickname does ride along, which is exactly the
+      // field that used to leak out of hey.pi.ai.
+      const piChatbot = new PiAIChatbot();
+      await expect(piChatbot.getNickname()).resolves.toBe("Piper");
+      await expect(piChatbot.hasNickname()).resolves.toBe(true);
+    } finally {
+      stored.mockRestore();
+    }
   });
 });

--- a/test/e2e/launch-args.spec.ts
+++ b/test/e2e/launch-args.spec.ts
@@ -20,6 +20,9 @@ describe("buildLaunchArgs", () => {
     expect(rule).toContain("MAP pi.ai 127.0.0.1:8443");
     // claude.ai shares the page server (Host-routed to the Claude mock page).
     expect(rule).toContain("MAP claude.ai 127.0.0.1:8443");
+    // hey.pi.ai too — the chat-adjacent host the #559 dictation spec loads. It
+    // is a pi.ai SUBdomain, so it needs its own MAP: `MAP pi.ai` is exact-host.
+    expect(rule).toContain("MAP hey.pi.ai 127.0.0.1:8443");
     expect(rule).toContain("MAP api.saypi.ai 127.0.0.1:8443");
     expect(rule).toContain("MAP www.saypi.ai 127.0.0.1:8443");
     expect(rule).toContain("MAP app.saypi.ai 127.0.0.1:8443");


### PR DESCRIPTION
pi.ai now bounces every logged-out visitor to https://hey.pi.ai/ — a Framer
marketing splash with no composer, no messages, no chat UI of any kind. Loading
it logs:

    [SayPi INFO] Say, Pi extension loading in chat mode for pi

That is the worst of both worlds. The chat content script isn't even there
(`entrypoints/saypi.content.ts` matches `https://pi.ai/*`, which is the host
`pi.ai` and nothing else), so it's the *universal* script that loaded — and then
took the chat branch anyway, because `isInChatMode()` was derived from
`identifyChatbot()`, which deliberately collapses a hostname to its registrable
domain ("claude.ai" in "chat.claude.ai"). So chat machinery boots on a page with
nothing to decorate, while universal dictation stands down —
`UniversalDictationModule.isExcludedSite()` is literally `isInChatMode()`. The
user gets neither feature. Same story for any non-chat claude.ai or chat.com
subdomain.

The two questions were being answered by one predicate. "Which product is this?"
is attribution — `hey.pi.ai` is very much Pi. "Does this page have a chat UI to
decorate?" is mode, and that one is answered by the content-script injection
scope. So this splits them: a new `CHAT_APP_HOSTNAMES` list of the exact chat-app
hosts backs `isChatAppHost()`, and the two mode gates key off that.
`identifyChatbot()` and `getAppId()` are untouched — the spec pins their output
for all 13 corpus hosts, `hey.pi.ai` → "pi" included.

Two things this had to avoid breaking:

*Exhaustiveness.* Narrowing only `isInChatMode()` would drop `hey.pi.ai` into
NEITHER mode — chat gone, dictation still suppressed — a worse bug than the one
being fixed. `isInDictationMode()` is now the complement of the same predicate,
and a test asserts XOR over the whole corpus. The one carve-out, unchanged from
before, is a context with no `location` binding at all: no page, no mode, both
gates false. Note that is *not* the extension service worker — as
`getGlobalLocation()` has always said, a SW resolves to its own
`chrome-extension://<id>/` scope, so it has a hostname, isn't a chat-app host,
and lands in dictation mode exactly as it did before. A 32-char id-shaped host
covers that row.

*Hostname, not origin.* The injection scope this mirrors is written as host match
patterns, so a plain host list tracks it 1:1.

`CHAT_APP_HOSTNAMES` duplicates knowledge that lives in the entrypoints, which
are founder-gated and can't be edited from here. Both entrypoints also import
the same `src/saypi.index.js`, so the bundle can't learn at runtime which script
loaded it — restating the list is forced. `ChatbotIdentifier-injectionParity.spec.ts`
therefore reads both entrypoint files off disk, extracts their match patterns,
asserts all three lists agree, **and** asserts that `matches:` / `excludeMatches:`
actually reference that const — without which you can inline the five patterns
into the config, keep `CHATBOT_MATCHES` intact, and have a green guard while the
chat script double-injects. It guards against a vacuous pass (asserts the parse
found 5 patterns first) and deliberately does not normalise a leading `*.` away
— if someone writes `https://*.pi.ai/*` the extracted host is the literal
`*.pi.ai`, the equality fails, and a human decides.

## Making mode and implementation impossible to disagree

`ChatbotService.getChatbotSync()` still picked the concrete Chatbot with its own
SUBSTRING hostname test (`hostname.includes("pi.ai")`). That agreed with the mode
gate only by accident — both were domain-shaped. Narrowing mode removed the
accident: `hey.pi.ai` ran universal dictation while holding a `PiAIChatbot`, and
everything downstream that reads the chatbot rather than the mode went with it.
Concretely, `constructTranscriptionFormData()` appends a `nickname` field
whenever the chatbot's nickname differs from its name — so the same dictation
carried the user's Pi nickname on that one host and on no other site.

The implementation is now derived from the same predicate: not a chat-app host ⇒
`WebDictationChatbot`, otherwise switch on the identified chatbot. The five
chat-app hosts resolve exactly as before. The safety argument is that this moves
`hey.pi.ai` *off* a hybrid nothing else exercises and *onto* the path every
ordinary dictation site already takes — including the module-level
`StateMachineService` and `ButtonModule` singletons, which construct with the
chatbot in both modes, which is why `WebDictationChatbot`'s throwing stubs aren't
a hazard here.

One knock-on to be honest about: `buildUsageMetadata()` prefers
`chatbot.getID()` over `ChatbotIdentifier.getAppId()`, so `/transcribe` from
`hey.pi.ai` now reports `app: "web"` rather than `"pi"`. The identifier functions
themselves are untouched and still answer "pi"; the *emitted* field follows the
chatbot, and "generic dictation on a web page" is what that upload now is.
`addChatbotFlags()` is deliberately left domain-shaped (`body.pi` still lands
there) — it's attribution-flavoured, and pi.scss targets chat elements that don't
exist on the splash.

## Verification

Fail-first, with the constant exported but the gates still on the old code:

    FAIL test/chatbots/ChatbotIdentifier-chatOrigin.spec.ts > hey.pi.ai is a dictation page, not a chat page
    AssertionError: expected true to be false // Object.is equality
    - Expected  false
    + Received  true
     ❯ 70|       expect(ChatbotIdentifier.isInChatMode()).toBe(false);

    Tests  5 failed | 53 passed (58)

Fail-first for the chatbot-service half (`ChatbotService-modeAgreement.spec.ts`
against the old substring routing):

    Tests  10 failed | 16 passed (26)
    AssertionError: expected WebDictationChatbot{} to be an instance of ClaudeChatbot
    AssertionError: expected true to be false   // "pi.ai cannot disagree with its own mode"

A caveat worth stating rather than glossing: the `hey.pi.ai` row of that spec
passed even pre-fix, and could not have failed. The old `getChatbotSync()` read
`window.location.hostname` directly, and under our jsdom setup that property is a
**non-configurable own accessor** on a non-configurable `window.location` — it
cannot be stubbed, spied, or redefined (verified by probe), so every host under
test resolved to `localhost` and everything came back `WebDictationChatbot`. That
unstubbability is itself the finding: routing through `ChatbotIdentifier` is what
makes this assertable at Layer 1 at all. The test that *does* go red in the
target direction on pre-fix code is the Layer-3 one below.

Non-vacuity of the parity guard: the reference check is exercised against four
synthetic divergences (patterns inlined into the field, const spread into a wider
array, field pointed at a different const, field no longer referencing it) plus
an anchoring case proving `matches:` can't be satisfied by `excludeMatches:`.
Done with synthetic sources rather than by temporarily editing an entrypoint,
because `entrypoints/*.content.ts` are founder-gated — which also makes the
demonstration permanent coverage instead of a one-off manual experiment.

Layer 3 now covers the behaviour end to end, since `npm test` can't:
`hey.pi.ai` is mapped at the DNS layer like every other host, served a
composer-less marketing-splash mock, and `chat-adjacent-dictation.e2e.ts` asserts
the dictation button lands (positive signal first, `state: "attached"` since it
starts hidden) and that no call button does. Proved non-vacuous by reverting the
mode gate, rebuilding, and watching it time out:

    TimeoutError: page.waitForSelector: Timeout 20000ms exceeded.
      - waiting for locator('.saypi-dictation-button')

After the fix — `npm test` (typecheck + Jest + Vitest):

    Test Suites: 1 passed, 1 total
    Tests:       2 passed, 2 total
    Test Files  224 passed (224)
    Tests  2128 passed | 1 skipped (2129)

And Layer 3:

    14 passed (48.8s)

One cosmetic consequence worth knowing before the next sweep: hey.pi.ai now logs
"loading in dictation mode for pi". That reads oddly but is exactly right —
attribution stays `pi`, only the mode changes.

Part of #559

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5tDjPqe75yTHjCKavhrFx
