### PR TITLE
fix(audio): make the removal observer see the audio element it watches

### DIFF
--- a/src/audio/AudioModule.js
+++ b/src/audio/AudioModule.js
@@ -14,6 +14,7 @@ import { ttsVolumeForQuietMode } from "../tts/quietVolume.ts";
 import { ChatbotService } from "../chatbots/ChatbotService.ts";
 import OffscreenAudioBridge from "./OffscreenAudioBridge.js";
 import { BrowserCompatibilityModule } from "../compat/BrowserCompatibilityModule.ts";
+import { createAudioRemovalObserverCallback } from "./audioElementRemoval.ts";
 
 const INITIAL_PLAYBACK_BUFFER_TIMEOUT_MS = 5000;
 
@@ -279,22 +280,20 @@ export default class AudioModule {
     if (this.audioElement) {
       const config = { childList: true, subtree: false };
 
-      this.mutationObserver = new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-          if (mutation.type === "childList") {
-            for (const removedNode of mutation.removedNodes) {
-              const removedAudioElement = this.findAudioElement(removedNode);
-              if (removedAudioElement && removedAudioElement === this.audioElement) {
-                logger.debug("Audio element removed from the document");
-                this.cleanupAudioElement(this.audioElement);
-                this.audioElement = null;
-                this.listenForAudioElementSwap();
-                return;
-              }
-            }
+      // re-registered on every swap; don't leave the previous observer attached
+      this.mutationObserver?.disconnect();
+
+      this.mutationObserver = new MutationObserver(
+        createAudioRemovalObserverCallback(
+          () => this.audioElement,
+          () => {
+            logger.debug("Audio element removed from the document");
+            this.cleanupAudioElement(this.audioElement);
+            this.audioElement = null;
+            this.listenForAudioElementSwap();
           }
-        }
-      });
+        )
+      );
 
       // Use optional chaining and nullish coalescing for safer access
       const observeTarget = this.audioElement.parentNode ?? document.body;

--- a/src/audio/audioElementRemoval.ts
+++ b/src/audio/audioElementRemoval.ts
@@ -1,0 +1,58 @@
+/**
+ * Removal-detection logic for AudioModule's audio-element MutationObserver.
+ *
+ * Extracted from AudioModule.js because that module can't be imported by a test
+ * (its constructor drags in the whole content-script bootstrap), and this
+ * callback is exactly where two defects lived: it crashed on non-element
+ * removed nodes (#589) and never matched the audio element itself (#590).
+ */
+
+/**
+ * Whether `removedNode` is, or contains, the tracked audio element.
+ *
+ * `Node.contains()` is self-inclusive, so this covers both the direct-removal
+ * case the observer is scoped to report (`subtree: false` → `removedNodes`
+ * holds direct children of the observed parent) and the ancestor-container
+ * case. It is defined on every Node, so text and comment nodes answer `false`
+ * rather than throwing.
+ */
+export function removesAudioElement(
+  removedNode: Node | null | undefined,
+  audioElement: Node | null | undefined
+): boolean {
+  if (!removedNode || !audioElement) {
+    return false;
+  }
+  return (
+    typeof removedNode.contains === "function" &&
+    removedNode.contains(audioElement)
+  );
+}
+
+/**
+ * Builds the MutationObserver callback that watches for the tracked audio
+ * element being removed from its parent.
+ *
+ * @param getAudioElement reads the element currently tracked by AudioModule —
+ *   a getter, not a value, because AudioModule reassigns `this.audioElement`.
+ * @param onRemoved invoked once per batch when that element was removed.
+ */
+export function createAudioRemovalObserverCallback(
+  getAudioElement: () => Node | null | undefined,
+  onRemoved: () => void
+): MutationCallback {
+  return (mutations: MutationRecord[]) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== "childList") {
+        continue;
+      }
+      const audioElement = getAudioElement();
+      for (const removedNode of mutation.removedNodes) {
+        if (removesAudioElement(removedNode, audioElement)) {
+          onRemoved();
+          return;
+        }
+      }
+    }
+  };
+}

