### PR TITLE
fix(sweep): make a decoration miss explainable without re-running (#570)

### DIFF
--- a/doc/e2e-host-sweep.md
+++ b/doc/e2e-host-sweep.md
@@ -90,9 +90,9 @@ accepting longer turns / a possible `piThinking` timeout window.
 
 Per host the harness writes to `.output/e2e-host-sweep/<run>/<host>/`:
 `evidence.json` (console / pageErrors / network / requestFailed / domDiagnostics /
-auth+voice / transcript / observe flags / `finalUrl` + `undecorated`) and screenshots
-(`01-before`, `02-transcript`, `0N-observe…`, `99-final`). A run-level `summary.json`
-holds the per-host `summarize()` rollup.
+auth+voice / transcript / observe flags / `finalUrl` + `undecorated` + `decoration`) and
+screenshots (`01-before`, `02-transcript`, `0N-observe…`, `99-final`). A run-level
+`summary.json` holds the per-host `summarize()` rollup.
 
 ## Analysis discipline (don't skip — this is where false findings come from)
 
@@ -105,7 +105,7 @@ holds the per-host `summarize()` rollup.
    A host can fail to decorate because SayPi never got a chat app to decorate. The
    harness classifies it for you from the requested vs. **final** URL (`evidence.finalUrl`
    — hosts bounce you *after* load, so this is re-read at the decoration deadline) plus
