### PR TITLE
fix(voices): make the Voices studio honest and level

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -985,16 +985,20 @@
     "description": "Subheading for the voice catalog section in the settings AI Chat tab"
   },
   "voicesShelfHd": {
-    "message": "HD — richest sound",
-    "description": "Group heading for premium (HD) voices in the settings voice catalog"
+    "message": "HD voices",
+    "description": "Group heading for premium (HD) voices in the settings voice catalog. Rendered uppercase by CSS."
+  },
+  "voicesShelfHdBlurb": {
+    "message": "Our richest, most expressive sound.",
+    "description": "One-line note beside the HD group heading in the settings Voices studio."
   },
   "voicesShelfEveryday": {
-    "message": "Everyday — sounds great, lasts longer",
-    "description": "Group heading for value-tier voices in the settings voice catalog"
+    "message": "Everyday voices",
+    "description": "Group heading for value-tier voices in the settings voice catalog. Rendered uppercase by CSS."
   },
   "voicesShelfEverydayBlurb": {
-    "message": "Great quality — your monthly allowance lasts about 20× longer.",
-    "description": "One-line note under the Everyday voices group heading in the settings voice catalog"
+    "message": "Natural and clear — you can listen about 20× longer than with HD.",
+    "description": "One-line note beside the Everyday group heading in the settings Voices studio; the one place the studio states how much further this tier goes than HD."
   },
   "voicesUseShort": {
     "message": "Use",
@@ -1116,9 +1120,35 @@
       }
     }
   },
