### PR TITLE
Surface API error detail instead of discarding it

### DIFF
--- a/src/ApiError.ts
+++ b/src/ApiError.ts
@@ -1,0 +1,137 @@
+/**
+ * Structured errors from the Say, Pi API.
+ *
+ * The API answers a failed request with a JSON body describing what happened:
+ *
+ *   { "detail": { "error": "rate_limited",
+ *                 "message": "Too many transcription requests; retry after 30 seconds.",
+ *                 "retry_after_seconds": 30 } }
+ *
+ * Until now the client discarded all of it — every non-2xx became
+ * `throw new Error("HTTP 429: Too Many Requests")`, so the server's own
+ * explanation never reached the user and `Retry-After` was never honoured. A
+ * user whose request was refused saw dictation stop working with no reason
+ * given, and the client retried immediately, which is the worst possible
+ * response to being told to slow down.
+ *
+ * `ApiError` keeps that detail so callers can react to *why* a request failed
+ * rather than only that it did.
+ */
+
+/** Machine-readable error codes the API is known to send. */
+export type ApiErrorCode =
+  | "forbidden"
+  | "rate_limited"
+  | "payload_too_large"
+  | "transcription_timeout"
+  | "unknown";
+
+export class ApiError extends Error {
+  public readonly status: number;
+  public readonly code: ApiErrorCode;
+  /** Human-readable text from the server, safe to show to the user. */
+  public readonly detail: string | null;
+  /** Seconds to wait before retrying, from the body or the Retry-After header. */
+  public readonly retryAfterSeconds: number | null;
+
+  constructor(
+    status: number,
+    statusText: string,
+    code: ApiErrorCode = "unknown",
+    detail: string | null = null,
+    retryAfterSeconds: number | null = null,
+  ) {
+    super(detail ? `HTTP ${status}: ${detail}` : `HTTP ${status}: ${statusText}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+    this.detail = detail;
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+
+  /** Whether retrying this exact request could plausibly succeed later. */
+  public get isRetryable(): boolean {
+    return this.status === 429 || this.status >= 500;
+  }
+
+  /**
+   * Whether signing in is the remedy.
+   *
+   * Free usage is available without an account, so a limit reached while
+   * anonymous is resolved by signing in rather than by waiting.
+   */
+  public get isResolvedBySigningIn(): boolean {
+    return this.status === 429 || this.status === 403;
+  }
+}
+
+const KNOWN_CODES: ReadonlySet<string> = new Set([
+  "forbidden",
+  "rate_limited",
+  "payload_too_large",
+  "transcription_timeout",
+]);
+
+function parseRetryAfterHeader(value: string | null): number | null {
+  if (!value) return null;
+  // RFC 9110 allows either delta-seconds or an HTTP-date.
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds);
+  const date = Date.parse(value);
+  if (Number.isNaN(date)) return null;
+  return Math.max(0, Math.ceil((date - Date.now()) / 1000));
+}
+
+/**
+ * Build an {@link ApiError} from a failed response, reading the body when it
+ * has one.
+ *
+ * Never throws and never rejects: a malformed or absent body degrades to the
+ * status line, which is exactly what the caller used to get. Consuming the body
+ * is safe here because the caller has already established `!response.ok` and
+ * will not read it again.
+ */
+export async function apiErrorFromResponse(response: Response): Promise<ApiError> {
+  let retryAfterHeader: number | null = null;
+  try {
+    retryAfterHeader = parseRetryAfterHeader(
+      response.headers?.get?.("Retry-After") ?? null,
+    );
+  } catch {
+    // A header accessor that throws must not cost us the whole error object.
+  }
+
+  let code: ApiErrorCode = "unknown";
+  let detail: string | null = null;
+  let retryAfterBody: number | null = null;
+
+  try {
+    const body = await response.json();
+    // FastAPI nests our payload under `detail`; a plain string detail is what
+    // its own default handlers produce, so both shapes are accepted.
+    const payload = body?.detail ?? body;
+    if (typeof payload === "string") {
+      detail = payload;
+    } else if (payload && typeof payload === "object") {
+      if (typeof payload.error === "string" && KNOWN_CODES.has(payload.error)) {
+        code = payload.error as ApiErrorCode;
+      }
+      if (typeof payload.message === "string") {
+        detail = payload.message;
+      }
+      if (typeof payload.retry_after_seconds === "number") {
+        retryAfterBody = payload.retry_after_seconds;
+      }
+    }
+  } catch {
+    // No body, not JSON, or already consumed — the status line still stands.
+  }
+
+  return new ApiError(
+    response.status,
+    response.statusText,
+    code,
+    detail,
+    retryAfterBody ?? retryAfterHeader,
+  );
+}

--- a/src/TranscriptionModule.ts
+++ b/src/TranscriptionModule.ts
@@ -1,6 +1,7 @@
 import { config } from "./ConfigModule.js";
 import StateMachineService from "./StateMachineService.js";
 import { logger } from "./LoggingModule.js";
+import { ApiError, apiErrorFromResponse } from "./ApiError";
 import { UserPreferenceModule } from "./prefs/PreferenceModule";
 import { callApi } from "./ApiClient";
 import EventBus from "./events/EventBus";
@@ -516,7 +517,7 @@ async function uploadAudioForRefinementInternal(
     );
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      throw await apiErrorFromResponse(response);
     }
 
     const responseJson = await response.json();
@@ -640,7 +641,7 @@ async function uploadAudio(
     );
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      throw await apiErrorFromResponse(response);
     }
 
     emitTranscriptionServerTiming(response);
@@ -698,7 +699,21 @@ async function uploadAudio(
       // no need to emit transcription:received event here, it's handled by transcriptionReceived function
     }
   } catch (error: unknown) {
-    if (error instanceof Error) {
+    if (error instanceof ApiError) {
+      // The server told us why it refused. Log its reason rather than a bare
+      // status code, and where signing in is the remedy, prompt for it instead
+      // of leaving the user with dictation that silently stopped working.
+      logger.error(
+        `Transcription refused (${error.status} ${error.code}): ` +
+          `${error.detail ?? "no detail given"}` +
+          (error.retryAfterSeconds !== null
+            ? ` — retry after ${error.retryAfterSeconds}s`
+            : ""),
+      );
+      if (error.isResolvedBySigningIn) {
+        void promptSignInAfterRefusal();
+      }
+    } else if (error instanceof Error) {
       if (error.name === "AbortError") {
         logger.error("Fetch aborted due to timeout", error);
       } else {
@@ -710,6 +725,27 @@ async function uploadAudio(
 
     // re-throw the error if your logic requires it
     throw error;
+  }
+}
+
+/**
+ * Offer sign-in after the server refuses a request in a way an account fixes.
+ *
+ * Free usage works without an account, so the useful response to being refused
+ * is "sign in", not "wait" — and saying nothing at all is the worst option,
+ * since dictation just appears to stop working. Only ever a prompt: it never
+ * blocks, and a failure to show it must not mask the original error.
+ */
+async function promptSignInAfterRefusal(): Promise<void> {
+  try {
+    const { getJwtManagerSync } = await import("./JwtManager");
+    if (getJwtManagerSync().isAuthenticated()) {
+      return; // Already signed in — signing in again is not the remedy.
+    }
+    const { getAuthPromptController } = await import("./auth/AuthPromptController");
+    await getAuthPromptController().forceShowPrompt("soft-modal");
+  } catch (promptError) {
+    logger.debug("Could not surface the sign-in prompt", promptError);
   }
 }
 

--- a/test/ApiError.spec.ts
+++ b/test/ApiError.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { ApiError, apiErrorFromResponse } from "../src/ApiError";
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 429 ? "Too Many Requests" : "Error",
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+describe("apiErrorFromResponse", () => {
+  it("reads the server's own explanation instead of discarding it", async () => {
+    const error = await apiErrorFromResponse(
+      jsonResponse(429, {
+        detail: {
+          error: "rate_limited",
+          message: "Too many transcription requests; retry after 30 seconds.",
+          retry_after_seconds: 30,
+        },
+      }),
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(429);
+    expect(error.code).toBe("rate_limited");
+    expect(error.detail).toBe(
+      "Too many transcription requests; retry after 30 seconds.",
+    );
+    expect(error.retryAfterSeconds).toBe(30);
+  });
+
+  it("falls back to the Retry-After header when the body has no hint", async () => {
+    const error = await apiErrorFromResponse(
+      jsonResponse(429, { detail: { error: "rate_limited" } }, { "Retry-After": "45" }),
+    );
+    expect(error.retryAfterSeconds).toBe(45);
+  });
+
+  it("prefers the body's value over the header when both are present", async () => {
+    const error = await apiErrorFromResponse(
+      jsonResponse(
+        429,
+        { detail: { error: "rate_limited", retry_after_seconds: 30 } },
+        { "Retry-After": "999" },
+      ),
+    );
+    expect(error.retryAfterSeconds).toBe(30);
+  });
+
+  it("accepts an HTTP-date Retry-After", async () => {
+    const future = new Date(Date.now() + 60_000).toUTCString();
+    const error = await apiErrorFromResponse(
+      jsonResponse(429, {}, { "Retry-After": future }),
+    );
+    expect(error.retryAfterSeconds).toBeGreaterThan(50);
+    expect(error.retryAfterSeconds).toBeLessThanOrEqual(60);
+  });
+
+  it("handles a plain-string detail (FastAPI's own default shape)", async () => {
+    const error = await apiErrorFromResponse(jsonResponse(404, { detail: "Not found" }));
+    expect(error.detail).toBe("Not found");
+    expect(error.code).toBe("unknown");
+  });
+
+  it("degrades to the status line when the body is not JSON", async () => {
+    const response = new Response("<html>502</html>", {
+      status: 502,
+      statusText: "Bad Gateway",
+    });
+    const error = await apiErrorFromResponse(response);
+    expect(error.status).toBe(502);
+    expect(error.detail).toBeNull();
+    expect(error.message).toBe("HTTP 502: Bad Gateway");
+  });
+
+  it("degrades gracefully when there is no body at all", async () => {
+    const error = await apiErrorFromResponse(new Response(null, { status: 403 }));
+    expect(error.status).toBe(403);
+    expect(error.code).toBe("unknown");
+  });
+
+  it("ignores an unrecognised error code rather than trusting it", async () => {
+    const error = await apiErrorFromResponse(
+      jsonResponse(400, { detail: { error: "something_new_we_do_not_know" } }),
+    );
+    expect(error.code).toBe("unknown");
+  });
+
+  it("never throws, whatever the response looks like", async () => {
+    const hostile = {
+      status: 500,
+      statusText: "Server Error",
+      headers: {
+        get() {
+          throw new Error("boom");
+        },
+      },
+      json() {
+        throw new Error("boom");
+      },
+    } as unknown as Response;
+    await expect(apiErrorFromResponse(hostile)).resolves.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("ApiError classification", () => {
+  it("treats 429 and 5xx as retryable", () => {
+    expect(new ApiError(429, "Too Many Requests").isRetryable).toBe(true);
+    expect(new ApiError(503, "Unavailable").isRetryable).toBe(true);
+  });
+
+  it("does not treat a 413 as retryable — the same body will fail again", () => {
+    expect(new ApiError(413, "Payload Too Large").isRetryable).toBe(false);
+  });
+
+  it("flags the statuses where signing in is the remedy", () => {
+    expect(new ApiError(429, "Too Many Requests").isResolvedBySigningIn).toBe(true);
+    expect(new ApiError(403, "Forbidden").isResolvedBySigningIn).toBe(true);
+    expect(new ApiError(500, "Server Error").isResolvedBySigningIn).toBe(false);
+  });
+
+  it("puts the server's message in the thrown Error message when present", () => {
+    const error = new ApiError(429, "Too Many Requests", "rate_limited", "Slow down.");
+    expect(error.message).toBe("HTTP 429: Slow down.");
+  });
+});


### PR DESCRIPTION
## The problem

Every non-2xx response from `/transcribe` became:

```ts
throw new Error(`HTTP ${response.status}: ${response.statusText}`);
```

The API answers a refused request with a body explaining what happened, and
where relevant how long to wait:

```json
{ "detail": { "error": "rate_limited",
              "message": "Too many transcription requests; retry after 30 seconds.",
              "retry_after_seconds": 30 } }
```

None of it reached anyone. The body was never read, `Retry-After` is referenced
nowhere in `TranscriptionModule.ts`, and the catch block logs a console line and
re-throws. So a user whose request is refused sees dictation stop working with
no reason given — and the client immediately retries, which is the worst
possible response to being told to slow down.

## The change

`ApiError` (new, `src/ApiError.ts`) keeps the status, a machine-readable code,
the server's own message, and the retry hint — taken from the body, falling back
to the `Retry-After` header, accepting either delta-seconds or an HTTP-date per
RFC 9110. Both throw sites in `TranscriptionModule.ts` now produce one.

Callers can react to *why* a request failed rather than only that it did.
`isRetryable` distinguishes 429/5xx from a 413, where retrying the same body
will fail identically.

Where signing in is the remedy, the existing soft-modal auth prompt is offered.
Free usage works without an account, so being refused is resolved by signing in
rather than by waiting, and saying nothing at all is the worst of the options.
It is only ever a prompt: it never blocks, it is skipped when the user is
already authenticated, and a failure to show it cannot mask the original error.

## Robustness

Parsing is total by construction — a missing body, a non-JSON body (an HTML 502
from an edge, say), an unrecognised error code, or even a `headers.get()` that
throws all degrade to the status line, which is exactly what callers received
before. There is a test for each; the last of those caught a real bug in the
first draft, where the header read sat outside the try block.

## Verification

`npx vitest run`: 228 files, 2274 passed, 1 skipped. `tsc --noEmit` clean.
13 new tests in `test/ApiError.spec.ts`.

## Release note

Nothing in this PR changes what the client sends, only what it does with what it
gets back. No new permissions, no manifest change.