### PR TITLE
fix(sweep): distinguish "never reached the field" from "no dictation button" (#569)

### DIFF
--- a/doc/e2e-dictation-sweep.md
+++ b/doc/e2e-dictation-sweep.md
@@ -115,12 +115,22 @@ first — only **`saypi`** is a defect to hunt:
 
 Before giving up on an `overlay-blocked` field the harness makes one generic
 rescue attempt — Escape, then any control whose whole accessible name reads as a
-dismissal (`OVERLAY_DISMISS_LABELS`; never "OK"/"Accept"/"Continue", which would
-opt the run *into* something) — and retries the focus. It deliberately knows
-nothing about any specific overlay: X ships new promo creative with every Grok
-launch, so a rule keyed on one image would rot by the next one. A per-target
-consent dialog that recurs every run belongs in the target's `dismissModal`
-instead.
+dismissal (`OVERLAY_DISMISS_LABELS`; never "OK"/"Accept"/"Continue"/"Got it",
+which would opt the run *into* something) — and retries the focus. It
+deliberately knows nothing about any specific overlay: X ships new promo creative
+with every Grok launch, so a rule keyed on one image would rot by the next one. A
+per-target consent dialog that recurs every run belongs in the target's
+`dismissModal` instead.
+
+The name in the note comes from Playwright's own call log, and `describeInterceptor`
+picks the **most identifying** interception rather than the last one — a real log
+carries many (the checked-in fixture
+`test/fixtures/e2e-dictation-sweep/grok-promo-click-error.txt` has eight), and X's
+animating promo gets an anonymous wrapper `div` blamed both first and last with the
+labelled image in between. Ranking by identity (label > id > class) is what makes the
+note say `img.css-9pa8cd[Introducing Grok 4.5 for Chat]` instead of
+`div.css-175oi2r`. Keep that fixture verbatim if you touch it: a shortened one hid
+this exact bug during review.
 
 ## Analysis discipline (don't skip — this is where false findings come from)
 

--- a/doc/e2e-dictation-sweep.md
+++ b/doc/e2e-dictation-sweep.md
@@ -87,17 +87,50 @@ node scripts/e2e-dictation-sweep.mjs --headless  # re-test headless (real-site t
 
 Per field the harness writes to
 `.output/e2e-dictation-sweep/<run>/<target>__<index>/`: `evidence.json`
-(console / pageErrors / requestFailed / decorated / buttonAppeared /
-transcriptLanded / transcriptText) and screenshots (`01-focused`, `99-final` or
-`99-no-button` on failure). A run-level `summary.json` holds the per-field
-`summarizeField()` rollup.
+(console / pageErrors / requestFailed / decorated / fieldFocused / focusError /
+overlayDismissSteps / **outcome** / buttonAppeared / transcriptLanded /
+transcriptText) and screenshots (`01-focused`, then `99-<outcome.kind>.png` —
+`99-final.png` only on the fully-successful path). A run-level `summary.json`
+holds the per-field `summarizeField()` rollup, which carries `outcomeKind`,
+`owner`, `fieldReached` and `interceptor` alongside the raw booleans.
+
+### Read `outcome` before anything else (#569)
+
+Every swept field carries an `outcome` verdict — `classifyFieldOutcome()` in
+`scripts/e2e-dictation-sweep-lib.mjs`, the dictation counterpart to the host
+sweep's `classifyUndecorated` (#559). It exists because `transcriptLanded: false`
+on its own is not triageable: it conflates "universal dictation is broken here"
+with "the harness never got a focused field in front of it". `owner` answers that
+first — only **`saypi`** is a defect to hunt:
+
+| `outcome.kind` | `owner` | means |
+|---|---|---|
+| `reached` | saypi | field focused, button appeared — `transcriptLanded` is a real product signal |
+| `no-button` | **saypi** | focused a decorated page's field and no `.saypi-dictation-button` appeared — **the defect case** |
+| `overlay-blocked` | host | an interstitial (launch promo, consent, upsell) sat over the field and swallowed every click; the note names the element Playwright blamed |
+| `field-absent` | automation | the field selector never matched — usually a sign-in wall (see Preconditions), sometimes a drifted selector in `TARGETS` |
+| `focus-failed` | automation | the field resolved but couldn't be clicked for some other reason |
+| `not-injected` | automation | no `data-saypi-build` stamp — the content script never ran (stale `e2e:build`, extension disabled, out of injection scope) |
+| `run-aborted` | automation | Cloudflare challenge or a harness throw — nothing about this field was observed |
+
+Before giving up on an `overlay-blocked` field the harness makes one generic
+rescue attempt — Escape, then any control whose whole accessible name reads as a
+dismissal (`OVERLAY_DISMISS_LABELS`; never "OK"/"Accept"/"Continue", which would
+opt the run *into* something) — and retries the focus. It deliberately knows
+nothing about any specific overlay: X ships new promo creative with every Grok
+launch, so a rule keyed on one image would rot by the next one. A per-target
+consent dialog that recurs every run belongs in the target's `dismissModal`
+instead.
 
 ## Analysis discipline (don't skip — this is where false findings come from)
 
-1. **Corroborate every finding with a screenshot AND the console trace before
-   concluding.** A `transcriptLanded=false` could mean a real regression, a button
-   that never appeared, or a harness timing issue (slow real-site content-script
-   injection) — open the screenshot before deciding which.
+1. **Read `outcome.owner` first, then corroborate with the screenshot AND the console
+   trace.** A `transcriptLanded=false` could mean a real regression, a button that
+   never appeared, a host interstitial the harness never got past, or a harness timing
+   issue (slow real-site content-script injection) — the `outcome` table above says
+   which, and the screenshot confirms it. Only `owner: "saypi"` is a candidate finding;
+   an `owner: "host"`/`"automation"` field was **never judged** and must not be
+   reported as a dictation defect (that mistake is exactly #569).
 2. **Attribute to SayPi only.** `summarizeField()` splits `saypiErrors`/
    `saypiWarnings` from `hostErrors` (reusing `e2e-host-sweep-lib.mjs`'s
    `classifyConsoleLine` — Mistral's composer is also ProseMirror, so the same
@@ -115,8 +148,14 @@ transcriptLanded / transcriptText) and screenshots (`01-focused`, `99-final` or
    defect.** Since `grok` is included in the default (no-args) target list but
    requires a one-time manual X sign-in (see Preconditions), a profile that hasn't
    been signed in will legitimately show `buttonAppeared=false`/`transcriptLanded=false`
-   for `grok` while `fixture`/`mistral` stay clean — sign in before concluding
-   there's a regression.
+   for `grok` while `fixture`/`mistral` stay clean — the outcome reads `field-absent`
+   (`owner: automation`); sign in before concluding there's a regression.
+6. **`grok` is also X's billboard.** A *signed-in* `grok` run can still fail
+   `overlay-blocked`: X promotes each Grok launch with a full-screen modal in
+   `div#layers` that swallows clicks at the composer, per-profile and per-campaign
+   (#569, "Introducing Grok 4.5 for Chat"). The harness tries a generic dismissal and
+   then reports the interceptor by name — dismiss it by hand in the seeded profile
+   once, re-run, and only then read anything into the `grok` verdict.
 
 ## Filing
 

--- a/scripts/e2e-dictation-sweep-lib.mjs
+++ b/scripts/e2e-dictation-sweep-lib.mjs
@@ -82,6 +82,13 @@ export const TARGETS = [
 
 export const DEFAULT_BUTTON_TIMEOUT_MS = 10_000;
 export const DEFAULT_TRANSCRIPT_TIMEOUT_MS = 30_000;
+/**
+ * Per focus *attempt* — deliberately under Playwright's 30s default, because the
+ * harness now spends two attempts (one, then a generic overlay dismissal, then one
+ * more). Two × 10s keeps the worst case inside the old single 30s budget, and an
+ * interstitial that hasn't yielded in 10s of retries isn't going to (#569).
+ */
+export const DEFAULT_FOCUS_TIMEOUT_MS = 10_000;
 
 /**
  * Flatten the target/field tree into one entry per field — the unit both the
@@ -131,6 +138,236 @@ export function transcriptLanded(value) {
 }
 
 /**
+ * Accessible names that dismiss an interstitial without navigating anywhere. Used by
+ * the harness's generic overlay rescue (see e2e-dictation-sweep.mjs) as a
+ * `getByRole("button", { name })` filter, so it must be a *whole-name* match: a
+ * substring match would happily click "Skip to sign up" or a "Close account" link.
+ *
+ * Deliberately dismissal-only — no "OK"/"Continue"/"Accept", which on a consent or
+ * upsell dialog opt the run *into* something rather than out of it (Mistral's ToS
+ * "Accept and continue" is handled explicitly per-target by `dismissModal`, not here).
+ */
+export const OVERLAY_DISMISS_LABELS =
+  /^\s*(close|close dialog|close modal|dismiss|not now|no thanks|no,? thanks|maybe later|later|skip|skip for now|got it|×|✕)\s*$/i;
+
+/**
+ * Strip the ANSI dim/reset codes Playwright wraps its call log in — the raw message is
+ * near-unreadable in evidence.json otherwise. Exported so the harness stores exactly the
+ * cleaned text the classifier reads (one implementation, not two).
+ */
+export const stripAnsi = (s) => String(s ?? "").replace(/\[[0-9;]*m/g, "");
+
+/** Opening tags only — `</div>` fails the leading letter check, so closing tags are skipped. */
+const OPEN_TAG = /<([a-zA-Z][a-zA-Z0-9-]*)((?:\s[^<>]*?)?)\/?>/g;
+
+/**
+ * Condense an HTML snippet's tag + attributes to a short, stable identity —
+ * `img.css-9pa8cd[Introducing Grok 4.5 for Chat]`, `div#layers`. Enough for a human
+ * to recognise the thing in the screenshot and for a future reader to tell one
+ * interstitial from another, without pasting a 300-char tag into a note.
+ */
+function condenseTag(tag, attrs) {
+  const attr = (name) => {
+    const m = new RegExp(`\\b${name}="([^"]*)"`, "i").exec(attrs);
+    return m ? m[1].trim() : "";
+  };
+  const id = attr("id");
+  const cls = attr("class").split(/\s+/).filter(Boolean)[0];
+  const label = attr("alt") || attr("aria-label") || attr("title") || attr("data-testid");
+  let out = tag.toLowerCase();
+  if (id) out += `#${id}`;
+  else if (cls) out += `.${cls}`;
+  if (label) out += `[${label}]`;
+  return out;
+}
+
+/**
+ * Pull the blocking element out of a Playwright click failure. Pure.
+ *
+ * When a click can't land, Playwright's call log already names the culprit —
+ * `<img alt="Introducing Grok 4.5 for Chat"/> from <div id="layers"> subtree
+ * intercepts pointer events` — so the harness never has to know anything about the
+ * specific overlay. That matters: X ships different promo creative for every launch
+ * (#569), and a rule matching this image would rot by the next one.
+ *
+ * The *last* interception in the log wins: Playwright retries for the whole timeout
+ * and the final report is the state the click actually died in (X's promo animates,
+ * so early lines can blame a transient wrapper `div`). And the window is clipped to
+ * the reported line so an earlier `locator resolved to <textarea …>` line can't be
+ * misread as the interceptor — blaming the target itself would be worse than the
+ * generic note this replaces.
+ *
+ * @param {string|null|undefined} message a Playwright error message / call log
+ * @returns {{element: string, container: string|null, raw: string}|null}
+ */
+export function describeInterceptor(message) {
+  const text = stripAnsi(message);
+  const MARK = "intercepts pointer events";
+  const at = text.lastIndexOf(MARK);
+  if (at < 0) return null;
+  // The reported line, or (single-line logs) a bounded tail — either way, scoped
+  // tightly enough that unrelated earlier tags stay out of it.
+  const lineStart = Math.max(text.lastIndexOf("\n", at) + 1, 0);
+  const window = text.slice(Math.max(lineStart, at - 700), at);
+  const tags = [...window.matchAll(OPEN_TAG)].map((m) => condenseTag(m[1], m[2] || ""));
+  if (!tags.length) return null;
+  const nested = /\bfrom\s+<[^<>]*>[^<]*(?:<\/[a-zA-Z0-9-]+>)?\s*subtree\s*$/.test(window) && tags.length > 1;
+  return {
+    element: nested ? tags[tags.length - 2] : tags[tags.length - 1],
+    container: nested ? tags[tags.length - 1] : null,
+    raw: (window + MARK).replace(/^\s*-\s*/, "").trim().slice(0, 400),
+  };
+}
+
+/**
+ * Why a field ended the run without a dictation button. The distinction is the whole
+ * point, and it's the one #559 drew for the host sweep's `classifyUndecorated`: only
+ * NO_BUTTON is a SayPi defect worth hunting — everything else means the harness
+ * never got the feature in front of a field it could judge (#569).
+ */
+export const FIELD_OUTCOME_KINDS = {
+  /** Field focused, page decorated, button present — a real product verdict follows. */
+  REACHED: "reached",
+  /** Something on top of the page swallowed the click (host interstitial/promo/consent). */
+  OVERLAY_BLOCKED: "overlay-blocked",
+  /** The field selector never resolved — a sign-in wall, or our selector drifted. */
+  FIELD_ABSENT: "field-absent",
+  /** The field resolved and the click still failed for some other reason. */
+  FOCUS_FAILED: "focus-failed",
+  /** No SayPi build stamp on the page — the content script never ran at all. */
+  NOT_INJECTED: "not-injected",
+  /** Focused a decorated page's field and no button appeared. THE defect case. */
+  NO_BUTTON: "no-button",
+  /** The run ended before the field could be judged (Cloudflare, harness throw). */
+  ABORTED: "run-aborted",
+};
+
+/**
+ * Uniform verdict shape — every branch returns the same keys so summary.json columns
+ * are stable (and a reader never has to wonder whether an absent field means "no" or
+ * "this code path forgot").
+ * @param {string} kind one of FIELD_OUTCOME_KINDS
+ * @param {"saypi"|"host"|"automation"} owner whose problem this is
+ * @param {boolean} fieldReached did the harness actually get the field focused?
+ * @param {string} note the human-readable explanation the sweep report quotes
+ * @param {{element: string, container: string|null, raw: string}|null} [interceptor]
+ */
+const verdict = (kind, owner, fieldReached, note, interceptor = null) => ({
+  kind,
+  owner,
+  fieldReached,
+  interceptor,
+  note,
+});
+
+/**
+ * Explain a field that produced no dictation button, from what the harness observed.
+ * Pure. `owner` answers the only question a reader has first: `saypi` = hunt it,
+ * `host` = the site did this to us, `automation` = fix the run.
+ *
+ * Precedence is deliberate:
+ *  - `abortedBecause` short-circuits (a Cloudflare challenge or a thrown harness
+ *    error means nothing downstream was observed, so a focus/button verdict would be
+ *    fabricated);
+ *  - then the focus outcome, because "we never reached the field" dominates
+ *    everything about the field — an overlay-blocked click leaves `buttonAppeared`
+ *    trivially false, which is exactly the false SayPi defect #569 was filed for;
+ *  - then the build stamp: no content script means no button by construction, and
+ *    that's a stale-`e2e:build`/injection-scope problem, not decoration drift;
+ *  - only a focused field on a decorated page can be NO_BUTTON.
+ *
+ * @param {{focusError?: string|null, dismissAttempted?: boolean, decorated?: boolean,
+ *          buttonAppeared?: boolean, abortedBecause?: string|null}} [input]
+ */
+export function classifyFieldOutcome(input = {}) {
+  const focusError = input.focusError || null;
+  const dismissed = input.dismissAttempted ? " after a generic dismiss attempt (Escape + any close/dismiss control)" : "";
+
+  if (input.abortedBecause) {
+    return verdict(
+      FIELD_OUTCOME_KINDS.ABORTED,
+      "automation",
+      false,
+      `no dictation button because ${input.abortedBecause} — the run ended before this field could be ` +
+        `judged, so it says NOTHING about universal dictation. Fix the run (re-seed with ` +
+        `npm run layer4cdp:seed for a Cloudflare block; read notes[]/console for a throw) and re-run.`,
+    );
+  }
+
+  if (focusError) {
+    const interceptor = describeInterceptor(focusError);
+    if (interceptor) {
+      return verdict(
+        FIELD_OUTCOME_KINDS.OVERLAY_BLOCKED,
+        "host",
+        false,
+        `the field was never focused${dismissed}: ${interceptor.element}` +
+          (interceptor.container ? ` (inside ${interceptor.container})` : "") +
+          ` sat over the composer and intercepted every click, so SayPi was never asked to decorate a ` +
+          `focused field — this run says NOTHING about universal dictation here. Hosts show these ` +
+          `interstitials (launch promos, consent, upsells) per-profile and per-campaign: open the ` +
+          `99-overlay-blocked.png screenshot, dismiss it by hand in the seeded profile once, and re-run. ` +
+          `If the same overlay keeps winning, teach the target a dismissModal for it.`,
+        interceptor,
+      );
+    }
+    if (!/locator resolved to/.test(stripAnsi(focusError))) {
+      return verdict(
+        FIELD_OUTCOME_KINDS.FIELD_ABSENT,
+        "automation",
+        false,
+        `the field selector never matched anything${dismissed}, so nothing was focused and this run says ` +
+          `NOTHING about universal dictation. Usually the profile is signed out and the host served a ` +
+          `login/sign-in wall instead of the composer (see the target's Preconditions); less often the ` +
+          `host moved the composer and the selector in TARGETS is what needs updating. Check the ` +
+          `screenshot before touching either.`,
+      );
+    }
+    return verdict(
+      FIELD_OUTCOME_KINDS.FOCUS_FAILED,
+      "automation",
+      false,
+      `the field resolved but could not be clicked${dismissed} (not a pointer-event interception — read ` +
+        `focusError in evidence.json), so it was never focused and this run says NOTHING about universal ` +
+        `dictation. Re-run; if it repeats, the field may be disabled/covered in a way Playwright reports ` +
+        `differently.`,
+    );
+  }
+
+  if (!input.decorated) {
+    return verdict(
+      FIELD_OUTCOME_KINDS.NOT_INJECTED,
+      "automation",
+      true,
+      `the field was focused, but the page carries no data-saypi-build stamp — the content script never ` +
+        `ran here, so no button could appear by construction. Not decoration drift: rebuild ` +
+        `(npm run e2e:build), confirm the unpacked extension is enabled in the seeded profile, and check ` +
+        `the host is in the universal content script's injection scope.`,
+    );
+  }
+
+  if (!input.buttonAppeared) {
+    return verdict(
+      FIELD_OUTCOME_KINDS.NO_BUTTON,
+      "saypi",
+      true,
+      `the field was focused on a decorated page (data-saypi-build present) and no ` +
+        `.saypi-dictation-button appeared — SayPi was in a position to decorate it and didn't. This is ` +
+        `the genuine defect case: hunt it (corroborate with the screenshot + console, then dedup against ` +
+        `GH issue #163's known-broken list before filing).`,
+    );
+  }
+
+  return verdict(
+    FIELD_OUTCOME_KINDS.REACHED,
+    "saypi",
+    true,
+    `the field was focused and .saypi-dictation-button appeared — the transcriptLanded verdict for this ` +
+      `field is a real product signal.`,
+  );
+}
+
+/**
  * Reduce a captured per-field evidence object to a flat, comparable summary. Pure —
  * mirrors e2e-host-sweep-lib.mjs's summarize(), but keyed on field-landed rather than
  * conversation-reply state.
@@ -139,6 +376,7 @@ export function summarizeField(evidence = {}) {
   const cons = Array.isArray(evidence.console) ? evidence.console : [];
   const byOrigin = (origin, type) =>
     cons.filter((c) => classifyConsoleLine(c.text) === origin && (!type || c.t === type)).length;
+  const outcome = evidence.outcome ?? null;
   return {
     target: evidence.target ?? null,
     field: evidence.field ?? null,
@@ -146,6 +384,12 @@ export function summarizeField(evidence = {}) {
     cloudflareBlocked: !!evidence.cloudflareBlocked,
     buttonAppeared: !!evidence.buttonAppeared,
     transcriptLanded: !!evidence.transcriptLanded,
+    // #569: `transcriptLanded: false` alone can't be triaged — these say whether
+    // the harness even reached the field, and whose problem the failure is.
+    outcomeKind: outcome?.kind ?? null,
+    owner: outcome?.owner ?? null,
+    fieldReached: !!outcome?.fieldReached,
+    interceptor: outcome?.interceptor?.element ?? null,
     consoleErrors: cons.filter((c) => c.t === "error").length,
     consoleWarnings: cons.filter((c) => c.t === "warning").length,
     saypiErrors: byOrigin("saypi", "error"),

--- a/scripts/e2e-dictation-sweep-lib.mjs
+++ b/scripts/e2e-dictation-sweep-lib.mjs
@@ -146,9 +146,11 @@ export function transcriptLanded(value) {
  * Deliberately dismissal-only — no "OK"/"Continue"/"Accept", which on a consent or
  * upsell dialog opt the run *into* something rather than out of it (Mistral's ToS
  * "Accept and continue" is handled explicitly per-target by `dismissModal`, not here).
+ * "Got it" is excluded for the same reason even though it *reads* like a dismissal: it
+ * is the accept-all button on a common genre of cookie banner.
  */
 export const OVERLAY_DISMISS_LABELS =
-  /^\s*(close|close dialog|close modal|dismiss|not now|no thanks|no,? thanks|maybe later|later|skip|skip for now|got it|×|✕)\s*$/i;
+  /^\s*(close|close dialog|close modal|dismiss|not now|no thanks|no,? thanks|maybe later|later|skip|skip for now|×|✕)\s*$/i;
 
 /**
  * Strip the ANSI dim/reset codes Playwright wraps its call log in — the raw message is
@@ -156,6 +158,9 @@ export const OVERLAY_DISMISS_LABELS =
  * cleaned text the classifier reads (one implementation, not two).
  */
 export const stripAnsi = (s) => String(s ?? "").replace(/\[[0-9;]*m/g, "");
+
+/** The phrase Playwright uses to blame an element for eating a click. */
+const MARK = "intercepts pointer events";
 
 /** Opening tags only — `</div>` fails the leading letter check, so closing tags are skipped. */
 const OPEN_TAG = /<([a-zA-Z][a-zA-Z0-9-]*)((?:\s[^<>]*?)?)\/?>/g;
@@ -182,6 +187,38 @@ function condenseTag(tag, attrs) {
 }
 
 /**
+ * How identifying is a condensed element? A human-readable label beats an id beats a
+ * bare class beats a naked tag. This is the ranking that decides which interception
+ * gets reported, and it is the whole reason the reader gets
+ * `img.css-9pa8cd[Introducing Grok 4.5 for Chat]` instead of `div.css-175oi2r`.
+ */
+const identityScore = (el) => (/\[.+\]$/.test(el) ? 3 : el.includes("#") ? 2 : el.includes(".") ? 1 : 0);
+
+/**
+ * Every interception Playwright reported, in log order. Each entry is scoped to the
+ * line that reported it, so an earlier `locator resolved to <textarea …>` line can
+ * never be mistaken for an interceptor — blaming the click's own target would be worse
+ * than the generic note this replaces.
+ */
+function parseInterceptions(text) {
+  const out = [];
+  for (let at = text.indexOf(MARK); at >= 0; at = text.indexOf(MARK, at + MARK.length)) {
+    // The reported line, or (single-line logs) a bounded tail.
+    const lineStart = text.lastIndexOf("\n", at) + 1;
+    const window = text.slice(Math.max(lineStart, at - 700), at);
+    const tags = [...window.matchAll(OPEN_TAG)].map((m) => condenseTag(m[1], m[2] || ""));
+    if (!tags.length) continue;
+    const nested = /\bfrom\s+<[^<>]*>[^<]*(?:<\/[a-zA-Z0-9-]+>)?\s*subtree\s*$/.test(window) && tags.length > 1;
+    out.push({
+      element: nested ? tags[tags.length - 2] : tags[tags.length - 1],
+      container: nested ? tags[tags.length - 1] : null,
+      raw: (window + MARK).replace(/^\s*-\s*/, "").trim().slice(0, 400),
+    });
+  }
+  return out;
+}
+
+/**
  * Pull the blocking element out of a Playwright click failure. Pure.
  *
  * When a click can't land, Playwright's call log already names the culprit —
@@ -190,33 +227,24 @@ function condenseTag(tag, attrs) {
  * specific overlay. That matters: X ships different promo creative for every launch
  * (#569), and a rule matching this image would rot by the next one.
  *
- * The *last* interception in the log wins: Playwright retries for the whole timeout
- * and the final report is the state the click actually died in (X's promo animates,
- * so early lines can blame a transient wrapper `div`). And the window is clipped to
- * the reported line so an earlier `locator resolved to <textarea …>` line can't be
- * misread as the interceptor — blaming the target itself would be worse than the
- * generic note this replaces.
+ * **Which** interception to report is not obvious, and getting it wrong is quiet: the
+ * real 4.7KB log from the run that motivated this carries EIGHT of them, because X's
+ * promo animates. An anonymous wrapper `div.css-175oi2r` is blamed both FIRST and
+ * LAST; the labelled image sits in the middle. So "take the last" — the intuitive
+ * "state the retries died in" rule — yields a name that tells a reader nothing. Rank
+ * by how identifying the element is instead, and break ties toward the freshest.
+ * (The verbatim log is checked in at
+ * test/fixtures/e2e-dictation-sweep/grok-promo-click-error.txt and pinned by the spec
+ * precisely so a shortened fixture can't make a broken rule look right again.)
  *
  * @param {string|null|undefined} message a Playwright error message / call log
  * @returns {{element: string, container: string|null, raw: string}|null}
  */
 export function describeInterceptor(message) {
-  const text = stripAnsi(message);
-  const MARK = "intercepts pointer events";
-  const at = text.lastIndexOf(MARK);
-  if (at < 0) return null;
-  // The reported line, or (single-line logs) a bounded tail — either way, scoped
-  // tightly enough that unrelated earlier tags stay out of it.
-  const lineStart = Math.max(text.lastIndexOf("\n", at) + 1, 0);
-  const window = text.slice(Math.max(lineStart, at - 700), at);
-  const tags = [...window.matchAll(OPEN_TAG)].map((m) => condenseTag(m[1], m[2] || ""));
-  if (!tags.length) return null;
-  const nested = /\bfrom\s+<[^<>]*>[^<]*(?:<\/[a-zA-Z0-9-]+>)?\s*subtree\s*$/.test(window) && tags.length > 1;
-  return {
-    element: nested ? tags[tags.length - 2] : tags[tags.length - 1],
-    container: nested ? tags[tags.length - 1] : null,
-    raw: (window + MARK).replace(/^\s*-\s*/, "").trim().slice(0, 400),
-  };
+  const hits = parseInterceptions(stripAnsi(message));
+  if (!hits.length) return null;
+  // `>=` keeps the freshest of equally-identifying candidates.
+  return hits.reduce((best, hit) => (identityScore(hit.element) >= identityScore(best.element) ? hit : best));
 }
 
 /**
@@ -280,7 +308,11 @@ const verdict = (kind, owner, fieldReached, note, interceptor = null) => ({
  *          buttonAppeared?: boolean, abortedBecause?: string|null}} [input]
  */
 export function classifyFieldOutcome(input = {}) {
-  const focusError = input.focusError || null;
+  // A *string* means the focus click failed — including the empty string. Coercing with
+  // `||` here (or trusting `.catch((e) => e.message)` upstream) turns an `Error("")`
+  // into an apparent success, and the field then classifies as no-button / owner:saypi:
+  // the exact false SayPi defect this function exists to prevent (#569 review).
+  const focusError = typeof input.focusError === "string" ? input.focusError : null;
   const dismissed = input.dismissAttempted ? " after a generic dismiss attempt (Escape + any close/dismiss control)" : "";
 
   if (input.abortedBecause) {
@@ -294,7 +326,7 @@ export function classifyFieldOutcome(input = {}) {
     );
   }
 
-  if (focusError) {
+  if (focusError !== null) {
     const interceptor = describeInterceptor(focusError);
     if (interceptor) {
       return verdict(
@@ -311,7 +343,8 @@ export function classifyFieldOutcome(input = {}) {
         interceptor,
       );
     }
-    if (!/locator resolved to/.test(stripAnsi(focusError))) {
+    const log = stripAnsi(focusError);
+    if (/waiting for locator/.test(log) && !/locator resolved to/.test(log)) {
       return verdict(
         FIELD_OUTCOME_KINDS.FIELD_ABSENT,
         "automation",
@@ -327,10 +360,10 @@ export function classifyFieldOutcome(input = {}) {
       FIELD_OUTCOME_KINDS.FOCUS_FAILED,
       "automation",
       false,
-      `the field resolved but could not be clicked${dismissed} (not a pointer-event interception — read ` +
-        `focusError in evidence.json), so it was never focused and this run says NOTHING about universal ` +
-        `dictation. Re-run; if it repeats, the field may be disabled/covered in a way Playwright reports ` +
-        `differently.`,
+      `the focus click failed for a reason the call log doesn't explain${dismissed} — no pointer-event ` +
+        `interception and no unmatched-selector signature (read focusError in evidence.json; it may be ` +
+        `empty). Nothing was focused, so this run says NOTHING about universal dictation. Re-run; if it ` +
+        `repeats, the field may be disabled or covered in a way Playwright reports differently.`,
     );
   }
 

--- a/scripts/e2e-dictation-sweep.mjs
+++ b/scripts/e2e-dictation-sweep.mjs
@@ -163,8 +163,15 @@ async function dismissBlockingOverlay(page) {
  * rather than collapsed into a note.
  */
 async function focusField(page, ev, selector) {
+  // `e.message` can legitimately be "" (some rejections carry no message), and "" is
+  // falsy — which would read as a successful focus and land the field on
+  // no-button/owner:saypi, the false SayPi defect this whole change prevents. Normalise
+  // to a non-empty string so "rejected" is never mistaken for "clicked" (#569 review).
   const attempt = () =>
-    page.click(selector, { timeout: DEFAULT_FOCUS_TIMEOUT_MS }).then(() => null).catch((e) => e.message);
+    page
+      .click(selector, { timeout: DEFAULT_FOCUS_TIMEOUT_MS })
+      .then(() => null)
+      .catch((e) => stripAnsi(e?.message).trim() || "page.click rejected without a message");
 
   let err = await attempt();
   if (err) {
@@ -176,8 +183,10 @@ async function focusField(page, ev, selector) {
     ev.overlayDismissSteps = await dismissBlockingOverlay(page);
     err = await attempt();
   }
-  ev.fieldFocused = !err;
-  ev.focusError = err ? stripAnsi(err).slice(0, 4000) : null;
+  ev.fieldFocused = err === null;
+  // Store the whole call log: the real grok one is ~4.7KB, and clipping it to 4000 is
+  // exactly what accidentally hid the trailing wrapper interception (#569 review).
+  ev.focusError = err === null ? null : err.slice(0, 8000);
   return ev.focusError;
 }
 

--- a/scripts/e2e-dictation-sweep.mjs
+++ b/scripts/e2e-dictation-sweep.mjs
@@ -34,7 +34,13 @@ import {
   flattenFields,
   summarizeField,
   transcriptLanded,
+  stripAnsi,
+  classifyFieldOutcome,
+  describeInterceptor,
+  FIELD_OUTCOME_KINDS,
+  OVERLAY_DISMISS_LABELS,
   DEFAULT_BUTTON_TIMEOUT_MS,
+  DEFAULT_FOCUS_TIMEOUT_MS,
   DEFAULT_TRANSCRIPT_TIMEOUT_MS,
 } from "./e2e-dictation-sweep-lib.mjs";
 import { enforceSpendCap } from "./l4-ledger.mjs";
@@ -117,12 +123,96 @@ async function dismissModalIfPresent(page, dismissModal) {
   return true;
 }
 
+/**
+ * Best-effort, creative-agnostic rescue for an interstitial that's swallowing clicks
+ * (#569: X dropped an "Introducing Grok 4.5 for Chat" promo into `div#layers` and the
+ * composer became unclickable for the whole 30s click timeout).
+ *
+ * Deliberately knows nothing about any specific overlay — X ships new promo creative
+ * with every launch, so a rule keyed on this image/alt text would rot immediately.
+ * Two generic moves only: Escape (the platform-standard dismissal for a modal), then
+ * a control whose *whole* accessible name reads as a dismissal
+ * (`OVERLAY_DISMISS_LABELS` — never "OK"/"Accept"/"Continue", which would opt the run
+ * into something). Per-target consent dialogs stay explicit (`dismissModal`).
+ *
+ * Only ever called after a focus attempt has already failed, so the clean targets
+ * (fixture, mistral) never execute a line of it.
+ * @returns {Promise<string[]>} the steps actually attempted, for the evidence trail
+ */
+async function dismissBlockingOverlay(page) {
+  const steps = [];
+  await page.keyboard.press("Escape").catch(() => {});
+  await page.waitForTimeout(400);
+  steps.push("Escape");
+
+  const btn = page.getByRole("button", { name: OVERLAY_DISMISS_LABELS }).first();
+  const visible = await btn.waitFor({ state: "visible", timeout: 2_000 }).then(() => true).catch(() => false);
+  if (visible) {
+    const name = (await btn.getAttribute("aria-label").catch(() => null)) || (await btn.textContent().catch(() => null)) || "";
+    const clicked = await btn.click({ timeout: 3_000 }).then(() => true).catch(() => false);
+    await page.waitForTimeout(500);
+    steps.push(`${clicked ? "clicked" : "failed to click"} dismiss control "${name.trim().slice(0, 40)}"`);
+  }
+  return steps;
+}
+
+/**
+ * Focus the field, with one overlay-rescue retry. Returns Playwright's error message
+ * from the LAST attempt (null on success) — that message is what `classifyFieldOutcome`
+ * reads to name the interceptor, so it is kept whole (ANSI-stripped) in the evidence
+ * rather than collapsed into a note.
+ */
+async function focusField(page, ev, selector) {
+  const attempt = () =>
+    page.click(selector, { timeout: DEFAULT_FOCUS_TIMEOUT_MS }).then(() => null).catch((e) => e.message);
+
+  let err = await attempt();
+  if (err) {
+    const blocker = describeInterceptor(err);
+    ev.notes.push(
+      `focus attempt 1 failed${blocker ? ` — ${blocker.element} intercepted the click` : ""}; ` +
+        `trying a generic overlay dismissal`,
+    );
+    ev.overlayDismissSteps = await dismissBlockingOverlay(page);
+    err = await attempt();
+  }
+  ev.fieldFocused = !err;
+  ev.focusError = err ? stripAnsi(err).slice(0, 4000) : null;
+  return ev.focusError;
+}
+
 async function sweepField(ctx, item, outDir, index) {
+  // The nullable/array fields carry explicit JSDoc types: the Vitest wiring spec reads
+  // this object as the function's return type, and a bare `null` initializer would
+  // infer as literal `null` and make `ev.outcome.kind` un-typeable from TypeScript.
   const ev = {
-    target: item.targetKey, targetLabel: item.targetLabel, field: item.fieldLabel,
-    selector: item.fieldSelector, build: null, decorated: false, cloudflareBlocked: false,
-    buttonAppeared: false, transcriptLanded: false, transcriptText: null,
-    console: [], pageErrors: [], requestFailed: [], notes: [],
+    target: item.targetKey,
+    targetLabel: item.targetLabel,
+    field: item.fieldLabel,
+    selector: item.fieldSelector,
+    /** @type {string|null} */
+    build: null,
+    decorated: false,
+    cloudflareBlocked: false,
+    fieldFocused: false,
+    /** @type {string|null} */
+    focusError: null,
+    /** @type {string[]} */
+    overlayDismissSteps: [],
+    /** @type {ReturnType<typeof classifyFieldOutcome>|null} */
+    outcome: null,
+    buttonAppeared: false,
+    transcriptLanded: false,
+    /** @type {string|null} */
+    transcriptText: null,
+    /** @type {{t: string, text: string}[]} */
+    console: [],
+    /** @type {{message: string, stack: string}[]} */
+    pageErrors: [],
+    /** @type {{url: string, failure: string|undefined}[]} */
+    requestFailed: [],
+    /** @type {string[]} */
+    notes: [],
   };
   const dir = join(outDir, `${item.targetKey}__${index}`);
   mkdirSync(dir, { recursive: true });
@@ -137,7 +227,13 @@ async function sweepField(ctx, item, outDir, index) {
   try {
     await page.goto(item.url, { waitUntil: "domcontentloaded", timeout: 25_000 }).catch((e) => ev.notes.push(`goto: ${e.message}`));
     const sig = { title: await page.title().catch(() => ""), url: page.url(), html: (await page.content().catch(() => "")).slice(0, 4000) };
-    if (isCloudflareChallenge(sig)) { ev.cloudflareBlocked = true; log(`${item.targetKey}: BLOCKED by Cloudflare`); return ev; }
+    if (isCloudflareChallenge(sig)) {
+      ev.cloudflareBlocked = true;
+      ev.outcome = classifyFieldOutcome({ abortedBecause: "the host served a Cloudflare challenge" });
+      ev.notes.push(ev.outcome.note);
+      log(`${item.targetKey}: BLOCKED by Cloudflare`);
+      return ev;
+    }
 
     await dismissModalIfPresent(page, item.dismissModal);
 
@@ -149,17 +245,29 @@ async function sweepField(ctx, item, outDir, index) {
     }
     ev.decorated = !!ev.build;
 
-    await page.click(item.fieldSelector).catch((e) => ev.notes.push(`focus: ${e.message}`));
+    const focusError = await focusField(page, ev, item.fieldSelector);
     await page.screenshot({ path: join(dir, "01-focused.png") }).catch(() => {});
 
-    ev.buttonAppeared = await page
-      .waitForSelector(".saypi-dictation-button:visible", { timeout: DEFAULT_BUTTON_TIMEOUT_MS })
-      .then(() => true)
-      .catch(() => false);
+    // Only wait for the button if there's actually a focused field for it to attach to —
+    // otherwise the 10s wait buys nothing but a `buttonAppeared: false` that reads as a
+    // decoration defect (#569).
+    ev.buttonAppeared = focusError
+      ? false
+      : await page
+          .waitForSelector(".saypi-dictation-button:visible", { timeout: DEFAULT_BUTTON_TIMEOUT_MS })
+          .then(() => true)
+          .catch(() => false);
 
-    if (!ev.buttonAppeared) {
-      ev.notes.push("no .saypi-dictation-button appeared for this field");
-      await page.screenshot({ path: join(dir, "99-no-button.png") }).catch(() => {});
+    ev.outcome = classifyFieldOutcome({
+      focusError,
+      dismissAttempted: ev.overlayDismissSteps.length > 0,
+      decorated: ev.decorated,
+      buttonAppeared: ev.buttonAppeared,
+    });
+
+    if (ev.outcome.kind !== FIELD_OUTCOME_KINDS.REACHED) {
+      ev.notes.push(ev.outcome.note);
+      await page.screenshot({ path: join(dir, `99-${ev.outcome.kind}.png`) }).catch(() => {});
       return ev;
     }
 
@@ -181,6 +289,9 @@ async function sweepField(ctx, item, outDir, index) {
     await page.screenshot({ path: join(dir, "99-final.png") }).catch(() => {});
   } catch (err) {
     ev.notes.push(`error: ${err.message}`);
+    // A throw means nothing downstream was observed — say so, rather than letting a
+    // default `buttonAppeared: false` read as a decoration verdict (#569).
+    ev.outcome = ev.outcome ?? classifyFieldOutcome({ abortedBecause: `the harness threw: ${err.message}` });
   } finally {
     writeFileSync(join(dir, "evidence.json"), JSON.stringify(ev, null, 2));
     await page.close().catch(() => {});
@@ -252,7 +363,8 @@ async function main() {
       const ev = await sweepField(ctx, item, outDir, idx++);
       const s = summarizeField(ev);
       summaries.push(s);
-      log(`${item.targetKey}/${item.fieldLabel}: decorated=${s.decorated} cf=${s.cloudflareBlocked} button=${s.buttonAppeared} transcriptLanded=${s.transcriptLanded} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures}`);
+      log(`${item.targetKey}/${item.fieldLabel}: outcome=${s.outcomeKind} (owner=${s.owner}) reachedField=${s.fieldReached} decorated=${s.decorated} cf=${s.cloudflareBlocked} button=${s.buttonAppeared} transcriptLanded=${s.transcriptLanded} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures}`);
+      if (s.owner && s.owner !== "saypi") log(`   ↳ ${ev.outcome?.note}`);
     }
   } finally {
     writeFileSync(join(outDir, "summary.json"), JSON.stringify(summaries, null, 2));
@@ -261,11 +373,26 @@ async function main() {
     if (fixtureServer) fixtureServer.close();
   }
 
+  // #569: split the failures by owner. A field the harness never reached (host
+  // interstitial, sign-in wall, stale build) is NOT a dictation finding, and lumping it
+  // in with the real ones is how a promo modal becomes an apparent SayPi defect.
   const failed = summaries.filter((s) => !s.transcriptLanded);
-  if (failed.length) {
-    log(`⚠️  ${failed.length}/${summaries.length} field(s) did NOT get a landed transcript — see evidence under ${outDir}.`);
+  const suspect = failed.filter((s) => s.owner === "saypi" || s.owner === null);
+  const unreached = failed.filter((s) => s.owner && s.owner !== "saypi");
+  if (suspect.length) {
+    log(`⚠️  ${suspect.length}/${summaries.length} field(s) reached but did NOT get a landed transcript — hunt these; evidence under ${outDir}.`);
+  }
+  if (unreached.length) {
+    log(`ℹ️  ${unreached.length}/${summaries.length} field(s) were never judged (${unreached.map((s) => `${s.target}:${s.outcomeKind}`).join(", ")}) — NOT dictation findings; fix the run and re-sweep.`);
   }
   log(`SWEEP DONE — evidence under ${outDir}`);
   process.exit(0);
 }
-main().catch((e) => { log(`fatal: ${e.message}`); process.exit(1); });
+// Run the CLI only when invoked directly — importing this module (the Vitest wiring
+// spec drives the real sweepField against stub pages) must not launch Chrome. Same
+// idiom as scripts/e2e-host-sweep.mjs.
+if (process.argv[1] && resolvePath(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => { log(`fatal: ${e.message}`); process.exit(1); });
+}
+
+export { sweepField };

--- a/test/fixtures/e2e-dictation-sweep/grok-promo-click-error.txt
+++ b/test/fixtures/e2e-dictation-sweep/grok-promo-click-error.txt
@@ -1,0 +1,61 @@
+page.click: Timeout 30000ms exceeded.
+Call log:
+[2m  - waiting for locator('textarea[placeholder]')[22m
+[2m    - locator resolved to <textarea dir="auto" autocorrect="on" autocomplete="on" spellcheck="true" autocapitalize="sentences" placeholder="Ask anything" class="r-30o5oe r-1dz5y72 r-1niwhzg r-17gur6a r-1yadl64 r-deolkf r-poiln3 r-xyw6el r-ea455c r-13awgt0 r-ubezar r-1ny4l3l r-13qz1uu r-fdjqy7">Hello there, this is a quick test of the voice ac…</textarea>[22m
+[2m  - attempting click action[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <div class="css-175oi2r r-f4gmv6 r-3pj75a">…</div> from <div id="layers" class="r-zchlnj r-1d2f490 r-u8s1d r-ipm5af">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m    - waiting 20ms[22m
+[2m    2 × waiting for element to be visible, enabled and stable[22m
+[2m      - element is visible, enabled and stable[22m
+[2m      - scrolling into view if needed[22m
+[2m      - done scrolling[22m
+[2m      - <img draggable="false" class="css-9pa8cd" alt="Introducing Grok 4.5 for Chat" src="https://abs.twimg.com/responsive-web/client-web/Grok-Promo-Popup-4-5-Launch.fc2ebfea.png"/> from <div id="layers" class="r-zchlnj r-1d2f490 r-u8s1d r-ipm5af">…</div> subtree intercepts pointer events[22m
+[2m    - retrying click action[22m
+[2m      - waiting 100ms[22m
+[2m    14 × waiting for element to be visible, enabled and stable[22m
+[2m       - element is visible, enabled and stable[22m
+[2m       - scrolling into view if needed[22m
+[2m       - done scrolling[22m
+[2m       - <img draggable="false" class="css-9pa8cd" alt="Introducing Grok 4.5 for Chat" src="https://abs.twimg.com/responsive-web/client-web/Grok-Promo-Popup-4-5-Launch.fc2ebfea.png"/> from <div id="layers" class="r-zchlnj r-1d2f490 r-u8s1d r-ipm5af">…</div> subtree intercepts pointer events[22m
+[2m     - retrying click action[22m
+[2m       - waiting 500ms[22m
+[2m       - waiting for element to be visible, enabled and stable[22m
+[2m       - element is visible, enabled and stable[22m
+[2m       - scrolling into view if needed[22m
+[2m       - done scrolling[22m
+[2m       - <div class="css-175oi2r r-f4gmv6 r-3pj75a">…</div> from <div id="layers" class="r-zchlnj r-1d2f490 r-u8s1d r-ipm5af">…</div> subtree intercepts pointer events[22m
+[2m     - retrying click action[22m
+[2m       - waiting 500ms[22m
+[2m       - waiting for element to be visible, enabled and stable[22m
+[2m       - element is visible, enabled and stable[22m
+[2m       - scrolling into view if needed[22m
+[2m       - done scrolling[22m
+[2m       - <img draggable="false" class="css-9pa8cd" alt="Introducing Grok 4.5 for Chat" src="https://abs.twimg.com/responsive-web/client-web/Grok-Promo-Popup-4-5-Launch.fc2ebfea.png"/> from <div id="layers" class="r-zchlnj r-1d2f490 r-u8s1d r-ipm5af">…</div> subtree intercepts pointer events[22m
+[2m     - retrying click action[22m
+[2m       - waiting 500ms[22m
+[2m       - waiting for element to be visible, enabled and stable[22m
+[2m       - element is visible, enabled and stable[22m
+[2m       - scrolling into view if needed[22m
+[2m       - done scrolling[22m
+[2m       - <img draggable="false" class="css-9pa8cd" alt="Introducing Grok 4.5 for Chat" src="https://abs.twimg.com/responsive-web/client-web/Grok-Promo-Popup-4-5-Launch.fc2ebfea.png"/> from <div id="layers" class="r-zchlnj r-1d2f490 r-u8s1d r-ipm5af">…</div> subtree intercepts pointer events[22m
+[2m     - retrying click action[22m
+[2m       - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <img draggable="false" class="css-9pa8cd" alt="Introducing Grok 4.5 for Chat" src="https://abs.twimg.com/responsive-web/client-web/Grok-Promo-Popup-4-5-Launch.fc2ebfea.png"/> from <div id="layers" class="r-zchlnj r-1d2f490 r-u8s1d r-ipm5af">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m
+[2m    - waiting for element to be visible, enabled and stable[22m
+[2m    - element is visible, enabled and stable[22m
+[2m    - scrolling into view if needed[22m
+[2m    - done scrolling[22m
+[2m    - <div class="css-175oi2r r-f4gmv6 r-3pj75a">…</div> from <div id="layers" class="r-zchlnj r-1d2f490 r-u8s1d r-ipm5af">…</div> subtree intercepts pointer events[22m
+[2m  - retrying click action[22m
+[2m    - waiting 500ms[22m

--- a/test/scripts/e2e-dictation-sweep-lib.spec.ts
+++ b/test/scripts/e2e-dictation-sweep-lib.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
 import {
   TARGETS,
   flattenFields,
@@ -195,56 +196,87 @@ describe("summarizeField", () => {
  * problem, says NOTHING about SayPi) vs. "got in front of the feature and it
  * didn't work" (the defect this sweep exists to find).
  *
- * The error text below is the real one from
- * `.output/e2e-dictation-sweep/2026-07-29T21-25-23-179Z/grok__4/evidence.json`,
- * ANSI dim codes and all — Playwright names the interceptor for us, so nothing
- * needs to match X's specific creative (which will change with the next launch).
+ * The fixture is the **verbatim** Playwright message from that run — extracted from
+ * `.output/e2e-dictation-sweep/2026-07-29T21-25-23-179Z/grok__4/evidence.json`'s
+ * `notes[0]` (minus the harness's own `"focus: "` prefix) and checked in, because
+ * `.output/` is gitignored. ANSI escapes intact: stripping them is the code's job,
+ * not the fixture's.
+ *
+ * **Do not trim it.** The first version of this spec used a hand-shortened excerpt,
+ * and that truncation hid a real bug. The real log carries EIGHT interceptions, and
+ * X's promo animates: the anonymous wrapper `div.css-175oi2r` is blamed both FIRST
+ * and LAST, while the informative labelled image sits in the middle. A "take the last
+ * one" rule looked right against the excerpt and returned `div.css-175oi2r` — useless
+ * to a reader — against reality. The only reason the sweep printed the useful name at
+ * all was that `focusError` happened to be sliced to 4000 chars, clipping the trailing
+ * wrapper: a coincidence, not a design, and one the 30s→10s timeout change could flip.
  */
-const GROK_PROMO_CLICK_ERROR = [
-  "page.click: Timeout 30000ms exceeded.",
-  "Call log:",
-  "\u001b[2m  - waiting for locator('textarea[placeholder]')\u001b[22m",
-  "\u001b[2m    - locator resolved to <textarea dir=\"auto\" spellcheck=\"true\" placeholder=\"Ask anything\" class=\"r-30o5oe r-1dz5y72\">Hello there, this is a quick test of the voice ac…</textarea>\u001b[22m",
-  "\u001b[2m  - attempting click action\u001b[22m",
-  "\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m",
-  "\u001b[2m      - element is visible, enabled and stable\u001b[22m",
-  "\u001b[2m      - scrolling into view if needed\u001b[22m",
-  "\u001b[2m      - done scrolling\u001b[22m",
-  "\u001b[2m      - <div class=\"css-175oi2r r-f4gmv6 r-3pj75a\">…</div> from <div id=\"layers\" class=\"r-zchlnj r-1d2f490\">…</div> subtree intercepts pointer events\u001b[22m",
-  "\u001b[2m    - retrying click action\u001b[22m",
-  "\u001b[2m      - waiting 100ms\u001b[22m",
-  "\u001b[2m    14 × waiting for element to be visible, enabled and stable\u001b[22m",
-  "\u001b[2m       - element is visible, enabled and stable\u001b[22m",
-  "\u001b[2m       - <img draggable=\"false\" class=\"css-9pa8cd\" alt=\"Introducing Grok 4.5 for Chat\" src=\"https://abs.twimg.com/responsive-web/client-web/Grok-Promo-Popup-4-5-Launch.fc2ebfea.png\"/> from <div id=\"layers\" class=\"r-zchlnj r-1d2f490\">…</div> subtree intercepts pointer events\u001b[22m",
-  "\u001b[2m     - retrying click action\u001b[22m",
-  "\u001b[2m       - waiting 500ms\u001b[22m",
-].join("\n");
+const REAL_GROK_LOG = readFileSync(
+  new URL("../fixtures/e2e-dictation-sweep/grok-promo-click-error.txt", import.meta.url),
+  "utf8",
+);
 
 describe("describeInterceptor — name the overlay Playwright already blamed (#569)", () => {
-  it("names the X promo image and the layer it lives in, from the real failure", () => {
-    const i = describeInterceptor(GROK_PROMO_CLICK_ERROR);
+  it("has a verbatim, untrimmed fixture (guards the truncation that hid the bug)", () => {
+    // Pinned so a future "tidy up the fixture" breaks loudly rather than silently
+    // restoring the excerpt that made a broken selection rule look correct.
+    expect(REAL_GROK_LOG.length).toBe(4726);
+    expect(REAL_GROK_LOG.match(/intercepts pointer events/g)).toHaveLength(8);
+    expect(REAL_GROK_LOG).toContain("[2m"); // ANSI intact
+    // The trap itself: the LAST interception blames the anonymous wrapper, not the
+    // labelled promo image.
+    const last = REAL_GROK_LOG.lastIndexOf("intercepts pointer events");
+    expect(REAL_GROK_LOG.slice(last - 300, last)).toContain("css-175oi2r");
+    expect(REAL_GROK_LOG.slice(last - 300, last)).not.toContain("Introducing Grok");
+  });
+
+  it("names the X promo image and the layer it lives in, from the REAL untrimmed log", () => {
+    const i = describeInterceptor(REAL_GROK_LOG);
     expect(i).not.toBeNull();
     // Identity, not creative: tag + class + accessible-ish label, so the note is
     // actionable without the harness knowing anything about this promo.
-    expect(i!.element).toBe('img.css-9pa8cd[Introducing Grok 4.5 for Chat]');
+    expect(i!.element).toBe("img.css-9pa8cd[Introducing Grok 4.5 for Chat]");
     expect(i!.container).toBe("div#layers");
     // No ANSI escapes leak into the human-readable raw line.
-    expect(i!.raw).not.toMatch(/\u001b\[/);
+    expect(i!.raw).not.toMatch(/\[/);
   });
 
   it("does not mistake the resolved target locator for the interceptor", () => {
     // The <textarea> appears EARLIER in the call log than any interceptor; blaming
     // it would be worse than the generic note it replaces.
-    expect(describeInterceptor(GROK_PROMO_CLICK_ERROR)!.element).not.toMatch(/textarea/);
+    expect(describeInterceptor(REAL_GROK_LOG)!.element).not.toMatch(/textarea/);
   });
 
-  it("reports the LAST interception in the log — the one the retries died on", () => {
+  it("prefers the most identifying interception over merely the last one", () => {
+    // A human-readable label beats an id beats a bare class — that's what makes the
+    // note actionable. Taking the last blindly is what broke against the real log.
+    const log = [
+      "  - <img alt=\"Introducing Something\" class=\"promo\"/> from <div id=\"layers\">…</div> subtree intercepts pointer events",
+      "  - retrying click action",
+      "  - <div class=\"css-wrapper\">…</div> from <div id=\"layers\">…</div> subtree intercepts pointer events",
+    ].join("\n");
+    expect(describeInterceptor(log)!.element).toBe("img.promo[Introducing Something]");
+  });
+
+  it("falls back to the last interception when none is more identifying than another", () => {
+    // Class-only throughout: no signal to prefer, so the freshest state wins and the
+    // reader still gets something rather than null.
     const log = [
       "  - <div class=\"early\">…</div> from <div id=\"layers\">…</div> subtree intercepts pointer events",
       "  - retrying click action",
-      "  - <button aria-label=\"Sign up\" class=\"late\">…</button> from <div id=\"layers\">…</div> subtree intercepts pointer events",
+      "  - <div class=\"late\">…</div> from <div id=\"layers\">…</div> subtree intercepts pointer events",
     ].join("\n");
-    expect(describeInterceptor(log)!.element).toBe("button.late[Sign up]");
+    const i = describeInterceptor(log)!;
+    expect(i.element).toBe("div.late");
+    expect(i.container).toBe("div#layers");
+  });
+
+  it("breaks ties toward the freshest interception among equally identifying ones", () => {
+    const log = [
+      "  - <button aria-label=\"Dismiss\" class=\"a\">…</button> from <div id=\"layers\">…</div> subtree intercepts pointer events",
+      "  - <button aria-label=\"Sign up\" class=\"b\">…</button> from <div id=\"layers\">…</div> subtree intercepts pointer events",
+    ].join("\n");
+    expect(describeInterceptor(log)!.element).toBe("button.b[Sign up]");
   });
 
   it("handles an interceptor reported without a `from … subtree` clause", () => {
@@ -274,7 +306,7 @@ describe("describeInterceptor — name the overlay Playwright already blamed (#5
 describe("classifyFieldOutcome — never reached the field vs. reached it and no button (#569)", () => {
   it("calls the real Grok promo-modal failure an overlay block, not a SayPi defect", () => {
     const o = classifyFieldOutcome({
-      focusError: GROK_PROMO_CLICK_ERROR,
+      focusError: REAL_GROK_LOG,
       dismissAttempted: true,
       decorated: true,
       buttonAppeared: false,
@@ -339,7 +371,7 @@ describe("classifyFieldOutcome — never reached the field vs. reached it and no
   it("short-circuits on an aborted run (Cloudflare / harness throw) ahead of every URL-ish verdict", () => {
     const o = classifyFieldOutcome({
       abortedBecause: "the host served a Cloudflare challenge",
-      focusError: GROK_PROMO_CLICK_ERROR,
+      focusError: REAL_GROK_LOG,
       decorated: false,
       buttonAppeared: false,
     });
@@ -355,7 +387,7 @@ describe("classifyFieldOutcome — never reached the field vs. reached it and no
       {},
       { focusError: "" },
       { decorated: true },
-      { focusError: GROK_PROMO_CLICK_ERROR },
+      { focusError: REAL_GROK_LOG },
       { abortedBecause: "boom" },
     ]) {
       const o = classifyFieldOutcome(input as Record<string, unknown>);
@@ -369,7 +401,7 @@ describe("classifyFieldOutcome — never reached the field vs. reached it and no
   it("returns a uniform shape whichever branch fires (so summary.json columns stay stable)", () => {
     const keys = (o: object) => Object.keys(o).sort();
     const reached = classifyFieldOutcome({ decorated: true, buttonAppeared: true });
-    const blocked = classifyFieldOutcome({ focusError: GROK_PROMO_CLICK_ERROR });
+    const blocked = classifyFieldOutcome({ focusError: REAL_GROK_LOG });
     const aborted = classifyFieldOutcome({ abortedBecause: "boom" });
     expect(keys(blocked)).toEqual(keys(reached));
     expect(keys(aborted)).toEqual(keys(reached));
@@ -378,12 +410,30 @@ describe("classifyFieldOutcome — never reached the field vs. reached it and no
 
 describe("OVERLAY_DISMISS_LABELS — the generic, creative-agnostic dismiss step (#569)", () => {
   it("matches the dismissal affordances a promo/interstitial actually ships", () => {
-    for (const label of ["Close", "close", "Dismiss", "Not now", "No thanks", "Maybe later", "Skip", "Got it"]) {
+    for (const label of ["Close", "close", "Dismiss", "Not now", "No thanks", "Maybe later", "Skip", "✕"]) {
       expect(OVERLAY_DISMISS_LABELS.test(label)).toBe(true);
     }
   });
-  it("does not match controls that would take the run somewhere else", () => {
-    for (const label of ["Log in", "Sign up", "Continue with Google", "Send", "Accept and continue", "Try Grok 4.5", "Post"]) {
+  it("does not match controls that would take the run somewhere else, or consent to anything", () => {
+    for (const label of [
+      "Log in",
+      "Sign up",
+      "Continue with Google",
+      "Send",
+      "Accept and continue",
+      "Continue",
+      "OK",
+      "Allow",
+      "Try Grok 4.5",
+      "Post",
+      "Skip to sign up",
+      "Close account",
+      "Log out",
+      // "Got it" is the accept-all button on a common genre of cookie banner, so it
+      // lands on the wrong side of the dismiss-vs-consent line this set draws —
+      // clicking it would opt the run into tracking rather than closing a promo.
+      "Got it",
+    ]) {
       expect(OVERLAY_DISMISS_LABELS.test(label)).toBe(false);
     }
   });

--- a/test/scripts/e2e-dictation-sweep-lib.spec.ts
+++ b/test/scripts/e2e-dictation-sweep-lib.spec.ts
@@ -5,6 +5,10 @@ import {
   parseSweepArgs,
   transcriptLanded,
   summarizeField,
+  describeInterceptor,
+  classifyFieldOutcome,
+  FIELD_OUTCOME_KINDS,
+  OVERLAY_DISMISS_LABELS,
 } from "../../scripts/e2e-dictation-sweep-lib.mjs";
 
 describe("TARGETS registry", () => {
@@ -150,5 +154,240 @@ describe("summarizeField", () => {
     expect(s.decorated).toBe(true);
     expect(s.buttonAppeared).toBe(false);
     expect(s.transcriptLanded).toBe(false);
+  });
+  it("carries the field outcome's kind/owner/reached forward so summary.json can be triaged (#569)", () => {
+    const s = summarizeField({
+      target: "grok",
+      decorated: true,
+      buttonAppeared: false,
+      transcriptLanded: false,
+      outcome: {
+        kind: FIELD_OUTCOME_KINDS.OVERLAY_BLOCKED,
+        owner: "host",
+        fieldReached: false,
+        interceptor: { element: 'img.css-9pa8cd[Introducing Grok 4.5 for Chat]', container: "div#layers", raw: "" },
+        note: "…",
+      },
+    });
+    expect(s.outcomeKind).toBe(FIELD_OUTCOME_KINDS.OVERLAY_BLOCKED);
+    expect(s.owner).toBe("host");
+    expect(s.fieldReached).toBe(false);
+    expect(s.interceptor).toBe('img.css-9pa8cd[Introducing Grok 4.5 for Chat]');
+  });
+  it("leaves the outcome fields null when a run predates / lacks a classification", () => {
+    const s = summarizeField({});
+    expect(s.outcomeKind).toBeNull();
+    expect(s.owner).toBeNull();
+    expect(s.fieldReached).toBe(false);
+    expect(s.interceptor).toBeNull();
+  });
+});
+
+/**
+ * #569: X served a "Introducing Grok 4.5 for Chat" promo modal into `div#layers`,
+ * which swallowed every click at the composer. `page.click` retried for 30s and
+ * failed, and the sweep then recorded the generic
+ * "no .saypi-dictation-button appeared for this field" — a note that reads as a
+ * SayPi decoration defect for a field the harness never actually reached.
+ *
+ * The distinction to draw is exactly the one #559 drew for the host sweep's
+ * `classifyUndecorated`: "never got in front of the feature" (automation/host
+ * problem, says NOTHING about SayPi) vs. "got in front of the feature and it
+ * didn't work" (the defect this sweep exists to find).
+ *
+ * The error text below is the real one from
+ * `.output/e2e-dictation-sweep/2026-07-29T21-25-23-179Z/grok__4/evidence.json`,
+ * ANSI dim codes and all — Playwright names the interceptor for us, so nothing
+ * needs to match X's specific creative (which will change with the next launch).
+ */
+const GROK_PROMO_CLICK_ERROR = [
+  "page.click: Timeout 30000ms exceeded.",
+  "Call log:",
+  "\u001b[2m  - waiting for locator('textarea[placeholder]')\u001b[22m",
+  "\u001b[2m    - locator resolved to <textarea dir=\"auto\" spellcheck=\"true\" placeholder=\"Ask anything\" class=\"r-30o5oe r-1dz5y72\">Hello there, this is a quick test of the voice ac…</textarea>\u001b[22m",
+  "\u001b[2m  - attempting click action\u001b[22m",
+  "\u001b[2m    2 × waiting for element to be visible, enabled and stable\u001b[22m",
+  "\u001b[2m      - element is visible, enabled and stable\u001b[22m",
+  "\u001b[2m      - scrolling into view if needed\u001b[22m",
+  "\u001b[2m      - done scrolling\u001b[22m",
+  "\u001b[2m      - <div class=\"css-175oi2r r-f4gmv6 r-3pj75a\">…</div> from <div id=\"layers\" class=\"r-zchlnj r-1d2f490\">…</div> subtree intercepts pointer events\u001b[22m",
+  "\u001b[2m    - retrying click action\u001b[22m",
+  "\u001b[2m      - waiting 100ms\u001b[22m",
+  "\u001b[2m    14 × waiting for element to be visible, enabled and stable\u001b[22m",
+  "\u001b[2m       - element is visible, enabled and stable\u001b[22m",
+  "\u001b[2m       - <img draggable=\"false\" class=\"css-9pa8cd\" alt=\"Introducing Grok 4.5 for Chat\" src=\"https://abs.twimg.com/responsive-web/client-web/Grok-Promo-Popup-4-5-Launch.fc2ebfea.png\"/> from <div id=\"layers\" class=\"r-zchlnj r-1d2f490\">…</div> subtree intercepts pointer events\u001b[22m",
+  "\u001b[2m     - retrying click action\u001b[22m",
+  "\u001b[2m       - waiting 500ms\u001b[22m",
+].join("\n");
+
+describe("describeInterceptor — name the overlay Playwright already blamed (#569)", () => {
+  it("names the X promo image and the layer it lives in, from the real failure", () => {
+    const i = describeInterceptor(GROK_PROMO_CLICK_ERROR);
+    expect(i).not.toBeNull();
+    // Identity, not creative: tag + class + accessible-ish label, so the note is
+    // actionable without the harness knowing anything about this promo.
+    expect(i!.element).toBe('img.css-9pa8cd[Introducing Grok 4.5 for Chat]');
+    expect(i!.container).toBe("div#layers");
+    // No ANSI escapes leak into the human-readable raw line.
+    expect(i!.raw).not.toMatch(/\u001b\[/);
+  });
+
+  it("does not mistake the resolved target locator for the interceptor", () => {
+    // The <textarea> appears EARLIER in the call log than any interceptor; blaming
+    // it would be worse than the generic note it replaces.
+    expect(describeInterceptor(GROK_PROMO_CLICK_ERROR)!.element).not.toMatch(/textarea/);
+  });
+
+  it("reports the LAST interception in the log — the one the retries died on", () => {
+    const log = [
+      "  - <div class=\"early\">…</div> from <div id=\"layers\">…</div> subtree intercepts pointer events",
+      "  - retrying click action",
+      "  - <button aria-label=\"Sign up\" class=\"late\">…</button> from <div id=\"layers\">…</div> subtree intercepts pointer events",
+    ].join("\n");
+    expect(describeInterceptor(log)!.element).toBe("button.late[Sign up]");
+  });
+
+  it("handles an interceptor reported without a `from … subtree` clause", () => {
+    const log = "  - <div id=\"cookie-banner\">…</div> intercepts pointer events";
+    const i = describeInterceptor(log)!;
+    expect(i.element).toBe("div#cookie-banner");
+    expect(i.container).toBeNull();
+  });
+
+  it("still works when the whole call log arrives as one line", () => {
+    const oneLine =
+      "page.click: Timeout exceeded. Call log: - locator resolved to <textarea placeholder=\"Ask anything\"></textarea> - " +
+      "<img class=\"promo\" alt=\"Promo\"/> from <div id=\"layers\">…</div> subtree intercepts pointer events - retrying";
+    const i = describeInterceptor(oneLine)!;
+    expect(i.element).toBe("img.promo[Promo]");
+    expect(i.container).toBe("div#layers");
+  });
+
+  it("returns null when the click failed for a reason other than interception", () => {
+    expect(describeInterceptor("page.click: Timeout 10000ms exceeded.\nCall log:\n  - waiting for locator('#nope')")).toBeNull();
+    expect(describeInterceptor("")).toBeNull();
+    expect(describeInterceptor(null)).toBeNull();
+    expect(describeInterceptor(undefined)).toBeNull();
+  });
+});
+
+describe("classifyFieldOutcome — never reached the field vs. reached it and no button (#569)", () => {
+  it("calls the real Grok promo-modal failure an overlay block, not a SayPi defect", () => {
+    const o = classifyFieldOutcome({
+      focusError: GROK_PROMO_CLICK_ERROR,
+      dismissAttempted: true,
+      decorated: true,
+      buttonAppeared: false,
+    });
+    expect(o.kind).toBe(FIELD_OUTCOME_KINDS.OVERLAY_BLOCKED);
+    expect(o.owner).not.toBe("saypi");
+    expect(o.fieldReached).toBe(false);
+    expect(o.interceptor?.element).toBe('img.css-9pa8cd[Introducing Grok 4.5 for Chat]');
+    // AC1: the note names the blocking overlay instead of the generic no-button line.
+    expect(o.note).toMatch(/img\.css-9pa8cd/);
+    expect(o.note).toMatch(/div#layers/);
+    expect(o.note).not.toMatch(/no \.saypi-dictation-button appeared/);
+    // and it says out loud that this run judged nothing about SayPi
+    expect(o.note).toMatch(/NOTHING about/i);
+  });
+
+  it("keeps the genuine defect case attributable to SayPi", () => {
+    const o = classifyFieldOutcome({ focusError: null, decorated: true, buttonAppeared: false });
+    expect(o.kind).toBe(FIELD_OUTCOME_KINDS.NO_BUTTON);
+    expect(o.owner).toBe("saypi");
+    expect(o.fieldReached).toBe(true);
+    expect(o.note).toMatch(/\.saypi-dictation-button/);
+  });
+
+  it("calls a focused, decorated, button-bearing field reached", () => {
+    const o = classifyFieldOutcome({ focusError: null, decorated: true, buttonAppeared: true });
+    expect(o.kind).toBe(FIELD_OUTCOME_KINDS.REACHED);
+    expect(o.fieldReached).toBe(true);
+  });
+
+  it("separates a field the selector never found (login wall / drifted selector) from an overlay", () => {
+    const o = classifyFieldOutcome({
+      focusError: "page.click: Timeout 10000ms exceeded.\nCall log:\n  - waiting for locator('textarea[placeholder]')",
+      decorated: true,
+      buttonAppeared: false,
+    });
+    expect(o.kind).toBe(FIELD_OUTCOME_KINDS.FIELD_ABSENT);
+    expect(o.owner).not.toBe("saypi");
+    expect(o.fieldReached).toBe(false);
+    expect(o.note).toMatch(/sign|login|selector/i);
+  });
+
+  it("falls back to a plain focus failure when the field resolved but the click still failed", () => {
+    const o = classifyFieldOutcome({
+      focusError:
+        "page.click: Timeout 10000ms exceeded.\nCall log:\n  - locator resolved to <textarea placeholder=\"Ask anything\"></textarea>\n  - element is not enabled",
+      decorated: true,
+      buttonAppeared: false,
+    });
+    expect(o.kind).toBe(FIELD_OUTCOME_KINDS.FOCUS_FAILED);
+    expect(o.fieldReached).toBe(false);
+    expect(o.owner).not.toBe("saypi");
+  });
+
+  it("blames the build, not decoration, when no SayPi build stamp was on the page", () => {
+    const o = classifyFieldOutcome({ focusError: null, decorated: false, buttonAppeared: false });
+    expect(o.kind).toBe(FIELD_OUTCOME_KINDS.NOT_INJECTED);
+    expect(o.owner).not.toBe("saypi");
+    expect(o.note).toMatch(/e2e:build|content script/i);
+  });
+
+  it("short-circuits on an aborted run (Cloudflare / harness throw) ahead of every URL-ish verdict", () => {
+    const o = classifyFieldOutcome({
+      abortedBecause: "the host served a Cloudflare challenge",
+      focusError: GROK_PROMO_CLICK_ERROR,
+      decorated: false,
+      buttonAppeared: false,
+    });
+    expect(o.kind).toBe(FIELD_OUTCOME_KINDS.ABORTED);
+    expect(o.owner).not.toBe("saypi");
+    expect(o.fieldReached).toBe(false);
+    expect(o.note).toMatch(/Cloudflare challenge/);
+  });
+
+  it("is total: every input shape gets a kind, an owner and a note (never null)", () => {
+    for (const input of [
+      undefined,
+      {},
+      { focusError: "" },
+      { decorated: true },
+      { focusError: GROK_PROMO_CLICK_ERROR },
+      { abortedBecause: "boom" },
+    ]) {
+      const o = classifyFieldOutcome(input as Record<string, unknown>);
+      expect(Object.values(FIELD_OUTCOME_KINDS)).toContain(o.kind);
+      expect(typeof o.owner).toBe("string");
+      expect(o.note.length).toBeGreaterThan(0);
+      expect(typeof o.fieldReached).toBe("boolean");
+    }
+  });
+
+  it("returns a uniform shape whichever branch fires (so summary.json columns stay stable)", () => {
+    const keys = (o: object) => Object.keys(o).sort();
+    const reached = classifyFieldOutcome({ decorated: true, buttonAppeared: true });
+    const blocked = classifyFieldOutcome({ focusError: GROK_PROMO_CLICK_ERROR });
+    const aborted = classifyFieldOutcome({ abortedBecause: "boom" });
+    expect(keys(blocked)).toEqual(keys(reached));
+    expect(keys(aborted)).toEqual(keys(reached));
+  });
+});
+
+describe("OVERLAY_DISMISS_LABELS — the generic, creative-agnostic dismiss step (#569)", () => {
+  it("matches the dismissal affordances a promo/interstitial actually ships", () => {
+    for (const label of ["Close", "close", "Dismiss", "Not now", "No thanks", "Maybe later", "Skip", "Got it"]) {
+      expect(OVERLAY_DISMISS_LABELS.test(label)).toBe(true);
+    }
+  });
+  it("does not match controls that would take the run somewhere else", () => {
+    for (const label of ["Log in", "Sign up", "Continue with Google", "Send", "Accept and continue", "Try Grok 4.5", "Post"]) {
+      expect(OVERLAY_DISMISS_LABELS.test(label)).toBe(false);
+    }
+  });
+  it("is anchored (a stray 'skip' inside prose must not fire it)", () => {
+    expect(OVERLAY_DISMISS_LABELS.test("Skip this step and close the dialog forever")).toBe(false);
   });
 });

--- a/test/scripts/e2e-dictation-sweep-wiring.spec.ts
+++ b/test/scripts/e2e-dictation-sweep-wiring.spec.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { sweepField } from "../../scripts/e2e-dictation-sweep.mjs";
+import { FIELD_OUTCOME_KINDS } from "../../scripts/e2e-dictation-sweep-lib.mjs";
+
+/**
+ * The lib spec next door proves the classifier in isolation. This one proves the
+ * WIRING — the invariant doc/e2e-dictation-sweep.md now states as fact and the
+ * analysis checklist tells agents to rely on:
+ *
+ *   every swept field carries an `outcome` verdict in evidence.json, and a field the
+ *   harness never reached is never reported as "no button appeared".
+ *
+ * #569's failure was entirely in the wiring: `classifyFieldOutcome`'s equivalent
+ * reasoning could have been done by a human reading the 30s click timeout, but the
+ * harness wrote "no .saypi-dictation-button appeared for this field" into notes[] and
+ * that's what got read. So these tests read evidence.json off disk, same as the host
+ * sweep's undecorated-wiring spec.
+ *
+ * Stub pages, not a browser: sweepField only touches a handful of Playwright methods,
+ * so the real function runs unmodified.
+ */
+
+/** The real interception message from the 2026-07-29 grok run, ANSI codes and all. */
+const GROK_PROMO_CLICK_ERROR = [
+  "page.click: Timeout 10000ms exceeded.",
+  "Call log:",
+  "\u001b[2m  - waiting for locator('textarea[placeholder]')\u001b[22m",
+  "\u001b[2m    - locator resolved to <textarea placeholder=\"Ask anything\">…</textarea>\u001b[22m",
+  "\u001b[2m      - <img draggable=\"false\" class=\"css-9pa8cd\" alt=\"Introducing Grok 4.5 for Chat\" src=\"https://abs.twimg.com/responsive-web/client-web/Grok-Promo-Popup-4-5-Launch.fc2ebfea.png\"/> from <div id=\"layers\" class=\"r-zchlnj\">…</div> subtree intercepts pointer events\u001b[22m",
+  "\u001b[2m    - retrying click action\u001b[22m",
+].join("\n");
+
+const CF_HTML = '<html><head><title>Just a moment...</title></head><body>cf-chl-bypass</body></html>';
+
+const GROK_ITEM = {
+  targetKey: "grok",
+  targetLabel: "Grok (x.com)",
+  url: "https://x.com/i/grok",
+  dismissModal: null,
+  fieldSelector: "textarea[placeholder]",
+  fieldType: "textarea" as const,
+  fieldLabel: "Composer (Ask anything)",
+};
+
+type Calls = { clicks: string[]; escapes: number; screenshots: string[]; dismissLookups: number };
+
+/**
+ * Minimal Playwright-page stand-in. `clickResults` is consumed one per field-click
+ * attempt: a string rejects that attempt with it, null resolves.
+ */
+function stubPage(opts: {
+  clickResults?: (string | null)[];
+  buttonAppears?: boolean;
+  dismissControlVisible?: boolean;
+  content?: string;
+  title?: string;
+  build?: string | null;
+  calls: Calls;
+}) {
+  const clickResults = [...(opts.clickResults ?? [null])];
+  const noop = async () => undefined;
+  const page: Record<string, unknown> = {
+    on: () => {},
+    goto: noop,
+    title: async () => opts.title ?? "Grok / X",
+    content: async () => opts.content ?? "<html><body>ok</body></html>",
+    url: () => "https://x.com/i/grok",
+    evaluate: async (fn: unknown) => {
+      // Two different evaluate() uses: the build-stamp read, and the dev-feed-speech dispatch.
+      const src = String(fn);
+      if (src.includes("saypiBuild")) return opts.build === undefined ? "abc123@main" : opts.build;
+      return undefined;
+    },
+    click: async (selector: string) => {
+      if (selector.includes("saypi-dictation-button")) return undefined;
+      opts.calls.clicks.push(selector);
+      const next = clickResults.length > 1 ? clickResults.shift() : clickResults[0];
+      if (next) throw new Error(next);
+      return undefined;
+    },
+    keyboard: {
+      press: async () => {
+        opts.calls.escapes += 1;
+      },
+    },
+    getByRole: () => {
+      opts.calls.dismissLookups += 1;
+      const locator = {
+        first: () => locator,
+        waitFor: async () => {
+          if (!opts.dismissControlVisible) throw new Error("not visible");
+        },
+        getAttribute: async () => "Close",
+        textContent: async () => "Close",
+        click: async () => undefined,
+      };
+      return locator;
+    },
+    waitForTimeout: noop,
+    waitForSelector: async () => {
+      if (opts.buttonAppears === false) throw new Error("not found");
+      return {};
+    },
+    waitForFunction: async () => ({ jsonValue: async () => "Hello there, this is a test." }),
+    screenshot: async ({ path }: { path: string }) => {
+      opts.calls.screenshots.push(path.split("/").pop() as string);
+    },
+    close: noop,
+  };
+  return page;
+}
+
+const freshCalls = (): Calls => ({ clicks: [], escapes: 0, screenshots: [], dismissLookups: 0 });
+
+const run = (page: unknown, outDir: string, item = GROK_ITEM) =>
+  sweepField({ newPage: async () => page }, item, outDir, 0);
+
+const evidenceOnDisk = (outDir: string, target = "grok") =>
+  JSON.parse(readFileSync(join(outDir, `${target}__0`, "evidence.json"), "utf8"));
+
+describe("sweepField always records an outcome, and never blames SayPi for an unreached field (#569)", () => {
+  let outDir: string;
+  let calls: Calls;
+
+  beforeEach(() => {
+    outDir = mkdtempSync(join(tmpdir(), "saypi-dictation-wiring-"));
+    calls = freshCalls();
+  });
+
+  afterEach(() => {
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  it("reports X's promo overlay by name instead of the generic no-button note", async () => {
+    const ev = await run(stubPage({ clickResults: [GROK_PROMO_CLICK_ERROR], calls }), outDir);
+
+    expect(ev.fieldFocused).toBe(false);
+    expect(ev.outcome!.kind).toBe(FIELD_OUTCOME_KINDS.OVERLAY_BLOCKED);
+    expect(ev.outcome!.owner).toBe("host");
+    expect(ev.outcome!.interceptor!.element).toBe("img.css-9pa8cd[Introducing Grok 4.5 for Chat]");
+
+    const onDisk = evidenceOnDisk(outDir);
+    expect(onDisk.outcome.kind).toBe(FIELD_OUTCOME_KINDS.OVERLAY_BLOCKED);
+    // AC1/AC2: the note a human reads names the overlay, and the misleading generic
+    // line is gone entirely.
+    expect(onDisk.notes.join("\n")).toMatch(/img\.css-9pa8cd\[Introducing Grok 4\.5 for Chat\]/);
+    expect(onDisk.notes.join("\n")).not.toMatch(/no \.saypi-dictation-button appeared for this field/);
+    // The screenshot is named for the verdict, so the evidence dir self-describes.
+    expect(calls.screenshots).toContain("99-overlay-blocked.png");
+  });
+
+  it("tries a generic dismissal (Escape, then a close-labelled control) before giving up", async () => {
+    await run(stubPage({ clickResults: [GROK_PROMO_CLICK_ERROR], dismissControlVisible: true, calls }), outDir);
+
+    expect(calls.escapes).toBe(1);
+    expect(calls.dismissLookups).toBe(1);
+    expect(calls.clicks.filter((c) => c === GROK_ITEM.fieldSelector)).toHaveLength(2); // one retry, not more
+    expect(evidenceOnDisk(outDir).overlayDismissSteps.join(" ")).toMatch(/Escape/);
+  });
+
+  it("recovers when the dismissal works: the retry focuses and a real verdict follows", async () => {
+    const ev = await run(
+      stubPage({ clickResults: [GROK_PROMO_CLICK_ERROR, null], dismissControlVisible: true, calls }),
+      outDir,
+    );
+
+    expect(ev.fieldFocused).toBe(true);
+    expect(ev.outcome!.kind).toBe(FIELD_OUTCOME_KINDS.REACHED);
+    expect(ev.transcriptLanded).toBe(true);
+  });
+
+  it("does not touch the overlay rescue when the first focus click lands (fixture/mistral path)", async () => {
+    const ev = await run(stubPage({ calls }), outDir);
+
+    expect(calls.escapes).toBe(0);
+    expect(calls.dismissLookups).toBe(0);
+    expect(ev.overlayDismissSteps).toEqual([]);
+    expect(ev.outcome!.kind).toBe(FIELD_OUTCOME_KINDS.REACHED);
+    expect(ev.transcriptLanded).toBe(true);
+  });
+
+  it("still calls a reached-but-buttonless field a SayPi defect", async () => {
+    const ev = await run(stubPage({ buttonAppears: false, calls }), outDir);
+
+    expect(ev.fieldFocused).toBe(true);
+    expect(ev.buttonAppeared).toBe(false);
+    expect(ev.outcome!.kind).toBe(FIELD_OUTCOME_KINDS.NO_BUTTON);
+    expect(ev.outcome!.owner).toBe("saypi");
+    expect(calls.screenshots).toContain("99-no-button.png");
+  });
+
+  it("classifies the Cloudflare early return, which bypasses the normal classifier", async () => {
+    const ev = await run(
+      stubPage({ title: "Just a moment...", content: CF_HTML, calls }),
+      outDir,
+    );
+
+    expect(ev.cloudflareBlocked).toBe(true);
+    expect(ev.outcome!.kind).toBe(FIELD_OUTCOME_KINDS.ABORTED);
+    expect(evidenceOnDisk(outDir).outcome).not.toBeNull();
+  });
+
+  it("classifies a run that throws mid-field rather than defaulting to no-button", async () => {
+    // Nearly every page call in sweepField is individually guarded (that's why a
+    // throw used to end up looking like "no button"), so throw from the un-guarded
+    // build-stamp re-check wait — the honest way to reach the outer catch.
+    const page = stubPage({ build: null, calls });
+    page.waitForTimeout = async () => {
+      throw new Error("Target closed");
+    };
+    const ev = await run(page, outDir);
+
+    expect(ev.outcome!.kind).toBe(FIELD_OUTCOME_KINDS.ABORTED);
+    expect(ev.notes.join("\n")).toMatch(/Target closed/);
+    expect(evidenceOnDisk(outDir).outcome).not.toBeNull();
+  });
+});

--- a/test/scripts/e2e-dictation-sweep-wiring.spec.ts
+++ b/test/scripts/e2e-dictation-sweep-wiring.spec.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { sweepField } from "../../scripts/e2e-dictation-sweep.mjs";
-import { FIELD_OUTCOME_KINDS } from "../../scripts/e2e-dictation-sweep-lib.mjs";
+import { FIELD_OUTCOME_KINDS, OVERLAY_DISMISS_LABELS } from "../../scripts/e2e-dictation-sweep-lib.mjs";
 
 /**
  * The lib spec next door proves the classifier in isolation. This one proves the
@@ -46,14 +46,22 @@ const GROK_ITEM = {
   fieldLabel: "Composer (Ask anything)",
 };
 
-type Calls = { clicks: string[]; escapes: number; screenshots: string[]; dismissLookups: number };
+type Calls = {
+  clicks: string[];
+  escapes: number;
+  screenshots: string[];
+  dismissLookups: number;
+  /** Every getByRole(role, opts) the harness issued — proves WHICH filter it passed. */
+  roleQueries: { role: string; name: unknown }[];
+};
 
 /**
  * Minimal Playwright-page stand-in. `clickResults` is consumed one per field-click
  * attempt: a string rejects that attempt with it, null resolves.
  */
 function stubPage(opts: {
-  clickResults?: (string | null)[];
+  /** One entry per field-click attempt: a string or Error rejects it, null resolves. */
+  clickResults?: (string | Error | null)[];
   buttonAppears?: boolean;
   dismissControlVisible?: boolean;
   content?: string;
@@ -79,6 +87,7 @@ function stubPage(opts: {
       if (selector.includes("saypi-dictation-button")) return undefined;
       opts.calls.clicks.push(selector);
       const next = clickResults.length > 1 ? clickResults.shift() : clickResults[0];
+      if (next instanceof Error) throw next;
       if (next) throw new Error(next);
       return undefined;
     },
@@ -87,8 +96,9 @@ function stubPage(opts: {
         opts.calls.escapes += 1;
       },
     },
-    getByRole: () => {
+    getByRole: (role: string, o: { name?: unknown } = {}) => {
       opts.calls.dismissLookups += 1;
+      opts.calls.roleQueries.push({ role, name: o.name });
       const locator = {
         first: () => locator,
         waitFor: async () => {
@@ -114,7 +124,7 @@ function stubPage(opts: {
   return page;
 }
 
-const freshCalls = (): Calls => ({ clicks: [], escapes: 0, screenshots: [], dismissLookups: 0 });
+const freshCalls = (): Calls => ({ clicks: [], escapes: 0, screenshots: [], dismissLookups: 0, roleQueries: [] });
 
 const run = (page: unknown, outDir: string, item = GROK_ITEM) =>
   sweepField({ newPage: async () => page }, item, outDir, 0);
@@ -217,5 +227,28 @@ describe("sweepField always records an outcome, and never blames SayPi for an un
     expect(ev.outcome!.kind).toBe(FIELD_OUTCOME_KINDS.ABORTED);
     expect(ev.notes.join("\n")).toMatch(/Target closed/);
     expect(evidenceOnDisk(outDir).outcome).not.toBeNull();
+  });
+  it("passes OVERLAY_DISMISS_LABELS itself as the getByRole filter (#569 review)", async () => {
+    // The stub used to ignore getByRole's arguments, so the one safeguard standing
+    // between the rescue and a "Accept all"/"Log in" button went untested where it is
+    // actually applied. Assert the real filter object reaches Playwright.
+    await run(stubPage({ clickResults: [GROK_PROMO_CLICK_ERROR], dismissControlVisible: true, calls }), outDir);
+
+    expect(calls.roleQueries).toHaveLength(1);
+    expect(calls.roleQueries[0].role).toBe("button");
+    expect(calls.roleQueries[0].name).toBe(OVERLAY_DISMISS_LABELS);
+  });
+
+  it("does not call an empty-message click rejection a success (#569 review)", async () => {
+    // `page.click(...).catch((e) => e.message)` yields "" for `new Error("")`, and ""
+    // is falsy — so the focus read as successful and the field classified as
+    // no-button / owner:saypi: the exact false SayPi defect #569 exists to prevent.
+    const ev = await run(stubPage({ clickResults: [new Error(""), new Error("")], calls }), outDir);
+
+    expect(ev.fieldFocused).toBe(false);
+    expect(ev.focusError).toBeTruthy();
+    expect(ev.outcome!.kind).not.toBe(FIELD_OUTCOME_KINDS.NO_BUTTON);
+    expect(ev.outcome!.owner).not.toBe("saypi");
+    expect(ev.outcome!.fieldReached).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

X dropped an "Introducing Grok 4.5 for Chat" promo modal into `div#layers` on `x.com/i/grok`. It sat over the composer and swallowed every click, so the dictation sweep's `page.click` retried for the full 30s and gave up — and then wrote down the only note it had:

```
"no .saypi-dictation-button appeared for this field"
```

That reads as a SayPi decoration defect. It wasn't one: the harness never reached the field, so the run produced **no evidence either way** about universal dictation on Grok. Playwright had actually named the culprit in its call log the whole time; nothing was listening.

This is exactly the conflation #559 removed from the host sweep, where `classifyUndecorated` split "we never got a chat app in front of the extension" from "the chat app rendered and SayPi failed to decorate it". The dictation sweep needed the same distinction, so it gets the same shape rather than a new invention.

## What

**`classifyFieldOutcome()`** (`scripts/e2e-dictation-sweep-lib.mjs`) — the dictation counterpart to `classifyUndecorated`. One verdict per swept field: a `kind`, an `owner`, `fieldReached`, and a note that says out loud when a run judged nothing about SayPi. `owner` answers the reader's first question:

| `kind` | `owner` | means |
|---|---|---|
| `reached` | saypi | focused + button present — `transcriptLanded` is a real product signal |
| `no-button` | **saypi** | focused a decorated page's field, no button — **the defect case** |
| `overlay-blocked` | host | an interstitial swallowed the clicks; the note names it |
| `field-absent` | automation | selector never matched (sign-in wall, or drifted selector) |
| `focus-failed` | automation | field resolved, click failed for another reason |
| `not-injected` | automation | no `data-saypi-build` stamp — content script never ran |
| `run-aborted` | automation | Cloudflare / harness throw — nothing observed |

**`describeInterceptor()`** reads the blocker back out of Playwright's own call log — `<img alt="Introducing Grok 4.5 for Chat"/> from <div id="layers"> subtree intercepts pointer events` — and condenses it to `img.css-9pa8cd[Introducing Grok 4.5 for Chat]` / `div#layers`. **Nothing matches this specific creative**, deliberately: X ships different art for every Grok launch, so a rule keyed on this image would rot by the next one. It takes the *last* interception in the log (the state the retries actually died in) and clips its search window to the reported line, so the earlier `locator resolved to <textarea …>` can't be misread as the interceptor — blaming the target itself would be worse than the generic note this replaces.

**A generic rescue before giving up:** Escape, then any control whose *whole* accessible name reads as a dismissal (`OVERLAY_DISMISS_LABELS` — never "OK"/"Accept"/"Continue", which would opt the run *into* something), then one focus retry. It only ever runs after a focus attempt has already failed, so `fixture` and `mistral` never execute a line of it. A recurring per-target consent dialog still belongs in that target's `dismissModal`.

Fallout worth noting: the button wait is now skipped when nothing was focused (10s that only ever bought a misleading `buttonAppeared: false`); failure screenshots are named `99-<kind>.png` so the evidence dir self-describes; `summary.json` carries `outcomeKind`/`owner`/`fieldReached`/`interceptor`; and the run-level tally splits "reached but didn't land" (hunt these) from "never judged" (fix the run). Per-attempt focus timeout is 10s, so two attempts stay inside the old single 30s budget.

## Verification

Fail-first, Layers 0–2 only — this is pure logic plus wiring. **No real-host run:** the shared CDP profile is ledgered and capped and a sibling agent may be using it. I don't think one is required here; the input this fix consumes is a captured Playwright error string, and the real one from the failing run is checked in as the test fixture. A future `grok` sweep on a signed-in profile will exercise it for free.

- **20 new unit tests** in `test/scripts/e2e-dictation-sweep-lib.spec.ts`, written first and confirmed failing (`TypeError: (0 , classifyFieldOutcome) is not a function`, `(0 , describeInterceptor) is not a function`, `Cannot read properties of undefined (reading 'OVERLAY_BLOCKED')`) — driven by the verbatim error text from the run that found this (`.output/e2e-dictation-sweep/2026-07-29T21-25-23-179Z/grok__4/evidence.json`), ANSI codes and all.
- **7 new wiring tests** in `test/scripts/e2e-dictation-sweep-wiring.spec.ts`, following the `e2e-host-sweep-undecorated-wiring.spec.ts` precedent (real `sweepField`, stub pages, evidence read back off disk). They prove the part that actually failed in #569 — the wiring, not the reasoning: the overlay note replaces the generic one; the dismissal fires **only** after a failed click (AC3: `fixture`/`mistral` untouched); a successful dismissal recovers into a real verdict; a reached-but-buttonless field is still `owner: saypi`; and the Cloudflare and throw paths still record a verdict instead of defaulting to "no button". Before the fix these failed at import: `Error: process.exit unexpectedly called with "1"` (importing the harness ran `main()`), now guarded by the same direct-invocation idiom `e2e-host-sweep.mjs` uses.
- **Full gate green** on a fresh rebase onto `main` @ 3cc91b2: `tsc --noEmit` clean, Jest 2/2, Vitest **227 files / 2193 passed, 1 skipped**.

Docs: `doc/e2e-dictation-sweep.md` gains the outcome table, the rescue rationale, a "read `outcome.owner` first" analysis rule, and a Grok-specific caveat (a *signed-in* run can still fail `overlay-blocked` — that's X's billboard, not a defect).

## Deliberately left out

- No `dismissModal` entry for X's promo. It's per-campaign creative; the generic path plus a named report is the durable answer, and a target-specific rule can be added if one overlay proves permanent.
- `describeInterceptor` reports one interceptor, not a stack. Playwright names one at a time and that's been sufficient.
- The host sweep's files are untouched — a sibling agent is concurrently working #570 there. `stripAnsi` is now exported from the dictation lib (it had been duplicated inline in the harness); the host sweep has no equivalent, so no shared-helper collision.

Fixes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZmcU3XWRo4CcYqiBoYxy6