-  "voicesNoStageVoice": {
-    "message": "No voice selected yet — pick one below.",
-    "description": "Stage placeholder in the settings Voices studio when the host has no current voice."
+  "voicesStageEmptyTitle": {
+    "message": "Choose how $host$ sounds",
+    "description": "Headline on the settings Voices studio stage when the host has no SayPi voice selected; $host$ is the assistant (e.g. Pi, Claude). Rendered at name size.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "message": "$host$ uses its own voice until you pick one below.",
+    "description": "Stage note when the host serves its own audio (e.g. Pi), so choosing a Say, Pi voice replaces the host's.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "message": "$host$ won't read replies aloud until you pick one below.",
+    "description": "Stage note when the host has no voice of its own (e.g. Claude), so nothing is read aloud until a Say, Pi voice is chosen.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
   },
   "voicesBuiltinsNote": {
     "message": "$host$'s own built-in voices always appear in its menu too.",

--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -186,18 +186,54 @@ interface StudioViewModel {
 
 /**
  * How a set of same-named voices is told apart (#474).
- * - "languages": every twin can render a count, so all of them do — the same
- *   sentence with a different number, which is the only parallel pair the
- *   served `/voices` payload can support.
- * - "description": at least one twin has no count, so the group falls back to
- *   description-first, leaving at least one row distinguished rather than both
- *   collapsing to the shared persona tagline.
+ * - "description": every twin carries its own distinct server description —
+ *   parallel AND the most informative pair the payload can give.
+ * - "languages": no such descriptions, but every twin has a DIFFERENT language
+ *   count — the same sentence with a different number, parallel in a weaker
+ *   register.
+ * - "description" is also the fallback when neither holds: description-first
+ *   per voice, which is non-parallel but at least tells the rows apart.
  */
 type DupStrategy = "languages" | "description";
 
 /** How many languages the server says a voice speaks (0 when it didn't say). */
 const languageCount = (voice: SpeechSynthesisVoiceRemote): number =>
   voice.languages?.length ?? 0;
+
+const describedAs = (voice: SpeechSynthesisVoiceRemote): string =>
+  (voice.description ?? "").trim();
+
+const allDistinct = (values: (string | number)[]): boolean =>
+  new Set(values).size === values.length;
+
+/**
+ * Pick the differentiator for one group of same-named voices (#474).
+ *
+ * Order matters, and it is an order of usefulness, not of preference for a
+ * data shape: distinct descriptions say something about how the voices differ;
+ * distinct counts merely differ. A tie in either is disqualifying — two cards
+ * printing the identical sentence differentiate nothing, which is worse than
+ * the non-parallel fallback.
+ */
+function dupStrategyFor(
+  name: string,
+  group: SpeechSynthesisVoiceRemote[]
+): DupStrategy {
+  const descriptions = group.map(describedAs);
+  if (descriptions.every(Boolean) && allDistinct(descriptions))
+    return "description";
+
+  const counts = group.map(languageCount);
+  if (counts.every((n) => n > 1) && allDistinct(counts)) return "languages";
+
+  // Neither axis separates the twins in the same register: the payload has
+  // gone thinner than #474 assumed (a missing `languages`, or twins the server
+  // reports identically). Say so rather than silently going non-parallel.
+  console.warn(
+    `Voice name "${name}" is shared by ${group.length} voices with no parallel differentiator (descriptions: ${JSON.stringify(descriptions)}, language counts: ${JSON.stringify(counts)}); falling back to description-first subtitles (#474).`
+  );
+  return "description";
+}
 
 const escapeCss = (value: string) =>
   typeof CSS !== "undefined" && CSS.escape
@@ -392,15 +428,7 @@ export class VoicesController {
     const dupNames = new Map<string, DupStrategy>();
     byName.forEach((group, name) => {
       if (group.length < 2) return;
-      const allCountable = group.every((voice) => languageCount(voice) > 1);
-      if (!allCountable) {
-        // The server stopped sending `languages` for at least one twin, which
-        // is #474 regressing — say so rather than silently going non-parallel.
-        console.warn(
-          `Voice name "${name}" is shared by ${group.length} voices but at least one has no language count; falling back to description subtitles (#474).`
-        );
-      }
-      dupNames.set(name, allCountable ? "languages" : "description");
+      dupNames.set(name, dupStrategyFor(name, group));
     });
 
     return {
@@ -522,8 +550,11 @@ export class VoicesController {
     if (getVoiceTier(current) === "hd") {
       chips.appendChild(this.renderTierChip());
     }
+    // The chip is a second facet of the voice, not an echo of the first: on a
+    // twin the subtitle IS the language sentence (#474), and printing it again
+    // 15px lower makes the hero repeat itself.
     const langs = this.languagesSubtitle(current);
-    if (langs) {
+    if (langs && langs !== subtitle.text) {
       const lang = document.createElement("span");
       lang.classList.add("voice-stage-lang");
       lang.textContent = langs;
@@ -777,6 +808,11 @@ export class VoicesController {
     tagline.classList.add("voice-card-tagline");
     if (subtitle.i18nKey) tagline.setAttribute("data-i18n", subtitle.i18nKey);
     tagline.textContent = subtitle.text;
+    // The card clamps this to two lines (voices.css), and on a twin the clipped
+    // text is the ONLY thing telling two same-named cards apart — nothing else
+    // in the card carries it. `title` is not touched by replaceI18n, so it
+    // survives a re-localization pass; a long locale gets it for free too.
+    if (subtitle.text) tagline.title = subtitle.text;
     card.appendChild(tagline);
 
     const actions = document.createElement("div");
@@ -899,11 +935,10 @@ export class VoicesController {
    * tiebreaker for twin display names (#474), where a shared persona tagline
    * can't tell two cards apart.
    *
-   * For a countable twin group the language count WINS over the server
-   * description (the inverse of the pre-#474 order): the long description
-   * exists on only one twin, and prose on one card beside a number on the
-   * other is precisely the non-parallelism that made the two Paolas read as a
-   * mistake rather than a choice.
+   * Which differentiator a twin group uses is decided once, for the whole
+   * group, by dupStrategyFor — a per-voice rule can land one twin on a number
+   * and the other on prose, which is the non-parallelism that made the two
+   * Paolas read as a mistake rather than a choice.
    */
   private subtitleFor(
     voice: SpeechSynthesisVoiceRemote,

--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -1,5 +1,8 @@
 import getMessage from "../../../../src/i18n";
-import { SpeechSynthesisVoiceRemote } from "../../../../src/tts/SpeechModel";
+import {
+  audioProviders,
+  SpeechSynthesisVoiceRemote,
+} from "../../../../src/tts/SpeechModel";
 import { SpeechSynthesisModule } from "../../../../src/tts/SpeechSynthesisModule";
 import { UserPreferenceModule } from "../../../../src/prefs/PreferenceModule";
 import { getJwtManagerSync } from "../../../../src/JwtManager";
@@ -172,9 +175,29 @@ interface StudioViewModel {
     /** current + pins have consumed every seat — no room to pin more. */
     full: boolean;
   } | null;
-  /** Display names appearing more than once (the twin-Paola problem, #474). */
-  dupNames: Set<string>;
+  /**
+   * Display names appearing more than once (the twin-Paola problem, #474),
+   * mapped to how the studio differentiates that whole GROUP. Group-level, not
+   * per-voice: a per-voice rule can land one twin on a language count and the
+   * other on a server description — non-parallel again, just differently.
+   */
+  dupNames: Map<string, DupStrategy>;
 }
+
+/**
+ * How a set of same-named voices is told apart (#474).
+ * - "languages": every twin can render a count, so all of them do — the same
+ *   sentence with a different number, which is the only parallel pair the
+ *   served `/voices` payload can support.
+ * - "description": at least one twin has no count, so the group falls back to
+ *   description-first, leaving at least one row distinguished rather than both
+ *   collapsing to the shared persona tagline.
+ */
+type DupStrategy = "languages" | "description";
+
+/** How many languages the server says a voice speaks (0 when it didn't say). */
+const languageCount = (voice: SpeechSynthesisVoiceRemote): number =>
+  voice.languages?.length ?? 0;
 
 const escapeCss = (value: string) =>
   typeof CSS !== "undefined" && CSS.escape
@@ -355,14 +378,30 @@ export class VoicesController {
           };
         })();
 
-    const nameCounts = new Map<string, number>();
+    // Twin display names (#474). The names themselves stay identical — the
+    // only suffix the payload would support is a model name, which /voices
+    // never serves — so the subtitle is the sole differentiator, and it is
+    // decided once per name group so both twins read in the same register.
+    const byName = new Map<string, SpeechSynthesisVoiceRemote[]>();
     catalog.forEach((voice) => {
       const name = String(voice.name ?? "").toLowerCase();
-      nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1);
+      const group = byName.get(name);
+      if (group) group.push(voice);
+      else byName.set(name, [voice]);
     });
-    const dupNames = new Set(
-      [...nameCounts.entries()].filter(([, n]) => n > 1).map(([name]) => name)
-    );
+    const dupNames = new Map<string, DupStrategy>();
+    byName.forEach((group, name) => {
+      if (group.length < 2) return;
+      const allCountable = group.every((voice) => languageCount(voice) > 1);
+      if (!allCountable) {
+        // The server stopped sending `languages` for at least one twin, which
+        // is #474 regressing — say so rather than silently going non-parallel.
+        console.warn(
+          `Voice name "${name}" is shared by ${group.length} voices but at least one has no language count; falling back to description subtitles (#474).`
+        );
+      }
+      dupNames.set(name, allCountable ? "languages" : "description");
+    });
 
     return {
       host,
@@ -438,12 +477,7 @@ export class VoicesController {
     const stage = document.createElement("div");
     stage.classList.add("voice-stage");
 
-    if (!current) {
-      stage.classList.add("voice-stage-empty");
-      stage.setAttribute("data-i18n", "voicesNoStageVoice");
-      stage.textContent = getMessage("voicesNoStageVoice");
-      return stage;
-    }
+    if (!current) return this.renderEmptyStage(stage, vm);
 
     const identity = getVoiceIdentity(current);
     stage.style.setProperty("--stage-from", identity.gradient[0]);
@@ -496,6 +530,51 @@ export class VoicesController {
       chips.appendChild(lang);
     }
     if (chips.childNodes.length > 0) meta.appendChild(chips);
+
+    stage.appendChild(meta);
+    return stage;
+  }
+
+  /**
+   * The stage with nothing on it — a hero that recruits, not a placeholder
+   * that apologises. Two lines: an imperative headline (host-generic) and one
+   * supporting line that MUST differ per host, because "no voice selected"
+   * means opposite things.
+   *
+   * The choice is a HOST PROPERTY, not an id list: a host that serves its own
+   * audio keeps speaking in its own voice until a Say, Pi voice replaces it; a
+   * host with no voice of its own reads nothing aloud until one is chosen. A
+   * third host therefore needs no new copy and no new branch here.
+   *
+   * The headline is the call to action — no button. The cards are already in
+   * the same viewport of the settings window, so a control whose only job is
+   * to scroll one screen would be chrome; "below" does the orienting work.
+   */
+  private renderEmptyStage(
+    stage: HTMLElement,
+    vm: StudioViewModel
+  ): HTMLElement {
+    stage.classList.add("voice-stage-empty");
+    const meta = document.createElement("div");
+    meta.classList.add("voice-stage-meta");
+
+    const title = document.createElement("div");
+    title.classList.add("voice-stage-empty-title");
+    // No data-i18n on substituted text (replaceI18n clobber — see renderEmptyState).
+    title.textContent = getMessage("voicesStageEmptyTitle", [vm.host.label]);
+    meta.appendChild(title);
+
+    const note = document.createElement("div");
+    note.classList.add("voice-stage-empty-note");
+    const hostServesItsOwnAudio =
+      audioProviders.getDefaultForChatbot(vm.host.id) !== audioProviders.SayPi;
+    note.textContent = getMessage(
+      hostServesItsOwnAudio
+        ? "voicesStageEmptyNoteReplace"
+        : "voicesStageEmptyNoteSilent",
+      [vm.host.label]
+    );
+    meta.appendChild(note);
 
     stage.appendChild(meta);
     return stage;
@@ -609,8 +688,13 @@ export class VoicesController {
     );
 
     if (hd.length > 0 && everyday.length > 0) {
+      // Studio-only blurbs. `hdVoicesAllowanceNote` is deliberately NOT reused
+      // here: it is also the HD chip tooltip and Claude's in-chat menu
+      // footnote, where no Everyday shelf sits beside it to carry the ratio.
+      // Here the HD shelf leads with what you get and the trade is stated once,
+      // one line below, where it reads as a gain.
       shelves.appendChild(
-        this.renderShelf("hd", "voicesShelfHd", "hdVoicesAllowanceNote", hd, vm)
+        this.renderShelf("hd", "voicesShelfHd", "voicesShelfHdBlurb", hd, vm)
       );
       shelves.appendChild(
         this.renderShelf(
@@ -812,16 +896,26 @@ export class VoicesController {
 
   /**
    * Metadata fallback for voices without an authored tagline — and the
-   * tiebreaker for twin display names (#474): when a name appears twice,
-   * metadata (description/languages) differentiates where a shared persona
-   * tagline can't.
+   * tiebreaker for twin display names (#474), where a shared persona tagline
+   * can't tell two cards apart.
+   *
+   * For a countable twin group the language count WINS over the server
+   * description (the inverse of the pre-#474 order): the long description
+   * exists on only one twin, and prose on one card beside a number on the
+   * other is precisely the non-parallelism that made the two Paolas read as a
+   * mistake rather than a choice.
    */
   private subtitleFor(
     voice: SpeechSynthesisVoiceRemote,
-    dupNames: Set<string>
+    dupNames: Map<string, DupStrategy>
   ): { text: string; i18nKey?: string } {
+    const strategy = dupNames.get(String(voice.name ?? "").toLowerCase());
+    if (strategy === "languages") {
+      // Substituted ($count$) → no i18nKey, so replaceI18n can't strip the number.
+      return { text: this.languagesSubtitle(voice) };
+    }
     const meta = voice.description || this.languagesSubtitle(voice);
-    if (dupNames.has(String(voice.name ?? "").toLowerCase()) && meta) {
+    if (strategy === "description" && meta) {
       return { text: meta };
     }
     const identity = getVoiceIdentity(voice);
@@ -835,7 +929,7 @@ export class VoicesController {
   }
 
   private languagesSubtitle(voice: SpeechSynthesisVoiceRemote): string {
-    const count = voice.languages?.length ?? 0;
+    const count = languageCount(voice);
     return count > 1
       ? getMessage("voiceSpeaksNLanguages", [String(count)])
       : "";

--- a/entrypoints/settings/tabs/voices/voices.css
+++ b/entrypoints/settings/tabs/voices/voices.css
@@ -14,6 +14,16 @@
 #tab-voices.tab-panel {
   max-width: none;
 }
+/* ...and the same 504px cap again, one level further in: .user-preference-item
+   is the card every tab wraps its controls in, and uncapping only the panel
+   left the studio at 504 − 2rem padding = 472px — barely half the 940px column
+   settingsWindowSize.ts grows the window to for this tab, and the reason the
+   shelf heads used to run out of room. The studio's own max-width (900px,
+   above) is what actually bounds it. ID+class so it wins wherever tabs.css
+   loads in the cascade; scoped to this card so no other tab moves. */
+#voices-preference.user-preference-item {
+  max-width: none;
+}
 
 /* No per-tab column widening here: `.content` is flex:1 inside the
    full-width .settings-container (global.css), so the studio already gets
@@ -391,17 +401,23 @@ button.voice-orb:hover {
 /* The heading leads and the blurb recedes: the heading names the tier, the
    blurb names the benefit. Before this the ALLCAPS heading and a full
    explanatory sentence competed at the same visual weight (the blurb was
-   actually the LARGER of the two). */
+   actually the LARGER of the two). The hierarchy is bought by DARKENING the
+   heading — the blurb stays at a WCAG-AA colour, because it is the one place
+   the studio says what HD costs. */
 .voice-shelf-title {
   font-size: 11.5px;
   font-weight: 750;
   letter-spacing: 0.07em;
   text-transform: uppercase;
   color: #3f3b35;
+  /* The head is a flex row; the default shrink makes the TITLE the thing that
+     gives when the pair is tight, stacking "EVERYDAY / VOICES" beside a
+     two-line blurb. The heading can't lead from two lines. */
+  flex-shrink: 0;
 }
 .voice-shelf-blurb {
   font-size: 11px;
-  color: #87817a;
+  color: #77726a; /* 4.8:1 on the white card — AA at this size. */
 }
 .voice-card-grid {
   list-style: none;

--- a/entrypoints/settings/tabs/voices/voices.css
+++ b/entrypoints/settings/tabs/voices/voices.css
@@ -85,6 +85,10 @@
   align-items: center;
   gap: 22px;
   padding: 24px 26px;
+  /* The lg orb (88px) + the stage's own padding. Pinning it here means the
+     empty stage — which has no orb — holds exactly the same room, so switching
+     to a host with no voice yet doesn't collapse the page. */
+  min-height: 136px;
   border-radius: 16px;
   margin-bottom: 16px;
   color: #ffffff;
@@ -96,13 +100,25 @@
     #0a100f
   );
 }
+/* Nothing staged yet: a hero that recruits, not a disabled placeholder. The
+   dashed outline and grey fill this replaced read as an error state. It keeps
+   the stage's full height and gets a gradient of its own, but a deliberately
+   quieter one — an empty stage has no voice identity to draw from, so it must
+   not out-shout a real selected voice. */
 .voice-stage.voice-stage-empty {
-  display: block;
-  color: #6f6a61;
-  background: #f4f4f2;
-  border: 1px dashed #d9d6cd;
-  font-size: 0.9rem;
-  padding: 18px 20px;
+  color: #1f2b26;
+  background: linear-gradient(118deg, #f6f5ef, #eceadf 58%, #e4e2d5);
+}
+.voice-stage-empty-title {
+  font-size: 28px;
+  font-weight: 750;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+.voice-stage-empty-note {
+  font-size: 13.5px;
+  color: #5c5a51;
+  margin-top: 6px;
 }
 .voice-stage-meta {
   min-width: 0;
@@ -372,16 +388,20 @@ button.voice-orb:hover {
   gap: 10px;
   margin-bottom: 8px;
 }
+/* The heading leads and the blurb recedes: the heading names the tier, the
+   blurb names the benefit. Before this the ALLCAPS heading and a full
+   explanatory sentence competed at the same visual weight (the blurb was
+   actually the LARGER of the two). */
 .voice-shelf-title {
-  font-size: 11px;
+  font-size: 11.5px;
   font-weight: 750;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: #6f6a61;
+  color: #3f3b35;
 }
 .voice-shelf-blurb {
-  font-size: 11.5px;
-  color: #77726a;
+  font-size: 11px;
+  color: #87817a;
 }
 .voice-card-grid {
   list-style: none;
@@ -433,17 +453,33 @@ button.voice-orb:hover {
   font-weight: 650;
   margin-top: 2px;
 }
+/* Two lines, always. Grid rows stretch, so ONE voice whose subtitle falls back
+   to a long server description used to grow every sibling card in its row
+   while their Use buttons stayed stranded mid-card. The clamp caps the tallest
+   tagline; min-height still reserves the space so a one-line tagline doesn't
+   shrink its card. */
 .voice-card-tagline {
   font-size: 11px;
   color: #77726a;
   line-height: 1.35;
   min-height: 2.7em;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  /* The card centers its children, which would shrink-wrap the clamped box to
+     its longest line; stretching it fixes the wrap point (and the ellipsis) at
+     the card's width. text-align: center still centers the text itself. */
+  align-self: stretch;
 }
+/* margin-top:auto bottoms the actions row out, so the buttons share a baseline
+   across a row even if a card is still taller than its content. */
 .voice-card-actions {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 1px;
+  margin-top: auto;
 }
 .voice-card-state {
   font-size: 10.5px;

--- a/test/settings/tabs/voices-controller.spec.tsx
+++ b/test/settings/tabs/voices-controller.spec.tsx
@@ -220,11 +220,41 @@ describe("VoicesController — stage", () => {
     );
   });
 
-  it("shows an empty stage when the host has no current voice", async () => {
+  it("recruits with a hero when the host has no current voice", async () => {
     const deps = makeDeps({ pi: [mkVoice("marin")] });
     const { container } = await mount(deps);
     const empty = q(container, ".voice-stage-empty")!;
-    expect(empty.dataset.i18n).toBe("voicesNoStageVoice");
+    // Substituted text must NOT carry data-i18n (replaceI18n clobber guard) —
+    // same contract as .voice-stage-eyebrow above.
+    const title = empty.querySelector(".voice-stage-empty-title") as HTMLElement;
+    expect(title.textContent).toBe("voicesStageEmptyTitle");
+    expect(title.dataset.i18n).toBeUndefined();
+    expect(empty.dataset.i18n).toBeUndefined();
+  });
+
+  // "No voice selected" means opposite things per host, so the supporting line
+  // is chosen from a HOST PROPERTY — whether the host serves its own audio —
+  // not from an id list. A third host needs no new copy and no new branch.
+  it("tells a self-voiced host's user that a pick REPLACES the host's voice", async () => {
+    const deps = makeDeps({ pi: [mkVoice("marin")] });
+    const { container } = await mount(deps);
+    const note = q(container, ".voice-stage-empty-note")!;
+    expect(note.textContent).toBe("voicesStageEmptyNoteReplace");
+    expect(note.dataset.i18n).toBeUndefined();
+  });
+
+  it("tells a voiceless host's user that nothing is read aloud until they pick", async () => {
+    const deps = makeDeps({ claude: [mkVoice("marin")] });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    const note = q(container, ".voice-stage-empty-note")!;
+    expect(note.textContent).toBe("voicesStageEmptyNoteSilent");
+    expect(note.dataset.i18n).toBeUndefined();
+  });
+
+  it("makes the headline the call to action — no button whose only job is to scroll", async () => {
+    const deps = makeDeps({ pi: [mkVoice("marin")] });
+    const { container } = await mount(deps);
+    expect(q(container, ".voice-stage-empty")!.querySelector("button")).toBeNull();
   });
 
   it("still shows a host-built-in current voice on the stage (not in the catalog)", async () => {
@@ -520,6 +550,51 @@ describe("VoicesController — explore cards", () => {
     ).toBeNull();
   });
 
+  it("labels each shelf with studio-only copy, not the in-chat allowance footnote", async () => {
+    // hdVoicesAllowanceNote is ALSO the HD chip tooltip and Claude's in-chat
+    // menu footnote, where no Everyday shelf sits beside it to carry the ratio.
+    // The studio states the ratio once, on the Everyday side.
+    const deps = makeDeps({ claude: [mkHdVoice("jarnathan"), mkVoice("nova")] });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    const blurbKey = (tier: string) =>
+      q(container, `.voice-shelf[data-tier='${tier}'] .voice-shelf-blurb`)!
+        .dataset.i18n;
+    const titleKey = (tier: string) =>
+      q(container, `.voice-shelf[data-tier='${tier}'] .voice-shelf-title`)!
+        .dataset.i18n;
+    expect(titleKey("hd")).toBe("voicesShelfHd");
+    expect(blurbKey("hd")).toBe("voicesShelfHdBlurb");
+    expect(titleKey("everyday")).toBe("voicesShelfEveryday");
+    expect(blurbKey("everyday")).toBe("voicesShelfEverydayBlurb");
+  });
+
+  // Defect 1's fix is pure CSS (clamp the tagline, bottom out the actions), so
+  // the rules themselves are asserted in voices-studio-layout.spec.ts. What a
+  // DOM test CAN prove is the class contract those rules hang off: both a
+  // curated short tagline and a long server description produce the same two
+  // elements, and the actions row is last so `margin-top: auto` can bottom it.
+  it("gives every card the same tagline+actions structure, however long its subtitle", async () => {
+    const deps = makeDeps({
+      claude: [
+        mkVoice("marin"),
+        mkVoice("wander", {
+          name: "Wander",
+          description:
+            "A long, unhurried server description that runs well past two lines in a 150px card and used to stretch its whole grid row.",
+        }),
+      ],
+    });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    for (const id of ["marin", "wander"]) {
+      const card = cardOf(container, id)!;
+      const tagline = card.querySelector(".voice-card-tagline");
+      const actions = card.querySelector(".voice-card-actions");
+      expect(tagline, `${id} should have a tagline element`).toBeTruthy();
+      expect(actions, `${id} should have an actions element`).toBeTruthy();
+      expect(card.lastElementChild, `${id}'s actions must be last`).toBe(actions);
+    }
+  });
+
   it("renders a single-tier catalog as a flat grid without shelf chrome", async () => {
     const deps = makeDeps({ claude: [mkVoice("marin"), mkVoice("nova")] });
     const { container } = await mount(deps, { initialHost: "claude" });
@@ -543,6 +618,128 @@ describe("VoicesController — explore cards", () => {
     ) as HTMLElement;
     expect(multiTagline.textContent).toBe("voiceSpeaksNLanguages");
     expect(multiTagline.dataset.i18n).toBeUndefined();
+  });
+});
+
+/**
+ * #474 — twin display names ("Paola" and "Paola"). The names stay identical:
+ * the only suffix the data would support is a model name, and /voices never
+ * serves one, so printing it would be inventing data. The SUBTITLE is the sole
+ * differentiator, and it must be the same sentence with a different number —
+ * prose on one card and a number on the other is precisely the defect.
+ *
+ * These use an interpolating getMessage so the two counts are observably
+ * different (the shared mock ignores substitutions).
+ */
+describe("VoicesController — twin display names (#474)", () => {
+  let originalGetMessage: any;
+  beforeEach(() => {
+    const i18n = (globalThis as any).chrome.i18n;
+    originalGetMessage = i18n.getMessage.getMockImplementation();
+    i18n.getMessage.mockImplementation((key: string, subs?: string | string[]) => {
+      const list = subs === undefined ? [] : Array.isArray(subs) ? subs : [subs];
+      return list.length ? `${key}:${list.join(",")}` : key;
+    });
+  });
+  afterEach(() => {
+    (globalThis as any).chrome.i18n.getMessage.mockImplementation(
+      originalGetMessage
+    );
+  });
+
+  const langs = (n: number) => Array.from({ length: n }, (_, i) => `l${i}`);
+  const taglineOf = (c: HTMLElement, id: string) =>
+    cardOf(c, id)!.querySelector(".voice-card-tagline")!.textContent;
+
+  const twins = () => [
+    mkHdVoice("paola-classic", {
+      name: "Paola",
+      description:
+        "Warm, versatile Italian voice, equally at home narrating and holding a conversation.",
+      languages: langs(33),
+    }),
+    mkHdVoice("paola-expressive", { name: "Paola", languages: langs(75) }),
+  ];
+
+  it("gives both twins the same sentence with a different number", async () => {
+    const deps = makeDeps({ claude: twins() });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    expect(taglineOf(container, "paola-classic")).toBe(
+      "voiceSpeaksNLanguages:33"
+    );
+    expect(taglineOf(container, "paola-expressive")).toBe(
+      "voiceSpeaksNLanguages:75"
+    );
+  });
+
+  it("never shows a server description on a twin while its sibling shows a count", async () => {
+    const deps = makeDeps({ claude: twins() });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    expect(taglineOf(container, "paola-classic")).not.toMatch(/Warm, versatile/);
+  });
+
+  it("generalises to any duplicate-named pair the server grows into", async () => {
+    // The catalog is server-driven and grows without a client release, so the
+    // rule keys on the name group, not on a hardcoded name.
+    const deps = makeDeps({
+      claude: [
+        mkHdVoice("kai-a", {
+          name: "Kai",
+          description: "A long server description that would break parallelism.",
+          languages: langs(12),
+        }),
+        mkHdVoice("kai-b", { name: "Kai", languages: langs(41) }),
+        mkVoice("marin"),
+      ],
+    });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    expect(taglineOf(container, "kai-a")).toBe("voiceSpeaksNLanguages:12");
+    expect(taglineOf(container, "kai-b")).toBe("voiceSpeaksNLanguages:41");
+    // A non-duplicate name keeps its curated persona tagline.
+    expect(taglineOf(container, "marin")).toBe("voiceTagline_marin");
+  });
+
+  it("decides per name-GROUP: one twin without a count falls the whole group back", async () => {
+    // languagesSubtitle returns "" when count <= 1, so a per-voice rule can
+    // still land one twin on a count and the other on a description —
+    // non-parallel again, just differently.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const deps = makeDeps({
+      claude: [
+        mkHdVoice("paola-classic", {
+          name: "Paola",
+          description: "Warm, versatile Italian voice.",
+          languages: langs(33),
+        }),
+        mkHdVoice("paola-mono", { name: "Paola" }),
+      ],
+    });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    // At least one row is distinguished, rather than both collapsing to the
+    // shared persona tagline.
+    expect(taglineOf(container, "paola-classic")).toBe(
+      "Warm, versatile Italian voice."
+    );
+    expect(taglineOf(container, "paola-mono")).toBe("voiceTagline_paola");
+    // The fallback means #474 is regressing — the server stopped sending
+    // `languages` — so it must be noisy, not silent.
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0][0])).toMatch(/paola/i);
+    warn.mockRestore();
+  });
+
+  it("renders the ▶ sample button on both twin cards", async () => {
+    // A language count is a weak differentiator for a monolingual listener, and
+    // nothing client-side describes how the two actually SOUND — hearing them
+    // is the real tiebreaker.
+    const deps = makeDeps({ claude: twins() });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    for (const id of ["paola-classic", "paola-expressive"]) {
+      expect(
+        cardOf(container, id)!.querySelector("button[data-orb-voice]"),
+        `${id} should be auditionable`
+      ).toBeTruthy();
+    }
   });
 });
 
@@ -672,6 +869,21 @@ describe("VoicesController — replaceI18n clobber immunity", () => {
     expect(textOf(".voice-stage-eyebrow")).toBe(before.eyebrow);
     expect(textOf(".voice-slots-title")).toBe(before.slotsTitle);
     expect(textOf(".voice-slots-overflow")).toBe(before.overflow);
+  });
+
+  it("keeps the empty stage's host name intact", async () => {
+    const deps = makeDeps({ pi: [mkVoice("marin")] });
+    const { container } = await mount(deps);
+    const textOf = (sel: string) => q(container, sel)!.textContent;
+    const before = {
+      title: textOf(".voice-stage-empty-title"),
+      note: textOf(".voice-stage-empty-note"),
+    };
+    expect(before.title).toContain("Pi");
+    expect(before.note).toContain("Pi");
+    replaceI18n();
+    expect(textOf(".voice-stage-empty-title")).toBe(before.title);
+    expect(textOf(".voice-stage-empty-note")).toBe(before.note);
   });
 
   it("keeps the built-ins note and load-error text intact too", async () => {

--- a/test/settings/tabs/voices-controller.spec.tsx
+++ b/test/settings/tabs/voices-controller.spec.tsx
@@ -595,6 +595,27 @@ describe("VoicesController — explore cards", () => {
     }
   });
 
+  // The clamp that keeps a row from going ragged also HIDES text — and on a
+  // twin card the clipped text is the only thing telling two same-named voices
+  // apart. Nothing else in the card exposes it, so the full string has to stay
+  // recoverable (also covers long-locale taglines, which clip where en doesn't).
+  it("keeps a clamped tagline recoverable in full", async () => {
+    const long =
+      "A long, unhurried server description that runs well past two lines in a 150px card and used to stretch its whole grid row.";
+    const deps = makeDeps({
+      claude: [mkVoice("marin"), mkVoice("wander", { name: "Wander", description: long })],
+    });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    for (const id of ["marin", "wander"]) {
+      const tagline = cardOf(container, id)!.querySelector(
+        ".voice-card-tagline"
+      ) as HTMLElement;
+      expect(tagline.title, `${id}'s clipped tagline must stay readable`).toBe(
+        tagline.textContent
+      );
+    }
+  });
+
   it("renders a single-tier catalog as a flat grid without shelf chrome", async () => {
     const deps = makeDeps({ claude: [mkVoice("marin"), mkVoice("nova")] });
     const { container } = await mount(deps, { initialHost: "claude" });
@@ -697,6 +718,82 @@ describe("VoicesController — twin display names (#474)", () => {
     expect(taglineOf(container, "kai-b")).toBe("voiceSpeaksNLanguages:41");
     // A non-duplicate name keeps its curated persona tagline.
     expect(taglineOf(container, "marin")).toBe("voiceTagline_marin");
+  });
+
+  // A count is the fallback differentiator, not the preferred one: when the
+  // server grows per-twin descriptions (the resolution #474 actually asks for)
+  // they are BOTH parallel and more informative, so they must win — otherwise
+  // shipping the server fix would make the studio worse, not better.
+  it("prefers distinct server descriptions over the count when every twin has one", async () => {
+    const deps = makeDeps({
+      claude: [
+        mkHdVoice("paola-narrator", {
+          name: "Paola",
+          description: "Warm Italian narrator.",
+          languages: langs(29),
+        }),
+        mkHdVoice("paola-conversational", {
+          name: "Paola",
+          description: "Expressive Italian conversationalist.",
+          languages: langs(74),
+        }),
+      ],
+    });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    expect(taglineOf(container, "paola-narrator")).toBe("Warm Italian narrator.");
+    expect(taglineOf(container, "paola-conversational")).toBe(
+      "Expressive Italian conversationalist."
+    );
+  });
+
+  it("won't print the same count on both twins when the counts tie", async () => {
+    // Two identical sentences differentiate nothing — worse than the
+    // non-parallel fallback, which at least tells the rows apart.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const deps = makeDeps({
+      claude: [
+        mkHdVoice("paola-described", {
+          name: "Paola",
+          description: "Warm, versatile Italian voice.",
+          languages: langs(33),
+        }),
+        mkHdVoice("paola-bare", { name: "Paola", languages: langs(33) }),
+      ],
+    });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    expect(taglineOf(container, "paola-described")).not.toBe(
+      taglineOf(container, "paola-bare")
+    );
+    expect(taglineOf(container, "paola-described")).toBe(
+      "Warm, versatile Italian voice."
+    );
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  // The stage prints the subtitle as its tagline AND the language count as a
+  // chip a few pixels below. On a twin those are the same sentence.
+  it("never says the same thing twice on the stage", async () => {
+    const [classic] = twins();
+    const deps = makeDeps({ claude: twins(), claudeCurrent: classic });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    const tagline = q(container, ".voice-stage-tagline")!.textContent;
+    expect(tagline).toBe("voiceSpeaksNLanguages:33");
+    expect(q(container, ".voice-stage-lang")?.textContent).not.toBe(tagline);
+  });
+
+  it("still chips the language count when the tagline says something else", async () => {
+    const deps = makeDeps({
+      claude: [mkVoice("marin", { languages: langs(12) })],
+      claudeCurrent: mkVoice("marin", { languages: langs(12) }),
+    });
+    const { container } = await mount(deps, { initialHost: "claude" });
+    expect(q(container, ".voice-stage-tagline")!.textContent).toBe(
+      "voiceTagline_marin"
+    );
+    expect(q(container, ".voice-stage-lang")!.textContent).toBe(
+      "voiceSpeaksNLanguages:12"
+    );
   });
 
   it("decides per name-GROUP: one twin without a count falls the whole group back", async () => {

--- a/test/settings/tabs/voices-studio-copy.spec.ts
+++ b/test/settings/tabs/voices-studio-copy.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Copy contract for the settings Voices studio, asserted against the REAL en
+ * locale (the source locale) rather than the test mock, so a re-texted or
+ * orphaned key is caught here rather than on a user's screen.
+ *
+ * Two things this file is really guarding:
+ *  - the studio's shelf blurbs are studio-only strings. `hdVoicesAllowanceNote`
+ *    is ALSO the HD chip tooltip and Claude's in-chat menu footnote, where no
+ *    Everyday shelf sits beside it to carry the ratio — it must keep its text
+ *    and its in-chat callers.
+ *  - every substituted stage string must exist with a declared `$host$`
+ *    placeholder (i18n-validate.cjs enforces the declaration; this pins the
+ *    substitution itself, which is what replaceI18n() would otherwise erase).
+ */
+const root = resolve(__dirname, "../../..");
+const en = JSON.parse(
+  readFileSync(resolve(root, "_locales/en/messages.json"), "utf8")
+);
+const controllerSrc = readFileSync(
+  resolve(root, "entrypoints/settings/tabs/voices/voices-controller.ts"),
+  "utf8"
+);
+const claudeMenuSrc = readFileSync(
+  resolve(root, "src/chatbots/ClaudeVoiceMenu.ts"),
+  "utf8"
+);
+
+describe("Defect 2 — the empty stage recruits", () => {
+  it("has a host-generic imperative headline", () => {
+    expect(en.voicesStageEmptyTitle?.message).toBe("Choose how $host$ sounds");
+    expect(en.voicesStageEmptyTitle.placeholders?.host?.content).toBe("$1");
+  });
+
+  it("has a supporting line for hosts that serve their own audio", () => {
+    expect(en.voicesStageEmptyNoteReplace?.message).toBe(
+      "$host$ uses its own voice until you pick one below."
+    );
+    expect(en.voicesStageEmptyNoteReplace.placeholders?.host?.content).toBe("$1");
+  });
+
+  it("has a supporting line for hosts with no voice of their own", () => {
+    expect(en.voicesStageEmptyNoteSilent?.message).toBe(
+      "$host$ won't read replies aloud until you pick one below."
+    );
+    expect(en.voicesStageEmptyNoteSilent.placeholders?.host?.content).toBe("$1");
+  });
+
+  it("ends both supporting lines on the same clause, so the hosts read as one product", () => {
+    const tail = "until you pick one below.";
+    expect(en.voicesStageEmptyNoteReplace.message.endsWith(tail)).toBe(true);
+    expect(en.voicesStageEmptyNoteSilent.message.endsWith(tail)).toBe(true);
+  });
+
+  it("retires voicesNoStageVoice — key deleted and nothing references it", () => {
+    expect(en.voicesNoStageVoice).toBeUndefined();
+    expect(controllerSrc).not.toMatch(/voicesNoStageVoice/);
+  });
+});
+
+describe("Defect 3 — tier copy: the heading names the tier, the blurb names the benefit", () => {
+  it("names the HD tier without an em-dash descriptor", () => {
+    expect(en.voicesShelfHd?.message).toBe("HD voices");
+  });
+
+  it("leads the HD blurb with sound, never with cost", () => {
+    expect(en.voicesShelfHdBlurb?.message).toBe(
+      "Our richest, most expressive sound."
+    );
+    expect(en.voicesShelfHdBlurb.message).not.toMatch(
+      /allowance|credit|faster|cost|price/i
+    );
+    // Substitution-free → data-i18n is safe, so it must declare no placeholder.
+    expect(en.voicesShelfHdBlurb.message).not.toMatch(/\$.+\$/);
+  });
+
+  it("names the Everyday tier in parallel with HD", () => {
+    expect(en.voicesShelfEveryday?.message).toBe("Everyday voices");
+  });
+
+  it("states the ratio exactly once, on the side where it is a gain", () => {
+    expect(en.voicesShelfEverydayBlurb?.message).toBe(
+      "Natural and clear — you can listen about 20× longer than with HD."
+    );
+    // "Allowance" is the vendor's ledger, not something a listener can picture.
+    expect(en.voicesShelfEverydayBlurb.message).not.toMatch(
+      /allowance|credit/i
+    );
+    // The referent stays explicit: a locale reflow (or a single-tier catalog,
+    // which collapses the shelves into a flat grid) removes the adjacent shelf.
+    expect(en.voicesShelfEverydayBlurb.message).toMatch(/than with HD/);
+  });
+
+  it("passes the studio-only blurb keys, not the in-chat allowance footnote", () => {
+    // The quoted form is the key being PASSED to renderShelf; the studio may
+    // still mention the other key in a comment saying why it isn't reused.
+    expect(controllerSrc).toMatch(/"voicesShelfHdBlurb"/);
+    expect(controllerSrc).not.toMatch(/"hdVoicesAllowanceNote"/);
+  });
+
+  it("leaves hdVoicesAllowanceNote and its in-chat callers untouched", () => {
+    expect(en.hdVoicesAllowanceNote?.message).toBe(
+      "HD voices use your monthly allowance about 20× faster."
+    );
+    const callers = claudeMenuSrc.match(/hdVoicesAllowanceNote/g) ?? [];
+    expect(callers.length).toBe(2); // HD chip tooltip + menu footnote
+  });
+});

--- a/test/settings/tabs/voices-studio-layout.spec.ts
+++ b/test/settings/tabs/voices-studio-layout.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * CSS contract guards for the settings Voices studio.
+ *
+ * A JSDOM test can render the studio's DOM but never lays it out, so the three
+ * layout defects these guard cannot be caught by asserting geometry. They are
+ * caught here instead, by reading the shipped stylesheet back and asserting the
+ * declarations the fixes consist of. The matching DOM-side class contract (that
+ * the elements these rules target actually exist, on every card) lives in
+ * voices-controller.spec.tsx.
+ *
+ * What this proves: the rules are present with the right values.
+ * What it does NOT prove: that the rendered result looks right. Real-browser
+ * confirmation is a Layer-4 settings-page check.
+ */
+const root = resolve(__dirname, "../../..");
+const css = readFileSync(
+  resolve(root, "entrypoints/settings/tabs/voices/voices.css"),
+  "utf8"
+);
+
+/** The declarations of a single (flat, un-nested) rule, by exact selector. */
+function ruleBody(selector: string): string {
+  const at = css.indexOf(`${selector} {`);
+  expect(at, `voices.css should declare ${selector}`).toBeGreaterThan(-1);
+  const open = css.indexOf("{", at);
+  const close = css.indexOf("}", open);
+  return css.slice(open + 1, close);
+}
+
+const fontSizePx = (body: string): number => {
+  const m = /font-size:\s*([\d.]+)px/.exec(body);
+  expect(m, "rule should declare a px font-size").toBeTruthy();
+  return Number(m![1]);
+};
+
+/** Relative brightness of a #rrggbb literal — lower is darker (leads). */
+function luminance(body: string): number {
+  const m = /(?:^|[^-])color:\s*(#[0-9a-f]{6})/i.exec(body);
+  expect(m, "rule should declare a hex color").toBeTruthy();
+  const hex = m![1];
+  const [r, g, b] = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+describe("Defect 1 — voice cards must not go ragged", () => {
+  // A voice whose subtitle falls back to a long server `description` (the
+  // second Paola) stretches its grid row; because grid rows stretch, every
+  // sibling card grows too while their Use buttons stay stranded mid-card.
+  const tagline = () => ruleBody(".voice-card-tagline");
+  const actions = () => ruleBody(".voice-card-actions");
+
+  it("clamps the card tagline to two lines", () => {
+    const body = tagline();
+    expect(body).toMatch(/display:\s*-webkit-box/);
+    expect(body).toMatch(/-webkit-box-orient:\s*vertical/);
+    expect(body).toMatch(/-webkit-line-clamp:\s*2/);
+    // The standard property alongside the prefixed one, so the clamp survives
+    // an engine that drops the -webkit- alias.
+    expect(body).toMatch(/[^-]line-clamp:\s*2/);
+    expect(body).toMatch(/overflow:\s*hidden/);
+  });
+
+  it("still reserves the tagline's space so short taglines don't shrink a card", () => {
+    expect(tagline()).toMatch(/min-height:/);
+  });
+
+  it("bottoms out the actions row so every Use button shares a baseline", () => {
+    expect(actions()).toMatch(/margin-top:\s*auto/);
+  });
+});
+
+describe("Defect 2 — the empty stage is a hero, not an error state", () => {
+  const emptyStage = () => ruleBody(".voice-stage.voice-stage-empty");
+
+  it("drops the dashed outline and the grey fill that read as 'disabled'", () => {
+    const body = emptyStage();
+    expect(body).not.toMatch(/dashed/);
+    expect(body).not.toMatch(/background:\s*#f4f4f2/i);
+  });
+
+  it("keeps a stage-shaped gradient rather than a flat box", () => {
+    expect(emptyStage()).toMatch(/background:\s*linear-gradient/);
+  });
+
+  it("holds the same room as a real stage, so switching hosts doesn't jump", () => {
+    expect(ruleBody(".voice-stage")).toMatch(/min-height:/);
+  });
+
+  it("sets the headline at name size and the note at tagline size", () => {
+    expect(fontSizePx(ruleBody(".voice-stage-empty-title"))).toBe(
+      fontSizePx(ruleBody(".voice-stage-name"))
+    );
+    expect(fontSizePx(ruleBody(".voice-stage-empty-note"))).toBe(
+      fontSizePx(ruleBody(".voice-stage-tagline"))
+    );
+  });
+});
+
+describe("Defect 3 — the shelf heading leads, the blurb recedes", () => {
+  it("does not let the blurb out-size the heading", () => {
+    expect(fontSizePx(ruleBody(".voice-shelf-title"))).toBeGreaterThan(
+      fontSizePx(ruleBody(".voice-shelf-blurb"))
+    );
+  });
+
+  it("keeps the heading darker than the blurb", () => {
+    expect(luminance(ruleBody(".voice-shelf-title"))).toBeLessThan(
+      luminance(ruleBody(".voice-shelf-blurb"))
+    );
+  });
+});

--- a/test/settings/tabs/voices-studio-layout.spec.ts
+++ b/test/settings/tabs/voices-studio-layout.spec.ts
@@ -37,13 +37,32 @@ const fontSizePx = (body: string): number => {
   return Number(m![1]);
 };
 
-/** Relative brightness of a #rrggbb literal — lower is darker (leads). */
-function luminance(body: string): number {
+/** The `color:` literal of a rule (not `background-color:` etc.). */
+function colorOf(body: string): string {
   const m = /(?:^|[^-])color:\s*(#[0-9a-f]{6})/i.exec(body);
   expect(m, "rule should declare a hex color").toBeTruthy();
-  const hex = m![1];
+  return m![1];
+}
+
+/** Relative brightness of a #rrggbb literal — lower is darker (leads). */
+function luminance(body: string): number {
+  const hex = colorOf(body);
   const [r, g, b] = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG 2.x relative luminance (gamma-corrected), unlike the raw brightness above. */
+function wcagLuminance(hex: string): number {
+  const [r, g, b] = [1, 3, 5]
+    .map((i) => parseInt(hex.slice(i, i + 2), 16) / 255)
+    .map((c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG contrast ratio between two #rrggbb literals. */
+function contrast(fg: string, bg: string): number {
+  const [hi, lo] = [wcagLuminance(fg), wcagLuminance(bg)].sort((a, b) => b - a);
+  return (hi + 0.05) / (lo + 0.05);
 }
 
 describe("Defect 1 — voice cards must not go ragged", () => {
@@ -110,6 +129,37 @@ describe("Defect 3 — the shelf heading leads, the blurb recedes", () => {
   it("keeps the heading darker than the blurb", () => {
     expect(luminance(ruleBody(".voice-shelf-title"))).toBeLessThan(
       luminance(ruleBody(".voice-shelf-blurb"))
+    );
+  });
+
+  // "Recedes" is a hierarchy instruction, not a licence to go unreadable: the
+  // blurb is the ONLY place the studio states what HD costs, and it sits on the
+  // white .user-preference-item card (src/popup/tabs.css). At 11px it is normal
+  // text for WCAG, so AA is 4.5:1 — the hierarchy has to come from the heading
+  // getting darker, not the blurb getting paler.
+  it("keeps the blurb readable (WCAG AA) on the card it sits on", () => {
+    expect(
+      contrast(colorOf(ruleBody(".voice-shelf-blurb")), "#ffffff")
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("keeps the heading on one line so it can lead", () => {
+    // The head is a flex row; without this the TITLE is what gives when the
+    // pair overflows, stacking "EVERYDAY / VOICES" beside a two-line blurb.
+    expect(ruleBody(".voice-shelf-title")).toMatch(/flex-shrink:\s*0/);
+  });
+});
+
+describe("Defect 4 — the studio gets the column it is sized for", () => {
+  // settingsWindowSize.ts grows the settings window to 1120px for this tab so
+  // the studio can use a wide column, and #voice-studio asks for up to 900px —
+  // but its parent .user-preference-item carries the form-tab 504px cap from
+  // src/popup/tabs.css, so the studio never got past ~472px. #tab-voices was
+  // already uncapped one level up; this is the level that was missed.
+  it("uncaps the Voices preference card, not just the tab panel", () => {
+    expect(ruleBody("#tab-voices.tab-panel")).toMatch(/max-width:\s*none/);
+    expect(ruleBody("#voices-preference.user-preference-item")).toMatch(
+      /max-width:\s*none/
     );
   });
 });


### PR DESCRIPTION
Four defects on the settings Voices tab, found while reviewing the extended-voices UX end to end.

## The empty stage was the page's worst state — and the one new users see

`renderStage` early-returned a grey dashed box reading *"No voice selected yet — pick one below."* It occupied the hero, the largest element on the page, to report that nothing had happened.

It was also not true, and it was differently untrue per host. Tracing what actually happens with no SayPi voice selected:

- **Pi** keeps reading replies aloud in its own native voice — `getActiveAudioProvider` falls through to `audioProviders.Pi`, and during a call SayPi actively turns Pi's auto-read *on*. The user is not in silence; they just aren't hearing one of ours.
- **Claude** is completely silent — `getDefaultForChatbot("claude")` returns SayPi, which downgrades to `None` with no voice, and there is no fallback engine. Nothing reads anything.

So the stage now recruits instead of reporting, and tells the truth for the host in scope: *"Choose how Pi sounds — Pi uses its own voice until you pick one below."* vs *"Choose how Claude sounds — Claude won't read replies aloud until you pick one below."* It keeps the full stage height so switching hosts doesn't collapse the page.

## The tier copy stated one fact twice, from both ends

"HD voices use your monthly allowance about 20× faster" sat above "Great quality — your monthly allowance lasts about 20× longer." One ratio, said twice inverted, leaving the reader to notice it was the same fact — and leading the premium tier with a penalty.

Now it is stated once, on the tier where it reads as a benefit: **HD voices** / "Our richest, most expressive sound." and **Everyday voices** / "Natural and clear — you can listen about 20× longer than with HD."

We checked whether this could be denominated in minutes of speech instead of an abstract allowance. It can't, honestly: TTS quota is in credits, and `chars_per_minute` is null for all 22 voices and read by nothing. Rather than invent a number, the copy stays in the unit we can defend.

## Cards went ragged whenever one voice had a long description

`.voice-card-tagline` set `min-height: 2.7em` with no clamp and `.voice-card-actions` had no `margin-top: auto`, so a voice falling back to a long server `description` stretched its grid row and stranded every sibling's `Use` button mid-card. Taglines now clamp to two lines and the action row is pushed to the bottom, so a row of cards shares one button baseline regardless of subtitle length.

Also uncapped `#voices-preference.user-preference-item`, which was holding the studio at 472px inside the 940px column this tab already grows the window for — the reason the shelf heads ran out of room. Scoped to that one card, and deliberately *not* a per-tab column width rule, which is the #582/#583 regression class.

## Twin "Paola" cards were described in non-parallel registers

Two voices share the name Paola on Pi. `subtitleFor` handed one the raw server description and the other "Speaks 33 languages", so the reader had no way to compare them. Duplicate-named voices now pick a strategy: parallel language counts when those differ ("Speaks 33 languages" / "Speaks 74 languages"), descriptions otherwise. Generalises to any future duplicate pair, since the catalog is server-driven.

## Testing

Fail-first per the repo protocol. New `voices-studio-copy.spec.ts` and `voices-studio-layout.spec.ts` (23 tests) plus 313 lines added to the controller spec. Gate green: `tsc --noEmit`, 2266 vitest, jest, `i18n-validate`.

New keys are English-only pending a founder `translate` run; other locales fall back to `en`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5tQbn1thvBTD3eM3bUAMc