### PR TITLE
fix(test): stop the runners collecting sibling worktrees' tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,10 @@
     "transformIgnorePatterns": [
       "/node_modules/(?!rxjs)"
     ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/\\.worktrees/"
+    ],
     "testEnvironment": "jsdom",
     "extensionsToTreatAsEsm": [
       ".ts"

--- a/test/scripts/test-config-worktree-scope.spec.ts
+++ b/test/scripts/test-config-worktree-scope.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+// picomatch is Vitest's own glob matcher (hoisted, untyped). Matching the real
+// patterns with the real matcher is what stops this test degrading into "assert a
+// string is present in an array" — which would pass on a pattern matching nothing.
+// @ts-expect-error: untyped transitive dependency, used deliberately
+import picomatch from "picomatch";
+
+import vitestConfig from "../../vitest.config.js";
+
+/**
+ * Regression cover for #566: neither test runner excluded `.worktrees/`, so
+ * `npm test` from the shared main checkout also ran every sibling agent's
+ * in-progress specs — reporting THEIR failures as yours.
+ *
+ * That is worse than the wasted minute it costs. AGENTS.md mandates concurrent
+ * agents work in `.worktrees/`, and separately tells each one to attribute any new
+ * failure to its own change; together those send an agent chasing a red test on a
+ * branch it has never checked out (and must not touch).
+ *
+ * These tests exercise the patterns with each runner's real matching semantics —
+ * picomatch globs for Vitest, regexes for Jest — rather than asserting a string is
+ * present, which would pass on a pattern that matches nothing.
+ */
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Paths that belong to a SIBLING worktree — no runner should ever collect these. */
+const SIBLING_PATHS = [
+  ".worktrees/preact-foundation/test/chatbots/ChatGPTSidebarConfig.spec.ts",
+  ".worktrees/issue-460-pi-callbutton-initial-load/test/chatbots/ChatGPTSidebarConfig.spec.ts",
+  ".worktrees/some-future-branch/test/deep/nested/thing.spec.ts",
+  ".worktrees/some-future-branch/test/legacy.test.js",
+];
+
+/** Paths that belong to THIS checkout — every runner must still collect these. */
+const OWN_PATHS = [
+  "test/chatbots/ChatGPTSidebarConfig.spec.ts",
+  "test/scripts/e2e-host-sweep-lib.spec.ts",
+  "src/something.spec.ts",
+  "test/legacy.test.js",
+];
+
+const jestConfig = () =>
+  JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")).jest;
+
+describe("test runners stay inside their own checkout (#566)", () => {
+  it("vitest excludes sibling worktrees", () => {
+    const exclude = (vitestConfig as any).test.exclude as string[];
+    const excluded = picomatch(exclude);
+
+    for (const p of SIBLING_PATHS) expect(excluded(p), `should exclude ${p}`).toBe(true);
+    for (const p of OWN_PATHS) expect(excluded(p), `should NOT exclude ${p}`).toBe(false);
+  });
+
+  /**
+   * Jest matches testPathIgnorePatterns as regexes against the ABSOLUTE path, and
+   * expands `<rootDir>` first. That distinction is the whole trap: a bare
+   * `/\.worktrees/` looks equivalent, but when the checkout IS a worktree its own
+   * absolute path contains `.worktrees/`, so every Jest test would be silently
+   * ignored — a far worse failure than the one being fixed here, and a silent one.
+   * Hence `checkout` is a parameter below, exercised as both the shared main
+   * checkout and a worktree.
+   */
+  const jestIgnores = (checkout: string) => {
+    const patterns: string[] = jestConfig().testPathIgnorePatterns ?? [];
+    expect(patterns.length, "no testPathIgnorePatterns at all").toBeGreaterThan(0);
+    return (p: string) =>
+      patterns.some((pattern) =>
+        new RegExp(pattern.replace("<rootDir>", checkout)).test(join(checkout, p))
+      );
+  };
+
+  const MAIN_CHECKOUT = "/Users/dev/saypi-userscript";
+  const WORKTREE_CHECKOUT = "/Users/dev/saypi-userscript/.worktrees/some-branch";
+
+  it("jest ignores sibling worktrees when run from the shared checkout", () => {
+    const ignored = jestIgnores(MAIN_CHECKOUT);
+
+    for (const p of SIBLING_PATHS) expect(ignored(p), `should ignore ${p}`).toBe(true);
+    for (const p of OWN_PATHS) expect(ignored(p), `should NOT ignore ${p}`).toBe(false);
+  });
+
+  it("jest still runs a worktree's OWN tests when invoked from inside it", () => {
+    const ignored = jestIgnores(WORKTREE_CHECKOUT);
+
+    for (const p of OWN_PATHS) expect(ignored(p), `should NOT ignore ${p}`).toBe(false);
+    // A worktree nested inside a worktree is still somebody else's.
+    expect(ignored(".worktrees/nested/test/thing.test.js")).toBe(true);
+  });
+
+  it("jest still ignores node_modules, which the added patterns must not displace", () => {
+    expect(jestIgnores(MAIN_CHECKOUT)("node_modules/some-pkg/thing.test.js")).toBe(true);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -14,7 +14,10 @@ export default defineConfig({
   },
   test: {
     include: ["**/*.spec.ts", "**/*.spec.tsx"],
-    exclude: [...configDefaults.exclude, "e2e/**"],
+    // `.worktrees/**`: sibling agents work in git worktrees under there (AGENTS.md),
+    // and without this a run from the shared checkout collects THEIR specs and
+    // reports their failures as yours (#566).
+    exclude: [...configDefaults.exclude, "e2e/**", ".worktrees/**"],
     globals: true,
     setupFiles: ["test/vitest.setup.js"],
   },


### PR DESCRIPTION
## Why

`AGENTS.md` requires concurrent agents to work in git worktrees under `.worktrees/`. Neither test runner knew that directory existed, so `npm test` from the shared main checkout collects **every sibling agent's in-progress specs** — and goes red on a branch you have never checked out and are forbidden to touch, while `main` itself is perfectly green.

The wasted minute is the smaller half. `AGENTS.md` also tells each agent to attribute any new failure to its own change and dig until it finds the cause. This aims that instinct squarely at somebody else's work-in-progress.

Caught while verifying `main` after merging #564/#565.

## Evidence (on `f1ae5a3`, two sibling worktrees present)

```
$ npm test                       # from the shared checkout
FAIL .worktrees/issue-460-pi-callbutton-initial-load/test/chatbots/ChatGPTSidebarConfig.spec.ts
FAIL .worktrees/preact-foundation/test/chatbots/ChatGPTSidebarConfig.spec.ts
ERROR: "test:vitest" exited with 1.                       58.7s

$ npx vitest run --config vitest.config.js --exclude '.worktrees/**' …
Test Files  226 passed (226) / Tests 2155 passed | 1 skipped   19.8s
```

Jest had the same hole plus a second symptom — noise that quietly trains agents to ignore warnings:

```
$ npx jest --listTests                       # before
.worktrees/caution-map/test/text.test.js
.worktrees/fix-test-worktree-scan/test/text.test.js
.worktrees/issue-460-pi-callbutton-initial-load/test/text.test.js
.worktrees/preact-foundation/test/text.test.js
test/text.test.js
jest-haste-map: duplicate manual mock found: ConfigModule           (×4)
jest-haste-map: duplicate manual mock found: SpeechSynthesisModule  (×4)

$ npx jest --listTests --testPathIgnorePatterns "/node_modules/" "$PWD/\.worktrees/"
test/text.test.js
```

`tsc` was already safe — `tsconfig.json` scopes itself with `include`. CI is unaffected either way: it checks out a clean tree with no `.worktrees/`.

## What

- `vitest.config.js`: add `.worktrees/**` to `test.exclude`.
- `package.json` jest block: add `testPathIgnorePatterns: ["/node_modules/", "<rootDir>/\\.worktrees/"]`.

**The `<rootDir>` prefix is load-bearing, and the test is what caught it.** Jest matches these patterns as regexes against the *absolute* path, so a bare `/\.worktrees/` also matches a worktree's own path — silently ignoring **every** Jest test for any agent working inside one. That failure is both worse and quieter than the bug being fixed: a green run that executed nothing. `<rootDir>/\.worktrees/` is anchored to the checkout, so it means "a worktree nested inside me", which is the actual intent.

## Verification

Fail-first, all three assertions red before the change:

```
× vitest excludes sibling worktrees   → should exclude .worktrees/preact-foundation/…: expected false to be true
× jest ignores sibling worktrees      → no testPathIgnorePatterns at all: expected 0 to be greater than 0
× jest still ignores node_modules …   → expected false to be true
```

The spec matches with each runner's **real** semantics — picomatch globs for Vitest, `<rootDir>`-expanded regexes for Jest — rather than asserting a string is present in an array, which would pass on a pattern that matches nothing. It exercises both Jest invocation sites (from the shared checkout, and from inside a worktree) so the `<rootDir>` trap can't be reintroduced, and pins that `node_modules` is still ignored.

Confirmed empirically that Jest still runs a worktree's own tests after the change (`Test Suites: 1 passed`, run from inside this branch's worktree). Full suite from the worktree: **227 files, 2159 passed, 1 skipped**, type-check included.

Fixes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5tDjPqe75yTHjCKavhrFx