### PR TITLE
fix(settings): stop the sidebar shunt — fill the container instead of shrink-to-fit

### DIFF
--- a/e2e/specs/settings-layout.e2e.ts
+++ b/e2e/specs/settings-layout.e2e.ts
@@ -36,15 +36,21 @@ test.describe("settings page layout", () => {
 
     const banner = page.locator(".settings-header .profile-banner");
     await expect(banner).toBeVisible();
+    // Track the sidebar too: the 2026-07-30 shunt was the shrink-to-fit
+    // container re-centering (sidebar moved, banner did not), so asserting the
+    // banner alone misses half the failure modes.
+    const chip = page.locator('.tab-button[data-tab="general"]');
 
-    const positions: Record<string, number> = {};
+    const positions: Record<string, string> = {};
     let sawScrollingTab = false;
     for (const tab of TABS) {
       await page.locator(`.tab-button[data-tab="${tab}"]`).click();
       const panel = page.locator(`#tab-${tab}`);
       await expect(panel).toBeVisible();
       await expect(panel.locator(":scope > *")).not.toHaveCount(0);
-      positions[tab] = (await banner.boundingBox())!.x;
+      positions[tab] = `banner:${(await banner.boundingBox())!.x},sidebar:${
+        (await chip.boundingBox())!.x
+      }`;
       const overflows = await page.evaluate(
         () =>
           document.documentElement.scrollHeight >

--- a/entrypoints/settings/styles/global.css
+++ b/entrypoints/settings/styles/global.css
@@ -56,9 +56,36 @@ html {
 
 .settings-container {
   display: flex;
+  /* body.settings-root is a flex container (tabs.css), so this box is a flex
+     ITEM: with width:auto it shrink-to-fits its content, and — being centered
+     via auto margins — it re-centered itself whenever a pane's content width
+     changed (the Voices studio's card text literally moved the sidebar a few
+     pixels on every tab switch). Fill the row instead: constant geometry on
+     every tab, and the studio finally gets the wide column it was designed
+     for. */
+  width: 100%;
   max-width: 1200px;
   margin: 0 auto;
   padding: 0.5rem 0; /* Reduced from 2rem to minimize empty space */
+}
+
+/* Align the header with the settings container (same max-width + centering)
+   instead of a fixed 720px band centered on the viewport. Before, the
+   logo-over-sidebar alignment was a coincidence of the container's
+   shrink-to-fit width; now both boxes share the same geometry at every
+   window size. */
+.settings-header .profile-banner {
+  width: 100%;
+  max-width: 1200px;
+}
+.settings-header::after {
+  width: 100%;
+  max-width: 1200px;
+}
+/* Sit the logo exactly over the sidebar icon column: banner padding-left 8px
+   + 28px here = sidebar's 24px padding + the tab button's 12px padding. */
+.settings-header .profile-banner > .flex {
+  padding-left: 28px;
 }
 
 .sidebar {

--- a/entrypoints/settings/tabs/voices/voices.css
+++ b/entrypoints/settings/tabs/voices/voices.css
@@ -9,13 +9,17 @@
   margin-top: 0.75rem;
 }
 
-/* The settings content column is fixed at 504px (global.css) — right for the
-   form-style tabs, cramped for the studio's card grids. Widen the column only
-   while the Voices tab is the active panel. Engines without :has() keep the
-   504px column: narrower, never broken. */
-.content:has(#tab-voices:not(.hidden)) {
-  width: min(940px, 100%);
+/* The generic 504px .tab-panel cap (tabs.css) is right for the form tabs but
+   would squeeze the studio; give the Voices pane the full content column. */
+#tab-voices.tab-panel {
+  max-width: none;
 }
+
+/* No per-tab column widening here: `.content` is flex:1 inside the
+   full-width .settings-container (global.css), so the studio already gets
+   the wide column; #voice-studio's max-width caps it. A Voices-only width
+   rule is exactly what caused the tab-switch sidebar shunt (the container
+   used to shrink-to-fit its content). */
 
 /* --- host switcher -------------------------------------------------------- */
 


### PR DESCRIPTION
## The real mechanism (completes #582)

#582 fixed a genuine but secondary mechanism (scrollbar pop-in re-centering, only visible with space-taking scrollbars). The founder-visible shunt survived it: annotated screenshots showed the **logo moving ~16px relative to the sidebar icons** — the *sidebar* moves, and in the opposite direction to anything scrollbars can do.

Root cause: `body.settings-root` is `display: flex; flex-wrap: wrap` (tabs.css), so `.settings-container` is a flex **item** — `width: auto` shrink-to-fits its content instead of filling toward its `max-width: 1200px`. The Voices pane's content is wider than the form tabs (and card-text-driven, so not even a fixed amount); the centered container grew ~32px on Voices and re-centered itself, shunting the sidebar ~16px left while the viewport-centered header banner stayed put.

CDP probe on real Chrome, per tab: container `748px → 780px`, sidebar `x=518 → 502`, logo static at 552 — matching the annotated screenshots exactly, in overlay-scrollbar mode (no scrollbar involved).

## Fix

- **`.settings-container { width: 100% }`** — fills to the 1200px cap and centers; identical geometry on every tab.
- With the container full-width, `.content` (`flex: 1`) actually fills, so the Voices `:has()` width rule is inert — **deleted** (it was the trigger of the per-tab width change). Side effect: the Host Studio finally gets the wide column it was designed for — it had been rendering as an overflowing ~504px box since #520; the 940px column never materialized because of the shrink-to-fit container.
- Lift the generic 504px `.tab-panel` cap for `#tab-voices` only.
- **Header aligned to the container** (same max-width + centering, divider included), with the logo sitting exactly over the sidebar icon column (28px = sidebar 24px + tab-button 12px − banner 8px). The old logo/sidebar alignment was a coincidence of the shrink-to-fit width; now it's structural at every window size.

## Verification

- Probe (real Chrome, 1784px popup, all five tabs × repeated switches): every landmark pixel-identical across tabs, in overlay **and** forced-classic scrollbar modes; content column 956px, studio at its 900px cap.
- e2e `settings-layout` spec now tracks the **sidebar** as well as the banner. Fail-first against the old CSS: sidebar `282.5 → 413.5` on Voices in the hermetic env (the content-driven width at its most dramatic). Green with the fix.
- `npm test` ✓, settings e2e specs ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9VYkV4SNjFQDBT3v7S5D2