### PR TITLE
fix(callbutton): make the call button's presence a maintained invariant (#593)

### DIFF
--- a/src/buttons/CallButton.ts
+++ b/src/buttons/CallButton.ts
@@ -325,23 +325,40 @@ export class CallButton {
         button.classList.add(...this.chatbot.getExtraCallButtonClasses());
         this.element = button; // Store reference
 
+        // Attach FIRST, then render from state that is available synchronously.
+        // Only the button's LABEL depends on the user's nickname — the icon, the
+        // click handler and the element itself do not — so none of them waits on a
+        // chrome.storage round-trip to reach the DOM. Deferring the insert until
+        // after that await left a window in which a create was in flight while
+        // getElementById("saypi-callButton") still returned null (the guard every
+        // recovery path needs, and a duplicate-button trap for anything that used
+        // it), and a rejected lookup meant the button was never inserted at all
+        // and nobody heard about it (#593).
+        addChild(container, button, position);
+
         // Set initial state based on flag (could be true if module re-initializes during call)
         if (this.callIsActive) {
             this.callActive(button);
         } else {
-            await this.callInactive(button); // Await callInactive
+            // getName() is the same value getNickname() falls back to when no
+            // nickname is set, so for most users this label is already final.
+            this.renderInactive(button, this.chatbot.getName());
         }
-
-        addChild(container, button, position);
 
         // Tooltips (incl. this button's, which carries the `tooltip` class) are
         // handled globally by the body-level portal in src/ui/Tooltip.ts.
 
-        // Ensure segments drawn *after* initial SVG is added by callActive/callInactive
+        // Ensure segments drawn *after* initial SVG is added by callActive/renderInactive
         this.updateButtonSegments();
 
         if (this.callIsActive) {
             AnimationModule.startAnimation("glow");
+        } else {
+            // Refine the label with the stored nickname. The button is already live
+            // and usable; a failure here costs a personalised label, nothing more.
+            await this.callInactive(button).catch((error) => {
+                logger.debug("Could not read the nickname for the call button label", error);
+            });
         }
         return button;
     }