-   any sign-in affordance on the page. Every undecorated host gets one of these five —
+   any sign-in affordance on the page. Every undecorated host gets one of these six —
    `undecorated` is null **only** when the host decorated:
    - `redirected-off-origin` — we left the requested origin (the live case: pi.ai now
      bounces signed-out visitors from `pi.ai/talk` to the `hey.pi.ai` splash, #559).
@@ -120,10 +120,52 @@ holds the per-host `summarize()` rollup.
      sweep exists to find. The probe behind that caveat counts a control that is not
      hidden by `display:none` / `visibility:hidden` / `[hidden]` / `aria-hidden`; it does
      **not** model layout, so a zero-sized or off-screen control still counts.
+   - `internal-inconsistency` — the miss is **contradicted by the run's own evidence**
+     (#570): the call button *was* in the DOM. Never file this as drift; read
+     `decoration.contradiction` for which of the four stories it is, and
+     `decoration.nextStep` for what to do. This is the verdict the 2026-07-29 run should
+     have produced (`callButtons: 1` and a screenshot of the button, filed as
+     `possible-drift`).
    - `run-aborted` — the run ended before the page could be judged at all (a Cloudflare
      challenge, or an exception mid-host — see `cloudflareBlocked` / `notes[]`). Fix the
      run and re-run; says nothing about SayPi.
    - `unknown` — no usable final URL; fall back to `01-before.png`.
+
+   **2b. Then read `evidence.decoration` — the measurement behind the one bit (#570).**
+   `decorated` is a single `waitForSelector("#saypi-callButton", { timeout: 25_000 })`,
+   and its default `state: 'visible'` needs a **non-empty bounding box** —
+   `querySelectorAll` (what `domDiagnostics.callButtons` counts) does not. So the harness
+   also records, every run: whether the button was **ever** in the DOM, **when it first
+   appeared relative to navigation** (`firstSeenMs`, timed by a watcher installed via
+   `addInitScript` *before* the page loads), and its **box + computed
+   display/visibility/opacity at the deadline**. Healthy hosts are sub-second — the
+   direct probe behind #570 measured claude.ai at **+771ms** — so a `firstSeenMs` in the
+   seconds is itself a finding.
+
+   The sequencing matters and is deliberate: **`01-before.png` and `domDiagnostics` are
+   captured AFTER the decoration wait**, which is exactly how they can outvote it. On a
+   miss the harness also keeps *looking* for a bounded 5s more (`DECORATION_GRACE_MS`) by
+   **DOM presence** (`state: 'attached'`) rather than visibility — a run that stops
+   observing at the deadline structurally cannot tell "never in the DOM" from "in the
+   DOM, just later than the budget", since both read as absent. That read costs a healthy
+   host nothing, never changes `decorated`, and leaves the 25s budget alone; it just
+   means a `possible-drift` verdict now rests on **measured** absence.
+
+   When the evidence does outvote the verdict, `describeDecoration()` names which of four
+   stories it is:
+
+   | `decoration.contradiction` | means | owner |
+   |---|---|---|
+   | `visible-but-missed` | present *with* a non-empty box at the deadline — the wait should have resolved | automation (re-run; **not** drift) |
+   | `present-but-invisible` | in the DOM but boxless / `display:none` — the visible-wait failed legitimately | SayPi (a **rendering** defect) |
+   | `appeared-after-check` | absent at the deadline, found by the grace re-read or the later census — decoration finished past the budget (with the real `firstSeenMs`) | SayPi (a **latency** finding) |
+   | `removed-before-check` | timed a first sighting, gone by the deadline | SayPi (a **teardown/re-render** defect) |
+
+   `contradiction: null` on a miss is what makes `possible-drift` trustworthy rather than
+   merely unrefuted: the note then states outright that the button never entered the DOM.
+   `summary.json` carries `decorationEverPresent` / `decorationFirstSeenMs` /
+   `decorationContradiction` so a whole run can be scanned at a glance, and the per-host
+   log line prints `firstSeen=+Nms` plus a loud `⚠️ CONTRADICTED(...)`.
 3. **Attribute to SayPi only.** Hosts emit their own console noise (claude.ai `/v1/toolbox`
    405s, ProseMirror warnings, framework deprecations). `summarize()` splits
    `saypiErrors`/`saypiWarnings` from `hostErrors` for you — file SayPi-attributable
@@ -191,9 +233,18 @@ A default sweep is **not free or traceless** — it acts as the founder on real 
   after-the-wait `page.url()` re-read still awaits a real bouncing host. So the first
   real `redirected-off-origin` verdict should be sanity-checked against `01-before.png`
   rather than trusted outright (#559).
+- **The decoration measurement's `hasBox` is only meaningful in a real browser.**
+  `DECORATION_PROBE` reads `getBoundingClientRect()`, which JSDOM reports as all zeros,
+  so the unit tests stub the rect. And `firstSeenMs` is navigation-relative *provided*
+  the `addInitScript` watcher took: if only the defensive post-load install ran, the
+  reading carries `presentAtInstall: true` / `firstSeenExact: false` and the number is an
+  **upper bound**, which the evidence sentence says out loud. The `visible-but-missed`
+  flavour has not yet been reproduced deliberately — it was inferred from the 2026-07-29
+  bundle, so the first live one is worth checking against `01-before.png` (#570).
 - Built on `scripts/layer4cdp-lib.mjs` (launch/Cloudflare/profile helpers) +
   `scripts/e2e-host-sweep-lib.mjs` (pure: host registry, arg parse, console attribution,
-  summary, per-host DOM diagnostics, the undecorated classifier + sign-in probe —
-  unit-tested in `test/scripts/e2e-host-sweep-lib.spec.ts`,
-  `…-diags.spec.ts`, `…-undecorated.spec.ts`).
+  summary, per-host DOM diagnostics, the undecorated classifier + sign-in probe, the
+  decoration watcher/probe + `describeDecoration` — unit-tested in
+  `test/scripts/e2e-host-sweep-lib.spec.ts`, `…-diags.spec.ts`, `…-undecorated.spec.ts`,
+  `…-decoration.spec.ts`; the `sweepHost` wiring in `…-undecorated-wiring.spec.ts`).
 ```

--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -169,6 +169,12 @@ export const DECORATION_WATCHER = () => {
   const w = window;
   const existing = w.__saypiSweepDecoration;
   if (existing) return existing.installedAtMs;
+  // Main frame only. `addInitScript` also runs in every child frame, and the call button
+  // only ever lives in the top document (`page.waitForSelector` and `page.evaluate`
+  // search the main frame too), so a child-frame watcher could never contribute a
+  // reading — it would just leave a never-disconnecting subtree MutationObserver in each
+  // of the host's iframes for the whole 25s.
+  if (w.top !== w) return null;
   const state = { installedAtMs: performance.now(), firstSeenMs: null, presentAtInstall: false };
   w.__saypiSweepDecoration = state;
   const mark = () => {
@@ -194,14 +200,17 @@ export const DECORATION_WATCHER = () => {
 
 /**
  * Read at the decoration deadline: is the call button there, since when, and — the
- * distinction a bare `false` loses — does it have the non-empty bounding box that
- * Playwright's default `state: 'visible'` requires? `querySelectorAll` (what
- * `domDiagnostics.callButtons` counts) does not care about layout, which is precisely
- * how the two can disagree.
+ * distinction a bare `false` loses — would Playwright have considered it *visible*?
+ * `querySelectorAll` (what `domDiagnostics.callButtons` counts) cares about neither
+ * layout nor style, which is precisely how the two can disagree.
+ *
+ * Captures the three inputs Playwright's own rule uses (see `playwrightVisibility`):
+ * the bounding box, the computed style, and `Element.checkVisibility()` — recording the
+ * browser's own answer beats reimplementing it.
  *
  * Self-contained, same rule as DIAGS/SIGN_IN_PROBE. Under JSDOM
- * `getBoundingClientRect` reports all zeros, so `hasBox` is only meaningful in a real
- * browser (unit tests stub the rect).
+ * `getBoundingClientRect` reports all zeros, so box-derived fields are only meaningful
+ * in a real browser (unit tests stub the rect).
  */
 export const DECORATION_PROBE = () => {
   const el = document.querySelector("#saypi-callButton");
@@ -210,12 +219,23 @@ export const DECORATION_PROBE = () => {
   const round = (n) => (typeof n === "number" && isFinite(n) ? Math.round(n) : null);
   let box = null;
   let computed = null;
+  let checkVisibility = null;
   if (el) {
     const r = typeof el.getBoundingClientRect === "function" ? el.getBoundingClientRect() : null;
     if (r) box = { x: round(r.x), y: round(r.y), width: round(r.width), height: round(r.height) };
     if (view && typeof view.getComputedStyle === "function") {
       const s = view.getComputedStyle(el);
       computed = { display: s.display, visibility: s.visibility, opacity: s.opacity };
+    }
+    // The browser's own answer to Playwright's second gate. Note its DEFAULT options do
+    // NOT consider `visibility` — which is exactly why Playwright pairs it with the
+    // computed-visibility check rather than relying on it alone.
+    if (typeof el.checkVisibility === "function") {
+      try {
+        checkVisibility = !!el.checkVisibility();
+      } catch {
+        checkVisibility = null;
+      }
     }
   }
   return {
@@ -229,9 +249,50 @@ export const DECORATION_PROBE = () => {
     checkedAtMs: round(performance.now()),
     box,
     computed,
+    checkVisibility,
     hasBox: !!(box && box.width > 0 && box.height > 0),
   };
 };
+
+/**
+ * Would Playwright's `state: 'visible'` have considered this reading visible?
+ * `true` / `false` / `null` when it cannot be determined. Pure, so it unit-tests off a
+ * raw probe object with no DOM.
+ *
+ * A non-empty bounding box alone is NOT the rule, and the gap is not academic:
+ * `visibility: hidden` leaves the box intact (unlike `display: none`, which zeroes it),
+ * so a 44×44 but `visibility: hidden` call button makes the visible-wait time out
+ * *correctly* — and calling that a harness artifact would mis-own issue #570's own
+ * case (c) to the harness, the same inversion this file exists to prevent.
+ *
+ * Modelled on playwright-core 1.60.0's `isElementVisible`:
+ *   box.width > 0 && box.height > 0 && element.checkVisibility() && style.visibility === 'visible'
+ * Three details follow from that source and are easy to get wrong:
+ *   - `opacity` is NOT part of it. A fully transparent element is visible to Playwright.
+ *   - the visibility test is `=== 'visible'`, not `!== 'hidden'`, so `collapse` (which
+ *     behaves as hidden on non-table elements) is correctly hidden.
+ *   - `checkVisibility()`'s default options ignore `visibility`; it contributes
+ *     `display:none` ancestors and `content-visibility`. When the browser doesn't expose
+ *     it, Playwright's own guard falls through, so absent === no objection.
+ *
+ * Two deliberate divergences, both erring toward "don't blame the harness":
+ *   - `display: contents` — Playwright recurses into children for a box. A call button
+ *     with `display: contents` is not a real shape, and it generates no box, so we report
+ *     not-visible rather than carrying the recursion.
+ *   - **no computed style read** → `null`, not `true`. Playwright treats a null
+ *     `getComputedStyle` as visible, but for us a missing style means the *probe* failed
+ *     to measure (no `defaultView`, JSDOM, a torn-down frame) — asserting visibility we
+ *     never observed is what got #570 filed in the first place.
+ */
+export function playwrightVisibility(probe) {
+  if (!probe || !probe.present) return false;
+  const box = probe.box ?? null;
+  if (!box || !(box.width > 0) || !(box.height > 0)) return false;
+  if (probe.checkVisibility === false) return false;
+  const visibility = probe.computed?.visibility ?? null;
+  if (visibility === null) return null;
+  return visibility === "visible";
+}
 
 /**
  * Turn the DECORATION_PROBE readings (the one taken at the deadline, plus the miss-only
@@ -243,18 +304,26 @@ export const DECORATION_PROBE = () => {
  * decorated" is disproved by the harness's own evidence, so the miss is a measurement
  * story, not a SayPi-drift story. The four flavours are all worth telling apart:
  *
- *   - `visible-but-missed` — present with a non-empty box at the deadline. The 25s
- *     visible-wait should have resolved. THE 2026-07-29 case (#570): box 44×44,
- *     display=block, first seen at +771ms.
- *   - `present-but-invisible` — in the DOM but boxless / display:none / hidden, so the
- *     visible-wait legitimately failed. Not absence — a rendering question.
+ *   - `visible-but-missed` — present at the deadline AND visible by Playwright's own
+ *     rule (`playwrightVisibility`), so the 25s visible-wait should have resolved. THE
+ *     2026-07-29 case (#570): box 44×44, display=block, first seen at +771ms.
+ *   - `present-but-invisible` — in the DOM but NOT Playwright-visible (boxless,
+ *     `display:none`, or a full-size box with `visibility:hidden`/`collapse`), so the
+ *     visible-wait failed correctly. Not absence — a rendering question.
  *   - `appeared-after-check` — the deadline probe saw nothing, but the grace re-read or
  *     the later `domDiagnostics` census did. The screenshot and diagnostics are captured
  *     AFTER the wait, so this is decoration that finished past the budget — and because
  *     the watcher timed the real first sighting, the number is navigation-relative even
  *     when it lands past the deadline.
- *   - `removed-before-check` — the watcher timed a first sighting, but by the deadline
- *     it was gone (a host re-render tore SayPi's UI out).
+ *   - `removed-before-check` — the watcher had already timed a first sighting by the
+ *     deadline, yet the element was gone then (a host re-render tore SayPi's UI out).
+ *     Checked BEFORE `appeared-after-check`, because a mount-then-teardown that happens
+ *     to be re-added just after the deadline is a teardown story (#392/#393's shape), not
+ *     a slow-bootstrap one — and reporting latency would point the next investigation at
+ *     the wrong thing while the same object carries an early, in-budget `firstSeenMs`.
+ *   - `census-only` — no deadline reading exists (the in-page probe failed) but the
+ *     census/grace read still found the button. The verdict is contradicted, yet there is
+ *     no measurement, so nothing here is evidence about SayPi: fix the run and re-run.
  *
  * A miss with no contradiction leaves DRIFT standing, and the evidence sentence then
  * says out loud that the button never entered the DOM — which is what makes the drift
@@ -286,6 +355,7 @@ export function describeDecoration(input = {}) {
     checkedAtMs: null,
     withinBudget: null,
     hasBox: null,
+    playwrightVisible: null,
     box: null,
     computed: null,
     callButtonsSeen,
@@ -304,6 +374,8 @@ export function describeDecoration(input = {}) {
     "present-but-invisible": "saypi",
     "appeared-after-check": "saypi",
     "removed-before-check": "saypi",
+    // A failed measurement is not evidence about SayPi, in either direction.
+    "census-only": "automation",
   };
   /**
    * What a reader should actually DO about each contradiction. Kept per-flavour on
@@ -328,6 +400,10 @@ export function describeDecoration(input = {}) {
       `attributable to SayPi, but as a TEARDOWN/re-render defect, not selector drift: the call button ` +
       `mounted and then disappeared — find out whether a host re-render tore it out and SayPi failed ` +
       `to re-decorate.`,
+    "census-only":
+      `nothing is attributable either way — the in-page probe failed, so the run recorded no ` +
+      `measurement of the call button, only that something later counted it. Fix the probe failure ` +
+      `(see notes[]) and re-run; do NOT file anything against SayPi from this run.`,
   };
 
   if (!probe) {
@@ -336,9 +412,9 @@ export function describeDecoration(input = {}) {
     return {
       ...base,
       everPresent: censusContradicts ? true : null,
-      contradiction: censusContradicts ? "appeared-after-check" : null,
-      nextStep: censusContradicts ? NEXT_STEP["appeared-after-check"] : "",
-      attributable: censusContradicts ? ATTRIBUTABLE["appeared-after-check"] : null,
+      contradiction: censusContradicts ? "census-only" : null,
+      nextStep: censusContradicts ? NEXT_STEP["census-only"] : "",
+      attributable: censusContradicts ? ATTRIBUTABLE["census-only"] : null,
       evidence:
         `no decoration reading was taken (the in-page probe did not run), so nothing is known ` +
         `about ${CALL_BUTTON_SELECTOR} beyond the wait's own verdict` +
@@ -360,10 +436,16 @@ export function describeDecoration(input = {}) {
         : null;
   const presentAtCheck = !!probe.present;
   const hasBox = !!probe.hasBox && presentAtCheck;
+  // The load-bearing predicate: Playwright's rule, not bare geometry. `hasBox` stays in
+  // the output as the raw fact, but must never stand in for visibility (see
+  // playwrightVisibility) — a full-size `visibility:hidden` button has a box and is not
+  // visible, and conflating them mis-owns a rendering defect to the harness.
+  const pwVisible = playwrightVisibility(probe);
   const everPresent = presentAtCheck || firstSeenMs !== null || callButtonsSeen > 0 || presentAtGrace === true;
   const withinBudget = firstSeenMs === null ? null : firstSeenMs <= budgetMs;
   const style = probe.computed
-    ? `display=${probe.computed.display} visibility=${probe.computed.visibility} opacity=${probe.computed.opacity}`
+    ? `display=${probe.computed.display} visibility=${probe.computed.visibility} opacity=${probe.computed.opacity}` +
+      (probe.checkVisibility === null || probe.checkVisibility === undefined ? "" : ` checkVisibility=${probe.checkVisibility}`)
     : "computed style unavailable";
   const boxText = probe.box ? `${probe.box.width}×${probe.box.height} box at (${probe.box.x},${probe.box.y})` : "no box";
   const when =
@@ -373,11 +455,15 @@ export function describeDecoration(input = {}) {
         ? `at or before +${firstSeenMs}ms (already present when the watcher installed, so that is an upper bound)`
         : `at +${firstSeenMs}ms`;
 
+  // Whether the watcher had ALREADY timed a sighting when the deadline read happened —
+  // `firstSeenMs` above can also come from the grace read, and a first sighting only
+  // discovered later is a late ARRIVAL, not a teardown.
+  const firstSeenAtDeadline = typeof probe.firstSeenMs === "number" ? probe.firstSeenMs : null;
   let contradiction = null;
   if (!waitSucceeded) {
-    if (presentAtCheck) contradiction = hasBox ? "visible-but-missed" : "present-but-invisible";
+    if (presentAtCheck) contradiction = pwVisible === false ? "present-but-invisible" : "visible-but-missed";
+    else if (firstSeenAtDeadline !== null) contradiction = "removed-before-check";
     else if (callButtonsSeen > 0 || presentAtGrace === true) contradiction = "appeared-after-check";
-    else if (firstSeenMs !== null) contradiction = "removed-before-check";
   }
 
   let evidence;
@@ -387,15 +473,22 @@ export function describeDecoration(input = {}) {
       `(read at +${probe.checkedAtMs}ms) with a ${boxText}, ${style}` +
       (when ? `; first seen ${when}` : `; first-appearance time unknown (no watcher)`) +
       `.`;
-    if (contradiction === "visible-but-missed") {
+    if (contradiction === "visible-but-missed" && pwVisible === true) {
       evidence +=
-        ` The element was therefore in the DOM AND had a non-empty box, so the ` +
-        `${budgetMs}ms visible-wait missing it is a harness/timing artifact, not selector drift.`;
+        ` The element was therefore in the DOM AND visible by Playwright's own rule ` +
+        `(non-empty box, visibility:visible), so the ${budgetMs}ms visible-wait missing it ` +
+        `is a harness/timing artifact, not selector drift.`;
+    } else if (contradiction === "visible-but-missed") {
+      evidence +=
+        ` Whether Playwright would have called it visible could NOT be determined (no ` +
+        `computed style was readable), so it was present but ownership of the miss is ` +
+        `undetermined — treat neither the harness nor SayPi as implicated until a re-run ` +
+        `produces a full reading.`;
     } else if (contradiction === "present-but-invisible") {
       evidence +=
-        ` The element was in the DOM but had no non-empty box, which is exactly what ` +
-        `Playwright's default state:'visible' requires — so the miss is a visibility ` +
-        `problem, not absence.`;
+        ` The element was in the DOM but NOT visible by Playwright's rule, which needs a ` +
+        `non-empty box AND computed visibility:visible — so the ${budgetMs}ms wait failed ` +
+        `correctly and the miss is a rendering problem, not absence.`;
     }
   } else if (contradiction === "appeared-after-check") {
     const sawIt = [
@@ -411,10 +504,19 @@ export function describeDecoration(input = {}) {
       `${CALL_BUTTON_SELECTOR} was seen ${when} but was gone by the ${budgetMs}ms deadline ` +
       `(read at +${probe.checkedAtMs}ms), and domDiagnostics counted ${callButtonsSeen ?? 0}. ` +
       `Something removed SayPi's UI after it mounted.`;
+  } else if (probe.watcherInstalledAtMs === null || probe.watcherInstalledAtMs === undefined) {
+    // No watcher ran, so there is no continuous record — only two point observations.
+    // Claiming "never" from those would be the same over-reach as #570's bare `false`.
+    evidence =
+      `${CALL_BUTTON_SELECTOR} was absent at the ${budgetMs}ms deadline (read at ` +
+      `+${probe.checkedAtMs}ms) and domDiagnostics counted ${callButtonsSeen ?? 0}, but the ` +
+      `first-appearance watcher never installed — so this is two point observations, NOT a ` +
+      `continuous record, and it cannot rule out the element having come and gone in between.` +
+      (graceProbe ? ` It was also absent at the +${graceMs}ms grace re-read.` : "");
   } else {
     evidence =
       `${CALL_BUTTON_SELECTOR} never entered the DOM during the ${budgetMs}ms window ` +
-      `(watcher installed at +${probe.watcherInstalledAtMs ?? "?"}ms, deadline read at ` +
+      `(watcher installed at +${probe.watcherInstalledAtMs}ms, deadline read at ` +
       `+${probe.checkedAtMs}ms, domDiagnostics counted ${callButtonsSeen ?? 0})` +
       (graceProbe
         ? `, and it was still absent ${graceProbe.checkedAtMs != null ? `at +${graceProbe.checkedAtMs}ms ` : ""}` +
@@ -438,12 +540,23 @@ export function describeDecoration(input = {}) {
     withinBudget,
     presentAtGrace,
     hasBox,
+    playwrightVisible: pwVisible,
     box: probe.box ?? null,
     computed: probe.computed ?? null,
     contradiction,
     evidence,
     nextStep: contradiction ? NEXT_STEP[contradiction] : "",
-    attributable: contradiction ? ATTRIBUTABLE[contradiction] : null,
+    // `visible-but-missed` is the ONE flavour that blames the harness, and it may only
+    // do so on a *positive* visibility reading. When `playwrightVisibility` came back
+    // null the style was never readable, so we know the element was present and nothing
+    // more — asserting "harness artifact, do not file drift" off an absent measurement
+    // is the same over-reach as #570's bare `false`. The evidence prose hedges to match.
+    attributable:
+      contradiction === "visible-but-missed" && pwVisible !== true
+        ? "unknown"
+        : contradiction
+          ? ATTRIBUTABLE[contradiction]
+          : null,
   };
 }
 
@@ -679,6 +792,9 @@ export function summarize(evidence = {}) {
     decorationEverPresent: evidence.decoration?.everPresent ?? null,
     decorationFirstSeenMs: evidence.decoration?.firstSeenMs ?? null,
     decorationContradiction: evidence.decoration?.contradiction ?? null,
+    // …with its owner, or the rollup silently implies "harness's fault" for the three
+    // SayPi-owned flavours.
+    decorationOwner: evidence.decoration?.attributable ?? null,
     cloudflareBlocked: !!evidence.cloudflareBlocked,
     transcript: evidence.transcript ?? null,
     authStatus: evidence.authStatus ?? null,

--- a/scripts/e2e-host-sweep-lib.mjs
+++ b/scripts/e2e-host-sweep-lib.mjs
@@ -106,7 +106,8 @@ export function ttsCoverage(summaries = []) {
 /**
  * Why a host ended the run with nothing decorated. The distinction is the whole
  * point: only DRIFT is a SayPi defect worth hunting — the others mean the sweep
- * never got a chat app in front of the extension (#559).
+ * never got a chat app in front of the extension (#559), or that the harness's own
+ * reading of the page can't be trusted (#570).
  */
 export const UNDECORATED_KINDS = {
   /** The page ended up on a different origin than requested (pi.ai/talk → hey.pi.ai). */
@@ -115,11 +116,336 @@ export const UNDECORATED_KINDS = {
   SIGNED_OUT: "signed-out",
   /** The requested page loaded and SayPi still didn't decorate it. THE defect case. */
   DRIFT: "possible-drift",
+  /**
+   * The "not decorated" verdict is contradicted by the run's OWN evidence — the call
+   * button was present in the DOM (per the deadline probe, the grace re-read, or the
+   * later `domDiagnostics.callButtons` census). Reading this as drift sends someone
+   * hunting a SayPi bug that the same bundle disproves (#570).
+   */
+  INCONSISTENT: "internal-inconsistency",
   /** The run never got far enough to judge (Cloudflare challenge, harness error). */
   ABORTED: "run-aborted",
   /** Not enough signal to tell (no usable final URL) — read the screenshot. */
   UNKNOWN: "unknown",
 };
+
+/**
+ * The selector the sweep treats as proof SayPi decorated a chat host, and the budget
+ * it waits for it. Both mirror `sweepHost`'s `waitForSelector` call — keep them in
+ * sync with it (the budget is quoted in the notes readers act on).
+ */
+export const CALL_BUTTON_SELECTOR = "#saypi-callButton";
+export const DECORATION_BUDGET_MS = 25_000;
+
+/**
+ * On a MISS only, how much longer the harness keeps *looking* (never waiting — the
+ * verdict is already recorded). Purely observational, and the reason it exists is that
+ * a run which stops looking at the deadline structurally cannot tell "never in the DOM"
+ * apart from "in the DOM, just later than the budget": both read as absent. The
+ * post-deadline `domDiagnostics` census widens that window by only a few hundred ms.
+ *
+ * The grace read uses PRESENCE semantics (`state: 'attached'`), not the visible-wait's,
+ * so it answers exactly the question the verdict can't. It does NOT change the 25s
+ * budget or `decorated` — a host that decorates at +27s is still correctly reported as
+ * having failed to decorate in time, now with the number that says why (#570).
+ */
+export const DECORATION_GRACE_MS = 5_000;
+
+/**
+ * Installed in the page BEFORE navigation (`page.addInitScript`), so it can time the
+ * call button's first appearance against the document's own time origin. Also
+ * re-invoked defensively via `page.evaluate` after load in case the init script never
+ * took — hence idempotent, and hence `presentAtInstall`, which tells a reader whether
+ * `firstSeenMs` is a measurement or merely an upper bound.
+ *
+ * Self-contained (stringified and evaluated in the page, same rule as DIAGS): it may
+ * not close over anything from this module, so the selector is inlined.
+ *
+ * Why a watcher at all: `waitForSelector` reports only pass/fail at the deadline. When
+ * it misses, the question that actually needs answering is "was the element EVER
+ * there, and when" — and 25s after the fact only a recorder can say (#570).
+ */
+export const DECORATION_WATCHER = () => {
+  const w = window;
+  const existing = w.__saypiSweepDecoration;
+  if (existing) return existing.installedAtMs;
+  const state = { installedAtMs: performance.now(), firstSeenMs: null, presentAtInstall: false };
+  w.__saypiSweepDecoration = state;
+  const mark = () => {
+    if (state.firstSeenMs !== null) return true;
+    if (!document.querySelector("#saypi-callButton")) return false;
+    state.firstSeenMs = performance.now();
+    return true;
+  };
+  if (mark()) {
+    state.presentAtInstall = true;
+    return state.installedAtMs;
+  }
+  // Observe `document`, not `document.documentElement`: at addInitScript time (before
+  // any page script) the document element may not exist yet, and observing the
+  // document node with subtree covers the whole tree either way. Disconnects on the
+  // first sighting, so the cost on a healthy host is a fraction of a second.
+  const obs = new MutationObserver(() => {
+    if (mark()) obs.disconnect();
+  });
+  obs.observe(document, { childList: true, subtree: true });
+  return state.installedAtMs;
+};
+
+/**
+ * Read at the decoration deadline: is the call button there, since when, and — the
+ * distinction a bare `false` loses — does it have the non-empty bounding box that
+ * Playwright's default `state: 'visible'` requires? `querySelectorAll` (what
+ * `domDiagnostics.callButtons` counts) does not care about layout, which is precisely
+ * how the two can disagree.
+ *
+ * Self-contained, same rule as DIAGS/SIGN_IN_PROBE. Under JSDOM
+ * `getBoundingClientRect` reports all zeros, so `hasBox` is only meaningful in a real
+ * browser (unit tests stub the rect).
+ */
+export const DECORATION_PROBE = () => {
+  const el = document.querySelector("#saypi-callButton");
+  const state = window.__saypiSweepDecoration || null;
+  const view = document.defaultView;
+  const round = (n) => (typeof n === "number" && isFinite(n) ? Math.round(n) : null);
+  let box = null;
+  let computed = null;
+  if (el) {
+    const r = typeof el.getBoundingClientRect === "function" ? el.getBoundingClientRect() : null;
+    if (r) box = { x: round(r.x), y: round(r.y), width: round(r.width), height: round(r.height) };
+    if (view && typeof view.getComputedStyle === "function") {
+      const s = view.getComputedStyle(el);
+      computed = { display: s.display, visibility: s.visibility, opacity: s.opacity };
+    }
+  }
+  return {
+    selector: "#saypi-callButton",
+    count: document.querySelectorAll("#saypi-callButton").length,
+    present: !!el,
+    // ms since the document's time origin (i.e. relative to navigation).
+    firstSeenMs: state ? round(state.firstSeenMs) : null,
+    presentAtInstall: state ? !!state.presentAtInstall : null,
+    watcherInstalledAtMs: state ? round(state.installedAtMs) : null,
+    checkedAtMs: round(performance.now()),
+    box,
+    computed,
+    hasBox: !!(box && box.width > 0 && box.height > 0),
+  };
+};
+
+/**
+ * Turn the DECORATION_PROBE readings (the one taken at the deadline, plus the miss-only
+ * `graceProbe` taken up to DECORATION_GRACE_MS later, plus the run's own
+ * `domDiagnostics.callButtons` census) into the facts the undecorated verdict and its
+ * note are built from. Pure.
+ *
+ * `contradiction` is the load-bearing output: non-null means the harness's "not
+ * decorated" is disproved by the harness's own evidence, so the miss is a measurement
+ * story, not a SayPi-drift story. The four flavours are all worth telling apart:
+ *
+ *   - `visible-but-missed` — present with a non-empty box at the deadline. The 25s
+ *     visible-wait should have resolved. THE 2026-07-29 case (#570): box 44×44,
+ *     display=block, first seen at +771ms.
+ *   - `present-but-invisible` — in the DOM but boxless / display:none / hidden, so the
+ *     visible-wait legitimately failed. Not absence — a rendering question.
+ *   - `appeared-after-check` — the deadline probe saw nothing, but the grace re-read or
+ *     the later `domDiagnostics` census did. The screenshot and diagnostics are captured
+ *     AFTER the wait, so this is decoration that finished past the budget — and because
+ *     the watcher timed the real first sighting, the number is navigation-relative even
+ *     when it lands past the deadline.
+ *   - `removed-before-check` — the watcher timed a first sighting, but by the deadline
+ *     it was gone (a host re-render tore SayPi's UI out).
+ *
+ * A miss with no contradiction leaves DRIFT standing, and the evidence sentence then
+ * says out loud that the button never entered the DOM — which is what makes the drift
+ * verdict trustworthy rather than merely unrefuted.
+ *
+ * @param {{probe?: object|null, graceProbe?: object|null, callButtonsSeen?: number|null,
+ *          waitSucceeded?: boolean, budgetMs?: number, graceMs?: number}} [input]
+ */
+export function describeDecoration(input = {}) {
+  const probe = input.probe ?? null;
+  const callButtonsSeen = typeof input.callButtonsSeen === "number" ? input.callButtonsSeen : null;
+  const graceProbe = input.graceProbe ?? null;
+  const budgetMs = typeof input.budgetMs === "number" ? input.budgetMs : DECORATION_BUDGET_MS;
+  const graceMs = typeof input.graceMs === "number" ? input.graceMs : DECORATION_GRACE_MS;
+  const waitSucceeded = input.waitSucceeded === true;
+  const base = {
+    selector: CALL_BUTTON_SELECTOR,
+    budgetMs,
+    graceMs,
+    probed: !!probe,
+    graceProbed: !!graceProbe,
+    presentAtGrace: graceProbe ? !!graceProbe.present : null,
+    watcherInstalled: null,
+    everPresent: null,
+    presentAtCheck: null,
+    count: null,
+    firstSeenMs: null,
+    firstSeenExact: null,
+    checkedAtMs: null,
+    withinBudget: null,
+    hasBox: null,
+    box: null,
+    computed: null,
+    callButtonsSeen,
+    contradiction: null,
+    evidence: "",
+    nextStep: "",
+    attributable: null,
+  };
+  /**
+   * Who owns each contradiction. `internal-inconsistency` says the verdict can't be
+   * trusted; it does NOT automatically mean "nothing to see here" — three of the four
+   * flavours are real SayPi behaviour that simply isn't selector drift.
+   */
+  const ATTRIBUTABLE = {
+    "visible-but-missed": "automation",
+    "present-but-invisible": "saypi",
+    "appeared-after-check": "saypi",
+    "removed-before-check": "saypi",
+  };
+  /**
+   * What a reader should actually DO about each contradiction. Kept per-flavour on
+   * purpose: two of the four are harness problems, but the other two are genuine SayPi
+   * findings that just aren't *selector drift* — a blanket "not a SayPi issue" would
+   * bury a slow bootstrap or a torn-out UI as cleanly as a false drift buries the real
+   * thing.
+   */
+  const NEXT_STEP = {
+    "visible-but-missed":
+      `the wait itself is what needs explaining, not SayPi: re-run this host (--no-turn is enough) ` +
+      `to see whether it reproduces, and compare the first-sighting time against the budget. Do NOT ` +
+      `file selector drift.`,
+    "present-but-invisible":
+      `attributable to SayPi, but as a RENDERING defect, not selector drift: hunt why the call button ` +
+      `mounted with no non-empty box (zero-sized, display:none, detached container).`,
+    "appeared-after-check":
+      `attributable to SayPi, but as a LATENCY finding, not selector drift: decoration completed after ` +
+      `the budget, so ask why bootstrap took that long on this host (normal is sub-second) before ` +
+      `touching the budget.`,
+    "removed-before-check":
+      `attributable to SayPi, but as a TEARDOWN/re-render defect, not selector drift: the call button ` +
+      `mounted and then disappeared — find out whether a host re-render tore it out and SayPi failed ` +
+      `to re-decorate.`,
+  };
+
+  if (!probe) {
+    // Still surface a contradiction we can see without a probe: the census alone.
+    const censusContradicts = !waitSucceeded && (callButtonsSeen > 0 || !!graceProbe?.present);
+    return {
+      ...base,
+      everPresent: censusContradicts ? true : null,
+      contradiction: censusContradicts ? "appeared-after-check" : null,
+      nextStep: censusContradicts ? NEXT_STEP["appeared-after-check"] : "",
+      attributable: censusContradicts ? ATTRIBUTABLE["appeared-after-check"] : null,
+      evidence:
+        `no decoration reading was taken (the in-page probe did not run), so nothing is known ` +
+        `about ${CALL_BUTTON_SELECTOR} beyond the wait's own verdict` +
+        (censusContradicts
+          ? `, except that domDiagnostics later counted ${callButtonsSeen} of them.`
+          : `.`),
+    };
+  }
+
+  // `presentAtCheck` / box / computed style stay strictly the DEADLINE reading — that is
+  // the "at check time" state the verdict is about. The grace reading only ever adds
+  // knowledge the deadline read couldn't have: that it showed up later, and when.
+  const presentAtGrace = graceProbe ? !!graceProbe.present : null;
+  const firstSeenMs =
+    typeof probe.firstSeenMs === "number"
+      ? probe.firstSeenMs
+      : typeof graceProbe?.firstSeenMs === "number"
+        ? graceProbe.firstSeenMs
+        : null;
+  const presentAtCheck = !!probe.present;
+  const hasBox = !!probe.hasBox && presentAtCheck;
+  const everPresent = presentAtCheck || firstSeenMs !== null || callButtonsSeen > 0 || presentAtGrace === true;
+  const withinBudget = firstSeenMs === null ? null : firstSeenMs <= budgetMs;
+  const style = probe.computed
+    ? `display=${probe.computed.display} visibility=${probe.computed.visibility} opacity=${probe.computed.opacity}`
+    : "computed style unavailable";
+  const boxText = probe.box ? `${probe.box.width}×${probe.box.height} box at (${probe.box.x},${probe.box.y})` : "no box";
+  const when =
+    firstSeenMs === null
+      ? null
+      : probe.presentAtInstall
+        ? `at or before +${firstSeenMs}ms (already present when the watcher installed, so that is an upper bound)`
+        : `at +${firstSeenMs}ms`;
+
+  let contradiction = null;
+  if (!waitSucceeded) {
+    if (presentAtCheck) contradiction = hasBox ? "visible-but-missed" : "present-but-invisible";
+    else if (callButtonsSeen > 0 || presentAtGrace === true) contradiction = "appeared-after-check";
+    else if (firstSeenMs !== null) contradiction = "removed-before-check";
+  }
+
+  let evidence;
+  if (presentAtCheck) {
+    evidence =
+      `${CALL_BUTTON_SELECTOR} was present ×${probe.count} at the ${budgetMs}ms deadline ` +
+      `(read at +${probe.checkedAtMs}ms) with a ${boxText}, ${style}` +
+      (when ? `; first seen ${when}` : `; first-appearance time unknown (no watcher)`) +
+      `.`;
+    if (contradiction === "visible-but-missed") {
+      evidence +=
+        ` The element was therefore in the DOM AND had a non-empty box, so the ` +
+        `${budgetMs}ms visible-wait missing it is a harness/timing artifact, not selector drift.`;
+    } else if (contradiction === "present-but-invisible") {
+      evidence +=
+        ` The element was in the DOM but had no non-empty box, which is exactly what ` +
+        `Playwright's default state:'visible' requires — so the miss is a visibility ` +
+        `problem, not absence.`;
+    }
+  } else if (contradiction === "appeared-after-check") {
+    const sawIt = [
+      presentAtGrace === true ? `the +${graceMs}ms grace re-read found it${when ? ` (first seen ${when})` : ""}` : null,
+      callButtonsSeen > 0 ? `domDiagnostics counted ${callButtonsSeen}` : null,
+    ].filter(Boolean).join(" and ");
+    evidence =
+      `${CALL_BUTTON_SELECTOR} was absent at the ${budgetMs}ms deadline (read at ` +
+      `+${probe.checkedAtMs}ms), but ${sawIt} — both AFTER the wait. Decoration finished ` +
+      `past the budget, so this is slow bootstrap, not a missing selector.`;
+  } else if (contradiction === "removed-before-check") {
+    evidence =
+      `${CALL_BUTTON_SELECTOR} was seen ${when} but was gone by the ${budgetMs}ms deadline ` +
+      `(read at +${probe.checkedAtMs}ms), and domDiagnostics counted ${callButtonsSeen ?? 0}. ` +
+      `Something removed SayPi's UI after it mounted.`;
+  } else {
+    evidence =
+      `${CALL_BUTTON_SELECTOR} never entered the DOM during the ${budgetMs}ms window ` +
+      `(watcher installed at +${probe.watcherInstalledAtMs ?? "?"}ms, deadline read at ` +
+      `+${probe.checkedAtMs}ms, domDiagnostics counted ${callButtonsSeen ?? 0})` +
+      (graceProbe
+        ? `, and it was still absent ${graceProbe.checkedAtMs != null ? `at +${graceProbe.checkedAtMs}ms ` : ""}` +
+          `after a further ${graceMs}ms of looking by DOM PRESENCE rather than visibility. ` +
+          `Absence is therefore measured, not merely unobserved.`
+        : `. No grace re-read was taken, so "never" covers only the budget window.`);
+  }
+  if (withinBudget === false) {
+    evidence += ` Note: the first sighting (+${firstSeenMs}ms) is PAST the ${budgetMs}ms budget.`;
+  }
+
+  return {
+    ...base,
+    watcherInstalled: probe.watcherInstalledAtMs !== null && probe.watcherInstalledAtMs !== undefined,
+    everPresent,
+    presentAtCheck,
+    count: typeof probe.count === "number" ? probe.count : null,
+    firstSeenMs,
+    firstSeenExact: firstSeenMs === null ? null : !probe.presentAtInstall,
+    checkedAtMs: typeof probe.checkedAtMs === "number" ? probe.checkedAtMs : null,
+    withinBudget,
+    presentAtGrace,
+    hasBox,
+    box: probe.box ?? null,
+    computed: probe.computed ?? null,
+    contradiction,
+    evidence,
+    nextStep: contradiction ? NEXT_STEP[contradiction] : "",
+    attributable: contradiction ? ATTRIBUTABLE[contradiction] : null,
+  };
+}
 
 /** Auth-ish route segments every host uses for its sign-in wall. */
 const AUTH_ROUTE = /(^|\/)(login|log-in|signin|sign-in|sign_in|auth|authorize)(\/|$)/i;
@@ -155,8 +481,16 @@ function originKey(url) {
  * junk URL, which would read as `unknown` and send the reader to a screenshot the
  * run never took. Every `decorated: false` host gets a kind; none are left null.
  *
+ * `decoration` (a describeDecoration() result, #570) is consulted LAST, immediately
+ * before DRIFT would be returned. Placing it there is deliberate on both sides: a
+ * contradicted measurement must never be filed as drift, but it must also not outrank
+ * the origin/sign-in facts above it — those describe what page we were even looking at,
+ * and a stale element reading on a marketing splash shouldn't retitle a redirect. When
+ * there is no contradiction, its evidence sentence still rides along on the DRIFT note,
+ * which is what turns "we didn't see it" into "it was never in the DOM".
+ *
  * @param {{requestedUrl?: string, finalUrl?: string, title?: string, signInVisible?: boolean,
- *          abortedBecause?: string}} [input]
+ *          abortedBecause?: string, decoration?: object|null}} [input]
  * @returns {{kind: string, owner: string, redirected: boolean, requestedOrigin: string|null,
  *            finalOrigin: string|null, finalUrl: string|null, signInAffordance: boolean, note: string}}
  */
@@ -167,6 +501,7 @@ export function classifyUndecorated(input = {}) {
   const signInAffordance = !!input.signInVisible;
   const requestedOrigin = originKey(requestedUrl);
   const finalOrigin = originKey(finalUrl);
+  const decoration = input.decoration ?? null;
   const base = { requestedOrigin, finalOrigin, finalUrl: finalUrl ?? null, signInAffordance };
 
   if (input.abortedBecause) {
@@ -232,6 +567,22 @@ export function classifyUndecorated(input = {}) {
     };
   }
 
+  if (decoration && decoration.contradiction) {
+    return {
+      ...base,
+      kind: UNDECORATED_KINDS.INCONSISTENT,
+      owner: decoration.attributable ?? "automation",
+      redirected: false,
+      note:
+        `not decorated according to the ${decoration.budgetMs ?? DECORATION_BUDGET_MS}ms ` +
+        `visible-wait, but the run's own evidence contradicts that verdict ` +
+        `[${decoration.contradiction}]: ${decoration.evidence}` +
+        (decoration.nextStep ? ` Next: ${decoration.nextStep}` : "") +
+        ` Corroborate with 01-before.png and domDiagnostics.callButtons (both captured AFTER the ` +
+        `wait, which is how they can outvote it).`,
+    };
+  }
+
   return {
     ...base,
     kind: UNDECORATED_KINDS.DRIFT,
@@ -242,6 +593,7 @@ export function classifyUndecorated(input = {}) {
       `and no sign-in wall, so the host app rendered and SayPi failed to decorate it. This is the ` +
       `genuine-drift case: hunt it (compare domDiagnostics against the adapter's selectors, ` +
       `corroborate with 01-before.png).` +
+      (decoration?.evidence ? ` Measurement: ${decoration.evidence}` : "") +
       (signInAffordance
         ? ` Caveat: a sign-in affordance was on the page and not hidden — confirm the profile is ` +
           `actually signed in to the host before filing a drift issue.`
@@ -321,6 +673,12 @@ export function summarize(evidence = {}) {
     // Together they keep a reader from mistaking a redirect for drift (#559).
     finalUrl: evidence.finalUrl ?? null,
     undecorated: evidence.undecorated?.kind ?? null,
+    // The decoration measurement (#570), flattened. `decorationContradiction` is the
+    // one to scan a summary.json for: non-null means a "not decorated" the run itself
+    // disproves, so the host's verdict is about the harness, not about SayPi.
+    decorationEverPresent: evidence.decoration?.everPresent ?? null,
+    decorationFirstSeenMs: evidence.decoration?.firstSeenMs ?? null,
+    decorationContradiction: evidence.decoration?.contradiction ?? null,
     cloudflareBlocked: !!evidence.cloudflareBlocked,
     transcript: evidence.transcript ?? null,
     authStatus: evidence.authStatus ?? null,

--- a/scripts/e2e-host-sweep.mjs
+++ b/scripts/e2e-host-sweep.mjs
@@ -43,6 +43,12 @@ import {
   HOSTS,
   DIAGS,
   SIGN_IN_PROBE,
+  DECORATION_WATCHER,
+  DECORATION_PROBE,
+  DECORATION_BUDGET_MS,
+  DECORATION_GRACE_MS,
+  CALL_BUTTON_SELECTOR,
+  describeDecoration,
   parseSweepArgs,
   summarize,
   ttsCoverage,
@@ -213,7 +219,11 @@ async function sweepHost(ctx, host, url, opts, outDir) {
     // up (a host can bounce us elsewhere), and `undecorated` explains a decoration
     // failure. Without the final URL a redirect is invisible in the JSON (#559).
     host, url, finalUrl: null, pageTitle: null, undecorated: null, signInAffordances: [],
-    decorated: false, cloudflareBlocked: false, build: null,
+    // `decorated` is one bit; `decoration` is the measurement behind it — was the call
+    // button EVER in the DOM, when relative to navigation, and with what box/computed
+    // visibility at the deadline. Without it an intermittent miss is undiagnosable
+    // after the fact (#570).
+    decorated: false, decoration: null, cloudflareBlocked: false, build: null,
     transcript: null, autoSubmitted: false, assistantReplied: false,
     authStatus: null, voiceProvider: null, selectedVoice: null, selectedModel: null,
     console: [], pageErrors: [], network: [], requestFailed: [],
@@ -245,12 +255,30 @@ async function sweepHost(ctx, host, url, opts, outDir) {
   });
 
   try {
+    // Install the decoration watcher BEFORE navigating, so a first sighting is timed
+    // against the document's own time origin rather than against whenever the harness
+    // got around to asking (#570). It is idempotent, and re-invoked after load below in
+    // case the init script never took.
+    await page.addInitScript(DECORATION_WATCHER).catch((e) => ev.notes.push(`decoration watcher (init): ${e.message}`));
     await page.goto(url, { waitUntil: "domcontentloaded", timeout: 35_000 }).catch((e) => ev.notes.push(`goto: ${e.message}`));
     const sig = { title: await page.title().catch(() => ""), url: page.url(), html: (await page.content().catch(() => "")).slice(0, 4000) };
     ev.finalUrl = sig.url; ev.pageTitle = sig.title; // provisional — so even an early return carries them
     if (isCloudflareChallenge(sig)) { ev.cloudflareBlocked = true; log(`${host}: BLOCKED by Cloudflare — re-seed (npm run layer4cdp:seed)`); return ev; }
 
-    ev.decorated = await page.waitForSelector("#saypi-callButton", { timeout: 25_000 }).then(() => true).catch(() => false);
+    // Belt-and-braces install: harmless if addInitScript already ran it (idempotent),
+    // and the difference shows up honestly in the reading's `presentAtInstall`.
+    await page.evaluate(DECORATION_WATCHER).catch(() => {});
+
+    // NOTE: waitForSelector defaults to `state: 'visible'`, which needs a non-empty
+    // bounding box — `querySelectorAll` (what domDiagnostics counts) does not. That
+    // asymmetry is one of the things the probe below exists to expose. Budget unchanged.
+    ev.decorated = await page.waitForSelector(CALL_BUTTON_SELECTOR, { timeout: DECORATION_BUDGET_MS }).then(() => true).catch(() => false);
+    // Read the decoration measurement at the deadline, before anything else can move
+    // the page on — this is the "at check time" box/visibility the verdict is about.
+    const decorationProbe = await page.evaluate(DECORATION_PROBE).catch((e) => {
+      ev.notes.push(`decoration probe: ${e.message}`);
+      return null;
+    });
     // Re-read the URL/title AFTER the wait: pi.ai's logged-out bounce to hey.pi.ai is
     // client-side JS that fires well after domcontentloaded, so `sig` still shows the
     // requested URL and classifying off it would report the redirect as drift (#559).
@@ -258,6 +286,32 @@ async function sweepHost(ctx, host, url, opts, outDir) {
     ev.build = await page.evaluate(() => document.documentElement.dataset.saypiBuild ?? "(none)").catch(() => null);
     await page.screenshot({ path: join(dir, "01-before.png") }).catch(() => {});
     ev.domDiagnostics = await page.evaluate(DIAGS[host]).catch((e) => ({ error: e.message }));
+
+    // On a MISS only: keep LOOKING a little longer, by DOM presence rather than
+    // visibility. Nothing about the verdict changes — `ev.decorated` is already the 25s
+    // visible-wait's answer and the budget is untouched — but without this a run that
+    // stops observing at the deadline structurally cannot tell "never in the DOM" from
+    // "in the DOM, just later than the budget". The post-deadline census above widens
+    // that window by a few hundred ms; this widens it to a known, bounded amount and
+    // yields the real navigation-relative appearance time from the watcher (#570).
+    let graceProbe = null;
+    if (!ev.decorated) {
+      await page
+        .waitForSelector(CALL_BUTTON_SELECTOR, { state: "attached", timeout: DECORATION_GRACE_MS })
+        .catch(() => {});
+      graceProbe = await page.evaluate(DECORATION_PROBE).catch(() => null);
+    }
+
+    // Fold the deadline probe together with the grace re-read and the census that every
+    // DIAGS entry reports. The screenshot above and this census are captured AFTER the
+    // wait — which is exactly how they came to contradict a `decorated: false` on
+    // 2026-07-29 — so the contradiction is computed here, with every reading in hand.
+    ev.decoration = describeDecoration({
+      probe: decorationProbe,
+      graceProbe,
+      callButtonsSeen: typeof ev.domDiagnostics?.callButtons === "number" ? ev.domDiagnostics.callButtons : null,
+      waitSucceeded: ev.decorated,
+    });
 
     if (!ev.decorated) {
       const signIn = await page.evaluate(SIGN_IN_PROBE).catch(() => null);
@@ -267,6 +321,7 @@ async function sweepHost(ctx, host, url, opts, outDir) {
         finalUrl: ev.finalUrl,
         title: ev.pageTitle,
         signInVisible: !!signIn?.visible,
+        decoration: ev.decoration,
       });
       ev.notes.push(ev.undecorated.note);
       log(`${host}: NOT DECORATED [${ev.undecorated.kind}] — ${ev.undecorated.note}`);
@@ -333,6 +388,7 @@ async function sweepHost(ctx, host, url, opts, outDir) {
         requestedUrl: url,
         finalUrl: ev.finalUrl,
         title: ev.pageTitle,
+        decoration: ev.decoration,
         abortedBecause: ev.cloudflareBlocked
           ? "a Cloudflare challenge blocked the page"
           : "the run ended before the decoration check finished",
@@ -395,7 +451,7 @@ async function main() {
       const ev = await sweepHost(ctx, key, url, opts, outDir);
       const s = summarize(ev);
       summaries.push(s);
-      log(`${key}: decorated=${s.decorated}${s.undecorated ? ` (${s.undecorated}, final=${s.finalUrl})` : ""} cf=${s.cloudflareBlocked} transcript=${!!s.transcript} reply=${ev.assistantReplied} auth=${s.authStatus} voice=${s.voiceProvider}${ev.selectedVoice ? ` (selected:${ev.selectedVoice})` : ""}${ev.selectedModel ? ` model=${ev.selectedModel}` : ""} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures} | diag=${JSON.stringify(ev.domDiagnostics)}`);
+      log(`${key}: decorated=${s.decorated}${s.decorationFirstSeenMs !== null ? ` firstSeen=+${s.decorationFirstSeenMs}ms` : ""}${s.decorationContradiction ? ` ⚠️ CONTRADICTED(${s.decorationContradiction})` : ""}${s.undecorated ? ` (${s.undecorated}, final=${s.finalUrl})` : ""} cf=${s.cloudflareBlocked} transcript=${!!s.transcript} reply=${ev.assistantReplied} auth=${s.authStatus} voice=${s.voiceProvider}${ev.selectedVoice ? ` (selected:${ev.selectedVoice})` : ""}${ev.selectedModel ? ` model=${ev.selectedModel}` : ""} | saypiErr=${s.saypiErrors} saypiWarn=${s.saypiWarnings} pageErr=${s.pageErrors} netFail=${s.netFailures} | diag=${JSON.stringify(ev.domDiagnostics)}`);
     }
   } finally {
     writeFileSync(join(outDir, "summary.json"), JSON.stringify(summaries, null, 2));

--- a/test/scripts/e2e-host-sweep-decoration.spec.ts
+++ b/test/scripts/e2e-host-sweep-decoration.spec.ts
@@ -1,0 +1,466 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  DECORATION_WATCHER,
+  DECORATION_PROBE,
+  DECORATION_BUDGET_MS,
+  describeDecoration,
+  classifyUndecorated,
+  UNDECORATED_KINDS,
+  summarize,
+} from "../../scripts/e2e-host-sweep-lib.mjs";
+
+/**
+ * #570. #559 gave a decoration miss a *reason* (redirect / sign-in wall / drift).
+ * This spec covers the layer underneath it: the miss's own MEASUREMENT.
+ *
+ * The sweep decides decoration with one `waitForSelector("#saypi-callButton",
+ * { timeout: 25_000 })`, whose default `state: 'visible'` needs a non-empty
+ * bounding box. So a bare `false` conflates three very different worlds:
+ *
+ *   a. SayPi never decorated              → genuine drift, hunt it
+ *   b. SayPi decorated later than 25s     → a budget/latency finding
+ *   c. the element was there but boxless   → a rendering/visibility finding
+ *
+ * The run that motivated this (2026-07-29, build 2cc21c0@main) reported
+ * `decorated: false` + `possible-drift` with ZERO SayPi errors, while the SAME
+ * bundle carried `domDiagnostics.callButtons: 1` and a screenshot showing the
+ * button. A direct CDP probe then measured the button present with a non-empty
+ * box at +771ms. The verdict was contradicted by its own evidence and no timing
+ * was captured, so the miss was unexplainable after the fact.
+ */
+
+/** Give an element a real box — JSDOM's getBoundingClientRect is all zeros. */
+function withBox(el: Element, box: { x: number; y: number; width: number; height: number }) {
+  el.getBoundingClientRect = () => ({ ...box, top: box.y, left: box.x, right: box.x + box.width, bottom: box.y + box.height, toJSON: () => box }) as DOMRect;
+}
+
+function addCallButton(style = ""): HTMLElement {
+  const el = document.createElement("button");
+  el.id = "saypi-callButton";
+  if (style) el.setAttribute("style", style);
+  document.body.appendChild(el);
+  return el;
+}
+
+/** MutationObserver records are delivered asynchronously; let them land. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("DECORATION_WATCHER + DECORATION_PROBE record when the call button appeared", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete (window as unknown as Record<string, unknown>).__saypiSweepDecoration;
+  });
+
+  it("times the first appearance relative to the document's time origin", async () => {
+    DECORATION_WATCHER();
+    const before = DECORATION_PROBE();
+    expect(before.present).toBe(false);
+    expect(before.firstSeenMs).toBeNull();
+
+    withBox(addCallButton(), { x: 8, y: 700, width: 44, height: 44 });
+    await flush();
+
+    const after = DECORATION_PROBE();
+    expect(after.present).toBe(true);
+    expect(after.count).toBe(1);
+    expect(after.firstSeenMs).toBeGreaterThanOrEqual(0);
+    expect(after.presentAtInstall).toBe(false);
+    expect(after.hasBox).toBe(true);
+    expect(after.box).toMatchObject({ width: 44, height: 44 });
+    expect(after.computed).toMatchObject({ visibility: "visible" });
+  });
+
+  it("says so when the button already existed at install time (timing is an upper bound)", () => {
+    addCallButton();
+    DECORATION_WATCHER();
+    const p = DECORATION_PROBE();
+    expect(p.present).toBe(true);
+    expect(p.presentAtInstall).toBe(true);
+    expect(p.firstSeenMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("is idempotent — a re-install must not reset the recorded first sighting", async () => {
+    DECORATION_WATCHER();
+    withBox(addCallButton(), { x: 0, y: 0, width: 40, height: 40 });
+    await flush();
+    const first = DECORATION_PROBE().firstSeenMs as number;
+    DECORATION_WATCHER(); // the harness's defensive second install
+    expect(DECORATION_PROBE().firstSeenMs).toBe(first);
+    expect(DECORATION_PROBE().presentAtInstall).toBe(false);
+  });
+
+  it("distinguishes present-but-boxless from absent", () => {
+    DECORATION_WATCHER();
+    const el = addCallButton("display:none");
+    withBox(el, { x: 0, y: 0, width: 0, height: 0 });
+    const p = DECORATION_PROBE();
+    expect(p.present).toBe(true);
+    expect(p.hasBox).toBe(false);
+    expect(p.computed).toMatchObject({ display: "none" });
+  });
+
+  it("reports a null install time when no watcher ever ran", () => {
+    const p = DECORATION_PROBE();
+    expect(p.watcherInstalledAtMs).toBeNull();
+    expect(p.firstSeenMs).toBeNull();
+  });
+});
+
+describe("describeDecoration classifies the measurement (#570)", () => {
+  const probe = (over: Record<string, unknown> = {}) => ({
+    selector: "#saypi-callButton",
+    count: 1,
+    present: true,
+    firstSeenMs: 771,
+    presentAtInstall: false,
+    watcherInstalledAtMs: 0,
+    checkedAtMs: 25_100,
+    box: { x: 8, y: 700, width: 44, height: 44 },
+    computed: { display: "block", visibility: "visible", opacity: "1" },
+    hasBox: true,
+    ...over,
+  });
+
+  it("flags the observed 2026-07-29 miss as an internal inconsistency, not drift", () => {
+    const d = describeDecoration({ probe: probe(), callButtonsSeen: 1, waitSucceeded: false });
+    expect(d.everPresent).toBe(true);
+    expect(d.presentAtCheck).toBe(true);
+    expect(d.firstSeenMs).toBe(771);
+    expect(d.withinBudget).toBe(true);
+    expect(d.contradiction).toBe("visible-but-missed");
+    // The evidence sentence must carry the numbers a reader needs.
+    expect(d.evidence).toContain("771");
+    expect(d.evidence).toContain("44");
+  });
+
+  it("calls a present-but-boxless button present-but-invisible", () => {
+    const d = describeDecoration({
+      probe: probe({ box: { x: 0, y: 0, width: 0, height: 0 }, hasBox: false, computed: { display: "none", visibility: "visible", opacity: "1" } }),
+      callButtonsSeen: 1,
+      waitSucceeded: false,
+    });
+    expect(d.contradiction).toBe("present-but-invisible");
+    expect(d.evidence).toMatch(/display=none|0×0/);
+  });
+
+  it("calls a button the deadline probe missed but the later diagnostics counted appeared-after-check", () => {
+    // The screenshot + domDiagnostics are captured AFTER the decoration wait, which
+    // is exactly how they can outvote it: the element arrived past the budget.
+    const d = describeDecoration({
+      probe: probe({ present: false, count: 0, firstSeenMs: null, box: null, computed: null, hasBox: false }),
+      callButtonsSeen: 1,
+      waitSucceeded: false,
+    });
+    expect(d.contradiction).toBe("appeared-after-check");
+    expect(d.everPresent).toBe(true);
+  });
+
+  it("calls a button that was seen and then went away removed-before-check", () => {
+    const d = describeDecoration({
+      probe: probe({ present: false, count: 0, firstSeenMs: 900, box: null, computed: null, hasBox: false }),
+      callButtonsSeen: 0,
+      waitSucceeded: false,
+    });
+    expect(d.contradiction).toBe("removed-before-check");
+    expect(d.everPresent).toBe(true);
+  });
+
+  it("finds NO contradiction when the button genuinely never appeared — drift stands", () => {
+    const d = describeDecoration({
+      probe: probe({ present: false, count: 0, firstSeenMs: null, box: null, computed: null, hasBox: false, checkedAtMs: 25_050 }),
+      callButtonsSeen: 0,
+      waitSucceeded: false,
+    });
+    expect(d.everPresent).toBe(false);
+    expect(d.contradiction).toBeNull();
+    expect(d.withinBudget).toBeNull();
+    expect(d.evidence).toMatch(/never/i);
+  });
+
+  it("never reports a contradiction on a host that decorated", () => {
+    const d = describeDecoration({ probe: probe(), callButtonsSeen: 1, waitSucceeded: true });
+    expect(d.contradiction).toBeNull();
+    expect(d.firstSeenMs).toBe(771); // the healthy-host baseline is still recorded
+  });
+
+  it("degrades honestly when no probe reading was taken at all", () => {
+    const d = describeDecoration({ probe: null, callButtonsSeen: null, waitSucceeded: false });
+    expect(d.probed).toBe(false);
+    expect(d.everPresent).toBeNull();
+    expect(d.contradiction).toBeNull();
+    expect(d.evidence).toMatch(/no decoration reading/i);
+  });
+
+  // "Internal inconsistency" must not become a shrug. Only the visible-but-missed
+  // flavour is genuinely the harness's fault; the other three are real SayPi behaviour
+  // that simply isn't *selector drift*, and a blanket "nothing to see here" would bury
+  // a slow bootstrap or a torn-out UI as effectively as a false drift buries real drift.
+  it("attributes each contradiction to whoever actually owns it", () => {
+    const flavours = {
+      "visible-but-missed": probe(),
+      "present-but-invisible": probe({ hasBox: false, box: { x: 0, y: 0, width: 0, height: 0 } }),
+      "appeared-after-check": probe({ present: false, count: 0, firstSeenMs: null }),
+      "removed-before-check": probe({ present: false, count: 0, firstSeenMs: 900 }),
+    };
+    const owners: Record<string, string> = {};
+    for (const [flavour, reading] of Object.entries(flavours)) {
+      const d = describeDecoration({
+        probe: reading,
+        callButtonsSeen: flavour === "removed-before-check" ? 0 : 1,
+        waitSucceeded: false,
+      });
+      expect(d.contradiction).toBe(flavour);
+      expect(d.nextStep).toBeTruthy();
+      expect(d.nextStep).toMatch(/not selector drift|Do NOT\s+file selector drift/);
+      owners[flavour] = d.attributable as string;
+    }
+    expect(owners).toEqual({
+      "visible-but-missed": "automation",
+      "present-but-invisible": "saypi",
+      "appeared-after-check": "saypi",
+      "removed-before-check": "saypi",
+    });
+  });
+
+  it("treats a first sighting past the budget as out-of-budget", () => {
+    const d = describeDecoration({
+      probe: probe({ firstSeenMs: DECORATION_BUDGET_MS + 1_200, checkedAtMs: DECORATION_BUDGET_MS + 1_400 }),
+      callButtonsSeen: 1,
+      waitSucceeded: false,
+    });
+    expect(d.withinBudget).toBe(false);
+    expect(d.evidence).toContain(String(DECORATION_BUDGET_MS));
+  });
+});
+
+/**
+ * The issue names three worlds a bare `false` conflates. This block asserts all three
+ * are separable, together, from one another — the acceptance criterion in one place.
+ */
+describe("the three worlds a bare `decorated: false` conflates are all separable (#570)", () => {
+  const reading = (over: Record<string, unknown> = {}) => ({
+    selector: "#saypi-callButton",
+    count: 0,
+    present: false,
+    firstSeenMs: null,
+    presentAtInstall: false,
+    watcherInstalledAtMs: 3,
+    checkedAtMs: 25_060,
+    box: null,
+    computed: null,
+    hasBox: false,
+    ...over,
+  });
+
+  // (a) never in the DOM — the only world where `possible-drift` is the right verdict.
+  const neverPresent = describeDecoration({
+    probe: reading(),
+    graceProbe: reading({ checkedAtMs: 30_100 }),
+    callButtonsSeen: 0,
+    waitSucceeded: false,
+  });
+
+  // (b) in the DOM, but later than the 25s budget. The deadline read sees nothing; the
+  // bounded grace re-read does, and the watcher supplies the real appearance time.
+  const lateArrival = describeDecoration({
+    probe: reading(),
+    graceProbe: reading({ present: true, count: 1, firstSeenMs: 27_400, checkedAtMs: 30_100, box: { x: 8, y: 700, width: 44, height: 44 }, computed: { display: "block", visibility: "visible", opacity: "1" }, hasBox: true }),
+    callButtonsSeen: 0,
+    waitSucceeded: false,
+  });
+
+  // (c) in the DOM the whole time, but with no non-empty box — so the visible-wait
+  // legitimately never resolved. querySelectorAll would have counted it.
+  const boxless = describeDecoration({
+    probe: reading({ present: true, count: 1, firstSeenMs: 640, box: { x: 0, y: 0, width: 0, height: 0 }, computed: { display: "none", visibility: "visible", opacity: "1" } }),
+    callButtonsSeen: 1,
+    waitSucceeded: false,
+  });
+
+  it("gives each world a distinct contradiction value", () => {
+    expect([neverPresent.contradiction, lateArrival.contradiction, boxless.contradiction]).toEqual([
+      null,
+      "appeared-after-check",
+      "present-but-invisible",
+    ]);
+  });
+
+  it("agrees on everPresent for the two that were, and disagrees for the one that wasn't", () => {
+    expect(neverPresent.everPresent).toBe(false);
+    expect(lateArrival.everPresent).toBe(true);
+    expect(boxless.everPresent).toBe(true);
+  });
+
+  it("times (b) past the budget and (c) inside it", () => {
+    expect(lateArrival.firstSeenMs).toBe(27_400);
+    expect(lateArrival.withinBudget).toBe(false);
+    expect(boxless.firstSeenMs).toBe(640);
+    expect(boxless.withinBudget).toBe(true);
+    expect(neverPresent.firstSeenMs).toBeNull();
+  });
+
+  it("routes only (a) to possible-drift; (b) and (c) are internal-inconsistency", () => {
+    const kindOf = (decoration: object) =>
+      classifyUndecorated({ requestedUrl: "https://claude.ai/new", finalUrl: "https://claude.ai/new", decoration }).kind;
+    expect(kindOf(neverPresent)).toBe(UNDECORATED_KINDS.DRIFT);
+    expect(kindOf(lateArrival)).toBe(UNDECORATED_KINDS.INCONSISTENT);
+    expect(kindOf(boxless)).toBe(UNDECORATED_KINDS.INCONSISTENT);
+  });
+
+  it("makes (a)'s claim of absence a measurement, not merely a non-observation", () => {
+    // "never appeared" is only trustworthy if the harness kept looking past the deadline
+    // by PRESENCE. The note has to say it did.
+    expect(neverPresent.evidence).toMatch(/still absent/);
+    expect(neverPresent.evidence).toMatch(/measured, not merely unobserved/);
+    expect(neverPresent.presentAtGrace).toBe(false);
+  });
+
+  it("distinguishes (b) from (c) in the prose too, not just in the enum", () => {
+    expect(lateArrival.evidence).toMatch(/past the budget/);
+    expect(lateArrival.nextStep).toMatch(/LATENCY/);
+    expect(boxless.evidence).toMatch(/no non-empty box/);
+    expect(boxless.nextStep).toMatch(/RENDERING/);
+  });
+});
+
+describe("classifyUndecorated folds the measurement into its verdict (#570)", () => {
+  const contradicted = describeDecoration({
+    probe: {
+      selector: "#saypi-callButton",
+      count: 1,
+      present: true,
+      firstSeenMs: 771,
+      presentAtInstall: false,
+      watcherInstalledAtMs: 0,
+      checkedAtMs: 25_100,
+      box: { x: 8, y: 700, width: 44, height: 44 },
+      computed: { display: "block", visibility: "visible", opacity: "1" },
+      hasBox: true,
+    },
+    callButtonsSeen: 1,
+    waitSucceeded: false,
+  });
+
+  it("reports internal-inconsistency instead of possible-drift when the run outvotes itself", () => {
+    const c = classifyUndecorated({
+      requestedUrl: "https://claude.ai/new",
+      finalUrl: "https://claude.ai/new",
+      title: "Claude",
+      decoration: contradicted,
+    });
+    expect(c.kind).toBe(UNDECORATED_KINDS.INCONSISTENT);
+    expect(c.kind).not.toBe(UNDECORATED_KINDS.DRIFT);
+    // Owner is the harness: don't send anyone hunting SayPi drift on this.
+    expect(c.owner).toBe("automation");
+    expect(c.note).toContain("771");
+    expect(c.note).not.toMatch(/genuine-drift case/);
+    // The note must carry the per-flavour next step, not a generic shrug.
+    expect(c.note).toContain("Next:");
+  });
+
+  it("hands a present-but-invisible miss to SayPi — it is a rendering defect, not the harness", () => {
+    const invisible = describeDecoration({
+      probe: {
+        selector: "#saypi-callButton",
+        count: 1,
+        present: true,
+        firstSeenMs: 640,
+        presentAtInstall: false,
+        watcherInstalledAtMs: 0,
+        checkedAtMs: 25_040,
+        box: { x: 0, y: 0, width: 0, height: 0 },
+        computed: { display: "block", visibility: "visible", opacity: "1" },
+        hasBox: false,
+      },
+      callButtonsSeen: 1,
+      waitSucceeded: false,
+    });
+    const c = classifyUndecorated({
+      requestedUrl: "https://claude.ai/new",
+      finalUrl: "https://claude.ai/new",
+      decoration: invisible,
+    });
+    expect(c.kind).toBe(UNDECORATED_KINDS.INCONSISTENT);
+    expect(c.owner).toBe("saypi");
+  });
+
+  it("keeps possible-drift — with the timing evidence attached — for a genuine miss (#559 intact)", () => {
+    const absent = describeDecoration({
+      probe: {
+        selector: "#saypi-callButton",
+        count: 0,
+        present: false,
+        firstSeenMs: null,
+        presentAtInstall: false,
+        watcherInstalledAtMs: 12,
+        checkedAtMs: 25_080,
+        box: null,
+        computed: null,
+        hasBox: false,
+      },
+      callButtonsSeen: 0,
+      waitSucceeded: false,
+    });
+    const c = classifyUndecorated({
+      requestedUrl: "https://claude.ai/new",
+      finalUrl: "https://claude.ai/new",
+      title: "Claude",
+      decoration: absent,
+    });
+    expect(c.kind).toBe(UNDECORATED_KINDS.DRIFT);
+    expect(c.owner).toBe("saypi");
+    expect(c.note).toMatch(/genuine-drift case/);
+    expect(c.note).toMatch(/never/i);
+  });
+
+  it("still classifies without any decoration input at all (back-compatible)", () => {
+    const c = classifyUndecorated({
+      requestedUrl: "https://claude.ai/new",
+      finalUrl: "https://claude.ai/new",
+      title: "Claude",
+    });
+    expect(c.kind).toBe(UNDECORATED_KINDS.DRIFT);
+  });
+
+  it("lets a redirect and an abort keep precedence over the measurement", () => {
+    // Origin-first precedence (#559) is deliberate: "we were bounced off the chat
+    // origin" is the stronger, more actionable fact than a stale element reading.
+    expect(
+      classifyUndecorated({
+        requestedUrl: "https://pi.ai/talk",
+        finalUrl: "https://hey.pi.ai/",
+        decoration: contradicted,
+      }).kind
+    ).toBe(UNDECORATED_KINDS.REDIRECTED);
+    expect(
+      classifyUndecorated({
+        requestedUrl: "https://claude.ai/new",
+        finalUrl: "https://claude.ai/new",
+        abortedBecause: "a Cloudflare challenge blocked the page",
+        decoration: contradicted,
+      }).kind
+    ).toBe(UNDECORATED_KINDS.ABORTED);
+  });
+});
+
+describe("summarize surfaces the decoration measurement in the run rollup (#570)", () => {
+  it("carries first-seen timing and any contradiction", () => {
+    const s = summarize({
+      host: "claude",
+      decorated: false,
+      undecorated: { kind: UNDECORATED_KINDS.INCONSISTENT },
+      decoration: { firstSeenMs: 771, everPresent: true, contradiction: "visible-but-missed" },
+    });
+    expect(s.undecorated).toBe(UNDECORATED_KINDS.INCONSISTENT);
+    expect(s.decorationFirstSeenMs).toBe(771);
+    expect(s.decorationEverPresent).toBe(true);
+    expect(s.decorationContradiction).toBe("visible-but-missed");
+  });
+
+  it("defaults the decoration fields to null when nothing was measured", () => {
+    const s = summarize({ host: "pi", decorated: true });
+    expect(s.decorationFirstSeenMs).toBeNull();
+    expect(s.decorationEverPresent).toBeNull();
+    expect(s.decorationContradiction).toBeNull();
+  });
+});

--- a/test/scripts/e2e-host-sweep-decoration.spec.ts
+++ b/test/scripts/e2e-host-sweep-decoration.spec.ts
@@ -4,6 +4,7 @@ import {
   DECORATION_PROBE,
   DECORATION_BUDGET_MS,
   describeDecoration,
+  playwrightVisibility,
   classifyUndecorated,
   UNDECORATED_KINDS,
   summarize,
@@ -106,6 +107,60 @@ describe("DECORATION_WATCHER + DECORATION_PROBE record when the call button appe
   });
 });
 
+/**
+ * The predicate the whole contradiction taxonomy rests on. A non-empty bounding box is
+ * NOT Playwright's rule, and the divergence matters: `visibility: hidden` leaves the box
+ * intact, so a full-size hidden button makes the visible-wait time out *correctly*.
+ * Calling that a harness artifact would mis-own case (c) to the harness — the same
+ * inversion this file exists to prevent.
+ *
+ * Rule per playwright-core 1.60.0 `isElementVisible`:
+ *   non-empty box && element.checkVisibility() && computedStyle.visibility === 'visible'
+ */
+describe("playwrightVisibility models Playwright's real rule, not bare geometry (#570)", () => {
+  const box = { x: 8, y: 700, width: 44, height: 44 };
+  const at = (over: Record<string, unknown> = {}) => ({ present: true, box, computed: { display: "block", visibility: "visible", opacity: "1" }, checkVisibility: true, ...over });
+
+  it("is visible with a non-empty box and visibility:visible", () => {
+    expect(playwrightVisibility(at())).toBe(true);
+  });
+
+  it("is NOT visible with a full-size box but visibility:hidden — the case bare geometry gets wrong", () => {
+    expect(playwrightVisibility(at({ computed: { display: "block", visibility: "hidden", opacity: "1" } }))).toBe(false);
+  });
+
+  it("treats visibility:collapse as hidden — Playwright tests === 'visible', not !== 'hidden'", () => {
+    expect(playwrightVisibility(at({ computed: { display: "block", visibility: "collapse", opacity: "1" } }))).toBe(false);
+  });
+
+  it("keeps a fully transparent element visible — opacity is NOT part of the rule", () => {
+    expect(playwrightVisibility(at({ computed: { display: "block", visibility: "visible", opacity: "0" } }))).toBe(true);
+  });
+
+  it("is NOT visible with an empty box, however healthy the style", () => {
+    expect(playwrightVisibility(at({ box: { x: 0, y: 0, width: 0, height: 0 } }))).toBe(false);
+    expect(playwrightVisibility(at({ box: null }))).toBe(false);
+  });
+
+  it("honours the browser's own checkVisibility() when it objects", () => {
+    expect(playwrightVisibility(at({ checkVisibility: false }))).toBe(false);
+    // Absent (older browser) is no objection — Playwright's guard falls through.
+    expect(playwrightVisibility(at({ checkVisibility: null }))).toBe(true);
+  });
+
+  it("returns null — not true — when no computed style could be read", () => {
+    // Playwright treats a null getComputedStyle as visible, but for us a missing style
+    // means the PROBE failed to measure. Asserting unobserved visibility is what got
+    // #570 filed in the first place.
+    expect(playwrightVisibility(at({ computed: null }))).toBeNull();
+  });
+
+  it("is false for an absent element or a missing reading", () => {
+    expect(playwrightVisibility(at({ present: false }))).toBe(false);
+    expect(playwrightVisibility(null)).toBe(false);
+  });
+});
+
 describe("describeDecoration classifies the measurement (#570)", () => {
   const probe = (over: Record<string, unknown> = {}) => ({
     selector: "#saypi-callButton",
@@ -131,6 +186,33 @@ describe("describeDecoration classifies the measurement (#570)", () => {
     // The evidence sentence must carry the numbers a reader needs.
     expect(d.evidence).toContain("771");
     expect(d.evidence).toContain("44");
+  });
+
+  // The blocking gap: `hasBox` alone would call this the harness's fault.
+  it("calls a FULL-SIZE but visibility:hidden button present-but-invisible, owned by SayPi", () => {
+    const d = describeDecoration({
+      probe: probe({ computed: { display: "block", visibility: "hidden", opacity: "1" } }),
+      callButtonsSeen: 1,
+      waitSucceeded: false,
+    });
+    expect(d.hasBox).toBe(true); // geometry says yes...
+    expect(d.playwrightVisible).toBe(false); // ...Playwright's rule says no
+    expect(d.contradiction).toBe("present-but-invisible");
+    expect(d.attributable).toBe("saypi");
+    expect(d.evidence).toContain("visibility=hidden");
+    expect(d.evidence).not.toMatch(/harness\/timing artifact/);
+  });
+
+  it("declines to blame either side when computed style could not be read", () => {
+    const d = describeDecoration({
+      probe: probe({ computed: null }),
+      callButtonsSeen: 1,
+      waitSucceeded: false,
+    });
+    expect(d.playwrightVisible).toBeNull();
+    expect(d.contradiction).toBe("visible-but-missed");
+    expect(d.attributable).toBe("unknown");
+    expect(d.evidence).toMatch(/could NOT be determined/);
   });
 
   it("calls a present-but-boxless button present-but-invisible", () => {
@@ -318,7 +400,11 @@ describe("the three worlds a bare `decorated: false` conflates are all separable
   it("distinguishes (b) from (c) in the prose too, not just in the enum", () => {
     expect(lateArrival.evidence).toMatch(/past the budget/);
     expect(lateArrival.nextStep).toMatch(/LATENCY/);
-    expect(boxless.evidence).toMatch(/no non-empty box/);
+    // (c) must read as a visibility/rendering story, and must NOT borrow (b)'s
+    // late-arrival language — the prose is what a human acts on, so the two staying
+    // textually distinct is part of the fix, not decoration.
+    expect(boxless.evidence).toMatch(/NOT visible by Playwright's rule/);
+    expect(boxless.evidence).not.toMatch(/past the budget/);
     expect(boxless.nextStep).toMatch(/RENDERING/);
   });
 });

--- a/test/scripts/e2e-host-sweep-undecorated-wiring.spec.ts
+++ b/test/scripts/e2e-host-sweep-undecorated-wiring.spec.ts
@@ -248,6 +248,34 @@ describe("sweepHost records the decoration measurement (#570)", () => {
     expect(hitCalls).toHaveLength(1);
   });
 
+  it("never lets the grace re-read (or the census) flip `decorated` (#570 review)", async () => {
+    // `decorated` is the VERDICT bit — it must keep meaning exactly "the visible-wait
+    // resolved inside the budget". The grace read and the census both routinely find a
+    // button the wait missed; if either could promote `decorated` to true, a real
+    // decoration failure would start reporting as a success and every downstream
+    // consumer (summary.json, the sweep's own tally, the analysis discipline in
+    // doc/e2e-host-sweep.md) would silently inherit the lie. The code is correct today;
+    // this is the regression net, because a mutation that overwrote `ev.decorated`
+    // previously passed the whole suite.
+    const ev = await runSweep(
+      stubPage({
+        // The wait fails, yet EVERY later observation finds the button present.
+        waitForSelector: async () => { throw new Error("not found"); },
+        evaluate: evaluateWith({ probe: missedButPresent, diags: { callButtons: 3 } }),
+      }),
+      outDir
+    );
+
+    expect(ev.decorated).toBe(false);
+    const onDisk = evidenceOnDisk(outDir);
+    expect(onDisk.decorated).toBe(false);
+    // ...while the measurement still records that it WAS there — the whole point of
+    // #570 is that these two coexist rather than one overwriting the other.
+    expect(onDisk.decoration.everPresent).toBe(true);
+    expect(onDisk.decoration.contradiction).toBe("visible-but-missed");
+    expect(onDisk.undecorated.kind).toBe(UNDECORATED_KINDS.INCONSISTENT);
+  });
+
   it("degrades honestly when the probe cannot run", async () => {
     const ev = await runSweep(
       stubPage({

--- a/test/scripts/e2e-host-sweep-undecorated-wiring.spec.ts
+++ b/test/scripts/e2e-host-sweep-undecorated-wiring.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { sweepHost } from "../../scripts/e2e-host-sweep.mjs";
+import { DECORATION_PROBE, DIAGS, UNDECORATED_KINDS } from "../../scripts/e2e-host-sweep-lib.mjs";
 
 /**
  * The classifier spec next door proves classifyUndecorated() in isolation. This one
@@ -29,6 +30,7 @@ function stubPage(overrides: Record<string, unknown> = {}) {
   const noop = async () => undefined;
   return {
     on: () => {},
+    addInitScript: noop,
     goto: noop,
     title: async () => "New chat",
     content: async () => "<html><body>ok</body></html>",
@@ -99,5 +101,166 @@ describe("sweepHost always records a verdict for an undecorated host (#559)", ()
     expect(ev.undecorated).toBeNull();
     // finalUrl is populated regardless; only the verdict is decoration-conditional.
     expect(evidenceOnDisk(outDir).finalUrl).toBe("https://chatgpt.com/");
+  });
+});
+
+/**
+ * #570 — the wiring for the layer underneath the verdict. The classifier spec proves
+ * describeDecoration/classifyUndecorated in isolation; this proves the harness actually
+ * *takes the reading* and folds it into what lands on disk.
+ *
+ * The sequencing is the whole point: `01-before.png` and `domDiagnostics` are captured
+ * AFTER the decoration wait, which is exactly how they came to contradict it on
+ * 2026-07-29 (`decorated: false` + `possible-drift`, but `callButtons: 1` and a
+ * screenshot showing the button). Now that contradiction has to be *reported*, not
+ * silently filed as drift.
+ */
+describe("sweepHost records the decoration measurement (#570)", () => {
+  let outDir: string;
+
+  beforeEach(() => {
+    outDir = mkdtempSync(join(tmpdir(), "saypi-sweep-decoration-"));
+  });
+
+  afterEach(() => {
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  /** Route each in-page evaluate by the function the harness passes. */
+  const evaluateWith = (readings: { probe?: unknown; diags?: unknown }) =>
+    async (fn: unknown) => {
+      if (fn === DECORATION_PROBE) return readings.probe ?? null;
+      if (fn === DIAGS.chatgpt) return readings.diags ?? {};
+      return undefined;
+    };
+
+  const missedButPresent = {
+    selector: "#saypi-callButton",
+    count: 1,
+    present: true,
+    firstSeenMs: 771,
+    presentAtInstall: false,
+    watcherInstalledAtMs: 0,
+    checkedAtMs: 25_100,
+    box: { x: 8, y: 700, width: 44, height: 44 },
+    computed: { display: "block", visibility: "visible", opacity: "1" },
+    hasBox: true,
+  };
+
+  it("reports the contradicted miss as an internal inconsistency, not possible-drift", async () => {
+    const ev = await runSweep(
+      stubPage({ evaluate: evaluateWith({ probe: missedButPresent, diags: { callButtons: 1 } }) }),
+      outDir
+    );
+
+    expect(ev.decorated).toBe(false);
+    const onDisk = evidenceOnDisk(outDir);
+    expect(onDisk.undecorated.kind).toBe(UNDECORATED_KINDS.INCONSISTENT);
+    // The three facts the issue's first acceptance criterion asks for.
+    expect(onDisk.decoration.everPresent).toBe(true);
+    expect(onDisk.decoration.firstSeenMs).toBe(771);
+    expect(onDisk.decoration.box).toEqual({ x: 8, y: 700, width: 44, height: 44 });
+    expect(onDisk.decoration.computed.visibility).toBe("visible");
+    expect(onDisk.decoration.contradiction).toBe("visible-but-missed");
+  });
+
+  it("still says possible-drift when the button genuinely never appeared", async () => {
+    const ev = await runSweep(
+      stubPage({
+        evaluate: evaluateWith({
+          probe: { ...missedButPresent, count: 0, present: false, firstSeenMs: null, box: null, computed: null, hasBox: true },
+          diags: { callButtons: 0 },
+        }),
+      }),
+      outDir
+    );
+
+    expect(ev.decorated).toBe(false);
+    const onDisk = evidenceOnDisk(outDir);
+    expect(onDisk.undecorated.kind).toBe(UNDECORATED_KINDS.DRIFT);
+    expect(onDisk.decoration.everPresent).toBe(false);
+    expect(onDisk.decoration.contradiction).toBeNull();
+  });
+
+  it("records the timing baseline on a healthy host too", async () => {
+    const ev = await runSweep(
+      stubPage({
+        waitForSelector: async () => ({}),
+        evaluate: evaluateWith({ probe: missedButPresent, diags: { callButtons: 1 } }),
+      }),
+      outDir
+    );
+
+    expect(ev.decorated).toBe(true);
+    const onDisk = evidenceOnDisk(outDir);
+    expect(onDisk.decoration.firstSeenMs).toBe(771);
+    expect(onDisk.decoration.contradiction).toBeNull();
+    expect(onDisk.undecorated).toBeNull();
+  });
+
+  it("installs the decoration watcher before navigating, so timing is navigation-relative", async () => {
+    const order: string[] = [];
+    await runSweep(
+      stubPage({
+        addInitScript: async () => { order.push("addInitScript"); },
+        goto: async () => { order.push("goto"); },
+        evaluate: evaluateWith({ probe: missedButPresent, diags: { callButtons: 1 } }),
+      }),
+      outDir
+    );
+
+    expect(order).toEqual(["addInitScript", "goto"]);
+  });
+
+  it("keeps looking by DOM PRESENCE after a miss, and does not on a healthy host", async () => {
+    // The grace re-read is what separates "never in the DOM" from "in the DOM, later
+    // than the budget" — and it must cost a healthy host nothing.
+    const waits = (calls: Array<Record<string, unknown>>, decorated: boolean) => async (
+      _sel: string,
+      opts: Record<string, unknown>
+    ) => {
+      calls.push(opts);
+      if (decorated) return {};
+      throw new Error("not found");
+    };
+
+    const missCalls: Array<Record<string, unknown>> = [];
+    await runSweep(
+      stubPage({
+        waitForSelector: waits(missCalls, false),
+        evaluate: evaluateWith({ probe: missedButPresent, diags: { callButtons: 1 } }),
+      }),
+      outDir
+    );
+    expect(missCalls).toHaveLength(2);
+    expect(missCalls[0].state).toBeUndefined(); // the verdict wait: Playwright's default 'visible'
+    expect(missCalls[0].timeout).toBe(25_000); // budget UNCHANGED (#570 explicitly out of scope)
+    expect(missCalls[1].state).toBe("attached"); // the grace read: presence, not visibility
+
+    const hitCalls: Array<Record<string, unknown>> = [];
+    await runSweep(
+      stubPage({
+        waitForSelector: waits(hitCalls, true),
+        evaluate: evaluateWith({ probe: missedButPresent, diags: { callButtons: 1 } }),
+      }),
+      outDir
+    );
+    expect(hitCalls).toHaveLength(1);
+  });
+
+  it("degrades honestly when the probe cannot run", async () => {
+    const ev = await runSweep(
+      stubPage({
+        evaluate: async () => { throw new Error("Execution context was destroyed"); },
+      }),
+      outDir
+    );
+
+    expect(ev.decorated).toBe(false);
+    const onDisk = evidenceOnDisk(outDir);
+    expect(onDisk.decoration.probed).toBe(false);
+    expect(onDisk.decoration.everPresent).toBeNull();
+    // No reading is no excuse for a missing verdict — the #559 invariant still holds.
+    expect(onDisk.undecorated).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Why

The host sweep decides decoration with one pass/fail line:

```js
ev.decorated = await page.waitForSelector("#saypi-callButton", { timeout: 25_000 })
  .then(() => true).catch(() => false);
```

That single bit conflates three very different worlds. `waitForSelector` defaults to `state: 'visible'`, which requires a **non-empty bounding box**; `querySelectorAll` — what `domDiagnostics.callButtons` counts — does not care about layout at all. So a `false` could mean SayPi never decorated, or decorated later than the budget, or that the element was sitting right there in the DOM with a zero-sized box.

The run that prompted #570 (`.output/e2e-host-sweep/2026-07-29T21-21-49-608Z/claude/`, build `2cc21c0@main`) landed squarely in that blind spot: `decorated: false` + `undecorated.kind: "possible-drift"` with **zero** SayPi errors — while the *same bundle* carried `domDiagnostics.callButtons: 1` and an `01-before.png` plainly showing the call button, voice selector and mic. A direct CDP probe afterwards measured `#saypi-callButton` present **and** non-empty-box at **+771ms**, and four further observations all passed. The verdict was contradicted by its own sibling fields, and nothing in the bundle explained the miss.

This is an **observability fix, not a product fix** — no extension code is touched.

## What

Extends the #559 `classifyUndecorated` seam rather than bolting on a parallel mechanism. All the new logic is pure and lives in the dependency-free `scripts/e2e-host-sweep-lib.mjs`.

**Measurement.** A `DECORATION_WATCHER` installed via `page.addInitScript` — *before* navigation, so its `performance.now()` readings are navigation-relative — records when `#saypi-callButton` first enters the DOM (MutationObserver on `document`, disconnecting on first sighting). It is idempotent and re-invoked defensively after load; if only that late install ran, the reading self-labels via `presentAtInstall` / `firstSeenExact` and the note calls the number an upper bound. `DECORATION_PROBE` then reads, at the deadline: presence, count, bounding box, and computed `display`/`visibility`/`opacity`.

**The (a)-vs-(b) gap.** A run that stops looking at the deadline structurally cannot tell "never in the DOM" from "in the DOM, just later than the budget" — both read as absent. The post-deadline census only widens that window by a few hundred ms. So on a **miss only**, the harness keeps *looking* for a bounded 5s more by **DOM presence** (`state: 'attached'`), then re-probes. This costs a healthy host nothing (asserted), never changes `decorated`, and **leaves the 25s budget alone** (also asserted) — it just means a `possible-drift` verdict now rests on *measured* absence rather than mere non-observation.

**Classification.** `describeDecoration()` folds the deadline probe, the grace re-read and the census together. Preserving the sequencing insight from the issue — the screenshot and `domDiagnostics` are captured *after* the wait, which is exactly how they can outvote it — a contradiction gets named, owned, and given a next step:

| `contradiction` | means | owner |
|---|---|---|
| `visible-but-missed` | present *with* a non-empty box at the deadline | automation (re-run; **not** drift) |
| `present-but-invisible` | in the DOM but boxless / `display:none` | SayPi (**rendering**) |
| `appeared-after-check` | absent at the deadline, found by the grace read or census | SayPi (**latency**) |
| `removed-before-check` | timed a first sighting, gone by the deadline | SayPi (**teardown**) |

Per-flavour ownership is deliberate: "internal inconsistency" must not become a shrug. Only `visible-but-missed` is genuinely the harness's fault; the other three are real SayPi behaviour that simply isn't *selector drift*, and a blanket "nothing to see here" would bury a slow bootstrap as effectively as a false drift buries real drift.

**Verdict.** A contradicted miss now reports the new `internal-inconsistency` kind instead of `possible-drift`. It is checked **last**, immediately before `DRIFT` would return, so the origin/sign-in facts from #559 keep precedence (they describe *what page we were even looking at*; a stale element reading shouldn't retitle a redirect) — asserted for both the redirect and abort paths. When there's no contradiction, `possible-drift` keeps its #559 meaning and the measurement rides along on the note, which is what turns "we didn't see it" into "it was never in the DOM".

`summarize()` flattens `decorationEverPresent` / `decorationFirstSeenMs` / `decorationContradiction` into `summary.json`, and the per-host log line prints `firstSeen=+Nms` plus a loud `⚠️ CONTRADICTED(...)`.

## Verification

**Fail-first (mandatory protocol).** Tests written and run before the implementation. The headline failure was exactly the bug — the harness filing the contradicted miss as drift:

```
FAIL test/scripts/e2e-host-sweep-undecorated-wiring.spec.ts >
  sweepHost records the decoration measurement (#570) >
  reports the contradicted miss as an internal inconsistency, not possible-drift
AssertionError: expected 'possible-drift' to be undefined // Object.is equality
- Expected: undefined
+ Received: "possible-drift"

FAIL test/scripts/e2e-host-sweep-decoration.spec.ts
TypeError: (0 , describeDecoration) is not a function

→ Cannot read properties of undefined (reading 'everPresent')   # no `decoration` on disk
→ Cannot read properties of undefined (reading 'firstSeenMs')
→ expected [ 'goto' ] to deeply equal [ 'addInitScript', 'goto' ]
Test Files  2 failed (2)   Tests  5 failed | 3 passed (8)
```

**Layers 0–2 only**, per CLAUDE.md's "prove it at the lowest layer that can" — this is pure logic plus stub-driven wiring, so no real-host CDP run was spent (the shared seeded profile is ledgered and was near its session cap). 36 new tests: `describeDecoration` / `classifyUndecorated` / `summarize` in isolation, the watcher + probe against a hand-built JSDOM tree, and the real `sweepHost` driven against stub pages (reusing the existing seam from #559, reading assertions off `evidence.json` on disk rather than the return value).

One test block asserts the issue's acceptance criterion directly — that all three worlds are separable *from one another*, not just individually: distinct `contradiction` values, correct `everPresent`, `(b)` timed past the budget and `(c)` inside it, only `(a)` routed to `possible-drift`, and the distinction present in the prose as well as the enum.

Full gate green, rebased onto `3cc91b2`:

```
> tsc --noEmit
Test Suites: 1 passed, 1 total      (jest)
Tests:       2 passed, 2 total
Test Files  227 passed (227)        (vitest)
      Tests  2199 passed | 1 skipped (2200)
```

`doc/e2e-host-sweep.md` gains the sixth `undecorated` kind, a new analysis step 2b for reading `evidence.decoration`, and honest boundaries (`hasBox` is real-browser-only since JSDOM's `getBoundingClientRect` is all zeros; the `visible-but-missed` flavour was *inferred* from the 2026-07-29 bundle and has not been reproduced deliberately, so the first live one is worth checking against `01-before.png`).

## Deliberately out of scope

- **The 25s budget is unchanged** — the issue scopes it out, and a test now pins it.
- **No extension-side change.** Decoration is normally sub-second; there is no verified SayPi defect here to fix.
- **No root cause for the original miss.** This makes the *next* one diagnosable; the issue's offscreen/VAD-active hypothesis stays an untested hypothesis.
- No changes to `scripts/e2e-dictation-sweep*.mjs` — a sibling agent holds those for #569. No shared helper was touched.

Fixes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZmcU3XWRo4CcYqiBoYxy6