### PR TITLE
sweep: distinguish "never reached the chat app" from selector drift (#559)

### DIFF
--- a/doc/e2e-host-sweep.md
+++ b/doc/e2e-host-sweep.md
@@ -185,9 +185,12 @@ A default sweep is **not free or traceless** — it acts as the founder on real 
   `page.url()` *after* the 25s decoration wait, so a client-side bounce that fires past
   `domcontentloaded` is caught — has never run against a bouncing host. The case that
   motivated it (signed-out `pi.ai/talk` → `hey.pi.ai`) is no longer reproducible: the
-  seeded profile is signed in to pi.ai, so `/talk` doesn't bounce. First real
-  `redirected-off-origin` verdict should be sanity-checked against `01-before.png`
-  rather than trusted outright (#559).
+  seeded profile is signed in to pi.ai, so `/talk` doesn't bounce. Same for the
+  `finally` guard that makes "every undecorated host has a kind" true — the classifier
+  is unit-proven, the harness wiring around it is read, not run (`sweepHost` isn't
+  importable: the script calls `main()` at import). First real `redirected-off-origin`
+  verdict should be sanity-checked against `01-before.png` rather than trusted
+  outright (#559).
 - Built on `scripts/layer4cdp-lib.mjs` (launch/Cloudflare/profile helpers) +
   `scripts/e2e-host-sweep-lib.mjs` (pure: host registry, arg parse, console attribution,
   summary, per-host DOM diagnostics, the undecorated classifier + sign-in probe —

--- a/doc/e2e-host-sweep.md
+++ b/doc/e2e-host-sweep.md
@@ -105,7 +105,8 @@ holds the per-host `summarize()` rollup.
    A host can fail to decorate because SayPi never got a chat app to decorate. The
    harness classifies it for you from the requested vs. **final** URL (`evidence.finalUrl`
    — hosts bounce you *after* load, so this is re-read at the decoration deadline) plus
-   any sign-in affordance on the page:
+   any sign-in affordance on the page. Every undecorated host gets one of these five —
+   `undecorated` is null **only** when the host decorated:
    - `redirected-off-origin` — we left the requested origin (the live case: pi.ai now
      bounces signed-out visitors from `pi.ai/talk` to the `hey.pi.ai` splash, #559).
      **Automation/seeding problem** — sign in to the seeded profile and re-run. Says
@@ -114,9 +115,14 @@ holds the per-host `summarize()` rollup.
      automation/seeding, re-seed and re-run.
    - `possible-drift` — the requested page rendered and SayPi still didn't decorate it.
      **This is the real defect case** — hunt it against `domDiagnostics`. The classifier
-     deliberately biases here: a visible sign-in button alone stays `possible-drift`
-     (as a caveat in the note), because a false "signed out" would bury the very defect
-     class this sweep exists to find.
+     deliberately biases here: a sign-in button alone stays `possible-drift` (as a caveat
+     in the note), because a false "signed out" would bury the very defect class this
+     sweep exists to find. The probe behind that caveat counts a control that is not
+     hidden by `display:none` / `visibility:hidden` / `[hidden]` / `aria-hidden`; it does
+     **not** model layout, so a zero-sized or off-screen control still counts.
+   - `run-aborted` — the run ended before the page could be judged at all (a Cloudflare
+     challenge, or an exception mid-host — see `cloudflareBlocked` / `notes[]`). Fix the
+     run and re-run; says nothing about SayPi.
    - `unknown` — no usable final URL; fall back to `01-before.png`.
 3. **Attribute to SayPi only.** Hosts emit their own console noise (claude.ai `/v1/toolbox`
    405s, ProseMirror warnings, framework deprecations). `summarize()` splits
@@ -174,6 +180,14 @@ A default sweep is **not free or traceless** — it acts as the founder on real 
 - The synthetic source plays **one** utterance per call (`loop:false`); it cannot be
   re-armed mid-call, so **multi-turn** conversations can't be driven synthetically today
   (issue #364). Single-turn per host is what the sweep covers.
+- **The redirect classifier's live path is unproven.** `classifyUndecorated` and the
+  sign-in probe are unit-tested, but the mechanism that feeds them — re-reading
+  `page.url()` *after* the 25s decoration wait, so a client-side bounce that fires past
+  `domcontentloaded` is caught — has never run against a bouncing host. The case that
+  motivated it (signed-out `pi.ai/talk` → `hey.pi.ai`) is no longer reproducible: the
+  seeded profile is signed in to pi.ai, so `/talk` doesn't bounce. First real
+  `redirected-off-origin` verdict should be sanity-checked against `01-before.png`
+  rather than trusted outright (#559).
 - Built on `scripts/layer4cdp-lib.mjs` (launch/Cloudflare/profile helpers) +
   `scripts/e2e-host-sweep-lib.mjs` (pure: host registry, arg parse, console attribution,
   summary, per-host DOM diagnostics, the undecorated classifier + sign-in probe —

--- a/doc/e2e-host-sweep.md
+++ b/doc/e2e-host-sweep.md
@@ -90,7 +90,7 @@ accepting longer turns / a possible `piThinking` timeout window.
 
 Per host the harness writes to `.output/e2e-host-sweep/<run>/<host>/`:
 `evidence.json` (console / pageErrors / network / requestFailed / domDiagnostics /
-auth+voice / transcript / observe flags) and screenshots
+auth+voice / transcript / observe flags / `finalUrl` + `undecorated`) and screenshots
 (`01-before`, `02-transcript`, `0N-observe…`, `99-final`). A run-level `summary.json`
 holds the per-host `summarize()` rollup.
 
@@ -101,20 +101,37 @@ holds the per-host `summarize()` rollup.
    *false negative* because the composer **clears on auto-submit** — the turn actually
    succeeded. (This exact trap produced a wrong first read on ChatGPT in the sweep that
    first shipped this tool; the screenshot showed the reply had rendered.)
-2. **Attribute to SayPi only.** Hosts emit their own console noise (claude.ai `/v1/toolbox`
+2. **`decorated=false` is not automatically drift — read `undecorated.kind` first.**
+   A host can fail to decorate because SayPi never got a chat app to decorate. The
+   harness classifies it for you from the requested vs. **final** URL (`evidence.finalUrl`
+   — hosts bounce you *after* load, so this is re-read at the decoration deadline) plus
+   any sign-in affordance on the page:
+   - `redirected-off-origin` — we left the requested origin (the live case: pi.ai now
+     bounces signed-out visitors from `pi.ai/talk` to the `hey.pi.ai` splash, #559).
+     **Automation/seeding problem** — sign in to the seeded profile and re-run. Says
+     nothing about SayPi.
+   - `signed-out` — right origin, sign-in wall instead of the chat app. Same:
+     automation/seeding, re-seed and re-run.
+   - `possible-drift` — the requested page rendered and SayPi still didn't decorate it.
+     **This is the real defect case** — hunt it against `domDiagnostics`. The classifier
+     deliberately biases here: a visible sign-in button alone stays `possible-drift`
+     (as a caveat in the note), because a false "signed out" would bury the very defect
+     class this sweep exists to find.
+   - `unknown` — no usable final URL; fall back to `01-before.png`.
+3. **Attribute to SayPi only.** Hosts emit their own console noise (claude.ai `/v1/toolbox`
    405s, ProseMirror warnings, framework deprecations). `summarize()` splits
    `saypiErrors`/`saypiWarnings` from `hostErrors` for you — file SayPi-attributable
    issues, not host noise.
-3. **Beware harness artifacts.** Some signals are produced by the headed/background-tab
+4. **Beware harness artifacts.** Some signals are produced by the headed/background-tab
    harness, not normal use (e.g. an `exitFullscreen` "Document not active" rejection is
    amplified by a non-focused tab). Label these honestly.
-4. **`/transcribe` is invisible to the page listener** — it routes via the background SW
+5. **`/transcribe` is invisible to the page listener** — it routes via the background SW
    (so STT success shows in the console "Transcribed N words" line + the composer, not
    in `network[]`). Don't read its absence as a failure.
-5. **Dedup before filing** — check open **and closed** issues (`gh issue list --state all`);
+6. **Dedup before filing** — check open **and closed** issues (`gh issue list --state all`);
    host DOM-drift is a recurring class (#350/#351/#352/#362), so a "new" drift may be a
    re-occurrence or already tracked.
-6. **Honest per-host reporting.** A host whose core flows are healthy should be reported
+7. **Honest per-host reporting.** A host whose core flows are healthy should be reported
    **clean, with evidence** — do not pad with a low-value issue just to hit a per-host
    count.
 
@@ -159,5 +176,7 @@ A default sweep is **not free or traceless** — it acts as the founder on real 
   (issue #364). Single-turn per host is what the sweep covers.
 - Built on `scripts/layer4cdp-lib.mjs` (launch/Cloudflare/profile helpers) +
   `scripts/e2e-host-sweep-lib.mjs` (pure: host registry, arg parse, console attribution,
-  summary — unit-tested in `test/scripts/e2e-host-sweep-lib.spec.ts`).
+  summary, per-host DOM diagnostics, the undecorated classifier + sign-in probe —
+  unit-tested in `test/scripts/e2e-host-sweep-lib.spec.ts`,
+  `…-diags.spec.ts`, `…-undecorated.spec.ts`).
 ```

--- a/doc/e2e-host-sweep.md
+++ b/doc/e2e-host-sweep.md
@@ -185,12 +185,12 @@ A default sweep is **not free or traceless** — it acts as the founder on real 
   `page.url()` *after* the 25s decoration wait, so a client-side bounce that fires past
   `domcontentloaded` is caught — has never run against a bouncing host. The case that
   motivated it (signed-out `pi.ai/talk` → `hey.pi.ai`) is no longer reproducible: the
-  seeded profile is signed in to pi.ai, so `/talk` doesn't bounce. Same for the
-  `finally` guard that makes "every undecorated host has a kind" true — the classifier
-  is unit-proven, the harness wiring around it is read, not run (`sweepHost` isn't
-  importable: the script calls `main()` at import). First real `redirected-off-origin`
-  verdict should be sanity-checked against `01-before.png` rather than trusted
-  outright (#559).
+  seeded profile is signed in to pi.ai, so `/talk` doesn't bounce. The `finally` guard
+  that makes "every undecorated host has a kind" true IS run — `sweepHost` is importable
+  and `…-undecorated-wiring.spec.ts` drives it against stub pages — but only the
+  after-the-wait `page.url()` re-read still awaits a real bouncing host. So the first
+  real `redirected-off-origin` verdict should be sanity-checked against `01-before.png`
+  rather than trusted outright (#559).
 - Built on `scripts/layer4cdp-lib.mjs` (launch/Cloudflare/profile helpers) +
   `scripts/e2e-host-sweep-lib.mjs` (pure: host registry, arg parse, console attribution,
   summary, per-host DOM diagnostics, the undecorated classifier + sign-in probe —

--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -104,6 +104,151 @@ export function ttsCoverage(summaries = []) {
 }
 
 /**
+ * Why a host ended the run with nothing decorated. The distinction is the whole
+ * point: only DRIFT is a SayPi defect worth hunting — the others mean the sweep
+ * never got a chat app in front of the extension (#559).
+ */
+export const UNDECORATED_KINDS = {
+  /** The page ended up on a different origin than requested (pi.ai/talk → hey.pi.ai). */
+  REDIRECTED: "redirected-off-origin",
+  /** Right origin, but the host served a sign-in wall instead of the chat app. */
+  SIGNED_OUT: "signed-out",
+  /** The requested page loaded and SayPi still didn't decorate it. THE defect case. */
+  DRIFT: "possible-drift",
+  /** Not enough signal to tell (no usable final URL) — read the screenshot. */
+  UNKNOWN: "unknown",
+};
+
+/** Auth-ish route segments every host uses for its sign-in wall. */
+const AUTH_ROUTE = /(^|\/)(login|log-in|signin|sign-in|sign_in|auth|authorize)(\/|$)/i;
+const AUTH_TITLE = /\b(log ?in|sign ?in|sign ?up)\b/i;
+
+/** Origin key for comparison: host without a cosmetic leading "www.". null if unusable. */
+function originKey(url) {
+  try {
+    const u = new URL(String(url));
+    if (!/^https?:$/.test(u.protocol)) return null;
+    return u.host.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Explain a host that never decorated (#saypi-callButton never appeared), from
+ * what the harness can observe at that moment. Pure.
+ *
+ * Precedence is deliberate. Origin first: a marketing splash like hey.pi.ai also
+ * shows sign-up CTAs, and "we were bounced off the chat origin" is the stronger,
+ * more actionable fact. Then a corroborated sign-in wall — corroborated means the
+ * final URL is an auth route, or the page *title* reads as auth AND a sign-in
+ * affordance is on screen. A bare affordance on the requested page is NOT enough:
+ * we bias toward DRIFT because a false "signed out" quietly buries the highest-
+ * signal defect class this sweep exists to find, while a false "drift" only costs
+ * one investigation. The affordance still rides along in the note as a caveat.
+ *
+ * @param {{requestedUrl?: string, finalUrl?: string, title?: string, signInVisible?: boolean}} [input]
+ * @returns {{kind: string, owner: string, redirected: boolean, requestedOrigin: string|null,
+ *            finalOrigin: string|null, finalUrl: string|null, signInAffordance: boolean, note: string}}
+ */
+export function classifyUndecorated(input = {}) {
+  const requestedUrl = input.requestedUrl ?? null;
+  const finalUrl = input.finalUrl ?? null;
+  const title = String(input.title ?? "");
+  const signInAffordance = !!input.signInVisible;
+  const requestedOrigin = originKey(requestedUrl);
+  const finalOrigin = originKey(finalUrl);
+  const base = { requestedOrigin, finalOrigin, finalUrl: finalUrl ?? null, signInAffordance };
+
+  if (!requestedOrigin || !finalOrigin) {
+    return {
+      ...base,
+      kind: UNDECORATED_KINDS.UNKNOWN,
+      owner: "unknown",
+      redirected: false,
+      note:
+        `not decorated, and the final URL could not be read (requested ${requestedUrl ?? "?"}, ` +
+        `final ${finalUrl || "(none)"}) — can't tell a redirect / sign-in wall from SayPi selector ` +
+        `drift. Check the 01-before.png screenshot and the console before concluding anything.`,
+    };
+  }
+
+  if (finalOrigin !== requestedOrigin) {
+    return {
+      ...base,
+      kind: UNDECORATED_KINDS.REDIRECTED,
+      owner: "automation",
+      redirected: true,
+      note:
+        `not decorated because the page left the requested origin: ${requestedUrl} → ${finalUrl}. ` +
+        `SayPi never saw the chat app, so this run says NOTHING about SayPi selector drift. ` +
+        `Usually the seeded profile is signed out and the host bounces visitors to an intro/marketing ` +
+        `page; less often the host has moved its chat app. Next step: sign in to the seeded profile ` +
+        `(npm run layer4cdp:seed), re-run, and if it still lands on ${finalOrigin} while signed in, ` +
+        `the host URL in HOSTS is what changed.`,
+    };
+  }
+
+  let finalPath = "/";
+  try {
+    finalPath = new URL(finalUrl).pathname;
+  } catch {
+    /* originKey already proved it parses; keep the default */
+  }
+  if (AUTH_ROUTE.test(finalPath) || (AUTH_TITLE.test(title) && signInAffordance)) {
+    return {
+      ...base,
+      kind: UNDECORATED_KINDS.SIGNED_OUT,
+      owner: "automation",
+      redirected: false,
+      note:
+        `not decorated because ${finalOrigin} served a sign-in wall rather than the chat app ` +
+        `(${finalUrl}${title ? `, title "${title}"` : ""}). The chat DOM never rendered, so this run ` +
+        `says NOTHING about SayPi selector drift. Next step: sign in to the seeded profile ` +
+        `(npm run layer4cdp:seed) and re-run.`,
+    };
+  }
+
+  return {
+    ...base,
+    kind: UNDECORATED_KINDS.DRIFT,
+    owner: "saypi",
+    redirected: false,
+    note:
+      `not decorated on the requested page itself (${finalUrl}) — no redirect off ${requestedOrigin} ` +
+      `and no sign-in wall, so the host app rendered and SayPi failed to decorate it. This is the ` +
+      `genuine-drift case: hunt it (compare domDiagnostics against the adapter's selectors, ` +
+      `corroborate with 01-before.png).` +
+      (signInAffordance
+        ? ` Caveat: a sign-in affordance was visible on the page — confirm the profile is actually ` +
+          `signed in to the host before filing a drift issue.`
+        : ""),
+  };
+}
+
+/**
+ * Was a sign-in affordance on screen? Corroborating evidence for
+ * classifyUndecorated. Self-contained: the harness stringifies it and evaluates
+ * it in the page (same rule as DIAGS — it may not close over this module).
+ * Deliberately narrow — a short, button-shaped "Log in"/"Sign up" label or an
+ * auth href — so prose that merely mentions signing in doesn't fire it.
+ */
+export const SIGN_IN_PROBE = () => {
+  const LABEL = /^(sign[ -]?in|log[ -]?in|sign[ -]?up|register|get started|continue with [a-z]+)$/i;
+  const HREF = /\/(login|log-in|signin|sign-in|sign_in|auth|authorize)(\/|\?|$)/i;
+  const labels = [];
+  for (const el of document.querySelectorAll("a, button, [role='button']")) {
+    const text = (el.textContent || "").trim();
+    if (text.length > 40) continue; // prose, not a control
+    const href = el.getAttribute("href") || "";
+    if (!LABEL.test(text) && !(href && HREF.test(href))) continue;
+    const label = text || href.slice(0, 80);
+    if (label && !labels.includes(label)) labels.push(label);
+  }
+  return { visible: labels.length > 0, labels: labels.slice(0, 6) };
+};
+
+/**
  * Reduce a captured evidence object to a flat, comparable summary. Pure — takes
  * the shape the harness writes (console[], pageErrors[], requestFailed[], ...).
  */
@@ -114,6 +259,11 @@ export function summarize(evidence = {}) {
   return {
     host: evidence.host ?? null,
     decorated: !!evidence.decorated,
+    // Where the page actually ended up, and why nothing decorated if it didn't.
+    // Both are null on a healthy host; on an undecorated one they are the two
+    // fields that keep a reader from mistaking a redirect for selector drift (#559).
+    finalUrl: evidence.finalUrl ?? null,
+    undecorated: evidence.undecorated?.kind ?? null,
     cloudflareBlocked: !!evidence.cloudflareBlocked,
     transcript: evidence.transcript ?? null,
     authStatus: evidence.authStatus ?? null,

--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -115,6 +115,8 @@ export const UNDECORATED_KINDS = {
   SIGNED_OUT: "signed-out",
   /** The requested page loaded and SayPi still didn't decorate it. THE defect case. */
   DRIFT: "possible-drift",
+  /** The run never got far enough to judge (Cloudflare challenge, harness error). */
+  ABORTED: "run-aborted",
   /** Not enough signal to tell (no usable final URL) — read the screenshot. */
   UNKNOWN: "unknown",
 };
@@ -147,7 +149,14 @@ function originKey(url) {
  * signal defect class this sweep exists to find, while a false "drift" only costs
  * one investigation. The affordance still rides along in the note as a caveat.
  *
- * @param {{requestedUrl?: string, finalUrl?: string, title?: string, signInVisible?: boolean}} [input]
+ * `abortedBecause` short-circuits everything: the harness has paths that end a run
+ * before the page can be judged at all (a Cloudflare challenge, an exception), and
+ * those must not fall through to a URL-derived verdict — a crashed page reports a
+ * junk URL, which would read as `unknown` and send the reader to a screenshot the
+ * run never took. Every `decorated: false` host gets a kind; none are left null.
+ *
+ * @param {{requestedUrl?: string, finalUrl?: string, title?: string, signInVisible?: boolean,
+ *          abortedBecause?: string}} [input]
  * @returns {{kind: string, owner: string, redirected: boolean, requestedOrigin: string|null,
  *            finalOrigin: string|null, finalUrl: string|null, signInAffordance: boolean, note: string}}
  */
@@ -159,6 +168,20 @@ export function classifyUndecorated(input = {}) {
   const requestedOrigin = originKey(requestedUrl);
   const finalOrigin = originKey(finalUrl);
   const base = { requestedOrigin, finalOrigin, finalUrl: finalUrl ?? null, signInAffordance };
+
+  if (input.abortedBecause) {
+    return {
+      ...base,
+      kind: UNDECORATED_KINDS.ABORTED,
+      owner: "automation",
+      redirected: false,
+      note:
+        `not decorated because ${input.abortedBecause} — the run ended before SayPi could be judged ` +
+        `against a chat app, so it says NOTHING about SayPi selector drift. Fix the run ` +
+        `(re-seed with npm run layer4cdp:seed for a Cloudflare block; read notes[]/console for an ` +
+        `error) and re-run before reading anything into this host.`,
+    };
+  }
 
   if (!requestedOrigin || !finalOrigin) {
     return {
@@ -220,18 +243,29 @@ export function classifyUndecorated(input = {}) {
       `genuine-drift case: hunt it (compare domDiagnostics against the adapter's selectors, ` +
       `corroborate with 01-before.png).` +
       (signInAffordance
-        ? ` Caveat: a sign-in affordance was visible on the page — confirm the profile is actually ` +
-          `signed in to the host before filing a drift issue.`
+        ? ` Caveat: a sign-in affordance was on the page and not hidden — confirm the profile is ` +
+          `actually signed in to the host before filing a drift issue.`
         : ""),
   };
 }
 
 /**
- * Was a sign-in affordance on screen? Corroborating evidence for
+ * Was a sign-in affordance on the page, not hidden? Corroborating evidence for
  * classifyUndecorated. Self-contained: the harness stringifies it and evaluates
- * it in the page (same rule as DIAGS — it may not close over this module).
- * Deliberately narrow — a short, button-shaped "Log in"/"Sign up" label or an
- * auth href — so prose that merely mentions signing in doesn't fire it.
+ * it in the page (same rule as DIAGS — it may not close over this module, so the
+ * `hidden` helper lives inside the function body).
+ *
+ * Deliberately narrow — a short, button-shaped "Log in"/"Sign up" label or an auth
+ * href — so prose that merely mentions signing in doesn't fire it. And it skips
+ * anything hidden: every signed-in host ships a login link parked in some collapsed
+ * menu, and counting that would staple a "but a sign-in affordance was there"
+ * caveat onto essentially every genuine drift finding.
+ *
+ * `visible` means exactly "matched and not hidden by display:none /
+ * visibility:hidden / [hidden] / aria-hidden on itself or an ancestor". It does
+ * not model layout (offsetParent/getClientRects report nothing under JSDOM, so
+ * that branch could never be tested), so zero-sized or off-screen-positioned
+ * controls still count.
  */
 export const SIGN_IN_PROBE = () => {
   const LABEL = /^(sign[ -]?in|log[ -]?in|sign[ -]?up|register|get started|continue with [a-z]+)$/i;
@@ -239,6 +273,23 @@ export const SIGN_IN_PROBE = () => {
   // Sign-OUT is auth-shaped but means the opposite (we're signed in) — /api/auth/logout
   // matches HREF, and letting it through would staple a backwards caveat onto a note.
   const OUT = /(log|sign)[ -_]?out/i;
+  // Ancestor walk, not just the element: `display` doesn't inherit, so a
+  // <nav style="display:none"> hides its children without touching their own
+  // computed style. (Cost of the walk is why it runs only on label/href matches —
+  // a chat host's sidebar has hundreds of anchors.)
+  // (via document.defaultView, not the bare global: the probe has to work both in
+  // the page and under the JSDOM the unit tests hand-build, which exposes `document`
+  // without a global `getComputedStyle`.)
+  const view = document.defaultView;
+  const hidden = (el) => {
+    if (el.closest("[hidden], [aria-hidden='true']")) return true;
+    if (!view) return false;
+    for (let n = el; n && n.nodeType === 1; n = n.parentElement) {
+      const s = view.getComputedStyle(n);
+      if (s.display === "none" || s.visibility === "hidden") return true;
+    }
+    return false;
+  };
   const labels = [];
   for (const el of document.querySelectorAll("a, button, [role='button']")) {
     const text = (el.textContent || "").trim();
@@ -246,6 +297,7 @@ export const SIGN_IN_PROBE = () => {
     const href = el.getAttribute("href") || "";
     if (OUT.test(text) || OUT.test(href)) continue;
     if (!LABEL.test(text) && !(href && HREF.test(href))) continue;
+    if (hidden(el)) continue;
     const label = text || href.slice(0, 80);
     if (label && !labels.includes(label)) labels.push(label);
   }
@@ -264,8 +316,9 @@ export function summarize(evidence = {}) {
     host: evidence.host ?? null,
     decorated: !!evidence.decorated,
     // Where the page actually ended up, and why nothing decorated if it didn't.
-    // Both are null on a healthy host; on an undecorated one they are the two
-    // fields that keep a reader from mistaking a redirect for selector drift (#559).
+    // `finalUrl` is recorded on every run (a healthy claude.ai lands on a
+    // conversation URL); `undecorated` is null exactly when the host decorated.
+    // Together they keep a reader from mistaking a redirect for drift (#559).
     finalUrl: evidence.finalUrl ?? null,
     undecorated: evidence.undecorated?.kind ?? null,
     cloudflareBlocked: !!evidence.cloudflareBlocked,

--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -236,11 +236,15 @@ export function classifyUndecorated(input = {}) {
 export const SIGN_IN_PROBE = () => {
   const LABEL = /^(sign[ -]?in|log[ -]?in|sign[ -]?up|register|get started|continue with [a-z]+)$/i;
   const HREF = /\/(login|log-in|signin|sign-in|sign_in|auth|authorize)(\/|\?|$)/i;
+  // Sign-OUT is auth-shaped but means the opposite (we're signed in) — /api/auth/logout
+  // matches HREF, and letting it through would staple a backwards caveat onto a note.
+  const OUT = /(log|sign)[ -_]?out/i;
   const labels = [];
   for (const el of document.querySelectorAll("a, button, [role='button']")) {
     const text = (el.textContent || "").trim();
     if (text.length > 40) continue; // prose, not a control
     const href = el.getAttribute("href") || "";
+    if (OUT.test(text) || OUT.test(href)) continue;
     if (!LABEL.test(text) && !(href && HREF.test(href))) continue;
     const label = text || href.slice(0, 80);
     if (label && !labels.includes(label)) labels.push(label);

--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -144,7 +144,7 @@ function originKey(url) {
  * shows sign-up CTAs, and "we were bounced off the chat origin" is the stronger,
  * more actionable fact. Then a corroborated sign-in wall — corroborated means the
  * final URL is an auth route, or the page *title* reads as auth AND a sign-in
- * affordance is on screen. A bare affordance on the requested page is NOT enough:
+ * affordance is present and not hidden. A bare affordance on the requested page is NOT enough:
  * we bias toward DRIFT because a false "signed out" quietly buries the highest-
  * signal defect class this sweep exists to find, while a false "drift" only costs
  * one investigation. The affordance still rides along in the note as a caveat.

--- a/scripts/e2e-host-sweep.mjs
+++ b/scripts/e2e-host-sweep.mjs
@@ -324,6 +324,21 @@ async function sweepHost(ctx, host, url, opts, outDir) {
   } catch (err) {
     ev.notes.push(`error: ${err.message}`);
   } finally {
+    // Invariant: an undecorated host ALWAYS carries a verdict, so "read
+    // undecorated.kind first" never lands on null. The paths that return before
+    // the classifier runs — the Cloudflare block above, the catch, and anything
+    // added later — land here instead of silently reopening the gap (#559).
+    if (!ev.decorated && !ev.undecorated) {
+      ev.undecorated = classifyUndecorated({
+        requestedUrl: url,
+        finalUrl: ev.finalUrl,
+        title: ev.pageTitle,
+        abortedBecause: ev.cloudflareBlocked
+          ? "a Cloudflare challenge blocked the page"
+          : "the run ended before the decoration check finished",
+      });
+      ev.notes.push(ev.undecorated.note);
+    }
     writeFileSync(join(dir, "evidence.json"), JSON.stringify(ev, null, 2));
     await page.close().catch(() => {});
   }

--- a/scripts/e2e-host-sweep.mjs
+++ b/scripts/e2e-host-sweep.mjs
@@ -411,4 +411,11 @@ async function main() {
   log(`SWEEP DONE — evidence under ${outDir}`);
   process.exit(0);
 }
-main().catch((e) => { log(`fatal: ${e.message}`); process.exit(1); });
+// Run the CLI only when invoked directly — importing this module (the Vitest spec
+// drives the real sweepHost against stub pages) must not launch Chrome. Same idiom
+// as scripts/l4-ledger.mjs.
+if (process.argv[1] && resolvePath(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => { log(`fatal: ${e.message}`); process.exit(1); });
+}
+
+export { sweepHost };

--- a/scripts/e2e-host-sweep.mjs
+++ b/scripts/e2e-host-sweep.mjs
@@ -39,7 +39,16 @@ import { createServer } from "node:net";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveCdpProfileDir, buildCdpChromeArgs, isCloudflareChallenge } from "./layer4cdp-lib.mjs";
-import { HOSTS, DIAGS, parseSweepArgs, summarize, ttsCoverage, SAYPI_TTS_PROVIDER } from "./e2e-host-sweep-lib.mjs";
+import {
+  HOSTS,
+  DIAGS,
+  SIGN_IN_PROBE,
+  parseSweepArgs,
+  summarize,
+  ttsCoverage,
+  classifyUndecorated,
+  SAYPI_TTS_PROVIDER,
+} from "./e2e-host-sweep-lib.mjs";
 import { enforceSpendCap } from "./l4-ledger.mjs";
 
 const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
@@ -200,7 +209,11 @@ async function selectSaypiVoice(page, host) {
 
 async function sweepHost(ctx, host, url, opts, outDir) {
   const ev = {
-    host, url, decorated: false, cloudflareBlocked: false, build: null,
+    // `url` is what we ASKED for; `finalUrl`/`pageTitle` are where we actually ended
+    // up (a host can bounce us elsewhere), and `undecorated` explains a decoration
+    // failure. Without the final URL a redirect is invisible in the JSON (#559).
+    host, url, finalUrl: null, pageTitle: null, undecorated: null, signInAffordances: [],
+    decorated: false, cloudflareBlocked: false, build: null,
     transcript: null, autoSubmitted: false, assistantReplied: false,
     authStatus: null, voiceProvider: null, selectedVoice: null, selectedModel: null,
     console: [], pageErrors: [], network: [], requestFailed: [],
@@ -234,14 +247,31 @@ async function sweepHost(ctx, host, url, opts, outDir) {
   try {
     await page.goto(url, { waitUntil: "domcontentloaded", timeout: 35_000 }).catch((e) => ev.notes.push(`goto: ${e.message}`));
     const sig = { title: await page.title().catch(() => ""), url: page.url(), html: (await page.content().catch(() => "")).slice(0, 4000) };
+    ev.finalUrl = sig.url; ev.pageTitle = sig.title; // provisional — so even an early return carries them
     if (isCloudflareChallenge(sig)) { ev.cloudflareBlocked = true; log(`${host}: BLOCKED by Cloudflare — re-seed (npm run layer4cdp:seed)`); return ev; }
 
     ev.decorated = await page.waitForSelector("#saypi-callButton", { timeout: 25_000 }).then(() => true).catch(() => false);
+    // Re-read the URL/title AFTER the wait: pi.ai's logged-out bounce to hey.pi.ai is
+    // client-side JS that fires well after domcontentloaded, so `sig` still shows the
+    // requested URL and classifying off it would report the redirect as drift (#559).
+    ev.finalUrl = page.url(); ev.pageTitle = await page.title().catch(() => ev.pageTitle);
     ev.build = await page.evaluate(() => document.documentElement.dataset.saypiBuild ?? "(none)").catch(() => null);
     await page.screenshot({ path: join(dir, "01-before.png") }).catch(() => {});
     ev.domDiagnostics = await page.evaluate(DIAGS[host]).catch((e) => ({ error: e.message }));
 
-    if (!ev.decorated) { ev.notes.push("not decorated — selector drift or logged out"); return ev; }
+    if (!ev.decorated) {
+      const signIn = await page.evaluate(SIGN_IN_PROBE).catch(() => null);
+      ev.signInAffordances = signIn?.labels ?? [];
+      ev.undecorated = classifyUndecorated({
+        requestedUrl: url,
+        finalUrl: ev.finalUrl,
+        title: ev.pageTitle,
+        signInVisible: !!signIn?.visible,
+      });
+      ev.notes.push(ev.undecorated.note);
+      log(`${host}: NOT DECORATED [${ev.undecorated.kind}] — ${ev.undecorated.note}`);
+      return ev;
+    }
 
     // Select a faster claude.ai model (default) so the reply + readback finish in-window.
     if (!opts.noTurn && host === "claude" && opts.claudeModel !== "keep") {
@@ -350,7 +380,7 @@ async function main() {
       const ev = await sweepHost(ctx, key, url, opts, outDir);
       const s = summarize(ev);
       summaries.push(s);
-      log(`${key}: decorated=${s.decorated} cf=${s.cloudflareBlocked} transcript=${!!s.transcript} reply=${ev.assistantReplied} auth=${s.authStatus} voice=${s.voiceProvider}${ev.selectedVoice ? ` (selected:${ev.selectedVoice})` : ""}${ev.selectedModel ? ` model=${ev.selectedModel}` : ""} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures} | diag=${JSON.stringify(ev.domDiagnostics)}`);
+      log(`${key}: decorated=${s.decorated}${s.undecorated ? ` (${s.undecorated}, final=${s.finalUrl})` : ""} cf=${s.cloudflareBlocked} transcript=${!!s.transcript} reply=${ev.assistantReplied} auth=${s.authStatus} voice=${s.voiceProvider}${ev.selectedVoice ? ` (selected:${ev.selectedVoice})` : ""}${ev.selectedModel ? ` model=${ev.selectedModel}` : ""} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures} | diag=${JSON.stringify(ev.domDiagnostics)}`);
     }
   } finally {
     writeFileSync(join(outDir, "summary.json"), JSON.stringify(summaries, null, 2));

--- a/test/scripts/e2e-host-sweep-undecorated-wiring.spec.ts
+++ b/test/scripts/e2e-host-sweep-undecorated-wiring.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { sweepHost } from "../../scripts/e2e-host-sweep.mjs";
+
+/**
+ * The classifier spec next door proves classifyUndecorated() in isolation. This one
+ * proves the WIRING — specifically the invariant doc/e2e-host-sweep.md now states as
+ * fact and the analysis checklist tells agents to rely on:
+ *
+ *   an undecorated host ALWAYS carries an `undecorated` verdict in evidence.json.
+ *
+ * That invariant is held by a guard in sweepHost's `finally`, and it exists precisely
+ * because two paths return before the classifier would otherwise run (the Cloudflare
+ * early return, and the outer catch). Asserting it on the return value alone would be
+ * weaker than the claim — the checklist sends a reader to the FILE — so these tests
+ * read evidence.json off disk.
+ *
+ * Stub pages, not a browser: sweepHost only needs the handful of Playwright methods
+ * exercised before the early returns, so the real function runs unmodified.
+ */
+
+const CF_HTML = '<html><head><title>Just a moment...</title></head><body>cf-chl-bypass</body></html>';
+
+/** Minimal Playwright-page stand-in; `overrides` shape the path under test. */
+function stubPage(overrides: Record<string, unknown> = {}) {
+  const noop = async () => undefined;
+  return {
+    on: () => {},
+    goto: noop,
+    title: async () => "New chat",
+    content: async () => "<html><body>ok</body></html>",
+    url: () => "https://chatgpt.com/",
+    waitForSelector: async () => {
+      throw new Error("not found");
+    },
+    evaluate: noop,
+    screenshot: noop,
+    close: noop,
+    ...overrides,
+  };
+}
+
+const runSweep = (page: unknown, outDir: string) =>
+  sweepHost({ newPage: async () => page }, "chatgpt", "https://chatgpt.com/", { noTurn: true }, outDir);
+
+const evidenceOnDisk = (outDir: string) =>
+  JSON.parse(readFileSync(join(outDir, "chatgpt", "evidence.json"), "utf8"));
+
+describe("sweepHost always records a verdict for an undecorated host (#559)", () => {
+  let outDir: string;
+
+  beforeEach(() => {
+    outDir = mkdtempSync(join(tmpdir(), "saypi-sweep-wiring-"));
+  });
+
+  afterEach(() => {
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it("classifies the Cloudflare early return, which bypasses the normal classifier", async () => {
+    const ev = await runSweep(
+      stubPage({ title: async () => "Just a moment...", content: async () => CF_HTML }),
+      outDir
+    );
+
+    expect(ev.cloudflareBlocked).toBe(true);
+    expect(ev.decorated).toBe(false);
+    expect(ev.undecorated).not.toBeNull();
+    expect(evidenceOnDisk(outDir).undecorated).not.toBeNull();
+  });
+
+  it("classifies a run that throws after the decoration wait", async () => {
+    // page.url() is read again after waitForSelector and is NOT individually guarded,
+    // so throwing there is the honest way to reach the outer catch.
+    let urlCalls = 0;
+    const ev = await runSweep(
+      stubPage({
+        url: () => {
+          if (++urlCalls > 1) throw new Error("target closed");
+          return "https://chatgpt.com/";
+        },
+      }),
+      outDir
+    );
+
+    expect(ev.decorated).toBe(false);
+    expect(ev.notes.some((n: string) => n.includes("target closed"))).toBe(true);
+    expect(ev.undecorated).not.toBeNull();
+    expect(evidenceOnDisk(outDir).undecorated).not.toBeNull();
+  });
+
+  it("leaves the verdict null when the host decorated — the invariant is one-directional", async () => {
+    const ev = await runSweep(stubPage({ waitForSelector: async () => ({}) }), outDir);
+
+    expect(ev.decorated).toBe(true);
+    expect(ev.undecorated).toBeNull();
+    // finalUrl is populated regardless; only the verdict is decoration-conditional.
+    expect(evidenceOnDisk(outDir).finalUrl).toBe("https://chatgpt.com/");
+  });
+});

--- a/test/scripts/e2e-host-sweep-undecorated.spec.ts
+++ b/test/scripts/e2e-host-sweep-undecorated.spec.ts
@@ -130,6 +130,49 @@ describe("classifyUndecorated — the signed-out boundary", () => {
   });
 });
 
+describe("classifyUndecorated — the run never got far enough to judge", () => {
+  // The harness has early returns that leave the page unjudged: the Cloudflare
+  // challenge, and the outer catch when the run blows up mid-page. Those used to
+  // leave `undecorated: null` on an `decorated: false` host — a reader following
+  // "read undecorated.kind first" found nothing there. `abortedBecause` gives
+  // those paths a kind of their own so the field is never empty.
+  it("classifies a Cloudflare block as run-aborted, not drift", () => {
+    const c = classifyUndecorated({
+      requestedUrl: "https://claude.ai/new",
+      finalUrl: "https://claude.ai/new",
+      title: "Just a moment…",
+      abortedBecause: "a Cloudflare challenge blocked the page",
+    });
+
+    expect(c.kind).toBe(UNDECORATED_KINDS.ABORTED);
+    expect(c.owner).toBe("automation");
+    expect(c.redirected).toBe(false);
+    expect(c.note).toContain("a Cloudflare challenge blocked the page");
+    expect(c.note).toMatch(/nothing about saypi/i);
+  });
+
+  it("wins over every other signal — a junk final URL must not become 'unknown'", () => {
+    // A crashed/closed page reports no usable URL. Falling through to `unknown`
+    // would tell the reader to go read a screenshot the run never took.
+    const c = classifyUndecorated({
+      requestedUrl: "https://pi.ai/talk",
+      finalUrl: "",
+      abortedBecause: "the run ended before the decoration check finished",
+    });
+    expect(c.kind).toBe(UNDECORATED_KINDS.ABORTED);
+  });
+
+  it("wins over a URL pair that would otherwise read as a redirect", () => {
+    expect(
+      classifyUndecorated({
+        requestedUrl: "https://pi.ai/talk",
+        finalUrl: "https://hey.pi.ai/",
+        abortedBecause: "the run ended before the decoration check finished",
+      }).kind
+    ).toBe(UNDECORATED_KINDS.ABORTED);
+  });
+});
+
 describe("classifyUndecorated — origin comparison edges", () => {
   it("does not call a cosmetic www. hop a redirect", () => {
     const c = classifyUndecorated({ requestedUrl: "https://pi.ai/talk", finalUrl: "https://www.pi.ai/talk" });
@@ -188,6 +231,38 @@ describe("SIGN_IN_PROBE", () => {
     document.body.innerHTML = `<button>You can sign in later to keep your conversation history</button>`;
     expect(SIGN_IN_PROBE().visible).toBe(false);
   });
+
+  // The probe reports a field called `visible`, and its output staples a caveat
+  // onto a drift note. A login link parked in a collapsed menu is markup every
+  // signed-in host ships — counting it would put "but a sign-in affordance was
+  // there" on essentially every genuine drift finding, i.e. exactly the
+  // misattribution this classifier exists to prevent, in the other direction.
+  it("does not count a sign-in link hidden with display:none", () => {
+    document.body.innerHTML = `
+      <nav style="display:none"><a href="/login">Log in</a></nav>
+      <main><button>Send</button></main>`;
+    expect(SIGN_IN_PROBE()).toEqual({ visible: false, labels: [] });
+  });
+
+  it("does not count one hidden by visibility:hidden, [hidden], or aria-hidden", () => {
+    for (const markup of [
+      `<div style="visibility:hidden"><button>Sign in</button></div>`,
+      `<div hidden><button>Sign in</button></div>`,
+      `<div aria-hidden="true"><button>Sign in</button></div>`,
+    ]) {
+      document.body.innerHTML = markup;
+      expect(SIGN_IN_PROBE().visible).toBe(false);
+    }
+  });
+
+  it("still counts one that is on screen next to hidden ones", () => {
+    document.body.innerHTML = `
+      <nav style="display:none"><a href="/login">Log in</a></nav>
+      <header><button>Sign up</button></header>`;
+    const p = SIGN_IN_PROBE();
+    expect(p.visible).toBe(true);
+    expect(p.labels).toEqual(["Sign up"]);
+  });
 });
 
 describe("summarize carries the undecorated verdict + final URL", () => {
@@ -203,7 +278,20 @@ describe("summarize carries the undecorated verdict + final URL", () => {
     expect(s.undecorated).toBe(UNDECORATED_KINDS.REDIRECTED);
   });
 
-  it("leaves both null on a healthy decorated host", () => {
+  it("still carries finalUrl on a healthy host — only the verdict is null there", () => {
+    // The harness records finalUrl on every run, decorated or not (claude.ai/new
+    // navigates to a conversation URL), so "null on a healthy host" is wrong.
+    const s = summarize({
+      host: "claude",
+      url: "https://claude.ai/new",
+      finalUrl: "https://claude.ai/chat/2f0c1b1e-0000-4000-8000-000000000000",
+      decorated: true,
+    });
+    expect(s.finalUrl).toBe("https://claude.ai/chat/2f0c1b1e-0000-4000-8000-000000000000");
+    expect(s.undecorated).toBeNull();
+  });
+
+  it("defaults both to null when the evidence object omits them", () => {
     const s = summarize({ host: "claude", decorated: true });
     expect(s.undecorated).toBeNull();
     expect(s.finalUrl).toBeNull();

--- a/test/scripts/e2e-host-sweep-undecorated.spec.ts
+++ b/test/scripts/e2e-host-sweep-undecorated.spec.ts
@@ -176,6 +176,14 @@ describe("SIGN_IN_PROBE", () => {
     expect(SIGN_IN_PROBE().visible).toBe(false);
   });
 
+  it("does not mistake a LOG OUT link for a sign-in wall", () => {
+    // /api/auth/logout is auth-shaped but proves the opposite: we're signed in.
+    // Left unhandled it would staple a backwards caveat onto a drift note.
+    document.body.innerHTML = `
+      <main><button>Send</button><a href="/api/auth/logout">Log out</a></main>`;
+    expect(SIGN_IN_PROBE()).toEqual({ visible: false, labels: [] });
+  });
+
   it("ignores long prose that merely mentions signing in", () => {
     document.body.innerHTML = `<button>You can sign in later to keep your conversation history</button>`;
     expect(SIGN_IN_PROBE().visible).toBe(false);

--- a/test/scripts/e2e-host-sweep-undecorated.spec.ts
+++ b/test/scripts/e2e-host-sweep-undecorated.spec.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  classifyUndecorated,
+  UNDECORATED_KINDS,
+  SIGN_IN_PROBE,
+  summarize,
+} from "../../scripts/e2e-host-sweep-lib.mjs";
+
+/**
+ * When the sweep waits 25s for #saypi-callButton and never sees it, the note it
+ * records is the whole story a human gets. Until #559 that note was a single
+ * string — "not decorated — selector drift or logged out" — which conflates the
+ * two things a reader most needs to tell apart:
+ *
+ *   - the harness never reached the chat app (redirect / sign-in wall) → an
+ *     automation/seeding problem, nothing to hunt in SayPi;
+ *   - the chat app rendered and SayPi failed to decorate it → real DOM drift,
+ *     the highest-signal defect class this sweep exists to find.
+ *
+ * Real case that motivated it (2026-07-26): pi.ai now bounces signed-out
+ * visitors from https://pi.ai/talk to the https://hey.pi.ai/ marketing splash.
+ */
+
+describe("classifyUndecorated — the real pi.ai redirect (#559)", () => {
+  it("calls the pi.ai → hey.pi.ai bounce a redirect, not drift", () => {
+    const c = classifyUndecorated({
+      requestedUrl: "https://pi.ai/talk",
+      finalUrl: "https://hey.pi.ai/",
+      title: "Pi, your personal AI",
+    });
+
+    expect(c.kind).toBe(UNDECORATED_KINDS.REDIRECTED);
+    expect(c.owner).toBe("automation");
+    expect(c.redirected).toBe(true);
+    expect(c.requestedOrigin).toBe("pi.ai");
+    expect(c.finalOrigin).toBe("hey.pi.ai");
+    // The note must state the observation before the verdict, and must not
+    // leave "selector drift" hanging as a live possibility.
+    expect(c.note).toContain("https://pi.ai/talk");
+    expect(c.note).toContain("https://hey.pi.ai/");
+    expect(c.note).not.toMatch(/selector drift or logged out/);
+  });
+
+  it("keeps calling it a redirect even though hey.pi.ai shows sign-up CTAs", () => {
+    // The splash page has "Get started"/"Sign up" affordances, so the sign-in
+    // probe fires too. Origin wins: we never reached the chat app at all.
+    const c = classifyUndecorated({
+      requestedUrl: "https://pi.ai/talk",
+      finalUrl: "https://hey.pi.ai/",
+      signInVisible: true,
+    });
+    expect(c.kind).toBe(UNDECORATED_KINDS.REDIRECTED);
+  });
+});
+
+describe("classifyUndecorated — the genuine-drift case", () => {
+  it("reports drift when we are on the requested page with no redirect or wall", () => {
+    const c = classifyUndecorated({
+      requestedUrl: "https://claude.ai/new",
+      finalUrl: "https://claude.ai/new",
+      title: "Claude",
+    });
+
+    expect(c.kind).toBe(UNDECORATED_KINDS.DRIFT);
+    expect(c.owner).toBe("saypi");
+    expect(c.redirected).toBe(false);
+    expect(c.note).toMatch(/drift/i);
+  });
+
+  it("reports drift after an in-app navigation that stays on the chat origin", () => {
+    // claude.ai/new → claude.ai/chat/<uuid> is normal app behaviour, not a bounce.
+    const c = classifyUndecorated({
+      requestedUrl: "https://claude.ai/new",
+      finalUrl: "https://claude.ai/chat/2f0c1b1e-0000-4000-8000-000000000000",
+    });
+    expect(c.kind).toBe(UNDECORATED_KINDS.DRIFT);
+    expect(c.redirected).toBe(false);
+  });
+
+  it("does NOT let a bare sign-in affordance suppress a drift finding", () => {
+    // Bias: a false "drift" costs one investigation; a false "signed out"
+    // silently buries the defect class the sweep exists to find. A sign-in
+    // button on the right page is a caveat in the note, not a verdict.
+    const c = classifyUndecorated({
+      requestedUrl: "https://chatgpt.com/",
+      finalUrl: "https://chatgpt.com/",
+      signInVisible: true,
+    });
+    expect(c.kind).toBe(UNDECORATED_KINDS.DRIFT);
+    expect(c.signInAffordance).toBe(true);
+    expect(c.note).toMatch(/sign-in/i); // surfaced as a caveat, so the reader can rule it out
+  });
+});
+
+describe("classifyUndecorated — the signed-out boundary", () => {
+  it("reads a same-origin bounce to a login route as a sign-in wall", () => {
+    const c = classifyUndecorated({
+      requestedUrl: "https://claude.ai/new",
+      finalUrl: "https://claude.ai/login?returnTo=%2Fnew",
+      signInVisible: true,
+    });
+
+    expect(c.kind).toBe(UNDECORATED_KINDS.SIGNED_OUT);
+    expect(c.owner).toBe("automation");
+    expect(c.redirected).toBe(false);
+    expect(c.note).toContain("https://claude.ai/login?returnTo=%2Fnew");
+  });
+
+  it("recognises the other auth route shapes the hosts use", () => {
+    const kinds = [
+      "https://chatgpt.com/auth/login",
+      "https://chatgpt.com/api/auth/signin",
+      "https://pi.ai/sign-in",
+    ].map((finalUrl) => classifyUndecorated({ requestedUrl: new URL(finalUrl).origin + "/", finalUrl }).kind);
+    expect(kinds).toEqual([
+      UNDECORATED_KINDS.SIGNED_OUT,
+      UNDECORATED_KINDS.SIGNED_OUT,
+      UNDECORATED_KINDS.SIGNED_OUT,
+    ]);
+  });
+
+  it("treats a sign-in page title as corroboration on the requested route", () => {
+    const c = classifyUndecorated({
+      requestedUrl: "https://chatgpt.com/",
+      finalUrl: "https://chatgpt.com/",
+      title: "Log in | OpenAI",
+      signInVisible: true,
+    });
+    expect(c.kind).toBe(UNDECORATED_KINDS.SIGNED_OUT);
+  });
+});
+
+describe("classifyUndecorated — origin comparison edges", () => {
+  it("does not call a cosmetic www. hop a redirect", () => {
+    const c = classifyUndecorated({ requestedUrl: "https://pi.ai/talk", finalUrl: "https://www.pi.ai/talk" });
+    expect(c.kind).toBe(UNDECORATED_KINDS.DRIFT);
+    expect(c.redirected).toBe(false);
+  });
+
+  it("does call any other subdomain a redirect (hey.pi.ai is not pi.ai)", () => {
+    expect(
+      classifyUndecorated({ requestedUrl: "https://pi.ai/talk", finalUrl: "https://blog.pi.ai/" }).kind
+    ).toBe(UNDECORATED_KINDS.REDIRECTED);
+  });
+
+  it("falls back to unknown — never throws — when the final URL is missing or junk", () => {
+    for (const finalUrl of [undefined, "", "about:blank", "not a url"]) {
+      const c = classifyUndecorated({ requestedUrl: "https://pi.ai/talk", finalUrl });
+      expect(c.kind).toBe(UNDECORATED_KINDS.UNKNOWN);
+      expect(c.owner).toBe("unknown");
+      expect(c.note).toMatch(/screenshot/i); // tells the reader where to look instead
+    }
+    expect(() => classifyUndecorated()).not.toThrow();
+    expect(classifyUndecorated().kind).toBe(UNDECORATED_KINDS.UNKNOWN);
+  });
+});
+
+describe("SIGN_IN_PROBE", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("spots the sign-in affordances a walled host shows", () => {
+    document.body.innerHTML = `
+      <nav><a href="/login">Log in</a><button>Sign up</button></nav>
+      <main><p>Talk to Pi</p></main>`;
+    const p = SIGN_IN_PROBE();
+    expect(p.visible).toBe(true);
+    expect(p.labels).toContain("Log in");
+    expect(p.labels).toContain("Sign up");
+  });
+
+  it("stays quiet on a normal signed-in chat app", () => {
+    document.body.innerHTML = `
+      <main><button>Send</button><a href="/chat/abc">Yesterday's chat</a></main>`;
+    expect(SIGN_IN_PROBE().visible).toBe(false);
+  });
+
+  it("ignores long prose that merely mentions signing in", () => {
+    document.body.innerHTML = `<button>You can sign in later to keep your conversation history</button>`;
+    expect(SIGN_IN_PROBE().visible).toBe(false);
+  });
+});
+
+describe("summarize carries the undecorated verdict + final URL", () => {
+  it("surfaces finalUrl and the classification kind in the run rollup", () => {
+    const s = summarize({
+      host: "pi",
+      url: "https://pi.ai/talk",
+      finalUrl: "https://hey.pi.ai/",
+      decorated: false,
+      undecorated: { kind: UNDECORATED_KINDS.REDIRECTED, owner: "automation", note: "…" },
+    });
+    expect(s.finalUrl).toBe("https://hey.pi.ai/");
+    expect(s.undecorated).toBe(UNDECORATED_KINDS.REDIRECTED);
+  });
+
+  it("leaves both null on a healthy decorated host", () => {
+    const s = summarize({ host: "claude", decorated: true });
+    expect(s.undecorated).toBeNull();
+    expect(s.finalUrl).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

When `e2e-host-sweep` waits 25s for `#saypi-callButton` and never sees it, the single note it recorded was:

```
"not decorated — selector drift or logged out"
```

That asks the reader to guess between the two things they most need told apart — a seeding/automation problem (we never got a chat app in front of the extension) versus real SayPi DOM drift, which is the highest-signal defect class this sweep exists to find. Guessing wrong is expensive in both directions: chase a phantom drift, or shrug off a genuine regression as "probably logged out".

The 2026-07-26 sweep made it concrete. pi.ai now bounces signed-out visitors from `pi.ai/talk` to the `hey.pi.ai` marketing splash:

```
[pi-intro-debug] getBaseLogoutUrl {LOGOUT_BASE_URL: , INTRO_REDIRECT_ENABLED: true,
                                   INTRO_URL: https://hey.pi.ai, alreadyRedirected: false}
```

…followed by a main-frame navigation to `https://hey.pi.ai/`. The sweep spent its budget on a page with no chat UI and reported it exactly as it would report a broken adapter. Worse, the redirect was **invisible in `evidence.json`** — `url` is the URL we *requested* — so it was only discoverable by opening a screenshot.

## What

- **`classifyUndecorated()`** — pure, in `scripts/e2e-host-sweep-lib.mjs`. Takes the requested URL, the final URL, the page title, and whether a sign-in affordance was present and not hidden; returns `{ kind, owner, redirected, requestedOrigin, finalOrigin, finalUrl, signInAffordance, note }` with `kind` ∈ `redirected-off-origin` / `signed-out` / `possible-drift` / `run-aborted` / `unknown` — exhaustive, so an undecorated host never carries a null verdict (see the review follow-up comment).
- **`SIGN_IN_PROBE`** — a self-contained page probe in the `DIAGS` idiom (stringified and evaluated in the page), deliberately narrow: short button-shaped "Log in"/"Sign up" labels or auth `href`s, so prose that merely mentions signing in doesn't fire it.
- **Harness wiring** — `evidence.finalUrl` / `pageTitle` / `undecorated` / `signInAffordances`; the classified note replaces the old string; `summarize()` (and so `summary.json` + the per-host terminal line) carries `finalUrl` + the kind.
- **Doc** — a new analysis-discipline item, since the section previously trained readers to treat any undecorated host as possible drift with no way to tell.

Two judgement calls worth reviewing:

**Origin wins over sign-in.** `hey.pi.ai` is a marketing splash with sign-up CTAs, so the sign-in probe fires *and* the origin differs. Origin is checked first — "we were bounced off the chat origin" is the stronger, more actionable fact. Covered by a test that passes `signInVisible: true` on the pi.ai pair.

**The ambiguous middle is biased toward drift.** A bare sign-in affordance on the *requested* page stays `possible-drift` (surfaced as a caveat in the note); only a corroborated wall — an auth route in the final URL, or an auth-looking title *plus* an affordance — becomes `signed-out`. A false "signed out" silently buries a real defect; a false "drift" costs one investigation.

**The wiring detail that decides whether any of this works:** pi.ai's bounce is client-side JS firing long after `domcontentloaded`, so the URL captured next to the Cloudflare check is still `pi.ai/talk`. The harness re-reads `page.url()` **after** the 25s decoration wait — classifying off the earlier read would have reported the redirect as drift, the exact wrong answer on the exact case this fixes.

## Evidence

Fail-first (`npx vitest run test/scripts/e2e-host-sweep-undecorated.spec.ts`), test written before the implementation:

```
 ❯ test/scripts/e2e-host-sweep-undecorated.spec.ts (16 tests | 16 failed) 10ms
   × classifyUndecorated — the real pi.ai redirect (#559) > calls the pi.ai → hey.pi.ai bounce a redirect, not drift
     → (0 , classifyUndecorated) is not a function
   × classifyUndecorated — the genuine-drift case > reports drift when we are on the requested page with no redirect or wall
     → (0 , classifyUndecorated) is not a function
   ...
   × summarize carries the undecorated verdict + final URL > leaves both null on a healthy decorated host
     → expected undefined to be null

 Test Files  1 failed (1)
      Tests  16 failed (16)
```

After the implementation:

```
 ✓ test/scripts/e2e-host-sweep-undecorated.spec.ts (16 tests) 12ms
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

Full suite (`npm test` — typecheck + Jest + Vitest) from the worktree:

```
> tsc --noEmit
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
...
 Test Files  222 passed (222)
      Tests  2051 passed | 1 skipped (2052)
   Duration  18.83s
```

And the classifier run against the real URL pair from that sweep:

```
$ node -e "import('./scripts/e2e-host-sweep-lib.mjs').then(({classifyUndecorated}) => …)"
{
  "requestedOrigin": "pi.ai",
  "finalOrigin": "hey.pi.ai",
  "finalUrl": "https://hey.pi.ai/",
  "signInAffordance": true,
  "kind": "redirected-off-origin",
  "owner": "automation",
  "redirected": true,
  "note": "not decorated because the page left the requested origin: https://pi.ai/talk → https://hey.pi.ai/. SayPi never saw the chat app, so this run says NOTHING about SayPi selector drift. Usually the seeded profile is signed out and the host bounces visitors to an intro/marketing page; less often the host has moved its chat app. Next step: sign in to the seeded profile (npm run layer4cdp:seed), re-run, and if it still lands on hey.pi.ai while signed in, the host URL in HOSTS is what changed."
}
```

Everything here is proven at the unit layer — the sweep harness was **not** run against real hosts (costs real money, needs a headed browser and the shared profile).

## Scope

Part of #559 — this is the automation half (acceptance criterion 2). The product half (not initialising chat mode on non-chat `pi.ai`/`claude.ai` subdomains) and the founder's interactive pi.ai sign-in are the other slices; only all of them together close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5tDjPqe75yTHjCKavhrFx