@@ -515,6 +532,15 @@ export class CallButton {
 
     async callInactive(button: HTMLButtonElement | null = this.element) { // Make async
         const nickname = await this.chatbot.getNickname(); // Await nickname
+        this.renderInactive(button, nickname);
+    }
+
+    /**
+     * The synchronous half of callInactive: everything that does not need the
+     * stored nickname. Split out so createButton can mount a complete, clickable
+     * button without waiting on storage (#593).
+     */
+    private renderInactive(button: HTMLButtonElement | null, nickname: string) {
         const label = getMessage("callNotStarted", nickname);
         this.updateCallButton(button, callIconSVG, label, () =>
                 this.sayPiActor.send({ type: "saypi:call" }),

--- a/src/chatbots/bootstrap.ts
+++ b/src/chatbots/bootstrap.ts
@@ -25,6 +25,15 @@ export class DOMObserver {
   // Bumped by every initial-decoration pass so an older pass's pending retries
   // stand down instead of racing the newer one (see startInitialDecoration).
   private decorationGeneration: number = 0;
+  // Ancestors already watched for submit-button re-renders. decoratePromptControls
+  // is re-runnable now (#593), and without this each re-run would stack another
+  // MutationObserver on the same row.
+  private submitButtonMonitoredAncestors = new WeakSet<HTMLElement>();
+  // Per-composer budget for call-button restore attempts, reset whenever the
+  // button is present, so repeated losses each get a fresh set of tries while a
+  // permanently-failing create can't spin once per mutation batch (#593).
+  private callButtonRestoreAttempts = new WeakMap<HTMLElement, number>();
+  private static readonly MAX_CALL_BUTTON_RESTORE_ATTEMPTS = 3;
   private domMutationCallback = (mutations: MutationRecord[]) => {
     // Skip decoration work entirely on non-chatable pages
     if (!this.shouldDecorateUI()) {
@@ -85,6 +94,10 @@ export class DOMObserver {
     // hosts whose getVoiceSettingsSelector is empty (ChatGPT) or doesn't match
     // (Claude).
     this.findAndDecorateVoiceSettings(document.body);
+    // A host re-render can drop the injected call button without touching the
+    // prompt, and no finder notices — the prompt still reports "already
+    // decorated". Re-assert the invariant once per batch (#593).
+    this.ensureCallButtonPresent();
   };
   constructor(private chatbot: Chatbot) {
     this.voiceMenuUiMgr = new VoiceMenuUIManager(
@@ -243,6 +256,10 @@ export class DOMObserver {
     // Pi's Voice settings page has no chat prompt, so it is scanned separately —
     // see the note on the same call in domMutationCallback.
     this.findAndDecorateVoiceSettings(document.body);
+    // The composer may have been decorated on a previous pass and since lost its
+    // button (#593) — a state no finder above can detect, and one that route entry
+    // is a natural moment to repair.
+    this.ensureCallButtonPresent();
     if (promptObs.isReady()) {
       EventBus.emit("saypi:ui:content-loaded");
       return;
@@ -331,6 +348,24 @@ export class DOMObserver {
   // Function to decorate the prompt input element, and other elements that depend on it
   decoratePrompt(prompt: HTMLElement): void {
     prompt.id = "saypi-prompt";
+    this.decoratePromptControls(prompt);
+
+    // Trigger agent mode notice if needed (async call, no need to await)
+    this.agentNoticeModule.showNoticeIfNeeded().catch(error => {
+      console.debug('Failed to show agent notice:', error);
+    });
+  }
+
+  /**
+   * Decorates the containers around an (already id'd) prompt and inserts the call
+   * button. Split out from decoratePrompt so the call button can be restored
+   * WITHOUT re-stamping the prompt: `id=saypi-prompt` makes every finder report
+   * "already decorated", so a composer that lost its button had no way back (#593).
+   *
+   * Idempotent — it re-uses an existing call button and an existing submit-button
+   * observer rather than adding a second one.
+   */
+  private decoratePromptControls(prompt: HTMLElement): void {
     const promptContainer = this.chatbot.getPromptContainer(prompt);
     if (promptContainer) {
       // Ensure ChatGPT does not get the SayPi control panel decorations (Phase 1)
@@ -349,17 +384,69 @@ export class DOMObserver {
       if (controlsContainer) {
         controlsContainer.id = "saypi-prompt-controls-container";
         const ancestor = this.addIdPromptAncestor(controlsContainer);
-        if (ancestor) this.monitorForSubmitButton(ancestor);
-        const submitButtonSearch = this.findSubmitButton(controlsContainer);
-        const insertionPosition = submitButtonSearch.found ? -1 : 0;
-        buttonModule.createCallButton(controlsContainer, insertionPosition);
+        if (ancestor && !this.submitButtonMonitoredAncestors.has(ancestor)) {
+          this.submitButtonMonitoredAncestors.add(ancestor);
+          this.monitorForSubmitButton(ancestor);
+        }
+        if (!document.getElementById("saypi-callButton")) {
+          const submitButtonSearch = this.findSubmitButton(controlsContainer);
+          const insertionPosition = submitButtonSearch.found ? -1 : 0;
+          // createButton attaches the element synchronously and only then awaits
+          // the nickname for its label (#593), so the guard above is truthful and
+          // this promise can only fail AFTER the button is in the DOM. Still, a
+          // rejection here must be heard rather than swallowed.
+          Promise.resolve(
+            buttonModule.createCallButton(controlsContainer, insertionPosition)
+          ).catch((error) => {
+            logger.error("Call button creation failed", error);
+          });
+        }
       }
     }
-    
-    // Trigger agent mode notice if needed (async call, no need to await)
-    this.agentNoticeModule.showNoticeIfNeeded().catch(error => {
-      console.debug('Failed to show agent notice:', error);
-    });
+  }
+
+  /**
+   * Enforces the invariant that a decorated composer on a chatable page has a call
+   * button. A host re-render can discard the injected button while REUSING the
+   * prompt element — which keeps `id=saypi-prompt`, so every finder reports
+   * "already decorated" and nothing else would ever put the button back (#593).
+   * Cheap enough to run once per mutation batch: two getElementById lookups and an
+   * early return in the overwhelmingly common case.
+   */
+  private ensureCallButtonPresent(): void {
+    if (!this.shouldDecorateUI()) {
+      return;
+    }
+    const prompt = document.getElementById("saypi-prompt");
+    if (document.getElementById("saypi-callButton")) {
+      // Healthy: clear the budget so a LATER loss gets a full set of attempts.
+      if (prompt) this.callButtonRestoreAttempts.delete(prompt);
+      return;
+    }
+    if (!prompt) {
+      // No decorated composer: the prompt paths above own this case.
+      return;
+    }
+    // Restoring is only worth retrying while it can still work. If creation is
+    // broken outright (no CallButton singleton, say) the button never appears, and
+    // without a bound this check would re-run creation on every mutation batch of
+    // a busy page forever.
+    const attempts = this.callButtonRestoreAttempts.get(prompt) ?? 0;
+    if (attempts >= DOMObserver.MAX_CALL_BUTTON_RESTORE_ATTEMPTS) {
+      return;
+    }
+    this.callButtonRestoreAttempts.set(prompt, attempts + 1);
+    logger.debug("Call button missing from a decorated composer — restoring it");
+    this.decoratePromptControls(prompt);
+    if (
+      !document.getElementById("saypi-callButton") &&
+      attempts + 1 >= DOMObserver.MAX_CALL_BUTTON_RESTORE_ATTEMPTS
+    ) {
+      logger.error(
+        "Could not restore the call button after " +
+          `${DOMObserver.MAX_CALL_BUTTON_RESTORE_ATTEMPTS} attempts; giving up on this composer`
+      );
+    }
   }
 
   /**

--- a/test/buttons/CallButton-synchronous-mount.spec.ts
+++ b/test/buttons/CallButton-synchronous-mount.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the heavy module-level dependencies so CallButton imports cleanly in jsdom.
+vi.mock("../../src/i18n", () => ({
+  default: (key: string, sub?: string) => (sub ? `${key}:${sub}` : key),
+}));
+vi.mock("../../src/AnimationModule", () => ({
+  default: { startAnimation: vi.fn(), stopAnimation: vi.fn() },
+}));
+vi.mock("../../src/StateMachineService", () => ({ default: { actor: null } }));
+vi.mock("../../src/buttons/GlowColorUpdater", () => ({
+  GlowColorUpdater: class {
+    updateGlowColor() {}
+  },
+}));
+
+import { CallButton } from "../../src/buttons/CallButton";
+
+/**
+ * #593 — the call button must be in the DOM before createButton yields.
+ *
+ * createButton used to `await this.callInactive(button)` — a chrome.storage
+ * round-trip for the user's nickname — BEFORE addChild(). That left a window in
+ * which a create was in flight but `document.getElementById("saypi-callButton")`
+ * still returned null, which is exactly the guard every recovery path wants to
+ * use. Worse, if the await rejected (e.g. "Extension context invalidated") the
+ * button was never inserted at all, and nobody was listening for the rejection.
+ *
+ * The nickname only refines the button's LABEL. The icon, the click handler and
+ * the element itself do not depend on it, so none of them should wait for it.
+ */
+function buildCallButton(overrides: Record<string, any> = {}) {
+  const cb: any = Object.create(CallButton.prototype);
+  cb.sayPiActor = { send: vi.fn() };
+  cb.segments = [];
+  cb.currentSegment = null;
+  cb.callIsActive = false;
+  cb.element = null;
+  cb.glowColorUpdater = { updateGlowColor: vi.fn() };
+  cb.chatbot = {
+    getName: () => "Pi",
+    getID: () => "pi",
+    getNickname: async () => "Pi",
+    getExtraCallButtonClasses: () => [],
+    ...overrides,
+  };
+  return cb;
+}
+
+describe("CallButton.createButton — synchronous mount (#593)", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  it("attaches the button before awaiting the nickname", () => {
+    // A nickname lookup that never settles — the pathological cold-start case.
+    const cb = buildCallButton({ getNickname: () => new Promise<string>(() => {}) });
+
+    void cb.createButton(container, 0);
+
+    // No awaits here on purpose: the button must be in the document already.
+    const button = document.getElementById("saypi-callButton");
+    expect(button).not.toBeNull();
+    expect(button!.isConnected).toBe(true);
+    expect(container.contains(button)).toBe(true);
+  });
+
+  it("is clickable before the nickname resolves", () => {
+    const cb = buildCallButton({ getNickname: () => new Promise<string>(() => {}) });
+
+    void cb.createButton(container, 0);
+
+    const button = document.getElementById("saypi-callButton") as HTMLButtonElement;
+    button.click();
+    expect(cb.sayPiActor.send).toHaveBeenCalledWith({ type: "saypi:call" });
+  });
+
+  it("refines the label once the nickname resolves", async () => {
+    let resolveNickname: (value: string) => void = () => {};
+    const cb = buildCallButton({
+      getNickname: () => new Promise<string>((resolve) => { resolveNickname = resolve; }),
+    });
+
+    const created = cb.createButton(container, 0);
+    const button = document.getElementById("saypi-callButton") as HTMLButtonElement;
+    expect(button.getAttribute("aria-label")).toBe("callNotStarted:Pi");
+
+    resolveNickname("Sunshine");
+    await created;
+    await Promise.resolve();
+
+    expect(button.getAttribute("aria-label")).toBe("callNotStarted:Sunshine");
+  });
+
+  it("leaves exactly one connected button when the nickname lookup rejects", async () => {
+    const cb = buildCallButton({
+      getNickname: () => Promise.reject(new Error("Extension context invalidated")),
+    });
+
+    await expect(cb.createButton(container, 0)).resolves.toBeInstanceOf(HTMLButtonElement);
+
+    const buttons = document.querySelectorAll("#saypi-callButton");
+    expect(buttons.length).toBe(1);
+    expect((buttons[0] as HTMLElement).isConnected).toBe(true);
+    expect(buttons[0].querySelector("svg")).not.toBeNull();
+  });
+});

--- a/test/chatbots/BootstrapCallButtonRecovery.spec.ts
+++ b/test/chatbots/BootstrapCallButtonRecovery.spec.ts
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #593 — a decorated composer that has lost its call button must recover.
+ *
+ * `#saypi-prompt` doubles as an irreversible "this composer is done" latch:
+ * findPrompt returns foundAlreadyDecorated (isNew=false) the instant
+ * getElementById resolves, and findAndDecoratePrompt gates on isNew — and
+ * decoratePrompt is the sole caller of createCallButton. So once the id is
+ * stamped, a button that never landed (a rejected create) or that the host
+ * discarded (a React commit that reuses the textarea but rebuilds the row
+ * around it) can never come back short of a full reload.
+ *
+ * That latch is what turned #460 from a blip into "reload-only recoverable".
+ * These tests pin the invariant instead: on a chatable page, a connected
+ * composer implies a connected call button.
+ */
+
+vi.mock("../../src/dom/MessageElements", () => {
+  class AssistantResponse {}
+  class MessageControls {}
+  class UserMessage {}
+  return { AssistantResponse, MessageControls, UserMessage };
+});
+
+vi.mock("../../src/tts/VoiceMenu", () => {
+  class VoiceSelector {
+    constructor() {}
+    getId() { return "voice-selector"; }
+    getButtonClasses() { return []; }
+  }
+  return { VoiceSelector, addSvgToButton: () => {} };
+});
+
+vi.mock("../../src/prefs/PreferenceModule", () => ({
+  UserPreferenceModule: {
+    getInstance: () => ({
+      reloadCache: vi.fn(),
+      getLanguage: vi.fn().mockResolvedValue("en-US"),
+    }),
+  },
+}));
+
+vi.mock("../../src/tts/VoiceMenuUIManager", () => ({
+  VoiceMenuUIManager: class {
+    constructor() {}
+    findAndDecorateVoiceMenu() {}
+  },
+}));
+
+vi.mock("../../src/ui/AgentModeNoticeModule", () => ({
+  AgentModeNoticeModule: {
+    getInstance: () => ({ showNoticeIfNeeded: vi.fn().mockResolvedValue(undefined) }),
+  },
+}));
+
+vi.mock("../../src/ButtonModule.js", () => ({
+  buttonModule: {
+    createCallButton: vi.fn(),
+    createEnterButton: vi.fn(),
+    createExitButton: vi.fn(),
+    createMiniSettingsButton: vi.fn(),
+    createImmersiveModeButton: vi.fn(),
+    createSettingsButton: vi.fn(),
+    createImmersiveModeMenuButton: vi.fn(),
+    createSettingsMenuButton: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/chatbots/PiVoiceSettings", () => ({
+  PiVoiceSettings: class { constructor() {} },
+}));
+
+let DOMObserver: typeof import("../../src/chatbots/bootstrap").DOMObserver;
+let PiAIChatbot: typeof import("../../src/chatbots/Pi").PiAIChatbot;
+let buttonModule: typeof import("../../src/ButtonModule.js").buttonModule;
+
+beforeAll(async () => {
+  DOMObserver = (await import("../../src/chatbots/bootstrap")).DOMObserver;
+  PiAIChatbot = (await import("../../src/chatbots/Pi")).PiAIChatbot;
+  buttonModule = (await import("../../src/ButtonModule.js")).buttonModule;
+});
+
+function mountPiComposer(): void {
+  document.body.innerHTML = `
+    <div class="w-full">
+      <div class="controls">
+        <div class="prompt-container">
+          <textarea enterkeyhint="enter" placeholder="What's on your mind?"></textarea>
+        </div>
+        <button class="rounded-full transition-colors duration-300">Send</button>
+      </div>
+    </div>
+  `;
+}
+
+function setPath(path: string): void {
+  window.history.replaceState({}, "", path);
+}
+
+/** Nudge the MutationObserver with an unrelated DOM change, as a live host would. */
+function hostMutates(): void {
+  document.body.appendChild(document.createElement("span"));
+}
+
+function callButtons(): NodeListOf<Element> {
+  return document.querySelectorAll("#saypi-callButton");
+}
+
+/**
+ * A stand-in for the real createCallButton: it actually inserts an element, as
+ * production does, so the tests assert on the DOM rather than on mock bookkeeping
+ * — and so the "a decorated composer has a call button" invariant can be satisfied.
+ */
+function insertCallButton(container: HTMLElement, position: number) {
+  const button = document.createElement("button");
+  button.id = "saypi-callButton";
+  const reference = position < 0 ? container.children[container.children.length + position] : null;
+  if (reference) container.insertBefore(button, reference);
+  else container.appendChild(button);
+  return Promise.resolve(button);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  // clearAllMocks resets calls but NOT implementations, so re-arm the default here
+  // rather than letting a test's override leak into the next one.
+  (buttonModule.createCallButton as any).mockImplementation(insertCallButton);
+  // Give each test a FRESH body. DOMObserver has no teardown, so the
+  // MutationObservers of earlier tests would otherwise keep watching the shared
+  // body and act on this test's DOM (each with its own restore budget). Swapping
+  // the body leaves them watching a detached node; their route-poll intervals die
+  // with the fake clock in afterEach.
+  document.body.remove();
+  document.documentElement.appendChild(document.createElement("body"));
+  setPath("/talk");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function bootDecoratedComposer() {
+  const observer = new DOMObserver(new PiAIChatbot());
+  observer.observeDOM();
+  mountPiComposer();
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(document.getElementById("saypi-prompt")).not.toBeNull();
+  expect(callButtons().length).toBe(1);
+  return observer;
+}
+
+describe("#593 call button recovery on a decorated composer", () => {
+  it("restores a call button the host removed while reusing the composer", async () => {
+    await bootDecoratedComposer();
+
+    // A host re-render discards the injected button but keeps the textarea — so
+    // the prompt still carries id=saypi-prompt and every finder says "decorated".
+    document.getElementById("saypi-callButton")!.remove();
+    expect(callButtons().length).toBe(0);
+
+    hostMutates();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(callButtons().length).toBe(1);
+    expect(document.getElementById("saypi-callButton")!.isConnected).toBe(true);
+  });
+
+  it("ends up with a call button even when the first create fails outright", async () => {
+    // The first create rejects without inserting anything (e.g. extension context
+    // invalidated mid-decoration), leaving a decorated-but-buttonless composer —
+    // the state that used to be terminal.
+    (buttonModule.createCallButton as any).mockImplementationOnce(() =>
+      Promise.reject(new Error("Extension context invalidated"))
+    );
+
+    const observer = new DOMObserver(new PiAIChatbot());
+    observer.observeDOM();
+    mountPiComposer();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(document.getElementById("saypi-prompt")).not.toBeNull();
+
+    hostMutates();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(callButtons().length).toBe(1);
+    expect(document.getElementById("saypi-callButton")!.isConnected).toBe(true);
+    void observer;
+  });
+
+  it("restores the call button when the SPA routes back into the chat", async () => {
+    await bootDecoratedComposer();
+    document.getElementById("saypi-callButton")!.remove();
+
+    setPath("/discover");
+    await vi.advanceTimersByTimeAsync(1000);
+    setPath("/talk");
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(callButtons().length).toBe(1);
+  });
+
+  it("never creates a second call button while one is present", async () => {
+    await bootDecoratedComposer();
+
+    for (let i = 0; i < 5; i++) {
+      hostMutates();
+      await vi.advanceTimersByTimeAsync(500);
+    }
+    setPath("/talk/abc123");
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(callButtons().length).toBe(1);
+    expect((buttonModule.createCallButton as any).mock.calls.length).toBe(1);
+  });
+
+  it("does not restore the button on a non-chatable path", async () => {
+    await bootDecoratedComposer();
+    document.getElementById("saypi-callButton")!.remove();
+
+    setPath("/profile/account");
+    await vi.advanceTimersByTimeAsync(1000);
+    hostMutates();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(callButtons().length).toBe(0);
+  });
+
+  it("stops retrying when restoring never produces a button", async () => {
+    // A permanently broken create (e.g. the CallButton singleton is missing) must
+    // not turn the invariant check into an unbounded retry loop on a busy page.
+    (buttonModule.createCallButton as any).mockImplementation(() => undefined);
+
+    const observer = new DOMObserver(new PiAIChatbot());
+    observer.observeDOM();
+    mountPiComposer();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    for (let i = 0; i < 20; i++) {
+      hostMutates();
+      await vi.advanceTimersByTimeAsync(100);
+    }
+
+    // Bounded, not once-per-mutation-batch.
+    expect((buttonModule.createCallButton as any).mock.calls.length).toBeLessThanOrEqual(4);
+    void observer;
+  });
+
+  it("does not stack a submit-button observer each time the controls are re-decorated", async () => {
+    const realMutationObserver = window.MutationObserver;
+    let constructed = 0;
+    class CountingMutationObserver extends realMutationObserver {
+      constructor(callback: MutationCallback) {
+        super(callback);
+        constructed += 1;
+      }
+    }
+    vi.stubGlobal("MutationObserver", CountingMutationObserver);
+    try {
+      await bootDecoratedComposer();
+      const afterBoot = constructed;
+
+      for (let i = 0; i < 4; i++) {
+        document.getElementById("saypi-callButton")!.remove();
+        hostMutates();
+        await vi.advanceTimersByTimeAsync(500);
+        expect(callButtons().length).toBe(1);
+      }
+
+      // Four recoveries must not leave four extra observers watching the same row.
+      expect(constructed - afterBoot).toBe(0);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/test/chatbots/BootstrapRouteEntryDecoration.spec.ts
+++ b/test/chatbots/BootstrapRouteEntryDecoration.spec.ts
@@ -57,7 +57,15 @@ vi.mock("../../src/ui/AgentModeNoticeModule", () => ({
 
 vi.mock("../../src/ButtonModule.js", () => ({
   buttonModule: {
-    createCallButton: vi.fn(),
+    // Inserts a real element, as the production createCallButton does — the
+    // bootstrap now enforces "a decorated composer has a call button" (#593), so a
+    // mock that never inserts one would model a permanently broken host.
+    createCallButton: vi.fn((container: HTMLElement) => {
+      const button = document.createElement("button");
+      button.id = "saypi-callButton";
+      container.appendChild(button);
+      return Promise.resolve(button);
+    }),
     createEnterButton: vi.fn(),
     createExitButton: vi.fn(),
     createMiniSettingsButton: vi.fn(),
@@ -114,7 +122,11 @@ function setPath(path: string): void {
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
-  document.body.innerHTML = "";
+  // Fresh body per test: DOMObserver has no teardown, so earlier tests'
+  // MutationObservers would otherwise keep watching the shared body and act on
+  // this test's DOM. Swapping the body leaves them watching a detached node.
+  document.body.remove();
+  document.documentElement.appendChild(document.createElement("body"));
   setPath("/talk");
 });
 


### PR DESCRIPTION
## The latch

`#saypi-prompt` doubled as an irreversible *"this composer is done"* flag. `findPrompt` returns `foundAlreadyDecorated` (`isNew=false`) the instant `getElementById` resolves, `findAndDecoratePrompt` gates on `isNew`, and `decoratePrompt` is the **sole** caller of `createCallButton`. So once the id was stamped, a button that never landed — or one the host discarded — could not come back short of a full reload.

That latch is what turned #460 from a blip into "reload-only recoverable". #592 removed the trigger; this removes the amplifier, so a future missed insertion self-heals instead of becoming permanent.

One invariant: **on a chatable page, a decorated composer has a connected call button.**

## 1. `createButton` attaches first, then renders

It used to `await callInactive()` — a `chrome.storage` round-trip for the user's nickname — *before* `addChild()`. But only the **label** needs the nickname; the icon, the click handler and the element itself do not.

That ordering caused two problems:
- a window where a create was in flight while `getElementById("saypi-callButton")` returned null — the guard every recovery path wants, and a duplicate-button trap for anything that used it (the trap [#467](https://github.com/Pedal-Intelligence/saypi-userscript/pull/467) fell into);
- a rejected lookup (e.g. "Extension context invalidated") meant the button was **never inserted at all**, silently, because nobody awaited or caught the promise.

Now it mounts synchronously using `getName()` — the same value `getNickname()` falls back to, so there's no flicker for anyone without a custom nickname — and refines the label when storage answers. The fire-and-forget create in `decoratePrompt` is no longer swallowed.

## 2. `ensureCallButtonPresent()` re-asserts the invariant

Runs once per mutation batch and on route entry, restoring the button through `decoratePromptControls` — split out of `decoratePrompt` so it re-runs **without** re-stamping the prompt. Two bounds keep it honest:

- **Restore budget**: 3 attempts per composer, reset whenever a button is present. Without it, a permanently-failing create spins once per mutation batch on a busy page (measured: 23 attempts over 20 batches).
- **WeakSet on monitored ancestors**: without it, four recoveries left four extra `MutationObserver`s watching the same composer row (measured).

Both bounds were added test-first, and each was proven load-bearing by removing it and watching the test fail.

## Testing

**Fail-first** — `test/buttons/CallButton-synchronous-mount.spec.ts` (4) and `test/chatbots/BootstrapCallButtonRecovery.spec.ts` (7). Every behavioural spec failed on `main` for the bug's reason before the fix.

Two test-hygiene notes worth flagging for review:
- Both specs give each test a **fresh `document.body`**. `DOMObserver` has no teardown, so earlier tests' MutationObservers keep watching the shared jsdom body and act on later tests' DOM — that contamination produced a spurious failure while writing this.
- `BootstrapRouteEntryDecoration`'s `createCallButton` mock now **inserts a real element**, as production does. A mock that never inserts one models a permanently broken host, and it fights the new invariant rather than testing it.

**Gate** — typecheck + Jest + Vitest (232 files / 2302 tests) + Layer 3 e2e 17/17.

**Layer 4 (CDP), live hosts, this build** — remove `#saypi-callButton` while leaving the composer decorated (what a host re-render does), then watch:

| | recovery | restored button |
|---|---|---|
| pi.ai | **2–3 ms** | 1 button, `"Start a hands-free conversation with Pi"`, 36×36, in composer |
| claude.ai | **44 ms** | 1 button, correct label, `claude-call-button` classes retained, 32×32, in composer |

and the **restored** button drives the state machine on click — label → `"Connecting..."`, `callState` → `"starting"` — so this is "it works again", not "an element reappeared". **Control:** on `main` the same removal never recovers (15s timeout). No regression from `https://pi.ai`: 2/2 decorated, exactly one button, control panel decorated.

## Out of scope, filed separately

While verifying on chatgpt.com I measured `#saypi-callButton.onclick === null` ~2s after load, while an immediate click still works. **Identical on `main`**, so it is pre-existing and not from this change — but it's a different failure mode (element *present but inert*, which a presence check can't see). Filed separately with the evidence.

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RGd9g4a7iknBpwb3p3Gpwi
