### PR TITLE
fix(settings): stop the tab-switch layout shunt from scrollbar re-centering

### DIFF
--- a/e2e/fixtures/extension.ts
+++ b/e2e/fixtures/extension.ts
@@ -9,8 +9,15 @@ export const test = base.extend<{
   context: BrowserContext;
   extensionId: string;
   serviceWorker: Worker;
+  /**
+   * Opt-in (test.use): drop Playwright's default --hide-scrollbars so the page
+   * can lay out real (space-taking) scrollbars. Needed by layout-stability
+   * specs; everything else keeps the quieter default.
+   */
+  showScrollbars: boolean;
 }>({
-  context: async ({}, use) => {
+  showScrollbars: [false, { option: true }],
+  context: async ({ showScrollbars }, use) => {
     const piPort = Number(process.env.SAYPI_E2E_PI_PORT);
     const apiPort = Number(process.env.SAYPI_E2E_API_PORT);
     // Isolation by construction (#462): zero the mock API's transcribe state
@@ -25,6 +32,7 @@ export const test = base.extend<{
       channel: "chromium",
       args: buildLaunchArgs({ extensionDir: EXT_DIR, piPort, apiPort, wavPath: WAV }),
       ignoreHTTPSErrors: true,
+      ...(showScrollbars ? { ignoreDefaultArgs: ["--hide-scrollbars"] } : {}),
     });
     await use(context);
     await context.close();

--- a/e2e/specs/settings-layout.e2e.ts
+++ b/e2e/specs/settings-layout.e2e.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "../fixtures/extension";
+
+/**
+ * Settings page layout stability across tab switches.
+ *
+ * Only some panes are tall enough to scroll the document (on the real page,
+ * the Voices studio). When scrollbars take layout space — macOS with a mouse
+ * connected, Windows/Linux defaults — switching to such a pane pops the
+ * scrollbar in, shrinks the viewport, and re-centers the header and container
+ * ~7px left: a visible shunt on every tab switch (confirmed on real Chrome via
+ * a Layer-4 CDP probe; overlay-scrollbar environments hide it).
+ *
+ * Headless needs two nudges to lay out real scrollbars: drop Playwright's
+ * default --hide-scrollbars (the showScrollbars fixture option), and style
+ * ::-webkit-scrollbar (custom-styled scrollbars are never overlay).
+ */
+
+const TABS = ["general", "chat", "dictation", "voices", "about"] as const;
+
+test.use({ showScrollbars: true });
+
+test.describe("settings page layout", () => {
+  test("keeps the header anchored across tab switches (no scrollbar shunt)", async ({
+    context,
+    extensionId,
+    serviceWorker,
+  }) => {
+    // Seed a consent decision so the General tab renders its steady state.
+    await serviceWorker.evaluate(() =>
+      chrome.storage.local.set({ shareData: false }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/settings.html`);
+    await page.addStyleTag({ content: "::-webkit-scrollbar { width: 15px; }" });
+
+    const banner = page.locator(".settings-header .profile-banner");
+    await expect(banner).toBeVisible();
+
+    const positions: Record<string, number> = {};
+    let sawScrollingTab = false;
+    for (const tab of TABS) {
+      await page.locator(`.tab-button[data-tab="${tab}"]`).click();
+      const panel = page.locator(`#tab-${tab}`);
+      await expect(panel).toBeVisible();
+      await expect(panel.locator(":scope > *")).not.toHaveCount(0);
+      positions[tab] = (await banner.boundingBox())!.x;
+      const overflows = await page.evaluate(
+        () =>
+          document.documentElement.scrollHeight >
+          document.documentElement.clientHeight,
+      );
+      sawScrollingTab ||= overflows;
+    }
+
+    // Guard the guard: if no tab overflows, the scrollbar scenario silently
+    // stopped being exercised (e.g. the hermetic panes all got short) and this
+    // test proves nothing — fail loudly instead.
+    expect(
+      sawScrollingTab,
+      "no settings tab overflows the viewport — shrink the window or this test is vacuous",
+    ).toBe(true);
+
+    const xs = Object.values(positions);
+    expect(
+      positions,
+      `header banner shifted horizontally between tabs: ${JSON.stringify(positions)}`,
+    ).toEqual(Object.fromEntries(TABS.map((t) => [t, xs[0]])));
+
+    await page.close();
+  });
+});

--- a/entrypoints/settings/styles/global.css
+++ b/entrypoints/settings/styles/global.css
@@ -1,4 +1,17 @@
 /* Global settings page styles */
+
+/* Only some panes are tall enough to scroll (in practice the Voices studio).
+   Where scrollbars take layout space — macOS with a mouse connected,
+   Windows/Linux — the scrollbar popping in/out on tab switch re-centers the
+   header and container by half its width: a visible shunt. Always render the
+   scrollbar track so every tab lays out at the same width. (Not
+   `scrollbar-gutter: stable`: Chromium doesn't reserve the gutter for
+   custom-styled scrollbars.) Overlay-scrollbar environments take no space
+   either way, unchanged. */
+html {
+  overflow-y: scroll;
+}
+
 .settings-root {
   background: #f9fafb;
   /* No min-height - let content determine natural height */


### PR DESCRIPTION
## The bug

Switching between the Voices tab and any other settings tab shunts the header (greeting + Sign Out) and the centered container sideways by a few pixels — a jarring little jump on every switch.

## Root cause

Not content width: the Voices `.content` width override (504→940px) is inert, because `.content` has `flex: 1` (flex-basis 0) so the `width` property never affects layout.

The real mechanism is the document scrollbar. Voices is the only pane tall enough to scroll (~2190px vs ~980 for the next tallest). In environments where scrollbars take layout space — macOS with a mouse connected, Windows/Linux defaults — the scrollbar pops in on Voices and out on every other tab, shrinking the layout viewport by ~15px each way. Everything centered on the viewport (the 720px header banner, the `margin: 0 auto` container) re-centers by half that: the observed ~7px shunt. Overlay-scrollbar setups (trackpad-only macOS) never lay out scrollbar width, which is why the bug is invisible there and looked like a width bug instead.

Confirmed empirically on real Chrome via a Layer-4 CDP probe of the actual settings popup: with classic scrollbars, banner.x flips 200.0 ↔ 192.5 exactly when entering/leaving a scrollable tab; with the fix it is constant across seven consecutive tab switches.

## The fix

`html { overflow-y: scroll }` in the settings page CSS — always lay out the scrollbar track so every tab renders at the same width. Overlay-scrollbar environments are untouched (the track takes no space there either way).

Deliberately **not** `scrollbar-gutter: stable`: Chromium does not reserve the gutter for custom-styled (`::-webkit-scrollbar`) scrollbars (verified in isolation), so the modern property both fails the deterministic test rig and would silently stop protecting the page if scrollbar styling is ever added.

## Test (fail-first)

New `e2e/specs/settings-layout.e2e.ts` asserts the header stays anchored across all five tabs, with a vacuity guard (fails loudly if no pane overflows, i.e. the scenario stopped being exercised). Headless Chromium hides the bug twice over — Playwright passes `--hide-scrollbars`, and macOS scrollbars are overlay — so the fixture gains an opt-in `showScrollbars` option (drops the flag; default unchanged for all other specs) and the spec styles `::-webkit-scrollbar`, which always produces space-taking scrollbars. Reproduced the exact 7.5px shift against the unfixed build, then green after the one-line fix.

Full suite: `npm test` ✓, all 15 e2e specs ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9VYkV4SNjFQDBT3v7S5D2