### PR TITLE
feat(settings): open settings as a browser tab instead of a popup window (prototype)

### DIFF
--- a/e2e/specs/settings-layout.e2e.ts
+++ b/e2e/specs/settings-layout.e2e.ts
@@ -75,4 +75,41 @@ test.describe("settings page layout", () => {
 
     await page.close();
   });
+
+  test("fits small viewports without horizontal overflow", async ({
+    context,
+    extensionId,
+    serviceWorker,
+  }) => {
+    // The popup-era 736px min-width on html/body forced horizontal scrolling
+    // in any narrower tab and kept the ≤735px mobile layout permanently dead.
+    // Now the mobile layout (icon-row sidebar, full-width cards) must engage
+    // instead: every tab at phone width, and the boundary widths, render with
+    // no horizontal overflow.
+    await serviceWorker.evaluate(() =>
+      chrome.storage.local.set({ shareData: false }),
+    );
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/settings.html`);
+    await page.waitForSelector(".settings-header .profile-banner");
+
+    for (const width of [390, 735, 736]) {
+      await page.setViewportSize({ width, height: 844 });
+      for (const tab of TABS) {
+        await page.locator(`.tab-button[data-tab="${tab}"]`).click();
+        const panel = page.locator(`#tab-${tab}`);
+        await expect(panel).toBeVisible();
+        const overflow = await page.evaluate(
+          () =>
+            document.body.scrollWidth - document.documentElement.clientWidth,
+        );
+        expect(
+          overflow,
+          `horizontal overflow of ${overflow}px on ${tab} at ${width}px`,
+        ).toBeLessThanOrEqual(0);
+      }
+    }
+
+    await page.close();
+  });
 });

--- a/e2e/specs/settings-opens-in-tab.e2e.ts
+++ b/e2e/specs/settings-opens-in-tab.e2e.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "../fixtures/extension";
+
+/**
+ * Settings open as a full browser tab (the standard options-page pattern),
+ * not a separate popup window.
+ *
+ * Every entry point funnels through the background's openSettingsPage():
+ * the toolbar-icon click and the `openPopup` runtime message that
+ * openSettings() (content scripts, e.g. the voice menus' "More voices…"
+ * doors) sends. This spec drives the message path — the only one a test can
+ * reach — and asserts tab-not-window, focus-dedupe, and the manifest's
+ * options_ui registration.
+ */
+
+test.describe("settings tab flow", () => {
+  test("openPopup message opens settings in a tab, dedupes, and options_ui is registered", async ({
+    context,
+    extensionId,
+    serviceWorker,
+  }) => {
+    // Any extension page can send runtime messages to the background; the
+    // permissions prompt page is a quiet one (no auto side effects).
+    const trigger = await context.newPage();
+    await trigger.goto(`chrome-extension://${extensionId}/permissions.html`);
+
+    const pagePromise = context.waitForEvent("page");
+    await trigger.evaluate(() =>
+      chrome.runtime.sendMessage({ action: "openPopup" }),
+    );
+    const settingsPage = await pagePromise;
+    await settingsPage.waitForURL(/settings\.html/);
+
+    // The page must live in a normal (tabbed) window — no popup-type window
+    // may have been created anywhere in the browser.
+    const windowTypes = await serviceWorker.evaluate(async () => {
+      const wins = await chrome.windows.getAll({});
+      return wins.map((w) => w.type);
+    });
+    expect(
+      windowTypes.every((t) => t === "normal"),
+      `expected only normal windows, got: ${windowTypes.join(", ")}`,
+    ).toBe(true);
+
+    // A second open request focuses the existing settings tab instead of
+    // opening a duplicate.
+    const pagesBefore = context.pages().length;
+    await trigger.evaluate(() =>
+      chrome.runtime.sendMessage({ action: "openPopup" }),
+    );
+    await trigger.waitForTimeout(500);
+    expect(context.pages().length).toBe(pagesBefore);
+
+    // The manifest registers settings.html as the options page, opened in a
+    // tab — this lights up "Options" in the icon context menu and
+    // chrome://extensions, and enables runtime.openOptionsPage().
+    const optionsUi = await serviceWorker.evaluate(
+      () => chrome.runtime.getManifest().options_ui,
+    );
+    expect(optionsUi?.page).toContain("settings.html");
+    expect(optionsUi?.open_in_tab).toBe(true);
+
+    await settingsPage.close();
+    await trigger.close();
+  });
+});