--- a/test/audio/audioElementRemoval.spec.ts
+++ b/test/audio/audioElementRemoval.spec.ts
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  removesAudioElement,
+  createAudioRemovalObserverCallback,
+} from "../../src/audio/audioElementRemoval";
+
+/**
+ * Regression tests for AudioModule's removal observer:
+ *  - #589: a removed text/comment node crashed the callback
+ *          (`searchRoot.querySelector is not a function`), aborting the rest of
+ *          the batch — fired on any non-chatbot page via the universal script.
+ *  - #590: the audio element's own removal went undetected, because the old
+ *          `querySelector` probe matches descendants only — and `subtree:false`
+ *          means the audio element itself is the node reported.
+ *
+ * The observer is driven with REAL MutationRecords from a real MutationObserver
+ * so the `removedNodes` lists are the ones the browser would deliver.
+ */
+
+/** Runs `mutate()` under an observer and returns the delivered records. */
+async function recordMutations(
+  target: Node,
+  mutate: () => void
+): Promise<MutationRecord[]> {
+  const records: MutationRecord[] = [];
+  const observer = new MutationObserver((mutations) =>
+    records.push(...mutations)
+  );
+  observer.observe(target, { childList: true, subtree: false });
+  mutate();
+  // takeRecords() drains synchronously, avoiding a microtask race
+  records.push(...observer.takeRecords());
+  observer.disconnect();
+  return records;
+}
+
+function makeAudioElement(parent: HTMLElement): HTMLAudioElement {
+  const audio = document.createElement("audio");
+  audio.id = "saypi-audio-main";
+  parent.appendChild(audio);
+  return audio;
+}
+
+describe("removesAudioElement", () => {
+  it("matches the audio element itself (#590)", () => {
+    const audio = makeAudioElement(document.body);
+    expect(removesAudioElement(audio, audio)).toBe(true);
+  });
+
+  it("matches a removed ancestor container of the audio element", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const audio = makeAudioElement(container);
+    expect(removesAudioElement(container, audio)).toBe(true);
+  });
+
+  it("ignores non-element nodes without throwing (#589)", () => {
+    const audio = makeAudioElement(document.body);
+    const text = document.createTextNode("hello");
+    const comment = document.createComment("hi");
+    expect(() => removesAudioElement(text, audio)).not.toThrow();
+    expect(removesAudioElement(text, audio)).toBe(false);
+    expect(removesAudioElement(comment, audio)).toBe(false);
+  });
+
+  it("ignores an unrelated audio element", () => {
+    const tracked = makeAudioElement(document.body);
+    const other = document.createElement("audio");
+    document.body.appendChild(other);
+    expect(removesAudioElement(other, tracked)).toBe(false);
+  });
+
+  it("is false when nothing is tracked", () => {
+    const audio = makeAudioElement(document.body);
+    expect(removesAudioElement(audio, null)).toBe(false);
+  });
+});
+
+describe("createAudioRemovalObserverCallback", () => {
+  it("fires when the tracked audio element is removed from its parent (#590)", async () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const audio = makeAudioElement(parent);
+
+    const onRemoved = vi.fn();
+    const callback = createAudioRemovalObserverCallback(() => audio, onRemoved);
+
+    const records = await recordMutations(parent, () => audio.remove());
+    callback(records, {} as MutationObserver);
+
+    expect(onRemoved).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires when a container holding the audio element is removed", async () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const container = document.createElement("div");
+    parent.appendChild(container);
+    const audio = makeAudioElement(container);
+
+    const onRemoved = vi.fn();
+    const callback = createAudioRemovalObserverCallback(() => audio, onRemoved);
+
+    const records = await recordMutations(parent, () => container.remove());
+    callback(records, {} as MutationObserver);
+
+    expect(onRemoved).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw on removed text/comment nodes, and still sees a later audio removal in the same batch (#589)", async () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const text = parent.appendChild(document.createTextNode("hello"));
+    const comment = parent.appendChild(document.createComment("hi"));
+    const audio = makeAudioElement(parent);
+
+    const onRemoved = vi.fn();
+    const callback = createAudioRemovalObserverCallback(() => audio, onRemoved);
+
+    const records = await recordMutations(parent, () => {
+      // an SPA re-render: text/comment nodes go first, the audio element after
+      text.remove();
+      comment.remove();
+      audio.remove();
+    });
+
+    expect(() => callback(records, {} as MutationObserver)).not.toThrow();
+    expect(onRemoved).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet when unrelated siblings are removed", async () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const sibling = parent.appendChild(document.createElement("div"));
+    const audio = makeAudioElement(parent);
+
+    const onRemoved = vi.fn();
+    const callback = createAudioRemovalObserverCallback(() => audio, onRemoved);
+
+    const records = await recordMutations(parent, () => sibling.remove());
+    callback(records, {} as MutationObserver);
+
+    expect(onRemoved).not.toHaveBeenCalled();
+  });
+
+  it("reads the tracked element through the getter, not a snapshot", async () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const first = makeAudioElement(parent);
+    const second = makeAudioElement(parent);
+
+    let tracked: HTMLAudioElement = first;
+    const onRemoved = vi.fn();
+    const callback = createAudioRemovalObserverCallback(
+      () => tracked,
+      onRemoved
+    );
+
+    tracked = second;
+    const records = await recordMutations(parent, () => second.remove());
+    callback(records, {} as MutationObserver);
+
+    expect(onRemoved).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Wiring guard: AudioModule.js can't be imported by a test (its constructor
+ * pulls in the content-script bootstrap), so — following the repo's
+ * source-scanning guards (AudioModulePreviewWiring.spec.ts) — assert the
+ * observer still routes through the extracted callback and still performs the
+ * cleanup the acceptance criteria call for.
+ */
+describe("AudioModule removal-observer wiring", () => {
+  const source = readFileSync(
+    resolve(__dirname, "..", "..", "src/audio/AudioModule.js"),
+    "utf8"
+  );
+
+  it("builds its removal observer from createAudioRemovalObserverCallback", () => {
+    expect(source).toMatch(
+      /new MutationObserver\(\s*createAudioRemovalObserverCallback\(/
+    );
+  });
+
+  it("releases the audio element and arms the swap listener on removal", () => {
+    const handler = source.match(
+      /createAudioRemovalObserverCallback\([\s\S]*?\n {6}\);/
+    )?.[0];
+    expect(handler).toBeDefined();
+    expect(handler).toMatch(/this\.cleanupAudioElement\(this\.audioElement\)/);
+    expect(handler).toMatch(/this\.audioElement = null/);
+    expect(handler).toMatch(/this\.listenForAudioElementSwap\(\)/);
+  });
+});


### PR DESCRIPTION
Fixes #589, fixes #590 — two defects in the same six lines of `AudioModule.registerRemovalListener()`.

## What was wrong

The observer tested each removed node with `findAudioElement(removedNode)` — a `querySelector` probe. That's wrong twice over for the nodes this observer actually gets:

- **`querySelector` matches descendants only (#590).** The observer runs with `subtree: false`, so `removedNodes` holds *direct children* of the observed parent — meaning the audio element's own removal, the case the listener exists for, arrives as the node itself and never matched. `this.audioElement` stayed pointing at a detached node, `cleanupAudioElement()` never ran, and `listenForAudioElementSwap()` was never armed. Only the rarer ancestor-container removal ever fired.
- **`querySelector` doesn't exist on text or comment nodes (#589).** Any non-element removed node threw `TypeError: searchRoot.querySelector is not a function` out of the callback, aborting the remaining `removedNodes` in that batch. That matters most off the chatbot hosts: the universal content script injects into every other http(s) page and `findAndDecorateAudioElement()` appends a synthetic `<audio>` to `document.body`, so the observed parent is usually `document.body` itself and any SPA re-render trips it. Observed live on `saypi.ai/app/admin/usage`.

## The fix

`Node.contains()` answers both questions at once — it's self-inclusive (covers direct removal *and* the ancestor case) and it's defined on every `Node` (text/comment nodes answer `false` instead of throwing). It's also a tighter test than the old one: it asks "was *my* element removed", rather than "does this subtree contain some audio element that happens to be mine".

The logic moved to `src/audio/audioElementRemoval.ts` because `AudioModule.js` can't be imported by a test — its constructor drags in the whole content-script bootstrap — and this callback had earned a regression test.

While in there: `registerRemovalListener()` runs again on every swap and was leaving the previous `MutationObserver` attached each time. It now disconnects first.

## Fail-first evidence

Per the repo's TDD protocol, the spec was run against the pre-fix logic (the old `querySelector` body, dropped into the new module) before the fix went in:

```
× removesAudioElement > matches the audio element itself (#590)
  → expected false to be true
× removesAudioElement > ignores non-element nodes without throwing (#589)
  → 'TypeError: removedNode.querySelector is not a function' was thrown
× createAudioRemovalObserverCallback > fires when the tracked audio element is removed from its parent (#590)
  → expected "spy" to be called 1 times, but got 0 times
× createAudioRemovalObserverCallback > does not throw on removed text/comment nodes, and still sees a later audio removal in the same batch (#589)
  → 'TypeError: removedNode.querySelector is not a function' was thrown
```

Same `TypeError` string the issue captured from the live console. After the fix: 12/12 pass, and `npm test` is green (typecheck + Jest + Vitest, 2286 tests).

## Testing notes

The observer spec drives the callback with **real `MutationRecord`s** from a real `MutationObserver` (via `takeRecords()`), not hand-built fakes — so the `removedNodes` lists are the ones a browser would deliver, including the mixed text/comment/element batch from #589. The two `AudioModule.js` behaviours the acceptance criteria name — releasing `this.audioElement` and arming the swap listener — are covered by a source-scan guard, following `AudioModulePreviewWiring.spec.ts`, since that module resists import.

Layer 1/2 was enough here: pure logic, reproducible in a controlled DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWWR2pCFiYpZ3cEV7TumDq