--- a/entrypoints/settings/styles/global.css
+++ b/entrypoints/settings/styles/global.css
@@ -100,9 +100,13 @@ html {
   max-width: 1000px;
 }
 /* Sit the logo exactly over the sidebar icon column: banner padding-left 8px
-   + 28px here = sidebar's 24px padding + the tab button's 12px padding. */
-.settings-header .profile-banner > .flex {
-  padding-left: 28px;
+   + 28px here = sidebar's 24px padding + the tab button's 12px padding.
+   Desktop-only — the mobile layout drops the sidebar's left padding, so the
+   deeper indent has nothing to align with there. */
+@media (min-width: 736px) {
+  .settings-header .profile-banner > .flex {
+    padding-left: 28px;
+  }
 }
 
 .sidebar {
@@ -135,6 +139,10 @@ html {
 
   .sidebar {
     padding-left: 0;
+    /* The desktop 200px rail would clip the horizontal icon row (tabs.css
+       turns the sidebar into a full-width scrollable row on mobile; this
+       later-loaded file must not narrow it back). */
+    width: 100%;
   }
 
   .content {

--- a/entrypoints/settings/styles/global.css
+++ b/entrypoints/settings/styles/global.css
@@ -61,12 +61,29 @@ html {
      via auto margins — it re-centered itself whenever a pane's content width
      changed (the Voices studio's card text literally moved the sidebar a few
      pixels on every tab switch). Fill the row instead: constant geometry on
-     every tab, and the studio finally gets the wide column it was designed
-     for. */
+     every tab.
+
+     The 1000px cap is sized for the tab context: wide enough that the Voices
+     studio's card grid breathes, tight enough that a form tab (200px sidebar
+     + 504px panel) doesn't leave a large dead hole inside the frame — in a
+     full-width tab, leftover space should fall symmetrically OUTSIDE the
+     centered column (Chrome-settings proportions), not pool on its right. */
   width: 100%;
-  max-width: 1200px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 0.5rem 0; /* Reduced from 2rem to minimize empty space */
+}
+
+/* In a full browser tab (vs the old snug popup) give the page some vertical
+   breathing room, so the column reads as a centered document rather than
+   popup furniture pressed into a corner. */
+@media (min-width: 1100px) {
+  .settings-header {
+    margin-top: 1.25rem;
+  }
+  .settings-container {
+    padding-top: 0.75rem;
+  }
 }
 
 /* Align the header with the settings container (same max-width + centering)
@@ -76,11 +93,11 @@ html {
    window size. */
 .settings-header .profile-banner {
   width: 100%;
-  max-width: 1200px;
+  max-width: 1000px;
 }
 .settings-header::after {
   width: 100%;
-  max-width: 1200px;
+  max-width: 1000px;
 }
 /* Sit the logo exactly over the sidebar icon column: banner padding-left 8px
    + 28px here = sidebar's 24px padding + the tab button's 12px padding. */

--- a/src/popup/popupopener.ts
+++ b/src/popup/popupopener.ts
@@ -21,8 +21,8 @@ export function parseSettingsDeepLink(
 }
 
 /**
- * Opens the extension's settings popup by sending a message to the background script.
- * The background script will handle opening the popup in the native way.
+ * Opens the extension's settings page (a full browser tab) by sending a
+ * message to the background script, which creates or focuses the tab.
  * @param tab Optional settings tab to open on, with an optional `/detail`
  *            suffix (e.g. "voices/pi" opens the Voices tab scoped to Pi);
  *            defaults to the user's last-viewed tab.

--- a/src/popup/tabs.css
+++ b/src/popup/tabs.css
@@ -1,11 +1,9 @@
-:root {
-  --popup-min-content-width: 736px; /* Keep in sync with POPUP_MIN_CONTENT_WIDTH in background.ts */
-}
-
 html,
 body {
   width: 100%;
-  min-width: var(--popup-min-content-width); /* Uses CSS custom property for POPUP_MIN_CONTENT_WIDTH */
+  /* No min-width: the popup-era 736px floor (which kept the popup window
+     above the mobile breakpoint) would force horizontal scrolling in a
+     narrow browser tab. Below 735px the mobile layout takes over instead. */
 }
 
 /* Global hidden utility with high specificity */

--- a/src/svc/background.ts
+++ b/src/svc/background.ts
@@ -1,5 +1,5 @@
 import { browser, Browser } from "wxt/browser";
-import { isFirefox, isMobileDevice } from "../UserAgentModule";
+import { isFirefox } from "../UserAgentModule";
 import { deserializeApiRequest, type SerializedApiRequest } from "../utils/ApiRequestSerializer";
 import { authenticate, isPKCESupported } from "../auth/OAuthService";
 import { sendOnboardingHint, voiceGoalFromUrl } from "../auth/OnboardingHint";
@@ -8,8 +8,6 @@ import { pickSyntheticSpeechClip } from "../offscreen/syntheticSpeechPool";
 import { maybeOpenFirstRunTab } from "../onboarding/firstRun";
 import { seedVoiceDefaultsOnFreshInstall } from "../onboarding/voiceDefaults";
 import { detectPermissionLoss, buildPermissionsUrl, MIC_GRANTED_FLAG } from "../permissions/permissionLossDetection";
-import { SETTINGS_DEEP_LINK_KEY, parseSettingsDeepLink } from "../popup/popupopener";
-import { STUDIO_WINDOW, isRoomySettingsTab } from "../popup/settingsWindowSize";
 
 // Track when PKCE authentication is in progress to prevent cookie listener interference
 let isPKCEAuthInProgress = false;
@@ -32,17 +30,13 @@ function getExtensionURL(path: string): string {
   return `${protocol}${browser.runtime.id}/${path}`;
 }
 
-const POPUP_MIN_CONTENT_WIDTH = 736;
-const POPUP_DESKTOP_WIDTH = POPUP_MIN_CONTENT_WIDTH + 6; // The buffer value 6 accounts for window chrome (browser borders and controls) to ensure the content area stays above the 735px mobile breakpoint.
-
-async function openSettingsWindow() {
+async function openSettingsPage() {
   try {
-    const popupURL = getExtensionURL('settings.html');
+    const settingsURL = getExtensionURL('settings.html');
 
-    // Check if settings window/tab already exists
-    const existingTab = await findExistingSettingsTab(popupURL);
+    // Focus an existing settings tab instead of opening a duplicate.
+    const existingTab = await findExistingSettingsTab(settingsURL);
     if (existingTab) {
-      // Focus existing window/tab instead of opening a new one
       if (existingTab.windowId !== undefined) {
         await browser.windows.update(existingTab.windowId, { focused: true });
       }
@@ -52,43 +46,14 @@ async function openSettingsWindow() {
       return;
     }
 
-    // Decide initial height based on whether we need to show consent overlay
-    // We check local storage flag 'shareData'. If it's undefined, consent will show.
-    const { shareData } = await browser.storage.local.get('shareData');
-    const needsConsent = typeof shareData === 'undefined';
-    let width = POPUP_DESKTOP_WIDTH;
-    let height = needsConsent ? 640 : 512; // taller for consent (640px to match illustration), compact for settings (512px)
-
-    // A deep link into a roomy pane (the Voices studio) opens at full size
-    // directly, so the user never sees a compact window jolt larger. The
-    // page-side ensureRoomFor covers every other path (e.g. clicking the
-    // Voices tab later); Chrome clamps oversized windows to the screen.
-    try {
-      const stored = await browser.storage.local.get(SETTINGS_DEEP_LINK_KEY);
-      const link = parseSettingsDeepLink(stored?.[SETTINGS_DEEP_LINK_KEY]);
-      if (link && isRoomySettingsTab(link.tab)) {
-        width = STUDIO_WINDOW.width;
-        height = STUDIO_WINDOW.height;
-      }
-    } catch (e) {
-      // Best-effort sizing; the compact default is always safe.
-    }
-
-    // Firefox on Android does not support opening popup windows; open a tab instead
-    if (isFirefox() && isMobileDevice()) {
-      await browser.tabs.create({ url: popupURL, active: true });
-      return;
-    }
-
-    await browser.windows.create({
-      url: popupURL,
-      type: 'popup',
-      width,
-      height,
-      focused: true
-    });
+    // Settings open as a full browser tab (the standard options-page pattern),
+    // not a separate popup window: the page gets the whole viewport, so none
+    // of the popup-era window sizing (consent height, the Voices studio's
+    // adaptive growth) applies here. Deep links still arrive via the
+    // SETTINGS_DEEP_LINK_KEY storage handoff, which the page reads on boot.
+    await browser.tabs.create({ url: settingsURL, active: true });
   } catch (error) {
-    console.error('Failed to open popup:', error);
+    console.error('Failed to open settings:', error);
   }
 }
 
@@ -136,7 +101,7 @@ const actionNamespaces: Array<
 for (const actionNamespace of actionNamespaces) {
   if (actionNamespace?.onClicked?.addListener) {
     actionNamespace.onClicked.addListener(() => {
-      void openSettingsWindow();
+      void openSettingsPage();
     });
     break;
   }
@@ -1230,7 +1195,7 @@ browser.runtime.onMessage.addListener((message: any, sender: any, sendResponse: 
   }
 
   if (message.action === 'openPopup' || message.type === 'openPopup') {
-    openSettingsWindow();
+    openSettingsPage();
   } else if (message.type === 'GET_TTS_QUOTA_DETAILS') {
     // Handle TTS quota details request
     try {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -452,6 +452,16 @@ const configFactory = (
       action: {
         default_title: "Say, Pi",
       },
+      // Register settings.html as the browser-level options page, opened as a
+      // full tab (the standard pattern for rich extension configuration).
+      // This lights up "Options" in the toolbar-icon context menu and the
+      // chrome://extensions details card, and lets code use
+      // runtime.openOptionsPage(). The toolbar click itself is handled by
+      // action.onClicked in the background (no default_popup).
+      options_ui: {
+        page: "settings.html",
+        open_in_tab: true,
+      },
       permissions,
       host_permissions: HOST_PERMISSIONS,
       content_security_policy: {


### PR DESCRIPTION
## What this prototypes

The settings surface moves from a separate popup window to a **full browser tab** — the standard options-page pattern used by essentially every polished extension (uBlock Origin, Dark Reader, Bitwarden, 1Password). Discussion context: the popup window's fixed size is why the adaptive 742→1120 window-growth machinery (#522) exists at all; a tab gets the whole viewport for free, behaves like a normal page (zoom, tab strip, deep-linkable), and matches user muscle memory (right-click icon → Options).

**Draft on purpose** — this is a UX-direction prototype for founder evaluation, not an auto-merge candidate.

## Changes

- `openSettingsWindow()` → `openSettingsPage()` in the background: focuses an existing settings tab or opens a new one (`tabs.create`). Single choke point — the toolbar-icon click and every `openSettings()` caller (voice-menu doors, notices, sidebar) go through it, so nothing else changes.
- Manifest gains `options_ui { page: settings.html, open_in_tab: true }` (emitted for both Chrome MV3 and Firefox MV2 — verified in both generated manifests). This lights up "Options" in the icon context menu and `chrome://extensions`, and enables `runtime.openOptionsPage()`.
- Deep links (`voices/pi` etc. from the in-chat "More voices…" doors) are untouched — they travel via the `chrome.storage` handoff the page reads on boot. Verified live.
- Popup-era sizing in the background (consent height, roomy-tab growth) is deleted; the page-side growth helper (`settingsWindowSize.ts` + `ensureRoomFor`) **stays and self-disables** (`win.type !== 'popup'` guard) to keep the prototype easy to revert. If the direction is adopted, a follow-up deletes that module, its tests, and the `POPUP_MIN_CONTENT_WIDTH` plumbing.

## Verification

- New e2e spec (`settings-opens-in-tab.e2e.ts`) drives the real `openPopup` message end-to-end: asserts the page lands in a `normal` window (no popup-type window created), a second request focuses instead of duplicating, and `options_ui` is registered. **Fail-first proven** against the old build: `expected only normal windows, got: normal, popup`.
- Full e2e suite (16 specs) ✓, `npm test` ✓.
- Real Chrome (L4 CDP rig): `voices/pi` deep link opens the settings **tab** on the Pi studio; second open focuses the same tab. Screenshot below.

## To try it

Build this branch (`npm run e2e:build`) and reload the unpacked extension — **note the reload**: unpacked-extension service workers can be served stale from Chrome's script cache even across browser restarts, so hit ↻ on `chrome://extensions` (or `chrome.runtime.reload()`) after swapping build output.

## Open questions for evaluation

1. Does the in-chat "More voices…" door feel right landing in a tab (it takes over the screen mid-conversation), or should that one path keep a popup? The plumbing supports either.
2. If adopted: follow-up to delete `settingsWindowSize.ts` + page-side growth + related tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9VYkV4SNjFQDBT3v7S5D2