### PR TITLE
i18n: translate the 144 missing keys, and fix what that exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,7 @@ ngrok.yml
 
 # Credential-freshness state (timestamps only — release:freshness, #534)
 .credential-freshness.json
+
+# Python bytecode from tools/
+__pycache__/
+*.pyc

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "فائدة مذكورة في نافذة تسجيل الدخول - زيادة حدود الاستخدام.",
+    "message": "حدود استخدام أعلى مع حساب مجاني"
+  },
+  "authBenefitPremium": {
+    "description": "فائدة مذكورة في نافذة تسجيل الدخول - ميزات مميزة عبر روبوتات الدردشة.",
+    "message": "ميزات مميزة ودعم روبوتات الدردشة"
+  },
+  "authBenefitSupport": {
+    "description": "فائدة مذكورة في نافذة تسجيل الدخول - دعم بأولوية.",
+    "message": "دعم أولوية للمشكلات"
+  },
+  "authBenefitSync": {
+    "description": "فائدة مذكورة في نافذة تسجيل الدخول - مزامنة الإعدادات.",
+    "message": "زامن إعدادات الصوت في كل مكان"
+  },
+  "authBenefitTTS": {
+    "description": "فائدة مذكورة في نافذة تسجيل الدخول - ميزة تحويل النص إلى كلام.",
+    "message": "أصوات تحويل النص إلى كلام (الخطط المدفوعة)"
+  },
+  "authBenefitUsage": {
+    "description": "فائدة مذكورة في نافذة تسجيل الدخول - تتبّع الاستخدام.",
+    "message": "تتبّع استخدامك للصوت عبر الأجهزة"
+  },
+  "authPromptModalFull": {
+    "description": "وصف نافذة تسجيل الدخول المنبثقة الكاملة مع عرض القيمة.",
+    "message": "أنت تستخدم Say, Pi بشكل رائع. سجّل الدخول لحدود أعلى وأصوات تحويل النص إلى كلام وميزات مميزة عبر جميع روبوتات الدردشة المدعومة."
+  },
+  "authPromptModalSoft": {
+    "description": "وصف نافذة تسجيل الدخول المنبثقة الخفيفة.",
+    "message": "أنشئ حساب Say, Pi مجانيًا لحدود استخدام أعلى والوصول إلى ميزات صوت مميزة."
+  },
+  "authPromptTitle": {
+    "description": "عنوان نافذة تسجيل الدخول المنبثقة.",
+    "message": "افتح مزيدًا من ميزات الصوت"
+  },
+  "authPromptToast": {
+    "description": "إشعار منبثق يشجّع المستخدم على تسجيل الدخول.",
+    "message": "سجّل الدخول إلى Say, Pi لحدود أعلى وميزات مميزة"
+  },
   "autoReadAloudChatGPT": {
     "description": "وصف لمربع الاختيار لتمكين أو تعطيل قراءة ردود ChatGPT تلقائياً خلال المكالمات الصوتية.",
     "message": "القراءة التلقائية بصوت عالٍ (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "تعطيل النص إلى الكلام"
   },
+  "dismiss": {
+    "message": "فهمت",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "رفض"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "تركيز"
   },
+  "errorVadInitFailed": {
+    "description": "إشعار خطأ يظهر عندما يفشل اكتشاف نشاط الصوت في التهيئة.",
+    "message": "تعذر تهيئة اكتشاف الصوت"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "إشعار خطأ يظهر عند حدوث خطأ غير متوقع أثناء إعداد تسجيل الصوت.",
+    "message": "تعذر إعداد تسجيل الصوت"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "إشعار خطأ يظهر عندما يفشل عميل اكتشاف الصوت في بدء التسجيل.",
+    "message": "تعذر بدء تسجيل الصوت"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "إشعار خطأ يظهر عندما لا يكون عميل اكتشاف الصوت (VAD) متاحًا، لذلك لا يمكن بدء التسجيل.",
+    "message": "تسجيل الصوت غير متاح"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "الخروج من وضع التركيز"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "ملاحظة من سطر واحد تظهر في قوائم الصوت عندما تكون الأصوات المميزة (عالية الدقة) والأصوات الاقتصادية متاحة معًا",
+    "message": "تستخدم الأصوات عالية الدقة حصتك الشهرية أسرع بنحو 20×."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "سقيف هذا بعيدا ..."
   },
+  "maybeLater": {
+    "description": "نص زر لتجاهل مطالبة تسجيل الدخول.",
+    "message": "ربما لاحقًا"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "إعدادات الميكروفون لديك لا تتوافق مع المواصفات المطلوبة. \nحاول استخدام ميكروفون مختلف أو ضبط إعدادات الصوت."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "غير قادر على الوصول إلى الميكروفون. \nيرجى التحقق من إعدادات جهازك والمحاولة مرة أخرى."
   },
+  "microphonePermissionDeniedError": {
+    "description": "إشعار خطأ يظهر عندما يتم رفض إذن الميكروفون بعد تدفق طلب الإذن.",
+    "message": "لم يتم منح إذن الميكروفون. يُرجى التأكد من أنك سمحت بالوصول في النافذة المنبثقة وفي إعدادات الإضافة."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "دقة"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "أسرع استجابة، ولكن أقل دقة. \nعرضة للمقاطعة."
   },
+  "moreVoices": {
+    "description": "صف في القائمة يربط من قائمة الصوت داخل الصفحة إلى كتالوج الأصوات الكامل في إعدادات الإضافة",
+    "message": "مزيد من الأصوات…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "اسم المساعد"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "لم يتم تسجيل الدخول"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "تسمية الزر الذي يفتح ChatGPT.",
+    "message": "فتح ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "تسمية زر يفتح Claude.ai.",
+    "message": "فتح Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "تسمية زر يفتح Pi.ai.",
+    "message": "فتح Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "خيار البيئة: بالقرب من أشخاص آخرين.",
+    "message": "بين أشخاص آخرين"
+  },
+  "onboarding_envMixed": {
+    "description": "خيار البيئة: مزيج من المساحات الخاصة والمشتركة.",
+    "message": "مزيج من الأماكن"
+  },
+  "onboarding_envPrivate": {
+    "description": "خيار البيئة: مساحة خاصة.",
+    "message": "مكان خاص"
+  },
+  "onboarding_envQuietOff": {
+    "description": "تأكيد يُعرض عندما يترك جواب البيئة وضع الهدوء معطّلًا.",
+    "message": "حسنًا، سنبقي إعدادات الاستماع والتشغيل القياسية."
+  },
+  "onboarding_envQuietOn": {
+    "description": "تأكيد يظهر عندما يؤدي جواب البيئة إلى تفعيل الوضع الهادئ.",
+    "message": "تم تشغيل الوضع الهادئ — سنلتقط الكلام المنخفض ونرد بهدوء، لتتحدث بسرية."
+  },
+  "onboarding_envTitle": {
+    "description": "عنوان لسؤال الإعداد حول بيئة المستخدم.",
+    "message": "أين تتحدث عادةً؟"
+  },
+  "onboarding_footer": {
+    "description": "نص التذييل في صفحة الإعداد عند التشغيل لأول مرة.",
+    "message": "يمكنك الرجوع إلى هذا في أي وقت من إعدادات Say, Pi. خصوصيتك مهمة — لا يُلتقط الصوت إلا أثناء مكالمة نشطة."
+  },
+  "onboarding_heading": {
+    "description": "العنوان الرئيسي في صفحة الإعداد عند التشغيل لأول مرة.",
+    "message": "🗣️ مرحبًا بك في Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "فقرة المقدمة في صفحة الإعداد عند التشغيل لأول مرة.",
+    "message": "تفصلك خطوتان عن أول محادثة صوتية لك مع ذكاء اصطناعي. التحدث أسرع بنحو 3× من الكتابة، فلنقم بإعدادك."
+  },
+  "onboarding_micTestButton": {
+    "description": "زر يبدأ اختبار الميكروفون في الإعداد بدون أي تبعات.",
+    "message": "🎤 اختبر الميكروفون"
+  },
+  "onboarding_micTestDone": {
+    "description": "حالة تظهر بعد اكتمال اختبار الميكروفون في الإعداد بنجاح.",
+    "message": "جميل — الميكروفون يعمل! 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "حالة تظهر بينما يقيس اختبار الميكروفون في الإعداد مستوى الإدخال.",
+    "message": "جارٍ الاستماع — قل شيئًا! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "حالة تظهر أثناء انتظار اختبار الميكروفون في الإعداد للحصول على الإذن.",
+    "message": "جارٍ طلب إذن الميكروفون…"
+  },
+  "onboarding_micTestStop": {
+    "description": "تسمية زر لإيقاف اختبار الميكروفون في الإعداد أثناء تشغيله.",
+    "message": "إيقاف الاختبار"
+  },
+  "onboarding_step1Body": {
+    "description": "نص خطوة الإعداد الأولى الذي يشرح كيفية تثبيت الإضافة.",
+    "message": "انقر أيقونة قطعة الأحجية 🧩 أعلى يمين المتصفح، ثم دبوس التثبيت 📌 بجوار Say, Pi. بهذا يبقى زر الاتصال على بعد نقرة واحدة."
+  },
+  "onboarding_step1Title": {
+    "description": "عنوان خطوة الإعداد الأولى (تثبيت الإضافة).",
+    "message": "ثبّت Say, Pi في شريط الأدوات"
+  },
+  "onboarding_step2Body": {
+    "description": "نص خطوة الإعداد الثانية الذي يشرح كيفية بدء محادثة صوتية.",
+    "message": "انتقل إلى أحد المساعدين المدعومين أدناه، ثم اضغط زر اتصال Say, Pi وقل مرحبًا. سنطلب إذن الوصول إلى الميكروفون في المرة الأولى، وهذا متوقع، ولا نستمع إلا أثناء كونك في مكالمة بشكل فعلي."
+  },
+  "onboarding_step2Title": {
+    "description": "عنوان خطوة الإعداد الثانية (بدء محادثة).",
+    "message": "افتح دردشة ذكاء اصطناعي وابدأ التحدث"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "إذن الميكروفون"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "إرشادات الاستعادة عندما يكون إذن الميكروفون محظورًا.",
+    "message": "المتصفح يحظر الميكروفون. انقر على أيقونة الكاميرا أو القفل في شريط العنوان، واضبط Microphone على \"Allow\"، ثم حاول مرة أخرى. على macOS، تحقّق أيضًا من System Settings → Privacy & Security → Microphone."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "عنوان لوحة الاستعادة عندما يكون إذن الميكروفون مرفوضًا/محظورًا.",
+    "message": "تم حظر الوصول إلى الميكروفون"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "إرشادات الاستعادة عندما يكون الميكروفون مستخدمًا في مكان آخر.",
+    "message": "قد يكون تطبيق أو علامة تبويب أخرى يستخدم الميكروفون. أغلق أي شيء آخر قد يكون يسجل (مكالمات فيديو، مذكرات صوتية)، ثم حاول مرة أخرى."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "عنوان لوحة الاستعادة عندما يكون الميكروفون قيد الاستخدام من تطبيق آخر.",
+    "message": "الميكروفون قيد الاستخدام"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "إرشادات الاستعادة عندما لا يتوفر جهاز ميكروفون.",
+    "message": "لم نتمكن من العثور على ميكروفون. صِل واحدًا (أو صِل سماعة الرأس)، وتأكد من تحديده كجهاز إدخال، ثم حاول مرة أخرى."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "عنوان لوحة الاستعادة عندما لا يتوفر جهاز ميكروفون.",
+    "message": "لم يتم العثور على ميكروفون"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "إرشادات الاستعادة لخطأ ميكروفون غير معروف.",
+    "message": "حدث خطأ أثناء الوصول إلى الميكروفون. تحقّق من أنه متصل ومسموح به في إعدادات المتصفح، ثم حاول مرة أخرى."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "عنوان لوحة الاستعادة لخطأ ميكروفون غير معروف.",
+    "message": "لم نتمكن من الوصول إلى الميكروفون"
+  },
+  "permissions_retryButton": {
+    "description": "تسمية الزر الذي يعيد طلب إذن الميكروفون.",
+    "message": "حاول مرة أخرى"
+  },
+  "permissions_revokedHeading": {
+    "description": "عنوان يُعرض عندما كان الوصول إلى الميكروفون مُنح سابقًا ثم تم سحبه لاحقًا.",
+    "message": "🎙️ لنعِد توصيل الميكروفون"
+  },
+  "permissions_revokedInfo": {
+    "description": "نص معلوماتي يُعرض عندما تم سحب الوصول إلى الميكروفون بعد منحه.",
+    "message": "تم إيقاف الوصول إلى الميكروفون — وغالبًا ما يحدث هذا بعد تحديث للمتصفح أو للنظام. اسمح به مجددًا أدناه وسيعود $productName$ للاستماع عندما تكون في مكالمة.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "حساب تعريفي"
+  },
+  "quietModeLabel": {
+    "description": "تسمية لمفتاح التبديل الذي يفعّل وضع الهدوء/الهمس.",
+    "message": "الوضع الهادئ"
+  },
+  "quietModeTooltip": {
+    "description": "تلميح يوضح ما يفعله وضع الهدوء/الهمس.",
+    "message": "تحدث بهدوء — يلتقط الكلام الأكثر هدوءًا ويخفض مستوى صوت رد المساعد، لتتمكن من استخدام الصوت قرب الآخرين."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,6 +1044,10 @@
       }
     }
   },
+  "signingIn": {
+    "description": "نص زر تسجيل الدخول أثناء تقدّم عملية المصادقة.",
+    "message": "جارٍ تسجيل الدخول..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "تأثيرات الصوت"
@@ -833,9 +1055,23 @@
   "soundEffectsFirefoxDisabled": {
     "message": "تم تعطيل المؤثرات الصوتية في Firefox لمنع حدوث مشكلات في التعليقات الصوتية."
   },
+  "speedPayoffNoticeHeadline": {
+    "description": "عنوان إشعار فائدة السرعة الذي يظهر مرة واحدة بعد أول تبادل صوتي.",
+    "message": "جميل — التحدث أسرع بنحو 3× من الكتابة."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "سطر ثانٍ اختياري في إشعار فائدة السرعة يعرض عدد الدقائق الكاملة التي تم توفيرها.",
+    "message": "لقد تحدثت بالفعل أسرع من كتابته بنحو $minutes$ دقيقة.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
+  },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
-    "message": "$minutes$ دقيقة متبقية",
+    "message": "متبقّي $minutes$ دقيقة$plural$",
     "placeholders": {
       "minutes": {
         "content": "$1",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "إرسال فقط عند الضغط على الزر"
   },
+  "surveyQuestion": {
+    "description": "السؤال الوحيد في الاستبيان المصغّر الذي يظهر مرة واحدة بعد الفوز.",
+    "message": "كيف تسير تجربة الصوت معك حتى الآن؟"
+  },
+  "surveyRatingLabel": {
+    "description": "تسمية ميسّرة لزر تقييم الاستبيان.",
+    "message": "قيّم $rating$ من 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "رسالة إقرار تظهر بعد أن يجيب المستخدم عن الاستبيان الذي يظهر بعد الفوز.",
+    "message": "شكرًا، هذا يساعدنا على تحسين Say, Pi. 🙏"
+  },
   "tabAIChat": {
     "description": "تسمية التبويب لإعدادات الدردشة الذكية.",
     "message": "الدردشة الذكية"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "تسمية التبويب للقسم العام.",
     "message": "عام"
+  },
+  "tabVoices": {
+    "description": "تسمية علامة التبويب لقسم إعدادات الأصوات (كتالوج الأصوات لكل موقع).",
+    "message": "الأصوات"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "الاعتمادات"
   },
+  "ttsCreditsRemaining": {
+    "description": "نص يعرض حصة تحويل النص إلى كلام المتبقية كمخزون أرصدة لكل صوت (saypi-api #181 المرحلة 2)، وليس كعدد أحرف خام.",
+    "message": "متبقّي $credits$ رصيد",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "الأصوات متعددة اللغات غير مدعومة حاليًا في Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "جيل الصوت"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "انتبه! تشغيل الكلام غير متاح على $browserName$ مع $chatbotName$ حتى الآن. الأخبار الجيدة؟ إدخال الصوت يعمل بشكل رائع! بالنسبة لـ TTS، جرب Chrome أو Edge على سطح المكتب.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS غير متاح على $browserName$ + $chatbotName$. إدخال الصوت يعمل! جرب Chrome على سطح المكتب لـ TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "صوت TTS"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "تنشيط الميكروفون ..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "تفصيل VAD عندما تم رصد صوت يشبه الكلام لكنه كان خافتًا جدًا / منخفض الثقة بحيث لا يمكن تفريغه (إسقاط بوابة القبول على جانب العميل).",
+    "message": "الصوت خافت جدًا ولا يمكن تفريغه"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "خدمة VAD أغلق."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "تفصيل VAD يوضح أن المكالمة انتهت لأن الميكروفون تم حجزه بواسطة علامة تبويب أحدث.",
+    "message": "تم نقل إدخال الصوت إلى علامة تبويب أخرى"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "في انتظار الكلام"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "صوت غير متوفر. \nجرب Chrome أو Firefox على سطح المكتب."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "انتبه! تشغيل الكلام غير متاح على $browserName$ مع $chatbotName$ حتى الآن. الأخبار الجيدة؟ إدخال الصوت يعمل بشكل رائع! بالنسبة لـ TTS، جرب Chrome أو Edge على سطح المكتب.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS غير متاح على $browserName$ + $chatbotName$. إدخال الصوت يعمل! جرب Chrome على سطح المكتب لـ TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "فهمت",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "اختل"
   },
+  "vadStatusPreempted": {
+    "description": "حالة VAD المعروضة على علامة تبويب تم الاستيلاء على إدخالها الصوتي بواسطة علامة تبويب أخرى.",
+    "message": "متوقف مؤقتًا"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "يعالج"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "عرض التفاصيل"
   },
+  "voiceIntroductionGeneric": {
+    "description": "مقدمة صوتية عامة تُشغَّل عندما لا يحتوي صوت SayPi المحدد على نص تقديم خاص بالصوت (ولا توجد رسالة حديثة لقراءتها).",
+    "message": "مرحبًا، أنا $voice$. هكذا يبدو صوتي. آمل أن يعجبك هذا الصوت.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "مرحبا! \nخاص! \n你好! \nأنا باي، مساعد الذكاء الاصطناعي متعدد اللغات الخاص بك. \nومع وجود 32 لغة تحت تصرفي، يمكننا استكشاف الأفكار والثقافات من جميع أنحاء العالم. \nما رأيك في هذا الصوت؟"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "إعدادات الصوت"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "عنوان فرعي احتياطي لصف صوت في كتالوج الأصوات ضمن الإعدادات عندما لا يملك الصوت وصفًا؛ $count$ هو عدد اللغات التي يدعمها الصوت.",
+    "message": "يتحدث $count$ لغة",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Addison\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "مشرق ولبق"
+  },
+  "voiceTagline_alloy": {
+    "description": "سطر تعريفي بالشخصية مُؤلف لصوت \"Alloy\" (استوديو الأصوات في الإعدادات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "متوازن ومتعدد الاستخدامات"
+  },
+  "voiceTagline_ash": {
+    "description": "سطر تعريفي بالشخصية مُؤلف لصوت \"Ash\" (استوديو الأصوات في الإعدادات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "عميق، متأمل، هادئ"
+  },
+  "voiceTagline_ballad": {
+    "description": "سطر تعريفي بالشخصية مُؤلف لصوت \"Ballad\" (استوديو الأصوات في الإعدادات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "ناعم ولحني"
+  },
+  "voiceTagline_cassidy": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Cassidy\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "ودود وواضح"
+  },
+  "voiceTagline_cedar": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Cedar\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "ثابت ومطمئن"
+  },
+  "voiceTagline_coral": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Coral\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "طاقة مشرقة ومفعمة بالحيوية"
+  },
+  "voiceTagline_echo": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Echo\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "واضح ومحايد"
+  },
+  "voiceTagline_fable": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Fable\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "نبرة راوٍ للحكايات"
+  },
+  "voiceTagline_finn": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Finn\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "منعش ومفعم بالحيوية"
+  },
+  "voiceTagline_jamahal": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Jamahal\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "غني وجذاب"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Jarnathan\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "باريتون مخملي متأخر ليلًا"
+  },
+  "voiceTagline_jeff": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Jeff\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "واضح وثابت"
+  },
+  "voiceTagline_jessica": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Jessica\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "دفء ورزانة مصقولة"
+  },
+  "voiceTagline_joey": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Joey\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "أمريكي سهل وحواري"
+  },
+  "voiceTagline_juniper": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Juniper\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "نقي ومشرق وحيوي"
+  },
+  "voiceTagline_lucy": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Lucy\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "لطيف ومشرق"
+  },
+  "voiceTagline_marin": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Marin\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "هدوء دافئ كإذاعة الصباح"
+  },
+  "voiceTagline_mark": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Mark\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "راوٍ واضح وواثق"
+  },
+  "voiceTagline_nova": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Nova\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "سريع وفضولي"
+  },
+  "voiceTagline_onyx": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Onyx\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "عمق ورنين مهيب"
+  },
+  "voiceTagline_paola": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Paola\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "دفء إيطالي معبّر"
+  },
+  "voiceTagline_sage": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Sage\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "وضوح بصوت هادئ"
+  },
+  "voiceTagline_shimmer": {
+    "description": "شعار شخصية مُعدّ مسبقًا لصوت \"Shimmer\" (إعدادات استوديو الأصوات؛ خريطة هوية الصوت على جهة العميل).",
+    "message": "خفيف وهوائي"
+  },
+  "voicesAddToMenuShort": {
+    "description": "تسمية قصيرة على زر التثبيت في بطاقة الصوت (حالة الإيقاف) في استوديو الأصوات ضمن الإعدادات؛ الضغط يضيف الصوت إلى قائمة $host$ داخل الدردشة.",
+    "message": "+ القائمة"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "تسمية تسهيل الوصول لزر التثبيت في بطاقة الصوت (حالة الإيقاف)؛ $name$ هو الصوت، و$host$ هو المساعد.",
+    "message": "أضف $name$ إلى قائمة $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "تسمية على زر التبديل في شريط التحكم بالأصوات توضح ما إذا كان التنقّل في القائمة بمفاتيح الأسهم يشغّل كل صوت عند وصول التركيز إليه.",
+    "message": "تشغيل أثناء التنقّل"
+  },
+  "voicesArrowsLive": {
+    "description": "تأكيد لقارئ الشاشة، يُضاف إلى أول إعلان \"يتم تشغيل <صوت>\" في قائمة الأصوات ضمن الإعدادات، يفيد بأن مفاتيح الأسهم أصبحت مسموعة للتو. يعكس صياغة خيار \"التشغيل أثناء التنقل\" نفسه.",
+    "message": "الأسهم تشغّل الآن أثناء التنقل. Esc يوقف."
+  },
+  "voicesBuiltinsNote": {
+    "description": "ملاحظة أسفل خانات القائمة للمضيفين الذين يأتون بأصوات أصلية (مثل 8 أصوات مدمجة لـ Pi)، والتي لا يديرها الاستوديو؛ $host$ هو المساعد.",
+    "message": "أصوات $host$ المدمجة الخاصة به تظهر دائمًا في قائمته أيضًا.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "صيغة بديلة لـ voicesBuiltinsNote لمضيف لا يملك قائمة أصوات داخل الدردشة (أزال Pi قائمته في 2026)، حيث سيكون وعد الأصل بأن الأصوات المدمجة \"تظهر في قائمته\" غير صحيح؛ $host$ هو المساعد.",
+    "message": "لدى $host$ أيضًا أصوات مدمجة خاصة به، لكنها غير مدرجة هنا.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "مؤشر تقدم في شريط التحكم بالأصوات ضمن الإعدادات: عدد الأصوات المُدرجة التي سبق أن استمع إليها المستخدم. أرقام فقط، لذا يُقرأ بشكل صحيح عند 1 أيضًا — لا يحتوي Chrome i18n على صيغ جمع.",
+    "message": "تم الاستماع إلى $heard$ من $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "جزء من الاسم القابل للوصول لصف صوت في قائمة الأصوات ضمن الإعدادات، يميز صوتًا سبق لهذا الملف الاستماع إليه. بصريًا يُرسم ذلك كثافة حبر على بصمة الصوت، وهو ما لا يمكن لقارئ الشاشة رؤيته.",
+    "message": "تم الاستماع"
+  },
+  "voicesInHostMenu": {
+    "description": "عنوان قسم فوق صف خانات القائمة في استوديو الأصوات ضمن الإعدادات؛ $host$ هو المساعد.",
+    "message": "في قائمة $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "تسمية قصيرة على زر التثبيت في بطاقة الصوت (حالة التشغيل) في استوديو الأصوات ضمن الإعدادات.",
+    "message": "✓ في القائمة"
+  },
+  "voicesInUse": {
+    "description": "شارة ثابتة على الصوت المحدد حاليًا للمضيف في قائمة الأصوات ضمن الإعدادات، تُعرض بأحرف كبيرة. ليست عمدًا «يتحدث الآن»: في هذه الصفحة تشغّل الصفوف مقاطعها التجريبية، لذا لا يجب أن يدّعي صوت محدد لكنه صامت أنه يتحدث بينما صف مختلف هو الذي يُشغَّل.",
+    "message": "قيد الاستخدام"
+  },
+  "voicesKeyboardHint": {
+    "description": "تلميح لوحة مفاتيح من سطر واحد في شريط التحكم بالأصوات ضمن الإعدادات. الرموز هي مفاتيح: Space، وسهما الأعلى/الأسفل، وShift+Space.",
+    "message": "اضغط على Space للاستماع، وعلى ↑↓ للتنقل بين الأصوات، وعلى ⇧Space للتبديل للعودة."
+  },
+  "voicesLoadError": {
+    "description": "حالة خطأ داخل استوديو مضيف واحد عندما يفشل تحميل كتالوج أصوات ذلك المضيف؛ $host$ هو المساعد.",
+    "message": "تعذّر تحميل أصوات $host$. يُرجى المحاولة لاحقًا.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "تلميح/إرشاد على زر «+ القائمة» المعطّل عندما تكون قائمة $host$ داخل الدردشة قد وصلت إلى الحد الأقصى من الأصوات.",
+    "message": "القائمة ممتلئة — أزل صوتًا لإضافة صوت آخر"
+  },
+  "voicesMenuHint": {
+    "description": "تلميح من سطر واحد بجوار عنوان «في قائمة {host}»، يوضح أن صف الخانات يطابق قائمة الأصوات داخل الدردشة.",
+    "message": "ما ستراه في الدردشة"
+  },
+  "voicesMenuOverflow": {
+    "description": "ملاحظة أسفل خانات القائمة عندما يكون لدى المستخدم أصوات مثبّتة أكثر مما تستطيع قائمة الدردشة عرضَه (حالة قديمة)؛ $count$ هو عدد الأصوات التي لا تتسع، و$cap$ هو حجم القائمة.",
+    "message": "هناك $count$ من الأصوات المثبّتة الأخرى بانتظارك خارج $cap$ من خانات القائمة.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "صيغة المفرد لـ voicesMenuOverflow، تُستخدم عندما لا يتسع صوت مثبّت واحد بالضبط في قائمة الدردشة؛ $cap$ هو حجم القائمة.",
+    "message": "هناك صوت مثبّت واحد إضافي بانتظارك خارج $cap$ من خانات القائمة.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "سطر ملخص تحت قائمة الأصوات في الإعدادات يوضح مقدار امتلاء قائمة الأصوات داخل الدردشة لدى المضيف؛ $host$ هو المساعد، و$used$ عدد المقاعد المشغولة، و$cap$ العدد الإجمالي. مصاغ ليُقرأ بشكل صحيح عند 1 أيضًا — لا يحتوي Chrome i18n على صيغ جمع.",
+    "message": "قائمة $host$: $used$ من $cap$ مقعد",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "عنوان للمجموعة في نهاية قائمة الأصوات في الإعدادات التي تضم الأصوات التي لا تحتوي على مقطع عينة للتشغيل؛ $count$ هو العدد. مصاغ ليُقرأ بشكل صحيح عند 1 أيضًا — لا يحتوي Chrome i18n على صيغ جمع.",
+    "message": "لا توجد عينة بعد ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "يُعرض في كتالوج الأصوات ضمن الإعدادات عندما تكون قائمة الأصوات فارغة لمستخدم سجّل الدخول (مثلًا بسبب مشكلة في الشبكة).",
+    "message": "تعذر تحميل الأصوات الآن. يُرجى المحاولة لاحقًا."
+  },
+  "voicesNowPlaying": {
+    "description": "إعلان لقارئ الشاشة عند بدء تشغيل مقطع عينة صوت في قائمة الأصوات ضمن الإعدادات؛ $name$ هو الصوت.",
+    "message": "يتم تشغيل $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "زر في شريط التحكم بالأصوات ضمن الإعدادات يشغّل كل صوت مُدرج حاليًا، واحدًا تلو الآخر؛ $count$ هو العدد. مصاغ ليُقرأ بشكل صحيح عند 1 أيضًا — لا يحتوي Chrome i18n على صيغ جمع.",
+    "message": "تشغيل الكل ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "زر في شريط التحكم بالأصوات ضمن الإعدادات عند زيارة العودة: يشغّل فقط الأصوات المُدرجة التي لم تستمع إليها بعد؛ $count$ هو العدد. مصاغ ليُقرأ بشكل صحيح عند 1 أيضًا — لا يحتوي Chrome i18n على صيغ جمع.",
+    "message": "تشغيل الجديد ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "سطر في شريط التحكم بالأصوات في الإعدادات عندما يرفض المتصفح تشغيل عينة لأن الصفحة لم تتلقَّ أي تفاعل من المستخدم بعد.",
+    "message": "انقر على أي صوت لتفعيل الصوت."
+  },
+  "voicesPreview": {
+    "description": "تسمية تسهيل الوصول لزر التشغيل (▶) الذي يختبر مقطع العيّنة المجاني لصوت ضمن صف صوت؛ $name$ هو اسم الصوت.",
+    "message": "تشغيل عيّنة من $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "الاسم المتاح لقائمة الأصوات في الإعدادات (قائمة اختيار تحتوي على كل الأصوات، صف واحد لكل صوت).",
+    "message": "الأصوات، مرتّبة من الأعمق إلى الأكثر سطوعًا"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "تسمية تسهيل الوصول لزر التثبيت في بطاقة الصوت (حالة التشغيل) وزر الإزالة في خانة القائمة؛ $name$ هو الصوت، و$host$ هو المساعد.",
+    "message": "أزل $name$ من قائمة $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "سطر في شريط التحكم بالأصوات في الإعدادات عندما تفشل عينة صوت واحد في التحميل أو التشغيل؛ $name$ هو ذلك الصوت. غير نمطي — يستمر تشغيل سلسلة العينات بعده.",
+    "message": "تعذّر تشغيل عينة $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "عنوان فرعي لقسم كتالوج الأصوات في تبويب AI Chat ضمن الإعدادات",
+    "message": "اختر الصوت الذي يقرأ الردود بصوت عالٍ على كل موقع."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "عنوان فرعي أسفل عنوان إعدادات الأصوات، لمسار الأصوات المرتّبة حسب الحدة.",
+    "message": "كل صوت، من الأعمق إلى الأكثر سطوعًا. استمع ثم اختر."
+  },
+  "voicesSectionTitle": {
+    "description": "عنوان قسم كتالوج الأصوات في تبويب AI Chat ضمن الإعدادات",
+    "message": "الأصوات"
+  },
+  "voicesShelfEveryday": {
+    "description": "عنوان مجموعة للأصوات ذات الفئة الاقتصادية في كتالوج الأصوات ضمن الإعدادات. تُعرض بأحرف كبيرة عبر CSS.",
+    "message": "أصوات يومية"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "ملاحظة من سطر واحد بجانب عنوان مجموعة Everyday في استوديو الأصوات؛ المكان الوحيد الذي يذكر فيه الاستوديو مقدار زيادة هذه الفئة مقارنةً بـ HD.",
+    "message": "طبيعي وواضح، ويمكنك الاستماع لمدة أطول بنحو 20× مقارنةً بـ HD."
+  },
+  "voicesShelfHd": {
+    "description": "عنوان مجموعة للأصوات المميّزة (HD) في كتالوج الأصوات ضمن الإعدادات. تُعرض بأحرف كبيرة عبر CSS.",
+    "message": "أصوات HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "ملاحظة من سطر واحد بجانب عنوان مجموعة HD في استوديو الأصوات ضمن الإعدادات.",
+    "message": "أغنى صوت لدينا وأكثره تعبيرًا."
+  },
+  "voicesShowAll": {
+    "description": "خيار في عامل تصفية \"إظهار\" ضمن أصوات الإعدادات: بدون تصفية، تُعرض جميع الأصوات.",
+    "message": "كل الأصوات"
+  },
+  "voicesShowEveryday": {
+    "description": "خيار في عامل تصفية \"إظهار\" ضمن أصوات الإعدادات: اعرض فقط الأصوات القياسية (غير HD).",
+    "message": "اليومي فقط"
+  },
+  "voicesShowHd": {
+    "description": "خيار في عامل تصفية \"إظهار\" ضمن أصوات الإعدادات: اعرض فقط الأصوات المميزة (HD).",
+    "message": "HD فقط"
+  },
+  "voicesShowLabel": {
+    "description": "تسمية عامل التصفية في شريط التحكم بالأصوات في الإعدادات الذي يضيّق نطاق الأصوات التي تعرضها القائمة.",
+    "message": "إظهار"
+  },
+  "voicesShowUnheard": {
+    "description": "خيار في عامل تصفية \"إظهار\" ضمن أصوات الإعدادات: اعرض فقط الأصوات التي لم يستمع إليها المستخدم بعد.",
+    "message": "لم يُستمع إليه بعد"
+  },
+  "voicesSpeakingNow": {
+    "description": "تسمية حالة على الصوت المحدد حاليًا للمضيف في استوديو الأصوات ضمن الإعدادات (في خانة القائمة وبطاقة الصوت).",
+    "message": "يتحدث الآن"
+  },
+  "voicesSpeaksWith": {
+    "description": "سطر عنوان صغير فوق اسم الصوت الحالي على مسرح الاستوديو في إعدادات الأصوات؛ $host$ هو المساعد (مثل Pi). يُعرض بأحرف كبيرة عبر CSS.",
+    "message": "$host$ يتحدث بصوت",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "ملاحظة على المنصة عندما يقدّم المضيف صوته الخاص (مثل Pi)، لذا فإن اختيار صوت من Say, Pi يستبدل صوت المضيف.",
+    "message": "سيستخدم $host$ صوته الخاص إلى أن تختار واحدًا أدناه.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "ملاحظة على المنصة عندما لا يملك المضيف صوتًا خاصًا به (مثل Claude)، لذا لن تتم القراءة بصوت عالٍ حتى يتم اختيار صوت من Say, Pi.",
+    "message": "لن يقرأ $host$ الردود بصوت عالٍ إلى أن تختار واحدًا أدناه.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "عنوان رئيسي على منصة استوديو الأصوات في الإعدادات عندما لا يكون لدى المضيف أي صوت من Say, Pi محدّد؛ $host$ هو المساعد (مثل Pi أو Claude). يُعرض بحجم الاسم.",
+    "message": "اختر كيف سيبدو صوت $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "زر على منصة استوديو الأصوات في الإعدادات يشغّل مقطع العيّنة المجاني للصوت الحالي.",
+    "message": "استمع إلى عيّنة"
+  },
+  "voicesStopPlayback": {
+    "description": "زر في شريط التحكم بالأصوات ضمن الإعدادات يوقف تسلسل العينات الذي بدأه \"تشغيل الكل\".",
+    "message": "إيقاف"
+  },
+  "voicesSweepPosition": {
+    "description": "قراءة مباشرة للموقع في شريط التحكم بالأصوات في الإعدادات أثناء تنقّل خيار \"تشغيل الكل\" عبر القائمة؛ $index$ هو الصوت الذي يتم تشغيله الآن و $total$ عدد الأصوات الموجودة في قائمة الانتظار.",
+    "message": "$index$ من $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "تسمية تسهيل الوصول لعنصر المقارنة في شريط التحكم بالأصوات ضمن الإعدادات، والذي يعيد تشغيل الصوت الآخر من آخر صوتين تم سماعهما؛ $name$ هو ذلك الصوت.",
+    "message": "بدّل للعودة إلى $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "سطر في شريط التحكم بالأصوات في الإعدادات عند الضغط على \"تشغيل الكل\" في قائمة طويلة جداً لا يمكن متابعتها؛ $count$ هو عدد الأصوات و $minutes$ تقريباً عدد الدقائق التي ستستغرقها. اختصار \"min\" بحيث تُقرأ بشكل صحيح عند 1 — لا يوفّر Chrome i18n صيغ جمع.",
+    "message": "هذا $count$ صوت — نحو $minutes$ دقيقة. ضيّق القائمة أولاً.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "تسمية تسهيل الوصول لزر «استخدم هذا الصوت» لكل مضيف في كتالوج الأصوات ضمن الإعدادات؛ $name$ هو الصوت، و$host$ هو المساعد (مثل Pi وClaude).",
+    "message": "استخدم $name$ على $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "تسمية قصيرة على زر «استخدم هذا الصوت» لكل مضيف في كتالوج الأصوات ضمن الإعدادات الموحّدة (يُعرض المضيف بجانبه).",
+    "message": "استخدم"
+  },
+  "voicesYourVoice": {
+    "description": "زر في شريط التحكم ضمن قائمة الأصوات في الإعدادات ينقل التركيز إلى صف الصوت الذي يستخدمه هذا المضيف حاليًا؛ $name$ هو ذلك الصوت.",
+    "message": "صوتك: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "خطأ يُرمى عندما لا يستطيع المتصفح تخصيص ذاكرة WebAssembly كافية لنموذج اكتشاف الصوت.",
+    "message": "لا يمكن بدء اكتشاف الصوت: لا توجد ذاكرة WebAssembly كافية لنموذج الصوت. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "خطأ يُرمى عندما لا يوفّر المتصفح ذاكرة WebAssembly الأولية اللازمة لتشغيل نموذج اكتشاف الصوت.",
+    "message": "لا يمكن بدء اكتشاف الصوت: ذاكرة WebAssembly غير متاحة في هذا المتصفح."
   }
 }

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Предимство, изписано в модалния прозорец за вход/регистрация – увеличени лимити за използване.",
+    "message": "По-високи лимити за използване с безплатен акаунт"
+  },
+  "authBenefitPremium": {
+    "description": "Предимство, изписано в модалния прозорец за вход/регистрация – премиум функции за различни чатботове.",
+    "message": "Премиум функции и поддръжка за чатботове"
+  },
+  "authBenefitSupport": {
+    "description": "Предимство, изписано в модалния прозорец за вход/регистрация – приоритетна поддръжка.",
+    "message": "Приоритетна поддръжка при проблеми"
+  },
+  "authBenefitSync": {
+    "description": "Предимство, изписано в модалния прозорец за вход/регистрация – синхронизиране на настройки.",
+    "message": "Синхронизирайте настройките за глас навсякъде"
+  },
+  "authBenefitTTS": {
+    "description": "Предимство, изписано в модалния прозорец за вход/регистрация – функция за преобразуване на текст в реч.",
+    "message": "Гласове за преобразуване на текст в реч (платени планове)"
+  },
+  "authBenefitUsage": {
+    "description": "Предимство, изписано в модалния прозорец за вход/регистрация – проследяване на използването.",
+    "message": "Следете използването на гласови функции на различни устройства"
+  },
+  "authPromptModalFull": {
+    "description": "Описание за „пълната“ версия на модалния прозорец за вход/регистрация с представяне на стойността.",
+    "message": "Използвате SayPi много активно. Влезте за по-високи лимити, гласове за преобразуване на текст в реч и премиум функции във всички поддържани чатботове."
+  },
+  "authPromptModalSoft": {
+    "description": "Описание за „меката“ версия на модалния прозорец за вход/регистрация.",
+    "message": "Създайте безплатен акаунт в SayPi за по-високи лимити и достъп до премиум гласови функции."
+  },
+  "authPromptTitle": {
+    "description": "Заглавие на модалния прозорец за вход/регистрация.",
+    "message": "Отключете още гласови функции"
+  },
+  "authPromptToast": {
+    "description": "Изскачащо известие, което насърчава потребителя да влезе.",
+    "message": "Влезте в SayPi за по-високи лимити и премиум функции"
+  },
   "autoReadAloudChatGPT": {
     "description": "Отметка за разрешаване или забрана на автоматичното озвучаване на отговорите на ChatGPT по време на гласови обаждания.",
     "message": "Автоматично озвучаване (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Деактивирайте текста към реч"
   },
+  "dismiss": {
+    "message": "Разбрах",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Отменям"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Фокус"
   },
+  "errorVadInitFailed": {
+    "description": "Съобщение за грешка (toast), показвано когато засичането на гласова активност не успее да се инициализира.",
+    "message": "Неуспешно инициализиране на засичането на глас"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Съобщение за грешка (toast), показвано когато възникне неочаквана грешка при настройването на гласовото записване.",
+    "message": "Неуспешна настройка на гласовото записване"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Съобщение за грешка (toast), показвано когато клиентът за засичане на глас не успее да започне запис.",
+    "message": "Неуспешно стартиране на гласовото записване"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Съобщение за грешка (toast), показвано когато клиентът за засичане на гласова активност (VAD) не е наличен, така че записът не може да започне.",
+    "message": "Гласовото записване не е налично"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Излез от режими на фокус"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Едноредова бележка, показвана в менютата за глас, когато са налични както премиум (HD), така и value гласове",
+    "message": "HD гласовете изразходват месечната ви квота около 20× по-бързо."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Разменям това ..."
   },
+  "maybeLater": {
+    "description": "Текст на бутона за отказ/затваряне на подканата за вход.",
+    "message": "Може би по-късно"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Настройките на вашия микрофон не отговарят на изискваните спецификации. \nОпитайте да използвате различен микрофон или коригирайте аудио настройките си."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Няма достъп до микрофона. \nМоля, проверете настройките на вашето устройство и опитайте отново."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Съобщение за грешка (toast), показвано когато разрешението за микрофона е отказано след потока с подканата за разрешение.",
+    "message": "Разрешението за микрофона не беше предоставено. Уверете се, че сте разрешили достъпа в подканата и в настройките на разширението."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "точност"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Най-бързият отговор, но по-малко точен. \nСклонен към прекъсване."
   },
+  "moreVoices": {
+    "description": "Ред в менюто, който води от менюто за гласове на страницата към пълния каталог с гласове в настройките на разширението",
+    "message": "Още гласове…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Псевдоним на асистента"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Не е влязъл в"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Етикет на бутон, който отваря ChatGPT.",
+    "message": "Отвори ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Етикет на бутон, който отваря Claude.ai.",
+    "message": "Отворете Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Етикет на бутон, който отваря Pi.ai.",
+    "message": "Отворете Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Опция за среда: сред други хора.",
+    "message": "Сред други хора"
+  },
+  "onboarding_envMixed": {
+    "description": "Опция за среда: смесица от лични и споделени пространства.",
+    "message": "На различни места"
+  },
+  "onboarding_envPrivate": {
+    "description": "Опция за среда: лично пространство.",
+    "message": "Някъде насаме"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Потвърждение, показвано когато отговорът за средата оставя тихия режим изключен.",
+    "message": "Разбрахме се — ще запазим стандартните настройки за слушане и възпроизвеждане."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Потвърждение, показвано когато отговорът за средата включи тих режим.",
+    "message": "Тих режим е включен — ще улавяме по-тиха реч и ще отговаряме тихо, за да можеш да говориш дискретно."
+  },
+  "onboarding_envTitle": {
+    "description": "Заглавие за въпроса в първоначалното въвеждане за средата на потребителя.",
+    "message": "Къде обикновено ще говориш?"
+  },
+  "onboarding_footer": {
+    "description": "Текст във футъра на страницата за първоначално въвеждане при първо стартиране.",
+    "message": "Можеш да се върнеш към това по всяко време от настройките на Say, Pi. Поверителността ти е важна — аудио се записва само по време на активен разговор."
+  },
+  "onboarding_heading": {
+    "description": "Основно заглавие на страницата за първоначално въвеждане при първо стартиране.",
+    "message": "🗣️ Добре дошли в Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Въвеждащ абзац на страницата за първоначално въвеждане при първо стартиране.",
+    "message": "Остават ви две стъпки до първия ви разговор с AI с говор. Говоренето е около 3× по-бързо от писането — нека ви настроим."
+  },
+  "onboarding_micTestButton": {
+    "description": "Бутон, който стартира безрисковия тест на микрофона в първоначалното въвеждане.",
+    "message": "🎤 Тествай микрофона си"
+  },
+  "onboarding_micTestDone": {
+    "description": "Състояние, показвано след като тестът на микрофона в първоначалното въвеждане приключи успешно.",
+    "message": "Супер — микрофонът ти работи 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Състояние, показвано докато тестът на микрофона в първоначалното въвеждане измерва входа.",
+    "message": "Слушам — кажи нещо 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Състояние, показвано докато тестът на микрофона в първоначалното въвеждане чака разрешение.",
+    "message": "Искаме достъп до микрофона…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Етикет на бутон за спиране на теста на микрофона в първоначалното въвеждане, докато тече.",
+    "message": "Спри теста"
+  },
+  "onboarding_step1Body": {
+    "description": "Текст на първата стъпка от въвеждането, обясняващ как да закачите разширението.",
+    "message": "Кликнете иконата с пъзел 🧩 горе вдясно в браузъра, после карфицата 📌 до Say, Pi. Така бутонът за обаждане е на един клик разстояние."
+  },
+  "onboarding_step1Title": {
+    "description": "Заглавие на първата стъпка от въвеждането (закачане на разширението).",
+    "message": "Закачете Say, Pi към лентата с инструменти"
+  },
+  "onboarding_step2Body": {
+    "description": "Текст на втората стъпка от въвеждането, обясняващ как да започнете гласов разговор.",
+    "message": "Отидете при някой от поддържаните асистенти по-долу, после натиснете бутона за обаждане на Say, Pi и кажете здравей. Първия път ще поискаме достъп до микрофона — това е нормално, и слушаме само докато сте активно в разговор."
+  },
+  "onboarding_step2Title": {
+    "description": "Заглавие на втората стъпка от въвеждането (стартиране на разговор).",
+    "message": "Отворете AI чат и започнете да говорите"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Разрешение за микрофон"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Насоки за възстановяване, когато разрешението за микрофона е блокирано.",
+    "message": "Браузърът ви блокира микрофона. Щракнете иконата на камера или катинар в адресната лента, задайте Microphone на „Allow“, после опитайте отново. На macOS проверете и System Settings → Privacy & Security → Microphone."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Заглавие на панела за възстановяване, когато разрешението за микрофона е отказано/блокирано.",
+    "message": "Достъпът до микрофона е блокиран"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Насоки за възстановяване, когато микрофонът се използва другаде.",
+    "message": "Друго приложение или раздел може да използва микрофона ви. Затворете всичко, което може да записва (видеоразговори, гласови бележки), после опитайте отново."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Заглавие на панела за възстановяване, когато микрофонът се използва от друго приложение.",
+    "message": "Микрофонът ви е зает"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Насоки за възстановяване, когато няма налично устройство микрофон.",
+    "message": "Не успяхме да намерим микрофон. Включете такъв (или свържете слушалките си с микрофон), уверете се, че е избран като входно устройство, после опитайте отново."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Заглавие на панела за възстановяване, когато няма налично устройство микрофон.",
+    "message": "Не е открит микрофон"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Насоки за възстановяване при неизвестна грешка с микрофона.",
+    "message": "Нещо се обърка при достъпа до микрофона ви. Проверете дали е свързан и разрешен в настройките на браузъра, после опитайте отново."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Заглавие на панела за възстановяване при неизвестна грешка с микрофона.",
+    "message": "Не успяхме да получим достъп до микрофона ви"
+  },
+  "permissions_retryButton": {
+    "description": "Етикет за бутона, който отново изисква разрешение за микрофона.",
+    "message": "Опитайте отново"
+  },
+  "permissions_revokedHeading": {
+    "description": "Заглавие, показвано когато достъпът до микрофона е бил предоставен преди, но впоследствие е отнет.",
+    "message": "🎙️ Нека свържем микрофона ви отново"
+  },
+  "permissions_revokedInfo": {
+    "description": "Информационен текст, показван когато достъпът до микрофона е бил отнет след като е бил предоставен.",
+    "message": "Достъпът до микрофона ви беше изключен — това често се случва след актуализация на браузъра или системата. Разрешете го отново по-долу и $productName$ пак ще слуша, когато сте в разговор.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Профил"
+  },
+  "quietModeLabel": {
+    "description": "Етикет за превключвателя, който включва тих/шепотен режим.",
+    "message": "Тих режим"
+  },
+  "quietModeTooltip": {
+    "description": "Подсказка, която обяснява какво прави тих/шепотен режим.",
+    "message": "Говорете тихо — улавя по-тиха реч и намалява силата на отговора на асистента, за да можете да използвате глас около други хора."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Текст за бутона за вход, докато удостоверяването е в ход.",
+    "message": "Влизане…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Звукови ефекти"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Звуковите ефекти са деактивирани във Firefox, за да се предотвратят проблеми със звуковата обратна връзка."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Заглавие на еднократното известие за ползата от скоростта, показвано след първия разговор с глас.",
+    "message": "Добре — говоренето е около 3× по-бързо от писането."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Незадължителен втори ред на известието за ползата от скоростта, който показва спестените цели минути.",
+    "message": "Вече сте говорили с около $minutes$ мин по-бързо, отколкото ако го бяхте написали.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Изпратете само когато натиснете бутона"
   },
+  "surveyQuestion": {
+    "description": "Единственият въпрос в еднократното микро-проучване след успех.",
+    "message": "Как ви се струва гласът досега?"
+  },
+  "surveyRatingLabel": {
+    "description": "Достъпен етикет за бутон за оценка в проучването.",
+    "message": "Оценете: $rating$ от 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Потвърждение, показвано след като потребителят отговори на проучването след успех.",
+    "message": "Благодаря — това ни помага да направим Say, Pi по-добър. 🙏"
+  },
   "tabAIChat": {
     "description": "Етикет на таба за секцията с настройки на AI чата.",
     "message": "AI Чат"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Етикет на таба за секцията с общи настройки.",
     "message": "Общи"
+  },
+  "tabVoices": {
+    "description": "Етикет на раздела за секцията с настройки на гласовете (каталог с гласове по сайтове).",
+    "message": "Гласове"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "кредити"
   },
+  "ttsCreditsRemaining": {
+    "description": "Текст, показващ оставащата квота за TTS като пул от кредити за глас (saypi-api #181 Stage 2), а не като брой знаци.",
+    "message": "Остават $credits$ кредита",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Понастоящем в Safari не се поддържат многоезични гласове."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Гласово генериране"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Внимание! Възпроизвеждането на реч все още не е налично на $browserName$ с $chatbotName$. Добрата новина? Гласовият вход работи отлично! За TTS опитайте Chrome или Edge на работния плот.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS не е наличен на $browserName$ + $chatbotName$. Гласовият вход работи! Опитайте Chrome на работния плот за TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Tts глас"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Активиране на микрофон ..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Подробност от VAD, когато е засечено аудио, подобно на реч, но е било твърде тихо / с ниска увереност за транскрибиране (клиентско отхвърляне от admission gate).",
+    "message": "Аудиото е твърде тихо за транскрибиране"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "Сервизната услуга на VAD."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Подробност от VAD, обясняваща, че обаждането е приключило, защото микрофонът е бил заявен от по-нов таб.",
+    "message": "Гласовият вход е преместен в друг таб"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "В очакване на реч"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Гласът не е наличен. \nОпитайте Chrome или Firefox на работния плот."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Внимание! Възпроизвеждането на реч все още не е налично на $browserName$ с $chatbotName$. Добрата новина? Гласовият вход работи отлично! За TTS опитайте Chrome или Edge на работния плот.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS не е наличен на $browserName$ + $chatbotName$. Гласовият вход работи! Опитайте Chrome на работния плот за TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Разбрах",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Покритие"
   },
+  "vadStatusPreempted": {
+    "description": "Статус на VAD, показван в таб, чийто гласов вход е бил поет от друг таб.",
+    "message": "На пауза"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Обработка"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Вижте подробности"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Общо гласово представяне, което се пуска, когато избраният глас на Say, Pi няма специфичен скрипт за представяне (и няма скорошно съобщение за прочит).",
+    "message": "Здравейте, аз съм $voice$. Така звуча. Надявам се този глас да ви хареса.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Здравей! \nПривет! \n你好! \nАз съм Пи, вашият полиглот AI помощник. \nС 32 езика под мое управление можем да изследваме идеи и култури от цял ​​свят. \nКакво мислите за този глас?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Гласови настройки"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Резервен подзаглавен текст за ред с глас в каталога с гласове в настройките, когато гласът няма описание; $count$ е броят езици, които гласът поддържа.",
+    "message": "Говори $count$ езика",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Създаден слоган за личността на гласа „Addison“ (настройки: студио Voices; клиентска карта за идентичност на гласа).",
+    "message": "Слънчев и изразителен"
+  },
+  "voiceTagline_alloy": {
+    "description": "Авторски слоган за личността на гласа „Alloy“ (студио „Гласове“ в настройките; клиентска карта на идентичността на гласа).",
+    "message": "Балансиран и универсален"
+  },
+  "voiceTagline_ash": {
+    "description": "Авторски слоган за личността на гласа „Ash“ (студио „Гласове“ в настройките; клиентска карта на идентичността на гласа).",
+    "message": "Нисък, замислен, спокоен"
+  },
+  "voiceTagline_ballad": {
+    "description": "Авторски слоган за личността на гласа „Ballad“ (студио „Гласове“ в настройките; клиентска карта на идентичността на гласа).",
+    "message": "Плавен и мелодичен"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Създаден слоган за личността на гласа „Cassidy“ (настройки: студио Voices; клиентска карта за идентичност на гласа).",
+    "message": "Приветлив и делови"
+  },
+  "voiceTagline_cedar": {
+    "description": "Авторски слоган за личността на гласа „Cedar“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Спокоен и успокояващ"
+  },
+  "voiceTagline_coral": {
+    "description": "Авторски слоган за личността на гласа „Coral“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Светла, приповдигната енергия"
+  },
+  "voiceTagline_echo": {
+    "description": "Авторски слоган за личността на гласа „Echo“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Чист и неутрален"
+  },
+  "voiceTagline_fable": {
+    "description": "Авторски слоган за личността на гласа „Fable“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Разказвачески нюанс"
+  },
+  "voiceTagline_finn": {
+    "description": "Създаден слоган за личността на гласа „Finn“ (настройки: студио Voices; клиентска карта за идентичност на гласа).",
+    "message": "Свеж и енергичен"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Създаден слоган за личността на гласа „Jamahal“ (настройки: студио Voices; клиентска карта за идентичност на гласа).",
+    "message": "Плътен и магнетичен"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Авторски слоган за личността на гласа „Jarnathan“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Кадифен къснонощен баритон"
+  },
+  "voiceTagline_jeff": {
+    "description": "Създаден слоган за личността на гласа „Jeff“ (настройки: студио Voices; клиентска карта за идентичност на гласа).",
+    "message": "Прям и уравновесен"
+  },
+  "voiceTagline_jessica": {
+    "description": "Създаден слоган за личността на гласа „Jessica“ (настройки: студио Voices; клиентска карта за идентичност на гласа).",
+    "message": "Топла, изтънчена осанка"
+  },
+  "voiceTagline_joey": {
+    "description": "Авторски слоган за личността на гласа „Joey“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Лесен, разговорен американски"
+  },
+  "voiceTagline_juniper": {
+    "description": "Създаден слоган за личността на гласа „Juniper“ (настройки: студио Voices; клиентска карта за идентичност на гласа).",
+    "message": "Ясен, светъл, жив"
+  },
+  "voiceTagline_lucy": {
+    "description": "Създаден слоган за личността на гласа „Lucy“ (настройки: студио Voices; клиентска карта за идентичност на гласа).",
+    "message": "Нежен и сияен"
+  },
+  "voiceTagline_marin": {
+    "description": "Авторски слоган за личността на гласа „Marin“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Топъл, спокоен като сутрешно радио"
+  },
+  "voiceTagline_mark": {
+    "description": "Създаден слоган за личността на гласа „Mark“ (настройки: студио Voices; клиентска карта за идентичност на гласа).",
+    "message": "Ясен, уверен разказвач"
+  },
+  "voiceTagline_nova": {
+    "description": "Авторски слоган за личността на гласа „Nova“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Бърз и любопитен"
+  },
+  "voiceTagline_onyx": {
+    "description": "Авторски слоган за личността на гласа „Onyx“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Дълбока, плътна тежест"
+  },
+  "voiceTagline_paola": {
+    "description": "Авторски слоган за личността на гласа „Paola“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Изразителна италианска топлота"
+  },
+  "voiceTagline_sage": {
+    "description": "Авторски слоган за личността на гласа „Sage“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Тиха яснота"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Авторски слоган за личността на гласа „Shimmer“ (настройки: студио Гласове; клиентска карта на идентичността на гласа).",
+    "message": "Лек и ефирен"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Кратък етикет върху превключвателя за закачане на карта на глас (изключено състояние) в Voices studio в настройките; натискането добавя гласа към менюто на хоста в чата.",
+    "message": "+ Меню"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Достъпен етикет за превключвателя за закачане на карта на глас (изключено състояние); $name$ е гласът, $host$ е асистентът.",
+    "message": "Добави $name$ към менюто на $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Етикет на превключвателя в лентата за управление на „Гласове“, който указва дали придвижването в списъка с клавишите със стрелки пуска всеки глас, когато фокусът стигне до него.",
+    "message": "Пускай при придвижване"
+  },
+  "voicesArrowsLive": {
+    "description": "Потвърждение за екранен четец, добавено към първото съобщение „Възпроизвежда се <глас>“ в списъка „Гласове“ в настройките, което казва, че стрелките току-що са станали звукови. Повтаря формулировката на превключвателя „Възпроизвеждай при придвижване“.",
+    "message": "Стрелките вече възпроизвеждат при придвижване. Esc спира."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Бележка под местата в менюто за хостове, които идват с вградени гласове (напр. 8-те вградени гласа на Pi), които студиото не управлява; $host$ е асистентът.",
+    "message": "В менюто на $host$ винаги се показват и собствените вградени гласове.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Вариант на voicesBuiltinsNote за хост без меню за глас в чата (Pi премахна менюто си през 2026), при който обещанието от оригинала, че вградените гласове „се показват в менюто му“, би било невярно; $host$ е асистентът.",
+    "message": "$host$ има и собствени вградени гласове, които не са изброени тук.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Отчет за напредъка в лентата за управление на настройките „Гласове“: колко от изброените гласове потребителят вече е слушал. Само числа, така че да се чете правилно и при 1 — Chrome i18n няма множествени форми.",
+    "message": "Чути $heard$ от $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Част от достъпното име на ред за глас в списъка „Гласове“ в настройките, която отбелязва глас, който този профил вече е слушал. Визуално това е изобразено като плътност на мастилото в звуковия отпечатък на гласа, което екранният четец не може да види.",
+    "message": "Чут"
+  },
+  "voicesInHostMenu": {
+    "description": "Заглавие на раздел над реда със слотове в менюто в Voices studio в настройките; $host$ е асистентът.",
+    "message": "В менюто на $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Кратък етикет върху превключвателя за закачане на карта на глас (включено състояние) в Voices studio в настройките.",
+    "message": "✓ В менюто"
+  },
+  "voicesInUse": {
+    "description": "Постоянна значка върху текущо избрания глас на хоста в списъка с гласове в настройките, визуализирана с главни букви. Умишлено НЕ е „Говори в момента“: на тази страница редовете възпроизвеждат примерни клипове, така че избран, но мълчалив глас не бива да твърди, че говори, докато друг ред го прави.",
+    "message": "Използва се"
+  },
+  "voicesKeyboardHint": {
+    "description": "Едноредов подсказващ текст за клавиатурата в лентата за управление на настройките „Гласове“. Символите са клавиши: Space, стрелките нагоре/надолу и Shift+Space.",
+    "message": "Натиснете Space, за да слушате, ↑↓ за придвижване между гласове, ⇧Space за връщане назад."
+  },
+  "voicesLoadError": {
+    "description": "Състояние за грешка в студиото на конкретен хост, когато каталогът с гласове на този хост не успее да се зареди; $host$ е асистентът.",
+    "message": "Не успяхме да заредим гласовете на $host$. Моля, опитайте отново по-късно.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Подсказка/хинт върху деактивиран превключвател „+ Меню“, когато менюто на хоста в чата вече е достигнало максималния брой гласове.",
+    "message": "Менюто е пълно — премахни глас, за да добавиш друг"
+  },
+  "voicesMenuHint": {
+    "description": "Едноредова подсказка до заглавието „В менюто на {host}“, която обяснява, че редът със слотове отразява менюто с гласове в чата.",
+    "message": "Какво ще виждаш в чата"
+  },
+  "voicesMenuOverflow": {
+    "description": "Бележка под местата в менюто, когато потребителят има повече закачени гласове, отколкото менюто в чата може да покаже (наследено състояние); $count$ е колко не се побират, $cap$ е размерът на менюто.",
+    "message": "Още $count$ закачени гласа чакат след $cap$-те места в менюто.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Единствено число на voicesMenuOverflow, използва се когато точно един закачен глас не се побира в менюто в чата; $cap$ е размерът на менюто.",
+    "message": "Още 1 закачен глас чака след $cap$-те места в менюто.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Обобщаващ ред под списъка „Гласове“ в настройките, който показва колко е запълнено гласовото меню на хоста в чата; $host$ е асистентът, $used$ е колко места са заети, $cap$ е колко са общо. Формулирано да звучи правилно и при 1 — Chrome i18n няма множествени форми.",
+    "message": "Менюто на $host$: $used$ от $cap$ места",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Заглавие за групата в края на списъка „Гласове“ в настройките, която съдържа гласове без примерен клип за пускане; $count$ е колко са. Формулирано да звучи правилно и при 1 — Chrome i18n няма множествени форми.",
+    "message": "Още няма пример ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Показва се в каталога с гласове в настройките, когато списъкът с гласове е празен за влязъл потребител (напр. проблем с мрежата).",
+    "message": "Гласовете не могат да се заредят в момента. Опитайте отново по-късно."
+  },
+  "voicesNowPlaying": {
+    "description": "Съобщение за екранен четец, когато започне да се възпроизвежда примерният клип на глас в списъка „Гласове“ в настройките; $name$ е гласът.",
+    "message": "Възпроизвежда се $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Бутон в лентата за управление на настройките „Гласове“, който пуска всички текущо изброени гласове един след друг; $count$ е колко са. Формулирано да звучи правилно и при 1 — Chrome i18n няма множествени форми.",
+    "message": "Пуснете всички ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Бутон в лентата за управление на настройките „Гласове“ при повторно посещение: пуска само изброените гласове, които още не сте слушали; $count$ е колко са. Формулирано да звучи правилно и при 1 — Chrome i18n няма множествени форми.",
+    "message": "Пуснете новите ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Ред в лентата за управление „Гласове“ в настройките, когато браузърът отказва да пусне пример, защото страницата все още няма потребителско взаимодействие.",
+    "message": "Щракнете върху глас, за да разрешите звука."
+  },
+  "voicesPreview": {
+    "description": "Достъпен етикет за бутона за пускане (▶), който прослушва безплатния примерен клип на гласа в реда за глас; $name$ е името на гласа.",
+    "message": "Пусни пример с $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Достъпно име на списъка „Гласове“ в настройките (listbox с всеки глас, по един ред за всеки).",
+    "message": "Гласове, подредени от най-дълбокия до най-светлия"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Достъпен етикет за превключвателя за закачане на карта на глас (включено състояние) и бутона за премахване на слот в менюто; $name$ е гласът, $host$ е асистентът.",
+    "message": "Премахни $name$ от менюто на $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Ред в лентата за управление „Гласове“ в настройките, когато примерният клип на даден глас не успее да се зареди или да се възпроизведе; $name$ е този глас. Немодално — поредицата от примери продължава и след него.",
+    "message": "Не успяхме да пуснем примера на $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Подзаглавие на раздела с каталога на гласове в таба AI Chat на настройките",
+    "message": "Изберете гласа, който чете на глас отговорите на всеки сайт."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Подзаглавие под заглавието на настройките „Гласове“, за релсата с гласове, подредени по височина.",
+    "message": "Всеки глас, от най-дълбокия до най-светлия. Слушайте, после изберете."
+  },
+  "voicesSectionTitle": {
+    "description": "Заглавие на раздела с каталога на гласове в таба AI Chat на настройките",
+    "message": "Гласове"
+  },
+  "voicesShelfEveryday": {
+    "description": "Заглавие на група за гласове от по-достъпния клас в каталога с гласове в настройките. Рендерира се с главни букви чрез CSS.",
+    "message": "Ежедневни гласове"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Едноредова бележка до заглавието на групата Everyday в студиото Гласове в настройките; единственото място, където студиото казва колко по-далеч стига този клас спрямо HD.",
+    "message": "Естествени и ясни — можете да слушате около 20× по-дълго, отколкото с HD."
+  },
+  "voicesShelfHd": {
+    "description": "Заглавие на група за премиум (HD) гласове в каталога с гласове в настройките. Рендерира се с главни букви чрез CSS.",
+    "message": "HD гласове"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Едноредова бележка до заглавието на групата HD в студиото Гласове в настройките.",
+    "message": "Най-богатият и най-изразителният ни звук."
+  },
+  "voicesShowAll": {
+    "description": "Опция във филтъра „Покажи“ за „Гласове“ в настройките: без филтриране, показват се всички гласове.",
+    "message": "Всички гласове"
+  },
+  "voicesShowEveryday": {
+    "description": "Опция във филтъра „Покажи“ за „Гласове“ в настройките: показва само стандартните (не-HD) гласове.",
+    "message": "Само стандартни"
+  },
+  "voicesShowHd": {
+    "description": "Опция във филтъра „Покажи“ за „Гласове“ в настройките: показва само премиум (HD) гласовете.",
+    "message": "Само HD"
+  },
+  "voicesShowLabel": {
+    "description": "Етикет на филтъра в лентата за управление „Гласове“ в настройките, който стеснява кои гласове се показват в списъка.",
+    "message": "Покажи"
+  },
+  "voicesShowUnheard": {
+    "description": "Опция във филтъра „Покажи“ за „Гласове“ в настройките: показва само гласовете, които потребителят още не е слушал.",
+    "message": "Още нечутите"
+  },
+  "voicesSpeakingNow": {
+    "description": "Етикет за състояние върху текущо избрания глас на хоста в Voices studio в настройките (слот в менюто и карта на гласа).",
+    "message": "Говори в момента"
+  },
+  "voicesSpeaksWith": {
+    "description": "Ред над името на текущия глас на сцената Voices studio в настройките; $host$ е асистентът (напр. Pi). CSS го визуализира с главни букви.",
+    "message": "$host$ говори с",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Бележка на сцената, когато хостът има собствено аудио (напр. Pi), така че изборът на глас от Say, Pi заменя гласа на хоста.",
+    "message": "$host$ използва собствения си глас, докато не изберете един отдолу.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Бележка на сцената, когато хостът няма собствен глас (напр. Claude), така че нищо не се чете на глас, докато не бъде избран глас от Say, Pi.",
+    "message": "$host$ няма да чете отговорите на глас, докато не изберете един отдолу.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Заглавие на сцената в студиото „Гласове“ в настройките, когато за хоста не е избран глас от SayPi; $host$ е асистентът (напр. Pi, Claude). Рендерира се с размер на име.",
+    "message": "Изберете как звучи $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Бутон на сцената в студиото „Гласове“ в настройките, който пуска безплатния примерен клип на текущия глас.",
+    "message": "Чуйте откъс"
+  },
+  "voicesStopPlayback": {
+    "description": "Бутон в лентата за управление на настройките „Гласове“, който спира поредицата от примери, стартирана от „Пуснете всички“.",
+    "message": "Спиране"
+  },
+  "voicesSweepPosition": {
+    "description": "Показване на текущата позиция в лентата за управление „Гласове“ в настройките, докато „Пусни всички“ обхожда списъка; $index$ е гласът, който се възпроизвежда в момента, а $total$ е колко са на опашка.",
+    "message": "$index$ от $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Достъпен етикет за контролата за сравнение в лентата за управление на настройките „Гласове“, която пуска отново другия глас от последните два чути; $name$ е този глас.",
+    "message": "Върнете към $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Ред в лентата за управление „Гласове“ в настройките, когато „Пусни всички“ е натиснато за твърде дълъг списък; $count$ е колко са гласовете, а $minutes$ приблизително колко минути биха отнели. Съкратено „мин.“ така че да се чете правилно при 1 — Chrome i18n няма форми за множествено число.",
+    "message": "Това са $count$ гласа — около $minutes$ мин. Първо стеснете списъка.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Достъпен етикет за бутона „използвай този глас“ за конкретен хост в каталога с гласове в настройките; $name$ е гласът, $host$ е асистентът (напр. Pi, Claude).",
+    "message": "Използвай $name$ в $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Кратък етикет върху бутона „използвай този глас“ за конкретен хост в единния каталог с гласове в настройките (хостът се показва до него).",
+    "message": "Използвай"
+  },
+  "voicesYourVoice": {
+    "description": "Бутон в лентата за управление в списъка „Гласове“ в настройките, който премества фокуса към реда на гласа, който този хост използва в момента; $name$ е този глас.",
+    "message": "Вашият глас: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Грешка, хвърляна когато браузърът не може да задели достатъчно WebAssembly памет за модела за засичане на глас.",
+    "message": "Засичането на глас не може да стартира: няма достатъчно WebAssembly памет за гласовия модел. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Грешка, хвърляна когато браузърът не предоставя началната WebAssembly памет, нужна за изпълнение на модела за засичане на глас.",
+    "message": "Засичането на глас не може да стартира: в този браузър не е налична памет за WebAssembly."
   }
 }

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "অথ মোডালে তালিকাভুক্ত সুবিধা - ব্যবহার সীমা বৃদ্ধি।",
+    "message": "ফ্রি অ্যাকাউন্টে উচ্চতর ব্যবহার সীমা"
+  },
+  "authBenefitPremium": {
+    "description": "অথ মোডালে তালিকাভুক্ত সুবিধা - চ্যাটবট জুড়ে প্রিমিয়াম ফিচার।",
+    "message": "প্রিমিয়াম ফিচার ও চ্যাটবট সাপোর্ট"
+  },
+  "authBenefitSupport": {
+    "description": "অথ মোডালে তালিকাভুক্ত সুবিধা - অগ্রাধিকার সাপোর্ট।",
+    "message": "সমস্যার জন্য অগ্রাধিকার সাপোর্ট"
+  },
+  "authBenefitSync": {
+    "description": "অথ মোডালে তালিকাভুক্ত সুবিধা - সেটিংস সিঙ্ক।",
+    "message": "সবখানে ভয়েস সেটিংস সিঙ্ক করুন"
+  },
+  "authBenefitTTS": {
+    "description": "অথ মোডালে তালিকাভুক্ত সুবিধা - TTS ফিচার।",
+    "message": "টেক্সট-টু-স্পিচ ভয়েস (পেইড প্ল্যান)"
+  },
+  "authBenefitUsage": {
+    "description": "অথ মোডালে তালিকাভুক্ত সুবিধা - ব্যবহার ট্র্যাকিং।",
+    "message": "ডিভাইস জুড়ে আপনার ভয়েস ব্যবহার ট্র্যাক করুন"
+  },
+  "authPromptModalFull": {
+    "description": "ভ্যালু প্রপোজিশনসহ ফুল মোডাল অথ প্রম্পটের বর্ণনা।",
+    "message": "আপনি Say, Pi অনেক ব্যবহার করছেন। উচ্চ সীমা, টেক্সট-টু-স্পিচ ভয়েস এবং সব সমর্থিত চ্যাটবটে প্রিমিয়াম ফিচারের জন্য সাইন ইন করুন।"
+  },
+  "authPromptModalSoft": {
+    "description": "সফট মোডাল অথ প্রম্পটের বর্ণনা।",
+    "message": "উচ্চ ব্যবহার সীমা ও প্রিমিয়াম ভয়েস ফিচারে অ্যাক্সেস পেতে একটি ফ্রি Say, Pi অ্যাকাউন্ট তৈরি করুন।"
+  },
+  "authPromptTitle": {
+    "description": "অথ প্রম্পট মোডালের শিরোনাম।",
+    "message": "আরও ভয়েস ফিচার আনলক করুন"
+  },
+  "authPromptToast": {
+    "description": "ব্যবহারকারীকে সাইন ইন করতে উৎসাহিত করার টোস্ট নোটিফিকেশন।",
+    "message": "উচ্চ সীমা ও প্রিমিয়াম ফিচারের জন্য Say, Pi-তে সাইন ইন করুন"
+  },
   "autoReadAloudChatGPT": {
     "description": "ভয়েস কলের সময় ChatGPT এর প্রতিক্রিয়াগুলি স্বয়ংক্রিয়ভাবে পড়ার বিকল্প সক্ষম বা নিষ্ক্রিয় করার জন্য চেকবক্সের লেবেল।",
     "message": "স্বয়ংক্রিয়ভাবে পড়ুন (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "পাঠ্য থেকে স্পিচ অক্ষম করুন"
   },
+  "dismiss": {
+    "message": "বুঝেছি",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "খারিজ করা"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "মনোযোগ দিন"
   },
+  "errorVadInitFailed": {
+    "description": "ভয়েস-অ্যাক্টিভিটি ডিটেকশন শুরু করতে ব্যর্থ হলে দেখানো এরর টোস্ট।",
+    "message": "ভয়েস ডিটেকশন চালু করা যায়নি"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "ভয়েস রেকর্ডিং সেট আপ করার সময় অপ্রত্যাশিত ত্রুটি হলে দেখানো এরর টোস্ট।",
+    "message": "ভয়েস রেকর্ডিং সেট আপ করা যায়নি"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "ভয়েস-ডিটেকশন ক্লায়েন্ট রেকর্ডিং শুরু করতে ব্যর্থ হলে দেখানো এরর টোস্ট।",
+    "message": "ভয়েস রেকর্ডিং শুরু করা যায়নি"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "ভয়েস-ডিটেকশন (VAD) ক্লায়েন্ট অনুপলব্ধ থাকায় রেকর্ডিং শুরু করা না গেলে দেখানো এরর টোস্ট।",
+    "message": "ভয়েস রেকর্ডিং উপলব্ধ নয়"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "ফোকাস মোড থেকে বেরিয়ে আসুন"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "প্রিমিয়াম (HD) এবং ভ্যালু ভয়েস—দুটিই উপলব্ধ থাকলে ভয়েস মেনুতে দেখানো একলাইন নোট",
+    "message": "HD ভয়েসে আপনার মাসিক বরাদ্দ প্রায় ২০× দ্রুত খরচ হয়।"
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "এই দূরে টেক করা ..."
   },
+  "maybeLater": {
+    "description": "অথ প্রম্পট বাতিল করার বাটন টেক্সট।",
+    "message": "পরে হয়তো"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "আপনার মাইক্রোফোন সেটিংস প্রয়োজনীয় স্পেসিফিকেশন পূরণ করে না। \nএকটি ভিন্ন মাইক্রোফোন ব্যবহার করে দেখুন বা আপনার অডিও সেটিংস সামঞ্জস্য করুন৷"
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "মাইক্রোফোন অ্যাক্সেস করতে অক্ষম৷ \nঅনুগ্রহ করে আপনার ডিভাইস সেটিংস চেক করুন এবং আবার চেষ্টা করুন।"
   },
+  "microphonePermissionDeniedError": {
+    "description": "অনুমতি প্রম্পটের ধাপ শেষ হওয়ার পরও মাইক্রোফোনের অনুমতি অস্বীকার করা হলে দেখানো এরর টোস্ট।",
+    "message": "মাইক্রোফোনের অনুমতি দেওয়া হয়নি। অনুগ্রহ করে প্রম্পটে এবং এক্সটেনশন সেটিংসে অ্যাক্সেস অনুমোদিত আছে কি না নিশ্চিত করুন।"
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "নির্ভুলতা"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "দ্রুততম প্রতিক্রিয়া, কিন্তু কম সঠিক। \nবাধা প্রবণ."
   },
+  "moreVoices": {
+    "description": "ইন-পেজ ভয়েস মেনু থেকে এক্সটেনশন সেটিংসের সম্পূর্ণ ভয়েস ক্যাটালগে যাওয়ার মেনু সারি।",
+    "message": "আরও ভয়েস…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "সহায়কের ডাকনাম"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "সাইন ইন না"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "ChatGPT খোলে এমন বোতামের লেবেল।",
+    "message": "ChatGPT খুলুন"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Claude.ai খোলে—এমন বোতামের লেবেল।",
+    "message": "Claude খুলুন"
+  },
+  "onboarding_ctaPi": {
+    "description": "Pi.ai খোলে—এমন বোতামের লেবেল।",
+    "message": "Pi খুলুন"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "পরিবেশের বিকল্প: অন্য মানুষের আশেপাশে।",
+    "message": "অন্যদের আশেপাশে"
+  },
+  "onboarding_envMixed": {
+    "description": "পরিবেশের বিকল্প: ব্যক্তিগত ও শেয়ার করা স্থানের মিশ্রণ।",
+    "message": "বিভিন্ন জায়গায়"
+  },
+  "onboarding_envPrivate": {
+    "description": "পরিবেশের বিকল্প: একটি ব্যক্তিগত স্থান।",
+    "message": "কোনো ব্যক্তিগত জায়গায়"
+  },
+  "onboarding_envQuietOff": {
+    "description": "পরিবেশ সংক্রান্ত উত্তরে quiet mode বন্ধ থাকলে যে নিশ্চিতকরণ দেখানো হয়।",
+    "message": "ঠিক আছে — আমরা মানক শোনা ও প্লেব্যাক সেটিংসই রাখব।"
+  },
+  "onboarding_envQuietOn": {
+    "description": "পরিবেশের উত্তরে কোয়াইট মোড চালু হলে দেখানো নিশ্চিতকরণ।",
+    "message": "কোয়াইট মোড চালু — আমরা নরমভাবে বলা কথাও ধরব এবং নিচু স্বরে উত্তর দেব, যাতে আপনি আড়ালে কথা বলতে পারেন।"
+  },
+  "onboarding_envTitle": {
+    "description": "ব্যবহারকারীর পরিবেশ সম্পর্কে অনবোর্ডিং প্রশ্নের শিরোনাম।",
+    "message": "আপনি সাধারণত কোথায় কথা বলবেন?"
+  },
+  "onboarding_footer": {
+    "description": "প্রথমবার চালুর অনবোর্ডিং পৃষ্ঠার ফুটার টেক্সট।",
+    "message": "আপনি Say, Pi-এর সেটিংস থেকে যেকোনো সময় এটি আবার দেখতে পারবেন। আপনার গোপনীয়তা গুরুত্বপূর্ণ — শুধু সক্রিয় কল চলাকালীনই অডিও নেওয়া হয়।"
+  },
+  "onboarding_heading": {
+    "description": "প্রথমবার চালুর অনবোর্ডিং পাতার প্রধান শিরোনাম।",
+    "message": "🗣️ Say, Pi-এ স্বাগতম"
+  },
+  "onboarding_intro": {
+    "description": "প্রথমবার চালুর অনবোর্ডিং পাতার পরিচিতি অনুচ্ছেদ।",
+    "message": "AI-এর সাথে আপনার প্রথম কথোপকথন করতে আপনি আর মাত্র দুই ধাপ দূরে। বলা টাইপ করার চেয়ে প্রায় ৩× দ্রুত, তাই সেটআপ করে দিই।"
+  },
+  "onboarding_micTestButton": {
+    "description": "ঝুঁকিমুক্ত অনবোর্ডিং মাইক্রোফোন টেস্ট শুরু করে এমন বোতাম।",
+    "message": "🎤 আপনার মাইক্রোফোন পরীক্ষা করুন"
+  },
+  "onboarding_micTestDone": {
+    "description": "অনবোর্ডিং মাইক টেস্ট সফলভাবে শেষ হলে দেখানো স্ট্যাটাস।",
+    "message": "ভালো — আপনার মাইক্রোফোন কাজ করছে 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "অনবোর্ডিং মাইক টেস্ট ইনপুট মাপার সময় দেখানো স্ট্যাটাস।",
+    "message": "শোনা হচ্ছে — কিছু বলুন 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "অনবোর্ডিং মাইক টেস্ট অনুমতির জন্য অপেক্ষা করার সময় দেখানো স্ট্যাটাস।",
+    "message": "মাইক্রোফোনের অনুমতি চাওয়া হচ্ছে…"
+  },
+  "onboarding_micTestStop": {
+    "description": "অনবোর্ডিং মাইক টেস্ট চলার সময় তা থামানোর বোতামের লেবেল।",
+    "message": "টেস্ট বন্ধ করুন"
+  },
+  "onboarding_step1Body": {
+    "description": "এক্সটেনশন কীভাবে পিন করতে হয় তা ব্যাখ্যা করা অনবোর্ডিং-এর প্রথম ধাপের মূল লেখা।",
+    "message": "ব্রাউজারের উপরের ডানদিকে থাকা পাজল-পিস 🧩 আইকনে ক্লিক করুন, তারপর Say, Pi-এর পাশে পিন 📌-এ। এতে কল বোতাম এক ক্লিক দূরেই থাকে।"
+  },
+  "onboarding_step1Title": {
+    "description": "অনবোর্ডিং-এর প্রথম ধাপের শিরোনাম (এক্সটেনশন পিন করা)।",
+    "message": "টুলবারে Say, Pi পিন করুন"
+  },
+  "onboarding_step2Body": {
+    "description": "ভয়েস কথোপকথন কীভাবে শুরু করতে হয় তা ব্যাখ্যা করা অনবোর্ডিং-এর দ্বিতীয় ধাপের মূল লেখা।",
+    "message": "নিচে থাকা সমর্থিত সহকারীদের যেকোনো একটিতে যান, তারপর Say, Pi কল বোতাম ট্যাপ করে হ্যালো বলুন। প্রথমবার আমরা মাইক্রোফোনের অনুমতি চাইব—এটা স্বাভাবিক, আর আপনি সক্রিয়ভাবে কলে থাকলেই আমরা শুনি।"
+  },
+  "onboarding_step2Title": {
+    "description": "অনবোর্ডিং-এর দ্বিতীয় ধাপের শিরোনাম (কথোপকথন শুরু করা)।",
+    "message": "একটি AI চ্যাট খুলুন এবং কথা বলা শুরু করুন"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "মাইক্রোফোন অনুমতি"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "মাইক অনুমতি ব্লক থাকলে পুনরুদ্ধারের নির্দেশনা।",
+    "message": "আপনার ব্রাউজার মাইক্রোফোন ব্লক করছে। অ্যাড্রেস বারে ক্যামেরা বা লক আইকনে ক্লিক করুন, Microphone-কে \"Allow\" করুন, তারপর আবার চেষ্টা করুন। macOS-এ System Settings → Privacy & Security → Microphone-ও দেখুন।"
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "মাইক অনুমতি denied/blocked হলে রিকভারি প্যানেলের শিরোনাম।",
+    "message": "মাইক্রোফোন অ্যাক্সেস ব্লক করা আছে"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "মাইক্রোফোন অন্যত্র ব্যবহৃত হলে পুনরুদ্ধারের নির্দেশনা।",
+    "message": "অন্য কোনো অ্যাপ বা ট্যাব আপনার মাইক্রোফোন ব্যবহার করছে হতে পারে। যে কিছু রেকর্ড করছে এমন সবকিছু বন্ধ করুন (ভিডিও কল, ভয়েস মেমো), তারপর আবার চেষ্টা করুন।"
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "মাইক অন্য কোনো অ্যাপ ব্যবহার করলে রিকভারি প্যানেলের শিরোনাম।",
+    "message": "আপনার মাইক্রোফোন ব্যস্ত"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "কোনো মাইক্রোফোন ডিভাইস উপলব্ধ না থাকলে পুনরুদ্ধারের নির্দেশনা।",
+    "message": "আমরা কোনো মাইক্রোফোন খুঁজে পাইনি। একটি লাগান (বা আপনার হেডসেট সংযোগ করুন), নিশ্চিত করুন এটি আপনার ইনপুট ডিভাইস হিসেবে নির্বাচিত আছে, তারপর আবার চেষ্টা করুন।"
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "কোনো মাইক্রোফোন ডিভাইস উপলব্ধ না থাকলে রিকভারি প্যানেলের শিরোনাম।",
+    "message": "কোনো মাইক্রোফোন পাওয়া যায়নি"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "অজানা মাইক্রোফোন ত্রুটির জন্য পুনরুদ্ধারের নির্দেশনা।",
+    "message": "আপনার মাইক্রোফোনে পৌঁছাতে গিয়ে কিছু সমস্যা হয়েছে। এটি সংযুক্ত আছে কিনা এবং আপনার ব্রাউজার সেটিংসে অনুমোদিত আছে কিনা দেখুন, তারপর আবার চেষ্টা করুন।"
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "অজানা মাইক ত্রুটির জন্য রিকভারি প্যানেলের শিরোনাম।",
+    "message": "আমরা আপনার মাইক্রোফোনে অ্যাক্সেস করতে পারিনি"
+  },
+  "permissions_retryButton": {
+    "description": "মাইক্রোফোন অনুমতি আবার অনুরোধ করে এমন বোতামের লেবেল।",
+    "message": "আবার চেষ্টা করুন"
+  },
+  "permissions_revokedHeading": {
+    "description": "মাইক্রোফোনে অ্যাক্সেস আগে অনুমোদিত ছিল কিন্তু পরে প্রত্যাহার করা হলে যে শিরোনাম দেখানো হয়।",
+    "message": "🎙️ আপনার মাইক্রোফোন আবার সংযোগ দিই"
+  },
+  "permissions_revokedInfo": {
+    "description": "অনুমোদনের পর মাইক্রোফোন অ্যাক্সেস প্রত্যাহার করা হলে যে তথ্যপূর্ণ লেখা দেখানো হয়।",
+    "message": "আপনার মাইক্রোফোন অ্যাক্সেস বন্ধ করা হয়েছিল — ব্রাউজার বা সিস্টেম আপডেটের পর এটা প্রায়ই হয়। নিচে আবার অনুমতি দিন, আর আপনি কলের মধ্যে থাকলে $productName$ আবার শুনতে থাকবে।",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "প্রোফাইল"
+  },
+  "quietModeLabel": {
+    "description": "নীরব/ফিসফিস মোড চালু করার টগলের লেবেল।",
+    "message": "নীরব মোড"
+  },
+  "quietModeTooltip": {
+    "description": "নীরব/ফিসফিস মোড কী করে তা ব্যাখ্যা করা টুলটিপ।",
+    "message": "আলতো করে কথা বলুন — নিচু স্বরও ধরতে পারে এবং সহকারীর উত্তর দেওয়ার ভলিউম কমায়, যাতে অন্যদের পাশে ভয়েস ব্যবহার করতে পারেন।"
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "অথেনটিকেশন চলাকালীন সাইন ইন বোতামের টেক্সট।",
+    "message": "সাইন ইন করা হচ্ছে…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "শব্দ প্রভাব"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "অডিও প্রতিক্রিয়া সমস্যা প্রতিরোধ করতে ফায়ারফক্সে সাউন্ড এফেক্ট নিষ্ক্রিয় করা হয়েছে।"
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "প্রথম স্পোকেন এক্সচেঞ্জের পর একবার দেখানো speed-payoff নোটিসের শিরোনাম।",
+    "message": "ভালো — কথা বলা টাইপ করার চেয়ে প্রায় 3× দ্রুত।"
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "সাশ্রয় হওয়া পুরো মিনিট দেখানো speed-payoff নোটিসের ঐচ্ছিক দ্বিতীয় লাইন।",
+    "message": "আপনি ইতিমধ্যেই টাইপ করার চেয়ে আনুমানিক $minutes$ মিনিট দ্রুত বলেছেন।",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "আপনি বোতাম টিপে শুধুমাত্র জমা দিন"
   },
+  "surveyQuestion": {
+    "description": "একবারের পোস্ট-উইন মাইক্রো-সার্ভের একটিমাত্র প্রশ্ন।",
+    "message": "এখন পর্যন্ত ভয়েস আপনার কেমন লাগছে?"
+  },
+  "surveyRatingLabel": {
+    "description": "সার্ভে রেটিং বোতামের জন্য অ্যাক্সেসযোগ্য লেবেল।",
+    "message": "৫ এর মধ্যে $rating$ দিন",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "ব্যবহারকারী পোস্ট-উইন সার্ভের উত্তর দেওয়ার পর দেখানো স্বীকৃতি বার্তা।",
+    "message": "ধন্যবাদ — এতে Say, Pi আরও ভালো করতে আমাদের সাহায্য হয়। 🙏"
+  },
   "tabAIChat": {
     "description": "এআই চ্যাট সেটিংস বিভাগের জন্য ট্যাব লেবেল।",
     "message": "এআই চ্যাট"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "সাধারণ সেটিংস বিভাগের জন্য ট্যাব লেবেল।",
     "message": "সাধারণ"
+  },
+  "tabVoices": {
+    "description": "ভয়েস সেটিংস সেকশনের ট্যাব লেবেল (প্রতি-সাইট ভয়েস ক্যাটালগ)।",
+    "message": "ভয়েস"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "ক্রেডিট"
   },
+  "ttsCreditsRemaining": {
+    "description": "প্রতি-ভয়েস ক্রেডিট পুল হিসেবে অবশিষ্ট TTS কোটার টেক্সট (saypi-api #181 Stage 2), কাঁচা অক্ষর সংখ্যা নয়।",
+    "message": "$credits$ ক্রেডিট বাকি",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "বহুভাষিক ভয়েস বর্তমানে সাফারিতে সমর্থিত নয়।"
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "ভয়েস জেনারেশন"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "মনোযোগ দিন! $browserName$ এ $chatbotName$ এর সাথে স্পিচ প্লেব্যাক এখনও উপলব্ধ নয়। ভাল খবর? ভয়েস ইনপুট দুর্দান্ত কাজ করে! TTS এর জন্য, ডেস্কটপে Chrome বা Edge চেষ্টা করুন।",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "$browserName$ + $chatbotName$ এ TTS অনুপলব্ধ। ভয়েস ইনপুট কাজ করে! TTS এর জন্য Chrome ডেস্কটপ চেষ্টা করুন।",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "টিটিএস ভয়েস"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "সক্রিয় মাইক্রোফোন ..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "কথার মতো অডিও শনাক্ত হয়েছিল, কিন্তু তা খুব ক্ষীণ/কম-নিশ্চিত হওয়ায় লিখে নেওয়া যায়নি—এমন ক্ষেত্রে VAD বিস্তারিত (ক্লায়েন্ট-সাইড অ্যাডমিশন-গেট ড্রপ)।",
+    "message": "লিখে নেওয়ার জন্য অডিও খুবই ক্ষীণ"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "ভিএডি পরিষেবা বন্ধ।"
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "নতুন ট্যাব মাইক্রোফোন দখল করায় কল শেষ হয়েছে—এটা বোঝাতে VAD বিস্তারিত।",
+    "message": "ভয়েস ইনপুট অন্য ট্যাবে চলে গেছে"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "বক্তৃতার জন্য অপেক্ষা করছি"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "ভয়েস পাওয়া যায় না। \nডেস্কটপে ক্রোম বা ফায়ারফক্স চেষ্টা করুন।"
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "মনোযোগ দিন! $browserName$ এ $chatbotName$ এর সাথে স্পিচ প্লেব্যাক এখনও উপলব্ধ নয়। ভাল খবর? ভয়েস ইনপুট দুর্দান্ত কাজ করে! TTS এর জন্য, ডেস্কটপে Chrome বা Edge চেষ্টা করুন।",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "$browserName$ + $chatbotName$ এ TTS অনুপলব্ধ। ভয়েস ইনপুট কাজ করে! TTS এর জন্য Chrome ডেস্কটপ চেষ্টা করুন।",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "বুঝেছি",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "ভুল আগুন"
   },
+  "vadStatusPreempted": {
+    "description": "যে ট্যাবের ভয়েস ইনপুট অন্য ট্যাব দখল করেছে, সেই ট্যাবে দেখানো VAD স্ট্যাটাস।",
+    "message": "সাময়িক বিরতি"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "প্রক্রিয়াজাতকরণ"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "বিশদ দেখুন"
   },
+  "voiceIntroductionGeneric": {
+    "description": "যখন নির্বাচিত SayPi ভয়েসের জন্য নির্দিষ্ট পরিচিতিমূলক স্ক্রিপ্ট নেই (এবং পড়ার মতো সাম্প্রতিক বার্তাও নেই), তখন চালানো সাধারণ স্পোকেন পরিচিতি।",
+    "message": "হাই, আমি $voice$। আমার কণ্ঠ এমন শোনায়। আশা করি এই কণ্ঠটি আপনার পছন্দ হবে।",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "হোলা! \nপ্রিভেট! \n你好! \nআমি পাই, আপনার পলিগ্লট এআই সহকারী। \nআমার নির্দেশে 32টি ভাষার সাথে, আমরা সারা বিশ্ব থেকে ধারণা এবং সংস্কৃতি অন্বেষণ করতে পারি। \nআপনি এই ভয়েস কি মনে করেন?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "ভয়েস সেটিংস"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "সেটিংসের ভয়েস ক্যাটালগে কোনো ভয়েসের বর্ণনা না থাকলে ভয়েস সারির জন্য ফallback সাবটাইটেল; $count$ হলো ভয়েসটি যতটি ভাষা সমর্থন করে তার সংখ্যা।",
+    "message": "$count$টি ভাষায় কথা বলে",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "'Addison' ভয়েসের জন্য লেখা ব্যক্তিত্ব ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেনটিটি ম্যাপ)।",
+    "message": "প্রফুল্ল ও স্পষ্টভাষী"
+  },
+  "voiceTagline_alloy": {
+    "description": "‘Alloy’ ভয়েসের জন্য লেখা ব্যক্তিত্বের ট্যাগলাইন (সেটিংস Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "ভারসাম্যপূর্ণ, সব কাজে মানানসই"
+  },
+  "voiceTagline_ash": {
+    "description": "‘Ash’ ভয়েসের জন্য লেখা ব্যক্তিত্বের ট্যাগলাইন (সেটিংস Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "নিচু, ভাবুক, শান্ত"
+  },
+  "voiceTagline_ballad": {
+    "description": "‘Ballad’ ভয়েসের জন্য লেখা ব্যক্তিত্বের ট্যাগলাইন (সেটিংস Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "মসৃণ, সুরেলা"
+  },
+  "voiceTagline_cassidy": {
+    "description": "'Cassidy' ভয়েসের জন্য লেখা ব্যক্তিত্ব ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেনটিটি ম্যাপ)।",
+    "message": "বন্ধুসুলভ ও সোজাসাপ্টা"
+  },
+  "voiceTagline_cedar": {
+    "description": "'Cedar' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "স্থিতিশীল ও আশ্বস্তকারী"
+  },
+  "voiceTagline_coral": {
+    "description": "'Coral' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "উজ্জ্বল, চাঙা উদ্যম"
+  },
+  "voiceTagline_echo": {
+    "description": "'Echo' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "পরিচ্ছন্ন ও নিরপেক্ষ"
+  },
+  "voiceTagline_fable": {
+    "description": "'Fable' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "গল্পকারের সুরেলা টান"
+  },
+  "voiceTagline_finn": {
+    "description": "'Finn' ভয়েসের জন্য লেখা ব্যক্তিত্ব ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেনটিটি ম্যাপ)।",
+    "message": "টাটকা ও প্রাণবন্ত"
+  },
+  "voiceTagline_jamahal": {
+    "description": "'Jamahal' ভয়েসের জন্য লেখা ব্যক্তিত্ব ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেনটিটি ম্যাপ)।",
+    "message": "গভীর ও আকর্ষণীয়"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "'Jarnathan' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "মখমলি রাতজাগা ব্যারিটোন"
+  },
+  "voiceTagline_jeff": {
+    "description": "'Jeff' ভয়েসের জন্য লেখা ব্যক্তিত্ব ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেনটিটি ম্যাপ)।",
+    "message": "সোজাসাপ্টা ও স্থির"
+  },
+  "voiceTagline_jessica": {
+    "description": "'Jessica' ভয়েসের জন্য লেখা ব্যক্তিত্ব ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেনটিটি ম্যাপ)।",
+    "message": "উষ্ণ, পরিমার্জিত সৌম্যতা"
+  },
+  "voiceTagline_joey": {
+    "description": "'Joey' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "সহজ, কথোপকথনমুখর আমেরিকান"
+  },
+  "voiceTagline_juniper": {
+    "description": "'Juniper' ভয়েসের জন্য লেখা ব্যক্তিত্ব ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেনটিটি ম্যাপ)।",
+    "message": "ঝকঝকে, উজ্জ্বল, প্রাণচঞ্চল"
+  },
+  "voiceTagline_lucy": {
+    "description": "'Lucy' ভয়েসের জন্য লেখা ব্যক্তিত্ব ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেনটিটি ম্যাপ)।",
+    "message": "কোমল ও দীপ্তিময়"
+  },
+  "voiceTagline_marin": {
+    "description": "'Marin' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "উষ্ণ, মর্নিং-রেডিওর শান্ত ভাব"
+  },
+  "voiceTagline_mark": {
+    "description": "'Mark' ভয়েসের জন্য লেখা ব্যক্তিত্ব ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেনটিটি ম্যাপ)।",
+    "message": "স্পষ্ট, আত্মবিশ্বাসী বর্ণনাকারী"
+  },
+  "voiceTagline_nova": {
+    "description": "'Nova' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "দ্রুত ও কৌতূহলী"
+  },
+  "voiceTagline_onyx": {
+    "description": "'Onyx' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "গভীর, অনুরণিত গাম্ভীর্য"
+  },
+  "voiceTagline_paola": {
+    "description": "'Paola' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "প্রকাশভঙ্গিমায় ইতালীয় উষ্ণতা"
+  },
+  "voiceTagline_sage": {
+    "description": "'Sage' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "নিম্নস্বরে স্পষ্টতা"
+  },
+  "voiceTagline_shimmer": {
+    "description": "'Shimmer' ভয়েসের জন্য রচিত ব্যক্তিত্বের ট্যাগলাইন (সেটিংসের Voices স্টুডিও; ক্লায়েন্ট-সাইড ভয়েস আইডেন্টিটি ম্যাপ)।",
+    "message": "হালকা ও বাতাসি"
+  },
+  "voicesAddToMenuShort": {
+    "description": "সেটিংসের Voices স্টুডিওতে ভয়েস কার্ডের পিন টগলে (বন্ধ অবস্থায়) সংক্ষিপ্ত লেবেল; চাপলে ভয়েসটি হোস্টের ইন-চ্যাট মেনুতে যোগ হয়।",
+    "message": "+ মেনু"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "ভয়েস কার্ডের পিন টগলের (বন্ধ অবস্থায়) অ্যাক্সেসিবল লেবেল; $name$ হলো ভয়েস, $host$ হলো অ্যাসিস্ট্যান্ট।",
+    "message": "$host$-এর মেনুতে $name$ যোগ করুন",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Voices কন্ট্রোল বারে টগলের লেবেল, যা বলে তীরচিহ্ন কী দিয়ে তালিকা ঘোরার সময় ফোকাস যেই ভয়েসে যায় সেটি চালানো হবে কি না।",
+    "message": "সরার সঙ্গে সঙ্গে চালান"
+  },
+  "voicesArrowsLive": {
+    "description": "সেটিংসের Voices তালিকায় প্রথম 'Playing <voice>' ঘোষণার সাথে যুক্ত স্ক্রিন-রিডার নিশ্চিতকরণ, যা বলে অ্যারো কী এখন শোনা যাবে। 'Play as you move' টগলের নিজের ভাষার প্রতিধ্বনি।",
+    "message": "এখন সরালে অ্যারো কীগুলো বাজবে। Esc থামায়।"
+  },
+  "voicesBuiltinsNote": {
+    "description": "যেসব হোস্টে নেটিভ ভয়েস থাকে (যেমন Pi-এর 8টি বিল্ট-ইন), তাদের জন্য মেনু স্লটের নিচে নোট; এগুলো স্টুডিও পরিচালনা করে না; $host$ হলো সহকারী।",
+    "message": "$host$-এর নিজস্ব বিল্ট-ইন ভয়েসগুলোও তার মেনুতেই সবসময় দেখা যাবে।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "যে হোস্টে ইন-চ্যাট ভয়েস মেনু নেই তার জন্য voicesBuiltinsNote-এর ভ্যারিয়েন্ট (Pi 2026 সালে তার মেনু অবসর দিয়েছে), যেখানে মূলটির 'তার মেনুতে দেখা যাবে' প্রতিশ্রুতি মিথ্যা হবে; $host$ হলো সহকারী।",
+    "message": "$host$-এর নিজস্ব বিল্ট-ইন ভয়েসও আছে, যেগুলো এখানে তালিকাভুক্ত নেই।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারে অগ্রগতির রিডআউট: তালিকাভুক্ত ভয়েসগুলোর মধ্যে ব্যবহারকারী কতগুলো ইতিমধ্যে শুনেছেন। খালি সংখ্যা, তাই ১ হলেও ঠিকভাবে পড়ে — Chrome i18n-এ plural ফর্ম নেই।",
+    "message": "$total$-এর মধ্যে $heard$টি শোনা হয়েছে",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "সেটিংসের Voices তালিকায় কোনো ভয়েস সারির অ্যাক্সেসিবল নামের অংশ, যা চিহ্নিত করে যে এই প্রোফাইল ওই ভয়েসটি আগেই শুনেছে। দৃশ্যত এটি ভয়েসের সাউন্ডপ্রিন্টে কালি-ঘনত্ব হিসেবে আঁকা থাকে, যা স্ক্রিন রিডার দেখতে পারে না।",
+    "message": "শোনা হয়েছে"
+  },
+  "voicesInHostMenu": {
+    "description": "সেটিংসের Voices স্টুডিওতে মেনু স্লটগুলোর সারির উপরে থাকা সেকশন শিরোনাম; $host$ হলো অ্যাসিস্ট্যান্ট।",
+    "message": "$host$-এর মেনুতে",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "সেটিংসের Voices স্টুডিওতে ভয়েস কার্ডের পিন টগলে (চালু অবস্থায়) সংক্ষিপ্ত লেবেল।",
+    "message": "✓ মেনুতে"
+  },
+  "voicesInUse": {
+    "description": "সেটিংসের Voices তালিকায় হোস্টের বর্তমানে নির্বাচিত ভয়েসের স্থায়ী ব্যাজ, যা বড় হাতের অক্ষরে রেন্ডার করা হয়। ইচ্ছাকৃতভাবে “এখন কথা বলছে” নয়: এই পেজে সারিগুলো তাদের স্যাম্পল ক্লিপ চালায়, তাই নির্বাচিত কিন্তু নীরব ভয়েস অন্য সারি বাজলেও কথা বলছে বলে দাবি করবে না।",
+    "message": "ব্যবহৃত হচ্ছে"
+  },
+  "voicesKeyboardHint": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারে এক লাইনের কীবোর্ড হিন্ট। চিহ্নগুলো কীগুলোর নাম: Space, আপ/ডাউন অ্যারো, এবং Shift+Space।",
+    "message": "শুনতে Space চাপুন, ভয়েস বদলাতে ↑↓, আগেরটিতে ফিরতে ⇧Space।"
+  },
+  "voicesLoadError": {
+    "description": "একটি হোস্টের স্টুডিওর ভেতরে ত্রুটি অবস্থা, যখন ওই হোস্টের ভয়েস ক্যাটালগ লোড হতে ব্যর্থ হয়; $host$ হলো সহকারী।",
+    "message": "$host$-এর ভয়েস লোড করা যায়নি। পরে আবার চেষ্টা করুন।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "হোস্টের ইন-চ্যাট মেনুতে সর্বোচ্চ সংখ্যক ভয়েস আগে থেকেই থাকলে নিষ্ক্রিয় “+ মেনু” টগলের টুলটিপ/ইঙ্গিত।",
+    "message": "মেনু পূর্ণ — আরেকটি যোগ করতে একটি ভয়েস সরান"
+  },
+  "voicesMenuHint": {
+    "description": "“In {host}'s menu” শিরোনামের পাশে থাকা এক লাইনের ইঙ্গিত, যা ব্যাখ্যা করে স্লটগুলোর সারি চ্যাটের ভয়েস মেনুকে প্রতিফলিত করে।",
+    "message": "চ্যাটে আপনি যা দেখবেন"
+  },
+  "voicesMenuOverflow": {
+    "description": "ইন-চ্যাট মেনুতে দেখানো যায় তার চেয়ে বেশি পিন করা ভয়েস থাকলে (লেগেসি অবস্থা) মেনু স্লটের নিচে দেখানো নোট; $count$ কতগুলো ফিট করছে না, $cap$ হলো মেনুর আকার।",
+    "message": "মেনুর $cap$টি স্লটের বাইরে $count$টি আরও পিন করা ভয়েস অপেক্ষা করছে।",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "voicesMenuOverflow-এর একবচন রূপ, যখন ঠিক একটি পিন করা ভয়েস ইন-চ্যাট মেনুতে ফিট করে না; $cap$ হলো মেনুর আকার।",
+    "message": "মেনুর $cap$টি স্লটের বাইরে আরও 1টি পিন করা ভয়েস অপেক্ষা করছে।",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "সেটিংসের Voices তালিকার নিচের সারসংক্ষেপ লাইন, যা বলে হোস্টের ইন-চ্যাট ভয়েস মেনু কতটা ভরা; $host$ হলো অ্যাসিস্ট্যান্ট, $used$ কতটি আসন নেওয়া হয়েছে, $cap$ মোট কতটি। ১ হলেও যেন ঠিকভাবে পড়ে এমনভাবে লেখা — Chrome i18n-এ plural ফর্ম নেই।",
+    "message": "$host$-এর মেনু: $cap$-এর মধ্যে $used$টি আসন",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "সেটিংসের Voices তালিকার শেষে থাকা গ্রুপের শিরোনাম, যেখানে চালানোর মতো কোনো স্যাম্পল ক্লিপ নেই এমন ভয়েসগুলো থাকে; $count$ হলো কতগুলো। ১ হলেও যেন ঠিকভাবে পড়ে এমনভাবে লেখা — Chrome i18n-এ plural ফর্ম নেই।",
+    "message": "এখনও নমুনা নেই ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "সাইন-ইন করা ব্যবহারকারীর ক্ষেত্রে সেটিংসের ভয়েস ক্যাটালগে ভয়েস তালিকা খালি থাকলে দেখানো হয় (যেমন, নেটওয়ার্ক সমস্যায়)।",
+    "message": "এখন ভয়েস লোড করা যাচ্ছে না। পরে আবার চেষ্টা করুন।"
+  },
+  "voicesNowPlaying": {
+    "description": "সেটিংসের Voices তালিকায় কোনো ভয়েসের স্যাম্পল ক্লিপ চালু হলে স্ক্রিন রিডারের ঘোষণা; $name$ হলো ভয়েসের নাম।",
+    "message": "$name$ চালানো হচ্ছে",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারের বোতাম, যা তালিকাভুক্ত সব ভয়েস একের পর এক চালায়; $count$ হলো কতগুলো। ১ হলেও যেন ঠিকভাবে পড়ে এমনভাবে লেখা — Chrome i18n-এ plural ফর্ম নেই।",
+    "message": "সব চালান ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "পুনরায় এলে সেটিংসের Voices কন্ট্রোল বারের বোতাম: আপনি এখনও শোনেননি এমন তালিকাভুক্ত ভয়েসগুলোই শুধু চালায়; $count$ হলো কতগুলো। ১ হলেও যেন ঠিকভাবে পড়ে এমনভাবে লেখা — Chrome i18n-এ plural ফর্ম নেই।",
+    "message": "নতুন চালান ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারের লাইন, যখন পেজে এখনো কোনো ব্যবহারকারী ইন্টারঅ্যাকশন না থাকায় ব্রাউজার স্যাম্পল চালাতে অস্বীকার করেছে।",
+    "message": "শব্দ চালু করতে যেকোনো ভয়েসে ক্লিক করুন।"
+  },
+  "voicesPreview": {
+    "description": "ভয়েস সারিতে থাকা প্লে (▶) বোতামের জন্য অ্যাক্সেসিবল লেবেল, যা একটি ভয়েসের বিনামূল্যের নমুনা ক্লিপ চালিয়ে শোনায়; $name$ হলো ভয়েসের নাম।",
+    "message": "$name$-এর একটি নমুনা চালান",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "সেটিংসের Voices তালিকার অ্যাক্সেসিবল নাম (প্রতিটি সারিতে একটি করে ভয়েসসহ সব ভয়েসের একটি লিস্টবক্স)।",
+    "message": "ভয়েস, গভীরতম থেকে উজ্জ্বলতম পর্যন্ত সাজানো"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "ভয়েস কার্ডের পিন টগলের (চালু অবস্থায়) এবং মেনু স্লটের রিমুভ বোতামের অ্যাক্সেসিবল লেবেল; $name$ হলো ভয়েস, $host$ হলো অ্যাসিস্ট্যান্ট।",
+    "message": "$host$-এর মেনু থেকে $name$ সরান",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারের লাইন, যখন একটি ভয়েসের স্যাম্পল ক্লিপ লোড বা প্লে হতে ব্যর্থ হয়; $name$ হলো সেই ভয়েস। এটি নন-মোডাল — স্যাম্পলগুলোর ধারাবাহিক প্লে এটিকে পেরিয়ে চলতে থাকে।",
+    "message": "$name$-এর স্যাম্পল চালানো গেল না।",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "সেটিংসের AI Chat ট্যাবে ভয়েস ক্যাটালগ সেকশনের উপশিরোনাম।",
+    "message": "প্রতিটি সাইটে উত্তরগুলো যে ভয়েসে জোরে পড়ে শোনায়, সেটি বেছে নিন।"
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Voices সেটিংস শিরোনামের নিচে উপশিরোনাম, পিচ-অনুযায়ী সাজানো ভয়েস রেলের জন্য।",
+    "message": "গভীরতম থেকে উজ্জ্বলতম পর্যন্ত সব ভয়েস। শুনুন, তারপর বাছুন।"
+  },
+  "voicesSectionTitle": {
+    "description": "সেটিংসের AI Chat ট্যাবে ভয়েস ক্যাটালগ সেকশনের শিরোনাম।",
+    "message": "ভয়েস"
+  },
+  "voicesShelfEveryday": {
+    "description": "সেটিংস ভয়েস ক্যাটালগে ভ্যালু-টিয়ার ভয়েসগুলোর গ্রুপ শিরোনাম। CSS দিয়ে বড় হাতের অক্ষরে দেখানো হয়।",
+    "message": "দৈনন্দিন ভয়েস"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "সেটিংসের Voices স্টুডিওতে Everyday গ্রুপ শিরোনামের পাশে এক লাইনের নোট; স্টুডিওতে একমাত্র জায়গা যেখানে এই টিয়ার HD-এর চেয়ে কতটা বেশি দীর্ঘস্থায়ী তা বলা হয়।",
+    "message": "স্বাভাবিক এবং পরিষ্কার — HD-এর তুলনায় প্রায় ২০× বেশি সময় শুনতে পারবেন।"
+  },
+  "voicesShelfHd": {
+    "description": "সেটিংস ভয়েস ক্যাটালগে প্রিমিয়াম (HD) ভয়েসগুলোর গ্রুপ শিরোনাম। CSS দিয়ে বড় হাতের অক্ষরে দেখানো হয়।",
+    "message": "HD ভয়েস"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "সেটিংসের Voices স্টুডিওতে HD গ্রুপ শিরোনামের পাশে এক লাইনের নোট।",
+    "message": "আমাদের সবচেয়ে সমৃদ্ধ, সবচেয়ে অভিব্যক্তিপূর্ণ সাউন্ড।"
+  },
+  "voicesShowAll": {
+    "description": "সেটিংসের Voices ‘Show’ ফিল্টারের অপশন: কোনো ফিল্টার নয়, সব ভয়েস তালিকাভুক্ত হয়।",
+    "message": "সব ভয়েস"
+  },
+  "voicesShowEveryday": {
+    "description": "সেটিংসের Voices ‘Show’ ফিল্টারের অপশন: শুধু স্ট্যান্ডার্ড (non-HD) ভয়েসগুলো তালিকাভুক্ত হয়।",
+    "message": "শুধু Everyday"
+  },
+  "voicesShowHd": {
+    "description": "সেটিংসের Voices ‘Show’ ফিল্টারের অপশন: শুধু প্রিমিয়াম (HD) ভয়েসগুলো তালিকাভুক্ত হয়।",
+    "message": "শুধু HD"
+  },
+  "voicesShowLabel": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারে থাকা ফিল্টারের লেবেল, যা তালিকায় কোন কোন ভয়েস দেখাবে তা সীমিত করে।",
+    "message": "দেখান"
+  },
+  "voicesShowUnheard": {
+    "description": "সেটিংসের Voices ‘Show’ ফিল্টারের অপশন: ব্যবহারকারী এখনো শোনেননি এমন ভয়েসগুলোই শুধু তালিকাভুক্ত হয়।",
+    "message": "এখনও শোনা হয়নি"
+  },
+  "voicesSpeakingNow": {
+    "description": "সেটিংসের Voices স্টুডিওতে (মেনু স্লট ও ভয়েস কার্ডে) হোস্টের বর্তমানে নির্বাচিত ভয়েসের স্টেট লেবেল।",
+    "message": "এখন কথা বলছে"
+  },
+  "voicesSpeaksWith": {
+    "description": "সেটিংসের Voices স্টুডিও স্টেজে বর্তমান ভয়েসের নামের উপরে থাকা আইব্রো লাইন; $host$ হলো অ্যাসিস্ট্যান্ট (যেমন Pi)। CSS দিয়ে বড় হাতের অক্ষরে রেন্ডার করা হয়।",
+    "message": "$host$ কথা বলে",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "স্টেজ নোট যখন হোস্ট নিজস্ব অডিও দেয় (যেমন Pi), তাই Say, Pi ভয়েস বাছলে হোস্টেরটি প্রতিস্থাপিত হয়।",
+    "message": "নিচ থেকে একটি বাছা পর্যন্ত $host$ তার নিজের ভয়েস ব্যবহার করবে।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "স্টেজ নোট যখন হোস্টের নিজের কোনো ভয়েস নেই (যেমন Claude), তাই Say, Pi ভয়েস না বাছা পর্যন্ত কিছুই জোরে পড়া হয় না।",
+    "message": "নিচ থেকে একটি বাছা পর্যন্ত $host$ উত্তরগুলো জোরে পড়বে না।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "হোস্টের জন্য কোনো SayPi ভয়েস নির্বাচন না থাকলে সেটিংসের Voices স্টুডিও স্টেজে শিরোনাম; $host$ হলো সহকারী (যেমন Pi, Claude)। নামের আকারে রেন্ডার হয়।",
+    "message": "$host$-এর কণ্ঠস্বর কেমন হবে বাছুন",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "সেটিংসের Voices স্টুডিও স্টেজে বোতাম, যা বর্তমান ভয়েসের ফ্রি স্যাম্পল ক্লিপ চালায়।",
+    "message": "একটি নমুনা শুনুন"
+  },
+  "voicesStopPlayback": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারের বোতাম, যা 'Play all' থেকে শুরু হওয়া স্যাম্পলগুলোর চলা থামায়।",
+    "message": "থামান"
+  },
+  "voicesSweepPosition": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারে ‘Play all’ তালিকা জুড়ে চলার সময় লাইভ অবস্থান দেখায়; $index$ হলো এখন যে ভয়েস চলছে এবং $total$ হলো কিউতে মোট কতটি আছে।",
+    "message": "$total$ এর মধ্যে $index$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারে compare কন্ট্রোলের অ্যাক্সেসিবল লেবেল, যা শেষবার শোনা শেষ দুইটির মধ্যে অন্য ভয়েসটি আবার চালায়; $name$ হলো সেই ভয়েস।",
+    "message": "$name$-এ ফিরে যান",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "সেটিংসের Voices কন্ট্রোল বারের লাইন, যখন খুব বড় তালিকায় ‘Play all’ চাপা হয়; $count$ হলো কতটি ভয়েস এবং $minutes$ হলো আনুমানিক কত মিনিট লাগবে। ‘min’ সংক্ষিপ্ত রাখা হয়েছে যাতে 1 হলেও ঠিকভাবে পড়ে — Chrome i18n-এ বহুবচনের আলাদা ফর্ম নেই।",
+    "message": "এটা $count$টি ভয়েস — প্রায় $minutes$ min। আগে তালিকাটা ছোট করুন।",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "সেটিংসের ভয়েস ক্যাটালগে প্রতি-হোস্ট “এই ভয়েস ব্যবহার করুন” বোতামের অ্যাক্সেসিবল লেবেল; $name$ হলো ভয়েস, $host$ হলো অ্যাসিস্ট্যান্ট (যেমন Pi, Claude)।",
+    "message": "$host$-এ $name$ ব্যবহার করুন",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "ইউনিফাইড সেটিংসের ভয়েস ক্যাটালগে প্রতি-হোস্ট “এই ভয়েস ব্যবহার করুন” বোতামের সংক্ষিপ্ত লেবেল (এর পাশে হোস্টও দেখানো থাকে)।",
+    "message": "ব্যবহার করুন"
+  },
+  "voicesYourVoice": {
+    "description": "সেটিংসের Voices তালিকায় কন্ট্রোল-বারের বোতাম, যা এই হোস্ট বর্তমানে যে ভয়েস ব্যবহার করছে তার সারিতে ফোকাস নিয়ে যায়; $name$ হলো সেই ভয়েস।",
+    "message": "আপনার ভয়েস: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "ভয়েস-ডিটেকশন মডেলের জন্য পর্যাপ্ত WebAssembly মেমরি বরাদ্দ করতে না পারলে যে ত্রুটি দেখায়।",
+    "message": "ভয়েস ডিটেকশন শুরু করা যাচ্ছে না: ভয়েস মডেলের জন্য পর্যাপ্ত WebAssembly মেমরি নেই। $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "ভয়েস-ডিটেকশন মডেল চালাতে প্রয়োজনীয় প্রাথমিক WebAssembly মেমরি ব্রাউজার সরবরাহ না করলে যে ত্রুটি দেখায়।",
+    "message": "ভয়েস ডিটেকশন শুরু করা যাচ্ছে না: এই ব্রাউজারে WebAssembly মেমরি উপলব্ধ নয়।"
   }
 }

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Výhoda uvedená v modálu přihlášení – vyšší limity používání.",
+    "message": "Vyšší limity používání s bezplatným účtem"
+  },
+  "authBenefitPremium": {
+    "description": "Výhoda uvedená v modálu přihlášení – prémiové funkce napříč chatboty.",
+    "message": "Prémiové funkce a podpora chatbotů"
+  },
+  "authBenefitSupport": {
+    "description": "Výhoda uvedená v modálu přihlášení – přednostní podpora.",
+    "message": "Přednostní podpora při problémech"
+  },
+  "authBenefitSync": {
+    "description": "Výhoda uvedená v modálu přihlášení – synchronizace nastavení.",
+    "message": "Synchronizujte nastavení hlasu všude"
+  },
+  "authBenefitTTS": {
+    "description": "Výhoda uvedená v modálu přihlášení – funkce TTS.",
+    "message": "Hlasy převodu textu na řeč (placené tarify)"
+  },
+  "authBenefitUsage": {
+    "description": "Výhoda uvedená v modálu přihlášení – sledování používání.",
+    "message": "Sledujte využití hlasu napříč zařízeními"
+  },
+  "authPromptModalFull": {
+    "description": "Popis pro „full“ modální výzvu k přihlášení s hodnotovou nabídkou.",
+    "message": "Say, Pi už používáte opravdu naplno. Přihlaste se pro vyšší limity, hlasy převodu textu na řeč a prémiové funkce ve všech podporovaných chatbotech."
+  },
+  "authPromptModalSoft": {
+    "description": "Popis pro „soft“ modální výzvu k přihlášení.",
+    "message": "Vytvořte si bezplatný účet Say, Pi pro vyšší limity používání a přístup k prémiovým hlasovým funkcím."
+  },
+  "authPromptTitle": {
+    "description": "Nadpis modálního okna s výzvou k přihlášení.",
+    "message": "Odemknout další hlasové funkce"
+  },
+  "authPromptToast": {
+    "description": "Toast oznámení vybízející uživatele k přihlášení.",
+    "message": "Přihlaste se do Say, Pi a získejte vyšší limity a prémiové funkce"
+  },
   "autoReadAloudChatGPT": {
     "description": "Popisek zaškrtávacího políčka pro zapnutí/vypnutí automatického čtení odpovědí ChatGPT během hlasových hovorů.",
     "message": "Automatické čtení nahlas (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Zakázat text na řeč"
   },
+  "dismiss": {
+    "message": "Rozumím",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Propustit"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Zaměřit se"
   },
+  "errorVadInitFailed": {
+    "description": "Chybová hláška zobrazená, když se nepodaří inicializovat detekci hlasové aktivity.",
+    "message": "Nepodařilo se inicializovat detekci hlasu"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Chybová hláška zobrazená, když při nastavování nahrávání hlasu dojde k neočekávané chybě.",
+    "message": "Nepodařilo se nastavit nahrávání hlasu"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Chybová hláška zobrazená, když se klientovi pro detekci hlasu nepodaří spustit nahrávání.",
+    "message": "Nepodařilo se spustit nahrávání hlasu"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Chybová hláška zobrazená, když klient pro detekci hlasu (VAD) není dostupný, takže nelze spustit nahrávání.",
+    "message": "Nahrávání hlasu není k dispozici"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Opustit režim soustředění"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Jednořádková poznámka zobrazená v nabídkách hlasu, když jsou k dispozici prémiové (HD) i úsporné hlasy",
+    "message": "HD hlasy spotřebují váš měsíční limit asi 20× rychleji."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Zastrčit to pryč ..."
   },
+  "maybeLater": {
+    "description": "Text tlačítka pro zavření výzvy k přihlášení.",
+    "message": "Možná později"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Vaše nastavení mikrofonu nesplňuje požadované specifikace. \nZkuste použít jiný mikrofon nebo upravit nastavení zvuku."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Nelze získat přístup k mikrofonu. \nZkontrolujte nastavení zařízení a zkuste to znovu."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Chybová hláška zobrazená, když bylo po průchodu žádostí o oprávnění zamítnuto oprávnění k mikrofonu.",
+    "message": "Oprávnění k mikrofonu nebylo uděleno. Zkontrolujte, že jste povolili přístup ve výzvě i v nastavení rozšíření."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "přesnost"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Nejrychlejší odezva, ale méně přesná. \nNáchylné k vyrušování."
   },
+  "moreVoices": {
+    "description": "Řádek nabídky, který odkazuje z hlasové nabídky na stránce do kompletního katalogu hlasů v nastavení rozšíření",
+    "message": "Další hlasy…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Přezdívka asistenta"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Není přihlášeno"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Popisek tlačítka, které otevře ChatGPT.",
+    "message": "Otevřít ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Popisek tlačítka, které otevře Claude.ai.",
+    "message": "Otevřít Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Popisek tlačítka, které otevře Pi.ai.",
+    "message": "Otevřít Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Možnost prostředí: mezi ostatními lidmi.",
+    "message": "Mezi ostatními lidmi"
+  },
+  "onboarding_envMixed": {
+    "description": "Možnost prostředí: mix soukromých a sdílených prostor.",
+    "message": "Kombinace míst"
+  },
+  "onboarding_envPrivate": {
+    "description": "Možnost prostředí: soukromý prostor.",
+    "message": "Někde v soukromí"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Potvrzení zobrazené, když odpověď ohledně prostředí ponechá tichý režim vypnutý.",
+    "message": "Dobře, ponecháme standardní nastavení poslechu a přehrávání."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Potvrzení zobrazené, když odpověď na prostředí zapne tichý režim.",
+    "message": "Tichý režim zapnutý — zachytíme i tišší řeč a odpovíme potichu, abyste mohli mluvit diskrétně."
+  },
+  "onboarding_envTitle": {
+    "description": "Nadpis pro otázku v úvodním nastavení o prostředí uživatele.",
+    "message": "Kde budete obvykle mluvit?"
+  },
+  "onboarding_footer": {
+    "description": "Text v patičce na úvodní stránce při prvním spuštění.",
+    "message": "Kdykoli se k tomu můžete vrátit v nastavení Say, Pi. Na vašem soukromí záleží — zvuk se snímá jen během aktivního hovoru."
+  },
+  "onboarding_heading": {
+    "description": "Hlavní nadpis na stránce uvítání při prvním spuštění.",
+    "message": "🗣️ Vítejte v Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Úvodní odstavec na stránce uvítání při prvním spuštění.",
+    "message": "Od první mluvené konverzace s AI vás dělí dva kroky. Mluvení je asi 3× rychlejší než psaní — pojďme to nastavit."
+  },
+  "onboarding_micTestButton": {
+    "description": "Tlačítko, které spustí nezávazný test mikrofonu v úvodním nastavení.",
+    "message": "🎤 Otestovat mikrofon"
+  },
+  "onboarding_micTestDone": {
+    "description": "Stav zobrazený po úspěšném dokončení testu mikrofonu v úvodním nastavení.",
+    "message": "Skvělé — mikrofon funguje. 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Stav zobrazený, když test mikrofonu při úvodním nastavení měří vstup.",
+    "message": "Posloucháme — řekněte něco. 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Stav zobrazený, když test mikrofonu při úvodním nastavení čeká na povolení.",
+    "message": "Žádáme o přístup k mikrofonu…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Popisek tlačítka pro zastavení běžícího testu mikrofonu v úvodním nastavení.",
+    "message": "Zastavit test"
+  },
+  "onboarding_step1Body": {
+    "description": "Text prvního kroku úvodního nastavení vysvětlující, jak rozšíření připnout.",
+    "message": "Klikněte na ikonu dílku 🧩 vpravo nahoře v prohlížeči a pak na připínáček 📌 vedle Say, Pi. Tlačítko hovoru tak budete mít na jedno kliknutí."
+  },
+  "onboarding_step1Title": {
+    "description": "Název prvního kroku úvodního nastavení (připnutí rozšíření).",
+    "message": "Připněte si Say, Pi na panel nástrojů"
+  },
+  "onboarding_step2Body": {
+    "description": "Text druhého kroku úvodního nastavení vysvětlující, jak začít hlasovou konverzaci.",
+    "message": "Přejděte na jednoho z podporovaných asistentů níže, potom klepněte na tlačítko hovoru Say, Pi a pozdravte. Poprvé vás požádáme o přístup k mikrofonu — to je očekávané a posloucháme jen tehdy, když jste aktivně v hovoru."
+  },
+  "onboarding_step2Title": {
+    "description": "Název druhého kroku úvodního nastavení (zahájení konverzace).",
+    "message": "Otevřete AI chat a začněte mluvit"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Oprávnění mikrofonu"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Pokyny k obnovení, když je oprávnění k mikrofonu zablokované.",
+    "message": "Váš prohlížeč blokuje mikrofon. Klikněte na ikonu kamery nebo zámku v adresním řádku, nastavte Mikrofon na „Povolit“ a pak to zkuste znovu. Na macOS také zkontrolujte Nastavení systému → Soukromí a zabezpečení → Mikrofon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Název panelu obnovení, když bylo oprávnění k mikrofonu zamítnuto/zablokováno.",
+    "message": "Přístup k mikrofonu je zablokovaný"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Pokyny k obnovení, když se mikrofon používá jinde.",
+    "message": "Mikrofon může používat jiná aplikace nebo karta. Zavřete vše, co by mohlo nahrávat (videohovory, hlasové poznámky), a pak to zkuste znovu."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Název panelu obnovení, když mikrofon používá jiná aplikace.",
+    "message": "Váš mikrofon se používá"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Pokyny k obnovení, když není k dispozici žádné zařízení mikrofonu.",
+    "message": "Nepodařilo se nám najít mikrofon. Připojte ho (nebo připojte headset), ujistěte se, že je vybraný jako vstupní zařízení, a pak to zkuste znovu."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Název panelu obnovení, když není k dispozici žádné zařízení mikrofonu.",
+    "message": "Nebyl nalezen žádný mikrofon"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Pokyny k obnovení pro neznámou chybu mikrofonu.",
+    "message": "Při přístupu k mikrofonu se něco pokazilo. Zkontrolujte, že je připojený a povolený v nastavení prohlížeče, a pak to zkuste znovu."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Název panelu obnovení pro neznámou chybu mikrofonu.",
+    "message": "Nepodařilo se nám získat přístup k vašemu mikrofonu"
+  },
+  "permissions_retryButton": {
+    "description": "Popisek tlačítka, které znovu vyžádá oprávnění k mikrofonu.",
+    "message": "Zkusit znovu"
+  },
+  "permissions_revokedHeading": {
+    "description": "Nadpis zobrazený, když byl přístup k mikrofonu dříve povolen, ale později byl odebrán.",
+    "message": "🎙️ Znovu připojme váš mikrofon"
+  },
+  "permissions_revokedInfo": {
+    "description": "Informační text zobrazený, když byl přístup k mikrofonu po udělení odebrán.",
+    "message": "Přístup k mikrofonu byl vypnutý — často se to stává po aktualizaci prohlížeče nebo systému. Níže ho znovu povolte a $productName$ bude při hovoru zase poslouchat.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Popisek přepínače, který zapíná tichý/šeptací režim.",
+    "message": "Tichý režim"
+  },
+  "quietModeTooltip": {
+    "description": "Vysvětlivka, co dělá tichý/šeptací režim.",
+    "message": "Mluvte potichu — snímá tišší řeč a ztiší hlasitost odpovědi asistenta, abyste mohli používat hlas mezi ostatními."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Text na tlačítku přihlášení během probíhajícího ověřování.",
+    "message": "Přihlašování…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Zvukové efekty"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Zvukové efekty jsou ve Firefoxu zakázány, aby se předešlo problémům se zvukovou zpětnou vazbou."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Nadpis jednorázového upozornění na úsporu času, zobrazeného po první mluvené výměně.",
+    "message": "Hezké — mluvení je asi 3× rychlejší než psaní."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Volitelný druhý řádek upozornění na úsporu času zobrazující celé ušetřené minuty.",
+    "message": "Už jste mluvením ušetřili zhruba $minutes$ min oproti psaní.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Odešlete pouze po stisknutí tlačítka"
   },
+  "surveyQuestion": {
+    "description": "Jediná otázka jednorázového mikroprůzkumu po výhře.",
+    "message": "Jak se vám zatím používá hlas?"
+  },
+  "surveyRatingLabel": {
+    "description": "Popisek pro čtečky obrazovky u tlačítka hodnocení v průzkumu.",
+    "message": "Ohodnoťte $rating$ z 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Poděkování zobrazené poté, co uživatel odpoví na poprodejní průzkum.",
+    "message": "Děkujeme, pomáhá nám to zlepšovat Say, Pi."
+  },
   "tabAIChat": {
     "description": "Štítek záložky pro sekci nastavení AI chatu.",
     "message": "AI Chat"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Štítek záložky pro sekci obecných nastavení.",
     "message": "Obecné"
+  },
+  "tabVoices": {
+    "description": "Popisek karty pro sekci nastavení hlasů (katalog hlasů podle webu).",
+    "message": "Hlasy"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "Kredity"
   },
+  "ttsCreditsRemaining": {
+    "description": "Text zobrazující zbývající kvótu TTS jako fond kreditů na hlas (saypi-api #181 Stage 2), ne jako počet znaků.",
+    "message": "Zbývá $credits$ kreditů",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "V Safari momentálně nejsou podporovány vícejazyčné hlasy."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Generování hlasu"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Pozor! Přehrávání řeči ještě není k dispozici na $browserName$ s $chatbotName$. Dobrá zpráva? Hlasový vstup funguje skvěle! Pro TTS zkuste Chrome nebo Edge na ploše.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS není k dispozici na $browserName$ + $chatbotName$. Hlasový vstup funguje! Zkuste Chrome na ploše pro TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS hlas"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Detail VAD, když byl detekován zvuk podobný řeči, ale byl příliš tichý / s nízkou jistotou pro přepis (zahození při klientské kontrolní bráně).",
+    "message": "Zvuk je příliš tichý na přepis"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Detail VAD vysvětlující, že hovor skončil, protože mikrofon převzala novější karta.",
+    "message": "Hlasový vstup byl přesunut do jiné karty"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Hlas není k dispozici. \nVyzkoušejte Chrome nebo Firefox na ploše."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Pozor! Přehrávání řeči ještě není k dispozici na $browserName$ s $chatbotName$. Dobrá zpráva? Hlasový vstup funguje skvěle! Pro TTS zkuste Chrome nebo Edge na ploše.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS není k dispozici na $browserName$ + $chatbotName$. Hlasový vstup funguje! Zkuste Chrome na ploše pro TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Rozumím",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Stav VAD zobrazený na kartě, jejíž hlasový vstup převzala jiná karta.",
+    "message": "Pozastaveno"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Zobrazit podrobnosti"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Obecné mluvené představení přehrané, když vybraný hlas SayPi nemá vlastní úvodní skript (a není k dispozici žádná nedávná zpráva k přečtení).",
+    "message": "Ahoj, jsem $voice$. Takto zním. Doufám, že se vám tenhle hlas bude líbit.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Ahoj! \nПривет! \n你好! \nJsem Pi, váš polyglot AI asistent. \nS 32 jazyky pod mým vedením můžeme prozkoumávat myšlenky a kultury z celého světa. \nCo si myslíš o tomto hlase?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Nastavení hlasu"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Záložní podtitulek pro řádek hlasu v katalogu hlasů v nastavení, když hlas nemá popis; $count$ je počet jazyků, které hlas podporuje.",
+    "message": "Mluví $count$ jazyky",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Autorské motto osobnosti pro hlas „Addison“ (nastavení Studio hlasů; mapování identity hlasu na straně klienta).",
+    "message": "Optimistický a výřečný"
+  },
+  "voiceTagline_alloy": {
+    "description": "Autorský tagline osobnosti pro hlas „Alloy“ (Nastavení > Hlasy, studio; mapování identity hlasu na straně klienta).",
+    "message": "Vyvážený a univerzální"
+  },
+  "voiceTagline_ash": {
+    "description": "Autorský tagline osobnosti pro hlas „Ash“ (Nastavení > Hlasy, studio; mapování identity hlasu na straně klienta).",
+    "message": "Hluboký, zamyšlený, klidný"
+  },
+  "voiceTagline_ballad": {
+    "description": "Autorský tagline osobnosti pro hlas „Ballad“ (Nastavení > Hlasy, studio; mapování identity hlasu na straně klienta).",
+    "message": "Jemný a melodický"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Autorské motto osobnosti pro hlas „Cassidy“ (nastavení Studio hlasů; mapování identity hlasu na straně klienta).",
+    "message": "Přátelský a věcný"
+  },
+  "voiceTagline_cedar": {
+    "description": "Autorské osobnostní motto pro hlas „Cedar“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Klidný a uklidňující"
+  },
+  "voiceTagline_coral": {
+    "description": "Autorské osobnostní motto pro hlas „Coral“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Jasná, povzbudivá energie"
+  },
+  "voiceTagline_echo": {
+    "description": "Autorské osobnostní motto pro hlas „Echo“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Čistý a neutrální"
+  },
+  "voiceTagline_fable": {
+    "description": "Autorské osobnostní motto pro hlas „Fable“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Vypravěčský zpěvný tón"
+  },
+  "voiceTagline_finn": {
+    "description": "Autorské motto osobnosti pro hlas „Finn“ (nastavení Studio hlasů; mapování identity hlasu na straně klienta).",
+    "message": "Svěží a energický"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Autorské motto osobnosti pro hlas „Jamahal“ (nastavení Studio hlasů; mapování identity hlasu na straně klienta).",
+    "message": "Bohatý a přitažlivý"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Autorské osobnostní motto pro hlas „Jarnathan“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Sametový noční baryton"
+  },
+  "voiceTagline_jeff": {
+    "description": "Autorské motto osobnosti pro hlas „Jeff“ (nastavení Studio hlasů; mapování identity hlasu na straně klienta).",
+    "message": "Přímočarý a vyrovnaný"
+  },
+  "voiceTagline_jessica": {
+    "description": "Autorské motto osobnosti pro hlas „Jessica“ (nastavení Studio hlasů; mapování identity hlasu na straně klienta).",
+    "message": "Vřelý, uhlazený projev"
+  },
+  "voiceTagline_joey": {
+    "description": "Autorské osobnostní motto pro hlas „Joey“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Pohodový americký konverzační styl"
+  },
+  "voiceTagline_juniper": {
+    "description": "Autorské motto osobnosti pro hlas „Juniper“ (nastavení Studio hlasů; mapování identity hlasu na straně klienta).",
+    "message": "Jasný, zářivý, živý"
+  },
+  "voiceTagline_lucy": {
+    "description": "Autorské motto osobnosti pro hlas „Lucy“ (nastavení Studio hlasů; mapování identity hlasu na straně klienta).",
+    "message": "Jemný a zářivý"
+  },
+  "voiceTagline_marin": {
+    "description": "Autorské osobnostní motto pro hlas „Marin“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Hřejivý, klid ranního rádia"
+  },
+  "voiceTagline_mark": {
+    "description": "Autorské motto osobnosti pro hlas „Mark“ (nastavení Studio hlasů; mapování identity hlasu na straně klienta).",
+    "message": "Jasný, sebejistý vypravěč"
+  },
+  "voiceTagline_nova": {
+    "description": "Autorské osobnostní motto pro hlas „Nova“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Rychlý a zvídavý"
+  },
+  "voiceTagline_onyx": {
+    "description": "Autorské osobnostní motto pro hlas „Onyx“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Hluboká, rezonující vážnost"
+  },
+  "voiceTagline_paola": {
+    "description": "Autorské osobnostní motto pro hlas „Paola“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Výrazná italská vřelost"
+  },
+  "voiceTagline_sage": {
+    "description": "Autorské osobnostní motto pro hlas „Sage“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Jemná, srozumitelná jasnost"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Autorské osobnostní motto pro hlas „Shimmer“ (nastavení ve studiu Hlasy; mapování identity hlasu na straně klienta).",
+    "message": "Lehký a vzdušný"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Krátký štítek na přepínači připnutí na kartě hlasu (stav vypnuto) ve Studiu hlasů v nastavení; stisknutím se hlas přidá do nabídky v chatu u hostitele.",
+    "message": "+ Nabídka"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Popisek pro čtečky obrazovky pro přepínač připnutí na kartě hlasu (stav vypnuto); $name$ je hlas, $host$ je asistent.",
+    "message": "Přidat $name$ do nabídky $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Popisek u přepínače v ovládací liště Hlasů, který říká, zda procházení seznamu pomocí šipek přehraje každý hlas, jakmile na něj fokus dojde.",
+    "message": "Přehrávat při pohybu"
+  },
+  "voicesArrowsLive": {
+    "description": "Potvrzení pro čtečku obrazovky, připojené k prvnímu oznámení „Přehrává se <hlas>“ v seznamu Hlasů v nastavení, že šipky se právě staly slyšitelnými. Odpovídá formulaci přepínače „Přehrávat při pohybu“.",
+    "message": "Šipky teď přehrávají při pohybu. Esc zastaví."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Poznámka pod pozicemi v nabídce pro hostitele, kteří mají nativní hlasy (např. 8 vestavěných hlasů Pi), které studio nespravuje; $host$ je asistent.",
+    "message": "V nabídce se vždy zobrazují i vlastní vestavěné hlasy $host$.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Varianta voicesBuiltinsNote pro hostitele bez hlasové nabídky v chatu (Pi svou nabídku v roce 2026 zrušilo), kde by původní tvrzení, že se vestavěné hlasy „zobrazují v jeho nabídce“, nebylo pravdivé; $host$ je asistent.",
+    "message": "$host$ má také vlastní vestavěné hlasy, které tu nejsou uvedené.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Ukazatel průběhu v ovládací liště Hlasů v nastavení: kolik z uvedených hlasů si už uživatel poslechl. Holá čísla, takže to zní správně i při 1 — Chrome i18n nemá plurálové tvary.",
+    "message": "Poslechnuto $heard$ z $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Část přístupného názvu řádku hlasu v seznamu Hlasů v nastavení, označující hlas, který si tento profil už poslechl. Vizuálně je to vykresleno jako hustota inkoustu ve zvukovém otisku hlasu, což čtečka obrazovky nevidí.",
+    "message": "Poslechnuto"
+  },
+  "voicesInHostMenu": {
+    "description": "Nadpis sekce nad řádkem slotů nabídky ve Studiu hlasů v nastavení; $host$ je asistent.",
+    "message": "V nabídce $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Krátký štítek na přepínači připnutí na kartě hlasu (stav zapnuto) ve Studiu hlasů v nastavení.",
+    "message": "✓ V nabídce"
+  },
+  "voicesInUse": {
+    "description": "Trvalý odznak u aktuálně vybraného hlasu hostitele v seznamu Hlasů v nastavení, vykreslený velkými písmeny. Záměrně NE „Právě mluví“: na této stránce řádky přehrávají ukázky, takže vybraný, ale tichý hlas nesmí tvrdit, že mluví, zatímco je aktivní jiný řádek.",
+    "message": "Používá se"
+  },
+  "voicesKeyboardHint": {
+    "description": "Jednořádková nápověda ke klávesnici v ovládací liště Hlasů v nastavení. Glyfy jsou klávesy: mezerník, šipky nahoru/dolů a Shift+mezerník.",
+    "message": "Stiskněte mezerník pro poslech, ↑↓ pro pohyb mezi hlasy, ⇧mezerník pro přepnutí zpět."
+  },
+  "voicesLoadError": {
+    "description": "Chybový stav uvnitř studia jednoho hostitele, když se nepodařilo načíst katalog hlasů pro daného hostitele; $host$ je asistent.",
+    "message": "Hlasy pro $host$ se nepodařilo načíst. Zkuste to prosím později.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/nápověda u deaktivovaného přepínače „+ Nabídka“, když nabídka v chatu u hostitele už má maximální počet hlasů.",
+    "message": "Nabídka je plná — odeberte hlas a přidejte další"
+  },
+  "voicesMenuHint": {
+    "description": "Jednořádková nápověda vedle nadpisu „V nabídce {host}“, vysvětlující, že řádek slotů zrcadlí nabídku hlasů v chatu.",
+    "message": "Co uvidíte v chatu"
+  },
+  "voicesMenuOverflow": {
+    "description": "Poznámka pod pozicemi v nabídce, když má uživatel více připnutých hlasů, než může nabídka v chatu zobrazit (starší stav); $count$ je počet těch, které se nevejdou, $cap$ je velikost nabídky.",
+    "message": "Dalších připnutých hlasů ($count$) čeká mimo $cap$ pozic v nabídce.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Jednotné číslo pro voicesMenuOverflow, použije se, když se do nabídky v chatu nevejde přesně jeden připnutý hlas; $cap$ je velikost nabídky.",
+    "message": "1 další připnutý hlas čeká mimo $cap$ pozic v nabídce.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Souhrnný řádek pod seznamem Hlasů v nastavení, který říká, jak moc je zaplněná hlasová nabídka hostitele v chatu; $host$ je asistent, $used$ je počet obsazených míst, $cap$ je celkový počet. Formulováno tak, aby to znělo správně i při 1 — Chrome i18n nemá plurálové tvary.",
+    "message": "Nabídka $host$: $used$ z $cap$ míst",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Nadpis skupiny na konci seznamu Hlasů v nastavení, která obsahuje hlasy bez ukázkového klipu k přehrání; $count$ je počet. Formulováno tak, aby to znělo správně i při 1 — Chrome i18n nemá plurálové tvary.",
+    "message": "Zatím bez ukázky ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Zobrazuje se v katalogu hlasů v nastavení, když je seznam hlasů pro přihlášeného uživatele prázdný (např. problém se sítí).",
+    "message": "Hlasy se teď nepodařilo načíst. Zkuste to prosím později."
+  },
+  "voicesNowPlaying": {
+    "description": "Oznámení pro čtečku obrazovky, když se v seznamu Hlasů v nastavení začne přehrávat ukázkový klip hlasu; $name$ je hlas.",
+    "message": "Přehrává se $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Tlačítko v ovládací liště Hlasů v nastavení, které přehraje každý aktuálně uvedený hlas jeden po druhém; $count$ je počet. Formulováno tak, aby to znělo správně i při 1 — Chrome i18n nemá plurálové tvary.",
+    "message": "Přehrát vše ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Tlačítko v ovládací liště Hlasů v nastavení při návratu: přehraje pouze uvedené hlasy, které jste si ještě neposlechli; $count$ je počet. Formulováno tak, aby to znělo správně i při 1 — Chrome i18n nemá plurálové tvary.",
+    "message": "Přehrát nové ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Řádek v ovládací liště Nastavení > Hlasy, když prohlížeč odmítl přehrát ukázku, protože stránka zatím neměla žádnou interakci uživatele.",
+    "message": "Kliknutím na libovolný hlas zapnete zvuk."
+  },
+  "voicesPreview": {
+    "description": "Popisek pro asistivní technologie u tlačítka přehrát (▶), které spustí bezplatnou ukázkovou nahrávku hlasu v řádku hlasu; $name$ je název hlasu.",
+    "message": "Přehrát ukázku hlasu $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Přístupný název seznamu Hlasů v nastavení (listbox všech hlasů, jeden řádek na každý).",
+    "message": "Hlasy, seřazené od nejhlubšího po nejjasnější"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Popisek pro čtečky obrazovky pro přepínač připnutí na kartě hlasu (stav zapnuto) a pro tlačítko odebrání ve slotu nabídky; $name$ je hlas, $host$ je asistent.",
+    "message": "Odebrat $name$ z nabídky $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Řádek v ovládací liště Nastavení > Hlasy, když se u jednoho hlasu nepodařilo načíst nebo přehrát ukázkový klip; $name$ je daný hlas. Není modální — přehrávání dalších ukázek pokračuje dál.",
+    "message": "Ukázku hlasu $name$ se nepodařilo přehrát.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Podnadpis sekce katalogu hlasů v nastavení na kartě AI Chat",
+    "message": "Vyberte hlas, který bude na jednotlivých webech číst odpovědi nahlas."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Podtitulek pod nadpisem nastavení Hlasů, pro lištu hlasů seřazenou podle výšky.",
+    "message": "Každý hlas, od nejhlubšího po nejjasnější. Poslechněte si je a vyberte."
+  },
+  "voicesSectionTitle": {
+    "description": "Nadpis sekce katalogu hlasů v nastavení na kartě AI Chat",
+    "message": "Hlasy"
+  },
+  "voicesShelfEveryday": {
+    "description": "Nadpis skupiny pro dostupnější hlasy v katalogu hlasů v nastavení. CSS jej vykreslí velkými písmeny.",
+    "message": "Hlasy pro každý den"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Jednořádková poznámka vedle nadpisu skupiny Everyday v nastavení ve studiu Hlasy; jediné místo, kde studio uvádí, o kolik dál tato úroveň sahá než HD.",
+    "message": "Přirozené a srozumitelné, můžete poslouchat asi 20× déle než u HD."
+  },
+  "voicesShelfHd": {
+    "description": "Nadpis skupiny pro prémiové (HD) hlasy v katalogu hlasů v nastavení. CSS jej vykreslí velkými písmeny.",
+    "message": "HD hlasy"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Jednořádková poznámka vedle nadpisu skupiny HD v nastavení ve studiu Hlasy.",
+    "message": "Náš nejbohatší a nejvýraznější zvuk."
+  },
+  "voicesShowAll": {
+    "description": "Možnost ve filtru Nastavení > Hlasy „Zobrazit“: bez filtrování, vypíší se všechny hlasy.",
+    "message": "Všechny hlasy"
+  },
+  "voicesShowEveryday": {
+    "description": "Možnost ve filtru Nastavení > Hlasy „Zobrazit“: vypíše jen standardní (ne-HD) hlasy.",
+    "message": "Jen běžné"
+  },
+  "voicesShowHd": {
+    "description": "Možnost ve filtru Nastavení > Hlasy „Zobrazit“: vypíše jen prémiové (HD) hlasy.",
+    "message": "Jen HD"
+  },
+  "voicesShowLabel": {
+    "description": "Popisek filtru v ovládací liště Nastavení > Hlasy, který zužuje, které hlasy se v seznamu zobrazí.",
+    "message": "Zobrazit"
+  },
+  "voicesShowUnheard": {
+    "description": "Možnost ve filtru Nastavení > Hlasy „Zobrazit“: vypíše jen hlasy, které si uživatel ještě nepustil.",
+    "message": "Ještě neslyšené"
+  },
+  "voicesSpeakingNow": {
+    "description": "Stavový štítek u aktuálně vybraného hlasu hostitele ve Studiu hlasů v nastavení (slot v nabídce a karta hlasu).",
+    "message": "Právě mluví"
+  },
+  "voicesSpeaksWith": {
+    "description": "Řádek nad názvem aktuálního hlasu na scéně Studia hlasů v nastavení; $host$ je asistent (např. Pi). CSS jej vykreslí velkými písmeny.",
+    "message": "$host$ mluví hlasem",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Poznámka na scéně, když hostitel poskytuje vlastní zvuk (např. Pi), takže volba hlasu Say, Pi hlas hostitele nahradí.",
+    "message": "$host$ používá svůj vlastní hlas, dokud níže nějaký nevyberete.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Poznámka na scéně, když hostitel nemá žádný vlastní hlas (např. Claude), takže se nic nečte nahlas, dokud se nezvolí hlas Say, Pi.",
+    "message": "$host$ nebude číst odpovědi nahlas, dokud níže nějaký nevyberete.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Titulek na scéně studia Hlasů v nastavení, když hostitel nemá vybraný žádný hlas Say, Pi; $host$ je asistent (např. Pi, Claude). Zobrazuje se velikostí jako jméno.",
+    "message": "Vyberte, jak bude $host$ znít",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Tlačítko na scéně studia Hlasů v nastavení, které přehraje bezplatnou ukázku aktuálního hlasu.",
+    "message": "Přehrát ukázku"
+  },
+  "voicesStopPlayback": {
+    "description": "Tlačítko v ovládací liště Hlasů v nastavení, které zastaví sérii ukázek spuštěnou volbou „Přehrát vše“.",
+    "message": "Zastavit"
+  },
+  "voicesSweepPosition": {
+    "description": "Průběžný ukazatel pozice v ovládací liště Nastavení > Hlasy, když „Přehrát vše“ prochází seznam; $index$ je právě přehrávaný hlas a $total$ kolik jich je ve frontě.",
+    "message": "$index$ z $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Popisek pro přístupnost u ovládacího prvku porovnání v ovládací liště Hlasů v nastavení, který znovu přehraje druhý hlas z posledních dvou slyšených; $name$ je tento hlas.",
+    "message": "Přepnout zpět na $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Řádek v ovládací liště Nastavení > Hlasy, když se stiskne „Přehrát vše“ u příliš dlouhého seznamu; $count$ je počet hlasů a $minutes$ přibližný počet minut. Zkrácené „min“, aby to dávalo smysl i pro 1 — Chrome i18n nemá tvary množného čísla.",
+    "message": "To je $count$ hlasů — asi $minutes$ min. Nejdřív seznam zúžte.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Popisek pro čtečky obrazovky pro tlačítko „použít tento hlas“ pro konkrétního hostitele v katalogu hlasů v nastavení; $name$ je hlas, $host$ je asistent (např. Pi, Claude).",
+    "message": "Použít $name$ u $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Krátký štítek na tlačítku „použít tento hlas“ pro konkrétního hostitele v jednotném katalogu hlasů v nastavení (hostitel se zobrazuje vedle něj).",
+    "message": "Použít"
+  },
+  "voicesYourVoice": {
+    "description": "Tlačítko v ovládací liště v seznamu Hlasů v nastavení, které přesune fokus na řádek hlasu, který tento hostitel aktuálně používá; $name$ je tento hlas.",
+    "message": "Váš hlas: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Chyba vyhozená, když prohlížeč nedokáže alokovat dostatek paměti WebAssembly pro model detekce hlasu.",
+    "message": "Detekci hlasu nelze spustit: pro hlasový model není dost paměti WebAssembly. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Chyba vyhozená, když prohlížeč neposkytuje počáteční paměť WebAssembly potřebnou pro spuštění modelu detekce hlasu.",
+    "message": "Detekci hlasu nelze spustit: v tomto prohlížeči není k dispozici paměť WebAssembly."
   }
 }

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Fordel listet i auth-modal – øgede brugsgrænser.",
+    "message": "Højere brugsgrænser med gratis konto"
+  },
+  "authBenefitPremium": {
+    "description": "Fordel listet i auth-modal – premiumfunktioner på tværs af chatbots.",
+    "message": "Premiumfunktioner og chatbot-understøttelse"
+  },
+  "authBenefitSupport": {
+    "description": "Fordel listet i auth-modal – prioriteret support.",
+    "message": "Prioriteret support ved problemer"
+  },
+  "authBenefitSync": {
+    "description": "Fordel listet i auth-modal – synkronisering af indstillinger.",
+    "message": "Synkronisér stemmeindstillinger overalt"
+  },
+  "authBenefitTTS": {
+    "description": "Fordel listet i auth-modal – TTS-funktion.",
+    "message": "Tekst-til-tale-stemmer (betalingsplaner)"
+  },
+  "authBenefitUsage": {
+    "description": "Fordel listet i auth-modal – sporing af forbrug.",
+    "message": "Følg dit stemmeforbrug på tværs af enheder"
+  },
+  "authPromptModalFull": {
+    "description": "Beskrivelse til den fulde modal-godkendelsesprompt med værdiforslag.",
+    "message": "Du får rigtig meget ud af Say, Pi. Log ind for højere grænser, tekst-til-tale-stemmer og premiumfunktioner på tværs af alle understøttede chatbots."
+  },
+  "authPromptModalSoft": {
+    "description": "Beskrivelse til den bløde modal-godkendelsesprompt.",
+    "message": "Opret en gratis Say, Pi-konto for højere brugsgrænser og adgang til premium-stemmefunktioner."
+  },
+  "authPromptTitle": {
+    "description": "Titel til godkendelsespromptens modal.",
+    "message": "Få adgang til flere stemmefunktioner"
+  },
+  "authPromptToast": {
+    "description": "Toast-notifikation, der opfordrer brugeren til at logge ind.",
+    "message": "Log ind på Say, Pi for højere grænser og premiumfunktioner"
+  },
   "autoReadAloudChatGPT": {
     "description": "Etiket for afkrydsningsfeltet til at aktivere/deaktivere automatisk oplæsning af ChatGPT-svar under opkald med stemme.",
     "message": "Automatisk oplæsning (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Deaktiver tekst-til-tale"
   },
+  "dismiss": {
+    "message": "Forstået",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Afskedige"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Fokus"
   },
+  "errorVadInitFailed": {
+    "description": "Fejl-toast vist, når voice-activity detection ikke kan initialiseres.",
+    "message": "Kunne ikke initialisere stemmedetektion"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Fejl-toast vist, når der opstår en uventet fejl under opsætning af stemmeoptagelse.",
+    "message": "Kunne ikke konfigurere stemmeoptagelse"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Fejl-toast vist, når voice-detection-klienten ikke kan starte optagelsen.",
+    "message": "Kunne ikke starte stemmeoptagelse"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Fejl-toast vist, når voice-detection (VAD)-klienten ikke er tilgængelig, så optagelsen ikke kan starte.",
+    "message": "Stemmeoptagelse er ikke tilgængelig"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Afslut fokustilstand"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "En linje note, der vises i stemmemenuer, når både premium (HD) og value-stemmer er tilgængelige",
+    "message": "HD-stemmer bruger din månedlige kvote ca. 20× hurtigere."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Gemt dette væk ..."
   },
+  "maybeLater": {
+    "description": "Knaptekst til at afvise auth-prompt.",
+    "message": "Måske senere"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Dine mikrofonindstillinger opfylder ikke de påkrævede specifikationer. \nPrøv at bruge en anden mikrofon eller juster dine lydindstillinger."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Kan ikke få adgang til mikrofonen. \nTjek venligst dine enhedsindstillinger og prøv igen."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Fejl-toast vist, når mikrofontilladelse blev afvist efter tilladelsespromptforløbet.",
+    "message": "Mikrofontilladelse blev ikke givet. Sørg for, at du har givet adgang i prompten og i udvidelsesindstillingerne."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "nøjagtighed"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Hurtigste respons, men mindre præcis. \nTilbøjelig til at afbryde."
   },
+  "moreVoices": {
+    "description": "Menurække, der linker fra stemmemenuen på siden til det fulde stemmekatalog i udvidelsens indstillinger",
+    "message": "Flere stemmer…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Assistents kaldenavn"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Ikke logget ind"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Knaptekst, der åbner ChatGPT.",
+    "message": "Åbn ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Knaptekst, der åbner Claude.ai.",
+    "message": "Åbn Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Knaptekst, der åbner Pi.ai.",
+    "message": "Åbn Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Miljøvalg: omkring andre mennesker.",
+    "message": "Omkring andre mennesker"
+  },
+  "onboarding_envMixed": {
+    "description": "Miljøvalg: en blanding af private og fælles rum.",
+    "message": "En blanding af steder"
+  },
+  "onboarding_envPrivate": {
+    "description": "Miljøvalg: et privat sted.",
+    "message": "Et privat sted"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Bekræftelse, der vises, når svaret om miljøet efterlader stille tilstand slået fra.",
+    "message": "Okay — vi beholder standardindstillingerne for lytning og afspilning."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Bekræftelse, der vises, når svaret om omgivelser aktiverer stille tilstand.",
+    "message": "Stille tilstand til — vi opfanger blødere tale og svarer lavt, så du kan tale diskret."
+  },
+  "onboarding_envTitle": {
+    "description": "Overskrift til onboarding-spørgsmålet om brugerens omgivelser.",
+    "message": "Hvor taler du typisk?"
+  },
+  "onboarding_footer": {
+    "description": "Fodtekst på onboarding-siden ved første kørsel.",
+    "message": "Du kan altid finde dette igen i indstillingerne i Say, Pi. Dit privatliv er vigtigt — lyd optages kun under et aktivt opkald."
+  },
+  "onboarding_heading": {
+    "description": "Hovedoverskrift på onboarding-siden ved første kørsel.",
+    "message": "🗣️ Velkommen til Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Introafsnit på onboarding-siden ved første kørsel.",
+    "message": "Du er to trin fra din første samtale med en AI. At tale er ca. 3× hurtigere end at skrive, så lad os få dig sat op."
+  },
+  "onboarding_micTestButton": {
+    "description": "Knap, der starter den uforpligtende mikrofontest i onboarding.",
+    "message": "🎤 Test din mikrofon"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status, der vises, efter onboarding-mikrofontesten er gennemført.",
+    "message": "Fint — din mikrofon virker! 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status, der vises, mens onboarding-mikrofontesten måler input.",
+    "message": "Lytter — sig noget! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status, der vises, mens onboarding-mikrofontesten afventer tilladelse.",
+    "message": "Anmoder om mikrofon…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Knaptekst til at stoppe onboarding-mikrofontesten, mens den kører.",
+    "message": "Stop test"
+  },
+  "onboarding_step1Body": {
+    "description": "Brødtekst til første onboarding-trin, der forklarer hvordan du fastgør udvidelsen.",
+    "message": "Klik på puslespilsikonet 🧩 øverst til højre i din browser, og klik derefter på nålen 📌 ved siden af Say, Pi. Så er opkaldsknappen kun ét klik væk."
+  },
+  "onboarding_step1Title": {
+    "description": "Titel på første onboarding-trin (fastgør udvidelsen).",
+    "message": "Fastgør Say, Pi til værktøjslinjen"
+  },
+  "onboarding_step2Body": {
+    "description": "Brødtekst til andet onboarding-trin, der forklarer hvordan man starter en stemmesamtale.",
+    "message": "Gå til en af de understøttede assistenter nedenfor, tryk på Say, Pi-opkaldsknappen, og sig hej. Første gang beder vi om adgang til mikrofonen, og det er forventet, og vi lytter kun, mens du aktivt er i et opkald."
+  },
+  "onboarding_step2Title": {
+    "description": "Titel på andet onboarding-trin (start en samtale).",
+    "message": "Åbn en AI-chat og begynd at tale"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Mikrofon tilladelse"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Gendannelsesvejledning, når mikrofontilladelsen er blokeret.",
+    "message": "Din browser blokerer mikrofonen. Klik på kamera- eller låseikonet i adresselinjen, sæt Mikrofon til \"Tillad\", og prøv igen. På macOS: tjek også Systemindstillinger → Anonymitet og sikkerhed → Mikrofon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Titel på gendannelsespanelet, når mikrofontilladelse blev afvist/blokeret.",
+    "message": "Mikrofonadgang er blokeret"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Gendannelsesvejledning, når mikrofonen bruges et andet sted.",
+    "message": "En anden app eller fane bruger måske din mikrofon. Luk alt andet, der kan optage (videoopkald, stemmenoter), og prøv igen."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Titel på gendannelsespanelet, når mikrofonen bruges af en anden app.",
+    "message": "Din mikrofon er optaget"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Gendannelsesvejledning, når der ikke er nogen mikrofonenhed tilgængelig.",
+    "message": "Vi kunne ikke finde en mikrofon. Tilslut en (eller forbind dit headset), sørg for at den er valgt som inputenhed, og prøv igen."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Titel på gendannelsespanelet, når der ikke er nogen mikrofonenhed tilgængelig.",
+    "message": "Ingen mikrofon fundet"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Gendannelsesvejledning ved en ukendt mikrofonfejl.",
+    "message": "Noget gik galt med adgangen til din mikrofon. Tjek, at den er tilsluttet og tilladt i din browsers indstillinger, og prøv igen."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Titel på gendannelsespanelet ved en ukendt mikrofonfejl.",
+    "message": "Vi kunne ikke få adgang til din mikrofon"
+  },
+  "permissions_retryButton": {
+    "description": "Tekst på knappen, der anmoder om mikrofontilladelse igen.",
+    "message": "Prøv igen"
+  },
+  "permissions_revokedHeading": {
+    "description": "Overskrift, der vises, når mikrofonadgang tidligere blev givet, men siden er blevet tilbagekaldt.",
+    "message": "🎙️ Lad os tilslutte din mikrofon igen"
+  },
+  "permissions_revokedInfo": {
+    "description": "Informationstekst, der vises, når mikrofonadgang blev tilbagekaldt efter at være blevet givet.",
+    "message": "Din mikrofonadgang blev slået fra — det sker ofte efter en browser- eller systemopdatering. Tillad den igen nedenfor, så lytter $productName$ igen, når du er i et opkald.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Etiket til kontakten, der aktiverer stille-/hvisketilstand.",
+    "message": "Stille tilstand"
+  },
+  "quietModeTooltip": {
+    "description": "Værktøjstip, der forklarer, hvad stille-/hvisketilstand gør.",
+    "message": "Tal lavt — opfanger svagere tale og sænker assistentens svarlydstyrke, så du kan bruge stemmen omkring andre."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Tekst til knappen Log ind, mens godkendelsen er i gang.",
+    "message": "Logger ind…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Lyd effekter"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Lydeffekter er deaktiveret i Firefox for at forhindre problemer med lydfeedback."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Overskrift på den engangsvist speed-payoff-besked efter den første talte udveksling.",
+    "message": "Dejligt — det er cirka 3× hurtigere at tale end at skrive."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Valgfri anden linje i speed-payoff-beskeden, der viser hele minutter sparet.",
+    "message": "Du har allerede talt omtrent $minutes$ min hurtigere, end hvis du havde skrevet det.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Send først, når du trykker på knappen"
   },
+  "surveyQuestion": {
+    "description": "Det ene spørgsmål i den engangs micro-undersøgelse efter en win.",
+    "message": "Hvordan fungerer stemmen for dig indtil videre?"
+  },
+  "surveyRatingLabel": {
+    "description": "Tilgængelig etiket til en knap til bedømmelse i en undersøgelse.",
+    "message": "Bedøm $rating$ ud af 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Anerkendelse, der vises, efter at brugeren har besvaret undersøgelsen efter en win.",
+    "message": "Tak — det hjælper os med at gøre Say, Pi bedre."
+  },
   "tabAIChat": {
     "description": "Faneblad label for AI chatindstillingssektionen.",
     "message": "AI Chat"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Faneblad label for de generelle indstillinger.",
     "message": "Generelt"
+  },
+  "tabVoices": {
+    "description": "Fanebladets etiket for stemmeindstillinger (stemmeoversigt pr. site).",
+    "message": "Stemmer"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "Kreditter"
   },
+  "ttsCreditsRemaining": {
+    "description": "Tekst, der viser resterende TTS-kvote som en kreditpulje pr. stemme (saypi-api #181 Stage 2), ikke rå tegn.",
+    "message": "$credits$ kreditter tilbage",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Flersprogede stemmer understøttes i øjeblikket ikke i Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Stemmegenerering"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Heads up! Taleafspilning er ikke tilgængelig på $browserName$ med $chatbotName$ endnu. Den gode nyhed? Stemmeinput fungerer fantastisk! Til TTS skal du prøve Chrome eller Edge på desktop.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS ikke tilgængelig på $browserName$ + $chatbotName$. Stemmeinput fungerer! Prøv Chrome desktop til TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Tts stemme"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "VAD-detalje når taleagtig lyd blev registreret, men var for svag / med for lav sikkerhed til at blive transskriberet (klientside admission-gate drop).",
+    "message": "Lyden er for svag til at blive transskriberet"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "VAD-detalje der forklarer, at opkaldet sluttede, fordi mikrofonen blev taget i brug af en nyere fane.",
+    "message": "Stemmeinput flyttet til en anden fane"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Stemme ikke tilgængelig. \nPrøv Chrome eller Firefox på desktop."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Heads up! Taleafspilning er ikke tilgængelig på $browserName$ med $chatbotName$ endnu. Den gode nyhed? Stemmeinput fungerer fantastisk! Til TTS skal du prøve Chrome eller Edge på desktop.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS ikke tilgængelig på $browserName$ + $chatbotName$. Stemmeinput fungerer! Prøv Chrome desktop til TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Forstået",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "VAD-status vist på en fane, hvis stemmeinput blev overtaget af en anden fane.",
+    "message": "Sat på pause"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Se detaljer"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Generisk, talt introduktion, der afspilles, når en valgt SayPi-stemme ikke har et stemmespecifikt introduktionsmanuskript (og der ikke er en nylig besked at læse op).",
+    "message": "Hej, jeg er $voice$. Sådan lyder jeg. Jeg håber, du kan lide denne stemme.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hej! \nПривет! \n你好! \nJeg er Pi, din polyglot AI-assistent. \nMed 32 sprog på min kommando, kan vi udforske ideer og kulturer fra hele verden. \nHvad synes du om denne stemme?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Stemmeindstillinger"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Reserve-undertekst til en stemmerække i indstillingernes stemmekatalog, når stemmen ikke har en beskrivelse; $count$ er antallet af sprog, stemmen understøtter.",
+    "message": "Taler $count$ sprog",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Skrevet personlighedstagline til stemmen 'Addison' (indstillinger > stemmestudie; klientbaseret stemme-identitetskort).",
+    "message": "Solrig og velformuleret"
+  },
+  "voiceTagline_alloy": {
+    "description": "Forfattet personlighedstagline til stemmen 'Alloy' (indstillinger for stemmestudie; klient-side stemmeidentitetskort).",
+    "message": "Balanceret og alsidig"
+  },
+  "voiceTagline_ash": {
+    "description": "Forfattet personlighedstagline til stemmen 'Ash' (indstillinger for stemmestudie; klient-side stemmeidentitetskort).",
+    "message": "Dyb, eftertænksom, rolig"
+  },
+  "voiceTagline_ballad": {
+    "description": "Forfattet personlighedstagline til stemmen 'Ballad' (indstillinger for stemmestudie; klient-side stemmeidentitetskort).",
+    "message": "Blød og melodisk"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Skrevet personlighedstagline til stemmen 'Cassidy' (indstillinger > stemmestudie; klientbaseret stemme-identitetskort).",
+    "message": "Venlig og ligetil"
+  },
+  "voiceTagline_cedar": {
+    "description": "Forfattet personlighedstagline til stemmen 'Cedar' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Stabil og betryggende"
+  },
+  "voiceTagline_coral": {
+    "description": "Forfattet personlighedstagline til stemmen 'Coral' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Lys og optimistisk energi"
+  },
+  "voiceTagline_echo": {
+    "description": "Forfattet personlighedstagline til stemmen 'Echo' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Ren og neutral"
+  },
+  "voiceTagline_fable": {
+    "description": "Forfattet personlighedstagline til stemmen 'Fable' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "En fortællers melodiske tone"
+  },
+  "voiceTagline_finn": {
+    "description": "Skrevet personlighedstagline til stemmen 'Finn' (indstillinger > stemmestudie; klientbaseret stemme-identitetskort).",
+    "message": "Frisk og energisk"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Skrevet personlighedstagline til stemmen 'Jamahal' (indstillinger > stemmestudie; klientbaseret stemme-identitetskort).",
+    "message": "Fyldig og dragende"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Forfattet personlighedstagline til stemmen 'Jarnathan' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Fløjlsblød nattelig baryton"
+  },
+  "voiceTagline_jeff": {
+    "description": "Skrevet personlighedstagline til stemmen 'Jeff' (indstillinger > stemmestudie; klientbaseret stemme-identitetskort).",
+    "message": "Ligefrem og stabil"
+  },
+  "voiceTagline_jessica": {
+    "description": "Skrevet personlighedstagline til stemmen 'Jessica' (indstillinger > stemmestudie; klientbaseret stemme-identitetskort).",
+    "message": "Varm, poleret ro"
+  },
+  "voiceTagline_joey": {
+    "description": "Forfattet personlighedstagline til stemmen 'Joey' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Ubesværet, samtalende amerikansk"
+  },
+  "voiceTagline_juniper": {
+    "description": "Skrevet personlighedstagline til stemmen 'Juniper' (indstillinger > stemmestudie; klientbaseret stemme-identitetskort).",
+    "message": "Skarp, lys, livlig"
+  },
+  "voiceTagline_lucy": {
+    "description": "Skrevet personlighedstagline til stemmen 'Lucy' (indstillinger > stemmestudie; klientbaseret stemme-identitetskort).",
+    "message": "Blid og strålende"
+  },
+  "voiceTagline_marin": {
+    "description": "Forfattet personlighedstagline til stemmen 'Marin' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Varm ro som i morgenradio"
+  },
+  "voiceTagline_mark": {
+    "description": "Skrevet personlighedstagline til stemmen 'Mark' (indstillinger > stemmestudie; klientbaseret stemme-identitetskort).",
+    "message": "Klar og selvsikker fortæller"
+  },
+  "voiceTagline_nova": {
+    "description": "Forfattet personlighedstagline til stemmen 'Nova' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Hurtig og nysgerrig"
+  },
+  "voiceTagline_onyx": {
+    "description": "Forfattet personlighedstagline til stemmen 'Onyx' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Dyb og rungende autoritet"
+  },
+  "voiceTagline_paola": {
+    "description": "Forfattet personlighedstagline til stemmen 'Paola' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Udtryksfuld italiensk varme"
+  },
+  "voiceTagline_sage": {
+    "description": "Forfattet personlighedstagline til stemmen 'Sage' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Stille klarhed"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Forfattet personlighedstagline til stemmen 'Shimmer' (indstillinger Voices studio; identitetskort over stemmer på klientsiden).",
+    "message": "Let og luftig"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Kort etiket på et stemmekorts fastgør/skift-knap (slået fra) i indstillingerne (Voices studio); ved tryk tilføjes stemmen til værtens menu i chatten.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Tilgængelig etiket for et stemmekorts fastgør/skift-knap (slået fra); $name$ er stemmen, $host$ assistenten.",
+    "message": "Føj $name$ til $host$s menu",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Etiket på kontakten i kontrolbjælken for Stemmer, der angiver om gennemgang af listen med piletasterne afspiller hver stemme, når fokus når den.",
+    "message": "Afspil mens du flytter dig"
+  },
+  "voicesArrowsLive": {
+    "description": "Skærmlæserbekræftelse, føjet til den første \"Afspiller <stemme>\"-meddelelse i indstillingslisten over Stemmer, der fortæller at piletasterne lige er blevet hørbare. Matcher formuleringen i til/fra-knappen \"Afspil mens du bevæger dig\".",
+    "message": "Piletaster afspiller nu, mens du bevæger dig. Esc stopper."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Note under menupladserne for værter, der leveres med indbyggede stemmer (f.eks. Pi's 8 indbyggede), som studiet ikke administrerer; $host$ er assistenten.",
+    "message": "$host$s egne indbyggede stemmer vises altid også i menuen.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variant af voicesBuiltinsNote for en vært uden en stemmemenu i chatten (Pi udfasede sin menu i 2026), hvor løftet i originalen om at de indbyggede stemmer 'vises i menuen' ville være forkert; $host$ er assistenten.",
+    "message": "$host$ har også egne indbyggede stemmer, som ikke er listet her.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Status i indstillingskontrollen for Stemmer: hvor mange af de viste stemmer brugeren allerede har lyttet til. Kun tal, så det læses korrekt ved 1 — Chrome i18n har ingen flertalsformer.",
+    "message": "$heard$ af $total$ hørt",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Del af en stemmerækkes tilgængelige navn i indstillingslisten over Stemmer, som markerer en stemme denne profil allerede har lyttet til. Visuelt tegnes det som blæktæthed i stemmens lydaftryk, hvilket en skærmlæser ikke kan se.",
+    "message": "Hørt"
+  },
+  "voicesInHostMenu": {
+    "description": "Sektionsoverskrift over rækken med menuslots i indstillingerne (Voices studio); $host$ er assistenten.",
+    "message": "I $host$s menu",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Kort etiket på et stemmekorts fastgør/skift-knap (slået til) i indstillingerne (Voices studio).",
+    "message": "✓ I menu"
+  },
+  "voicesInUse": {
+    "description": "Vedvarende badge på værtens aktuelt valgte stemme i listen Stemmer i indstillingerne, gengivet med store bogstaver. Bevidst IKKE 'Taler nu': på denne side afspiller rækker deres sampleklip, så en valgt-men-tavs stemme må ikke påstå, at den taler, mens en anden række gør det.",
+    "message": "I brug"
+  },
+  "voicesKeyboardHint": {
+    "description": "Hint på én linje til tastaturbrug i indstillingskontrollen for Stemmer. Symbolerne er taster: mellemrum, pil op/ned og Skift+mellemrum.",
+    "message": "Tryk på mellemrum for at lytte, ↑↓ for at skifte mellem stemmer, ⇧Mellemrum for at skifte tilbage."
+  },
+  "voicesLoadError": {
+    "description": "Fejltilstand inde i én værts studie, når den værts stemmekatalog ikke kunne indlæses; $host$ er assistenten.",
+    "message": "Kunne ikke indlæse $host$s stemmer. Prøv igen senere.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/hint på en deaktiveret '+ Menu'-knap, når værtens menu i chatten allerede har det maksimale antal stemmer.",
+    "message": "Menuen er fuld — fjern en stemme for at tilføje en anden"
+  },
+  "voicesMenuHint": {
+    "description": "Enlinjet hint ved siden af overskriften 'I {host}'s menu', der forklarer at slots-rækken afspejler stemmemenuen i chatten.",
+    "message": "Det her ser du i chatten"
+  },
+  "voicesMenuOverflow": {
+    "description": "Note under menupladserne, når brugeren har flere fastgjorte stemmer, end menuen i chatten kan vise (legacy-tilstand); $count$ er hvor mange der ikke kan være der, $cap$ er menustørrelsen.",
+    "message": "$count$ flere fastgjorte stemmer venter uden for menuens $cap$ pladser.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Entalsform af voicesMenuOverflow, brugt når præcis én fastgjort stemme ikke kan være i menuen i chatten; $cap$ er menustørrelsen.",
+    "message": "1 flere fastgjort stemme venter uden for menuens $cap$ pladser.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Opsummeringslinje under indstillingslisten over Stemmer, der viser hvor meget af værtens stemmemenu i chatten der er fyldt; $host$ er assistenten, $used$ hvor mange pladser der er optaget, $cap$ hvor mange der er. Formuleret så det læses korrekt ved 1 — Chrome i18n har ingen flertalsformer.",
+    "message": "$host$'s menu: $used$ af $cap$ pladser",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Overskrift for gruppen til sidst i indstillingslisten over Stemmer med stemmer uden en prøveklip at afspille; $count$ er hvor mange. Formuleret så det læses korrekt ved 1 — Chrome i18n har ingen flertalsformer.",
+    "message": "Ingen prøve endnu ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Vises i indstillingernes stemmekatalog, når stemmelisten er tom for en bruger, der er logget ind (f.eks. et netværksproblem).",
+    "message": "Stemmer kunne ikke indlæses lige nu. Prøv igen senere."
+  },
+  "voicesNowPlaying": {
+    "description": "Skærmlæsermeddelelse når en stemmes prøveklip begynder at afspille i indstillingslisten over Stemmer; $name$ er stemmen.",
+    "message": "Afspiller $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Knap i indstillingskontrollen for Stemmer, som afspiller hver stemme, der vises i øjeblikket, én efter én; $count$ er hvor mange. Formuleret så det læses korrekt ved 1 — Chrome i18n har ingen flertalsformer.",
+    "message": "Afspil alle ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Knap i indstillingskontrollen for Stemmer ved et senere besøg: afspiller kun de viste stemmer, du ikke har lyttet til endnu; $count$ er hvor mange. Formuleret så det læses korrekt ved 1 — Chrome i18n har ingen flertalsformer.",
+    "message": "Afspil nye ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Linje i indstillingerne i stemmekontrollinjen, når browseren nægtede at afspille en prøve, fordi siden endnu ikke har haft brugerinteraktion.",
+    "message": "Klik på en vilkårlig stemme for at slå lyden til."
+  },
+  "voicesPreview": {
+    "description": "Tilgængelig etiket til afspilningsknappen (▶), der afspiller en stemmes gratis prøveklip på en stemmerække; $name$ er stemmens navn.",
+    "message": "Afspil en prøve med $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Tilgængeligt navn for listen over Stemmer i indstillingerne (en listeboks med alle stemmer, én række pr. stemme).",
+    "message": "Stemmer, sorteret fra dybest til lysest"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Tilgængelig etiket for et stemmekorts fastgør/skift-knap (slået til) og en menuslots fjern-knap; $name$ er stemmen, $host$ assistenten.",
+    "message": "Fjern $name$ fra $host$s menu",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Linje i indstillingerne i stemmekontrollinjen, når en stemmes prøvelyd ikke kunne indlæses eller afspilles; $name$ er den stemme. Ikke-modal — en række prøver fortsætter forbi den.",
+    "message": "Kunne ikke afspille prøven for $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Underoverskrift til stemmekatalog-sektionen i fanen AI Chat i indstillinger",
+    "message": "Vælg den stemme, der læser svar højt på hvert websted."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Underoverskrift under overskriften Stemmer i indstillingerne, til rækken af stemmer sorteret efter tonehøjde.",
+    "message": "Alle stemmer, fra dybest til lysest. Lyt, og vælg så."
+  },
+  "voicesSectionTitle": {
+    "description": "Overskrift til stemmekatalog-sektionen i fanen AI Chat i indstillinger",
+    "message": "Stemmer"
+  },
+  "voicesShelfEveryday": {
+    "description": "Gruppeoverskrift for value-tier-stemmer i stemmekataloget i indstillinger. Renderes med store bogstaver af CSS.",
+    "message": "Hverdagsstemmer"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Enlinjenote ved siden af gruppeoverskriften Hverdagsstemmer i Stemmer-studiet; det eneste sted, hvor studiet angiver, hvor meget længere dette niveau rækker end HD.",
+    "message": "Naturlig og klar — du kan lytte cirka 20× længere end med HD."
+  },
+  "voicesShelfHd": {
+    "description": "Gruppeoverskrift for premium (HD)-stemmer i stemmekataloget i indstillinger. Renderes med store bogstaver af CSS.",
+    "message": "HD-stemmer"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Enlinjenote ved siden af HD-gruppeoverskriften i indstillingerne for Stemmer.",
+    "message": "Vores mest fyldige og udtryksfulde lyd."
+  },
+  "voicesShowAll": {
+    "description": "Valgmulighed i 'Vis'-filteret for Stemmer i indstillingerne: ingen filtrering, alle stemmer vises.",
+    "message": "Alle stemmer"
+  },
+  "voicesShowEveryday": {
+    "description": "Valgmulighed i 'Vis'-filteret for Stemmer i indstillingerne: vis kun standardstemmerne (ikke-HD).",
+    "message": "Kun hverdagsstemmer"
+  },
+  "voicesShowHd": {
+    "description": "Valgmulighed i 'Vis'-filteret for Stemmer i indstillingerne: vis kun premium-stemmerne (HD).",
+    "message": "Kun HD"
+  },
+  "voicesShowLabel": {
+    "description": "Etiket på filteret i indstillingerne i stemmekontrollinjen, som indsnævrer hvilke stemmer listen viser.",
+    "message": "Vis"
+  },
+  "voicesShowUnheard": {
+    "description": "Valgmulighed i 'Vis'-filteret for Stemmer i indstillingerne: vis kun de stemmer, brugeren ikke har lyttet til endnu.",
+    "message": "Endnu ikke hørt"
+  },
+  "voicesSpeakingNow": {
+    "description": "Tilstandslabel på værtens aktuelt valgte stemme i indstillingerne (Voices studio) (menyslot og stemmekort).",
+    "message": "Taler nu"
+  },
+  "voicesSpeaksWith": {
+    "description": "Overskriftslinje over den aktuelle stemmes navn på scenen i indstillingerne (Voices studio); $host$ er assistenten (f.eks. Pi). Gengives med store bogstaver via CSS.",
+    "message": "$host$ taler med",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Scenenote når værten leverer sin egen lyd (f.eks. Pi), så valg af en Say, Pi-stemme erstatter værtens.",
+    "message": "$host$ bruger sin egen stemme, indtil du vælger en nedenfor.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Scenenote når værten ikke har sin egen stemme (f.eks. Claude), så intet bliver læst højt, før en Say, Pi-stemme vælges.",
+    "message": "$host$ læser ikke svar højt, før du vælger en nedenfor.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Overskrift på scenen i Stemmer-studiet i indstillingerne, når værten ikke har nogen SayPi-stemme valgt; $host$ er assistenten (f.eks. Pi, Claude). Vises i navnestørrelse.",
+    "message": "Vælg hvordan $host$ lyder",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Knap på scenen i Stemmer-studiet i indstillingerne, som afspiller den aktuelle stemmes gratis prøveklip.",
+    "message": "Hør en prøve"
+  },
+  "voicesStopPlayback": {
+    "description": "Knap i indstillingskontrollen for Stemmer, som stopper rækken af prøver startet af \"Afspil alle\".",
+    "message": "Stop"
+  },
+  "voicesSweepPosition": {
+    "description": "Live positionsvisning i indstillingerne i stemmekontrollinjen, mens 'Afspil alle' går gennem listen; $index$ er den stemme, der afspilles nu, og $total$ hvor mange der er i kø.",
+    "message": "$index$ af $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Tilgængelig etiket for sammenligningskontrollen i indstillingskontrollen for Stemmer, som afspiller den anden stemme af de sidste to, der blev hørt; $name$ er den stemme.",
+    "message": "Skift tilbage til $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Linje i indstillingerne i stemmekontrollinjen, når 'Afspil alle' trykkes på en liste, der er for lang at lytte til; $count$ er hvor mange stemmer og $minutes$ cirka hvor mange minutter de vil tage. Forkortet 'min' så det læses korrekt ved 1 — Chrome i18n har ingen flertalsformer.",
+    "message": "Det er $count$ stemmer — cirka $minutes$ min. Indsnævr listen først.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Tilgængelig etiket for knappen 'brug denne stemme' pr. vært i indstillingernes stemmekatalog; $name$ er stemmen, $host$ er assistenten (f.eks. Pi, Claude).",
+    "message": "Brug $name$ på $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Kort etiket på knappen 'brug denne stemme' pr. vært i den samlede stemmekatalogvisning i indstillingerne (værten vises ved siden af).",
+    "message": "Brug"
+  },
+  "voicesYourVoice": {
+    "description": "Knap i kontrolbjælken i indstillingslisten over Stemmer, som flytter fokus til rækken for den stemme, som denne vært bruger i øjeblikket; $name$ er den stemme.",
+    "message": "Din stemme: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Fejl, der kastes, når browseren ikke kan allokere tilstrækkelig WebAssembly-hukommelse til stemmedetektionsmodellen.",
+    "message": "Stemmedetektion kan ikke starte: ikke nok WebAssembly-hukommelse til stemmemodellen. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Fejl, der kastes, når browseren ikke eksponerer den indledende WebAssembly-hukommelse, der er nødvendig for at køre stemmedetektionsmodellen.",
+    "message": "Stemmedetektion kan ikke starte: WebAssembly-hukommelse er ikke tilgængelig i denne browser."
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Vorteil im Anmelde-Modal – erhöhte Nutzungslimits.",
+    "message": "Höhere Nutzungslimits mit kostenlosem Konto"
+  },
+  "authBenefitPremium": {
+    "description": "Vorteil im Anmelde-Modal – Premium-Funktionen über Chatbots hinweg.",
+    "message": "Premium-Funktionen und Chatbot-Unterstützung"
+  },
+  "authBenefitSupport": {
+    "description": "Vorteil im Anmelde-Modal – priorisierter Support.",
+    "message": "Priorisierter Support bei Problemen"
+  },
+  "authBenefitSync": {
+    "description": "Vorteil im Anmelde-Modal – Synchronisierung der Einstellungen.",
+    "message": "Stimmeinstellungen überall synchronisieren"
+  },
+  "authBenefitTTS": {
+    "description": "Vorteil im Anmelde-Modal – Text-to-Speech-Funktion.",
+    "message": "Text-to-Speech-Stimmen (kostenpflichtige Tarife)"
+  },
+  "authBenefitUsage": {
+    "description": "Vorteil im Anmelde-Modal – Nutzungsverfolgung.",
+    "message": "Verfolge deine Sprach-Nutzung geräteübergreifend"
+  },
+  "authPromptModalFull": {
+    "description": "Beschreibung für den vollständigen Modal-Anmelde-Prompt mit Nutzenversprechen.",
+    "message": "Du nutzt SayPi richtig viel. Melde dich an für höhere Limits, Text-to-Speech-Stimmen und Premium-Funktionen für alle unterstützten Chatbots."
+  },
+  "authPromptModalSoft": {
+    "description": "Beschreibung für den weichen Modal-Anmelde-Prompt.",
+    "message": "Erstelle ein kostenloses SayPi-Konto für höhere Nutzungslimits und Zugriff auf Premium-Stimmfunktionen."
+  },
+  "authPromptTitle": {
+    "description": "Titel für das Anmelde-Prompt-Modal.",
+    "message": "Mehr Stimmfunktionen freischalten"
+  },
+  "authPromptToast": {
+    "description": "Toast-Benachrichtigung, die Nutzer zur Anmeldung ermutigt.",
+    "message": "Bei SayPi anmelden für höhere Limits und Premium-Funktionen"
+  },
   "autoReadAloudChatGPT": {
     "description": "Beschriftung für das Kontrollkästchen, um das automatische Vorlesen von ChatGPT-Antworten während Sprachanrufen zu aktivieren/deaktivieren.",
     "message": "Automatisches Vorlesen (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Deaktivieren Sie Text-to-Speech"
   },
+  "dismiss": {
+    "message": "Verstanden",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Entlassen"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Fokus"
   },
+  "errorVadInitFailed": {
+    "description": "Fehler-Toast, der angezeigt wird, wenn die Sprachaktivitätserkennung nicht initialisiert werden kann.",
+    "message": "Spracherkennung konnte nicht initialisiert werden"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Fehler-Toast, der angezeigt wird, wenn beim Einrichten der Sprachaufzeichnung ein unerwarteter Fehler auftritt.",
+    "message": "Sprachaufzeichnung konnte nicht eingerichtet werden"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Fehler-Toast, der angezeigt wird, wenn der Client für die Spracherkennung die Aufnahme nicht starten kann.",
+    "message": "Sprachaufzeichnung konnte nicht gestartet werden"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Fehler-Toast, der angezeigt wird, wenn der Client für die Spracherkennung (VAD) nicht verfügbar ist und die Aufnahme daher nicht starten kann.",
+    "message": "Sprachaufzeichnung nicht verfügbar"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Fokusmodus verlassen"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Einzeiliger Hinweis in Sprachmenüs, wenn sowohl Premium- (HD) als auch Value-Stimmen verfügbar sind",
+    "message": "HD-Stimmen verbrauchen dein monatliches Kontingent etwa 20× schneller."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Das wegstecken ..."
   },
+  "maybeLater": {
+    "description": "Button-Text zum Schließen des Anmelde-Prompts.",
+    "message": "Vielleicht später"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Ihre Mikrofoneinstellungen entsprechen nicht den erforderlichen Spezifikationen. \nVersuchen Sie, ein anderes Mikrofon zu verwenden oder Ihre Audioeinstellungen anzupassen."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Auf das Mikrofon kann nicht zugegriffen werden. \nBitte überprüfen Sie Ihre Geräteeinstellungen und versuchen Sie es erneut."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Fehler-Toast, der angezeigt wird, wenn die Mikrofonberechtigung nach dem Berechtigungsdialog verweigert wurde.",
+    "message": "Mikrofonberechtigung wurde nicht erteilt. Bitte stelle sicher, dass du den Zugriff im Dialog und in den Erweiterungseinstellungen erlaubt hast."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "Genauigkeit"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Schnellste Antwort, aber weniger genau. \nNeigt dazu, zu unterbrechen."
   },
+  "moreVoices": {
+    "description": "Menüzeile, die vom In-Page-Stimmenmenü zum vollständigen Stimmenkatalog in den Erweiterungseinstellungen führt",
+    "message": "Mehr Stimmen…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Assistenten-Spitzname"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Nicht signiert"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Schaltflächenbeschriftung, die ChatGPT öffnet.",
+    "message": "ChatGPT öffnen"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Schaltflächenbeschriftung, die Claude.ai öffnet.",
+    "message": "Claude öffnen"
+  },
+  "onboarding_ctaPi": {
+    "description": "Schaltflächenbeschriftung, die Pi.ai öffnet.",
+    "message": "Pi öffnen"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Umgebungsoption: in der Nähe anderer Menschen.",
+    "message": "In der Nähe anderer Menschen"
+  },
+  "onboarding_envMixed": {
+    "description": "Umgebungsoption: eine Mischung aus privaten und geteilten Orten.",
+    "message": "An verschiedenen Orten"
+  },
+  "onboarding_envPrivate": {
+    "description": "Umgebungsoption: ein privater Ort.",
+    "message": "An einem privaten Ort"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Bestätigung, die angezeigt wird, wenn die Umgebungsantwort den Ruhemodus deaktiviert lässt.",
+    "message": "Alles klar — wir behalten die Standard-Einstellungen für Zuhören und Wiedergabe bei."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Bestätigung, die angezeigt wird, wenn die Umgebungsantwort den Leise-Modus aktiviert.",
+    "message": "Leise-Modus an – wir erfassen auch leiseres Sprechen und antworten leise, damit du unauffällig sprechen kannst."
+  },
+  "onboarding_envTitle": {
+    "description": "Überschrift für die Onboarding-Frage zur Umgebung der Nutzerin bzw. des Nutzers.",
+    "message": "Wo wirst du meist sprechen?"
+  },
+  "onboarding_footer": {
+    "description": "Fußzeilentext auf der Onboarding-Seite beim ersten Start.",
+    "message": "Du kannst das jederzeit in den Einstellungen von Say, Pi wieder aufrufen. Deine Privatsphäre zählt – Audio wird nur während eines aktiven Anrufs erfasst."
+  },
+  "onboarding_heading": {
+    "description": "Hauptüberschrift auf der Onboarding-Seite beim ersten Start.",
+    "message": "🗣️ Willkommen bei Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Einleitungstext auf der Onboarding-Seite beim ersten Start.",
+    "message": "Du bist nur zwei Schritte von deinem ersten gesprochenen Gespräch mit einer KI entfernt. Sprechen ist etwa 3× schneller als Tippen — lass uns alles einrichten."
+  },
+  "onboarding_micTestButton": {
+    "description": "Schaltfläche, die den unverbindlichen Mikrofontest im Onboarding startet.",
+    "message": "🎤 Mikrofon testen"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status, der angezeigt wird, nachdem der Mikrofontest im Onboarding erfolgreich abgeschlossen wurde.",
+    "message": "Super – dein Mikrofon funktioniert 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status, der angezeigt wird, während der Mikrofontest im Onboarding die Eingabe misst.",
+    "message": "Höre zu – sag etwas 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status, der angezeigt wird, während der Mikrofontest im Onboarding auf die Berechtigung wartet.",
+    "message": "Mikrofon wird angefordert…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Schaltflächenbeschriftung, um den laufenden Mikrofontest im Onboarding zu stoppen.",
+    "message": "Test stoppen"
+  },
+  "onboarding_step1Body": {
+    "description": "Text des ersten Onboarding-Schritts, der erklärt, wie man die Erweiterung anheftet.",
+    "message": "Klicke oben rechts im Browser auf das Puzzle-🧩-Symbol, dann auf die Pin-📌 neben Say, Pi. So ist die Anruf-Schaltfläche nur einen Klick entfernt."
+  },
+  "onboarding_step1Title": {
+    "description": "Titel des ersten Onboarding-Schritts (die Erweiterung anheften).",
+    "message": "Say, Pi an die Symbolleiste anheften"
+  },
+  "onboarding_step2Body": {
+    "description": "Text des zweiten Onboarding-Schritts, der erklärt, wie man ein Sprachgespräch startet.",
+    "message": "Geh zu einem der unten unterstützten Assistenten, tippe dann auf die Say, Pi Anruf-Schaltfläche und sag hallo. Beim ersten Mal fragen wir nach Mikrofonzugriff — das ist normal, und wir hören nur zu, während du aktiv in einem Anruf bist."
+  },
+  "onboarding_step2Title": {
+    "description": "Titel des zweiten Onboarding-Schritts (ein Gespräch starten).",
+    "message": "KI-Chat öffnen und lossprechen"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Mikrofonberechtigung"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Hinweise zur Wiederherstellung, wenn die Mikrofonberechtigung blockiert ist.",
+    "message": "Dein Browser blockiert das Mikrofon. Klicke in der Adressleiste auf das Kamera- oder Schloss-Symbol, setze Mikrofon auf „Zulassen“ und versuche es dann erneut. Unter macOS prüfe außerdem Systemeinstellungen → Datenschutz & Sicherheit → Mikrofon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Titel des Wiederherstellungsbereichs, wenn die Mikrofonberechtigung abgelehnt/blockiert wurde.",
+    "message": "Mikrofonzugriff ist blockiert"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Hinweise zur Wiederherstellung, wenn das Mikrofon anderswo in Verwendung ist.",
+    "message": "Eine andere App oder ein anderer Tab verwendet möglicherweise dein Mikrofon. Schließe alles, was sonst noch aufnehmen könnte (Videoanrufe, Sprachmemos), und versuche es dann erneut."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Titel des Wiederherstellungsbereichs, wenn das Mikrofon von einer anderen App verwendet wird.",
+    "message": "Dein Mikrofon ist belegt"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Hinweise zur Wiederherstellung, wenn kein Mikrofongerät verfügbar ist.",
+    "message": "Wir konnten kein Mikrofon finden. Schließe eins an (oder verbinde dein Headset), stelle sicher, dass es als Eingabegerät ausgewählt ist, und versuche es dann erneut."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Titel des Wiederherstellungsbereichs, wenn kein Mikrofongerät verfügbar ist.",
+    "message": "Kein Mikrofon gefunden"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Hinweise zur Wiederherstellung bei einem unbekannten Mikrofonfehler.",
+    "message": "Beim Zugriff auf dein Mikrofon ist etwas schiefgelaufen. Prüfe, dass es verbunden ist und in deinen Browser-Einstellungen erlaubt ist, und versuche es dann erneut."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Titel des Wiederherstellungsbereichs für einen unbekannten Mikrofonfehler.",
+    "message": "Wir konnten nicht auf dein Mikrofon zugreifen"
+  },
+  "permissions_retryButton": {
+    "description": "Beschriftung für die Schaltfläche, die die Mikrofonberechtigung erneut anfordert.",
+    "message": "Erneut versuchen"
+  },
+  "permissions_revokedHeading": {
+    "description": "Überschrift, die angezeigt wird, wenn der Mikrofonzugriff zuvor gewährt wurde, inzwischen aber widerrufen wurde.",
+    "message": "🎙️ Mikrofon wieder verbinden"
+  },
+  "permissions_revokedInfo": {
+    "description": "Informationstext, der angezeigt wird, wenn der Mikrofonzugriff nach dem Gewähren widerrufen wurde.",
+    "message": "Der Mikrofonzugriff wurde deaktiviert — das passiert oft nach einem Browser- oder Systemupdate. Erlaube ihn unten erneut, dann hört $productName$ wieder zu, wenn du in einem Anruf bist.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Beschriftung für den Schalter, der den Leise-/Flüstermodus aktiviert.",
+    "message": "Leise Modus"
+  },
+  "quietModeTooltip": {
+    "description": "Tooltip, der erklärt, was der Leise-/Flüstermodus macht.",
+    "message": "Spricht leiser — erkennt leisere Sprache und senkt die Antwortlautstärke des Assistenten, damit du Sprache auch in der Nähe anderer nutzen kannst."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Text für die Anmelden-Schaltfläche, während die Authentifizierung läuft.",
+    "message": "Anmelden..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Soundeffekte"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Soundeffekte sind in Firefox deaktiviert, um Audio-Feedback-Probleme zu vermeiden."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Überschrift des einmaligen Hinweises zum Geschwindigkeitsvorteil, der nach dem ersten gesprochenen Austausch angezeigt wird.",
+    "message": "Schön — Sprechen ist etwa 3× schneller als Tippen."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Optionale zweite Zeile des Hinweises zum Geschwindigkeitsvorteil, die ganze eingesparte Minuten anzeigt.",
+    "message": "Du hast bereits ungefähr $minutes$ min schneller gesprochen als es zu tippen.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Senden Sie es erst ab, wenn Sie auf die Schaltfläche klicken"
   },
+  "surveyQuestion": {
+    "description": "Die einzelne Frage der einmaligen Mikro-Umfrage nach dem Erfolg.",
+    "message": "Wie läuft es bisher mit der Stimme für dich?"
+  },
+  "surveyRatingLabel": {
+    "description": "Barrierefreies Label für eine Bewertungs-Schaltfläche der Umfrage.",
+    "message": "Bewerte mit $rating$ von 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Danksagung, die angezeigt wird, nachdem der Nutzer die Umfrage nach dem Erfolg beantwortet.",
+    "message": "Danke — das hilft uns, Say, Pi besser zu machen. 🙏"
+  },
   "tabAIChat": {
     "description": "Tab-Label für den Abschnitt der AI-Chat-Einstellungen.",
     "message": "AI Chat"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Tab-Label für den Abschnitt der allgemeinen Einstellungen.",
     "message": "Allgemein"
+  },
+  "tabVoices": {
+    "description": "Tab-Bezeichnung für den Abschnitt „Stimmen“ in den Einstellungen (standortspezifischer Stimmenkatalog).",
+    "message": "Stimmen"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "Credits"
   },
+  "ttsCreditsRemaining": {
+    "description": "Text, der das verbleibende TTS-Kontingent als Guthaben-Pool pro Stimme anzeigt (saypi-api #181 Stage 2), nicht als Rohzeichen.",
+    "message": "Noch $credits$ Guthaben",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Mehrsprachige Stimmen werden derzeit in Safari nicht unterstützt."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Sprachgenerierung"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Achtung! Sprachwiedergabe ist auf $browserName$ mit $chatbotName$ noch nicht verfügbar. Die gute Nachricht? Spracheingabe funktioniert großartig! Für TTS versuchen Sie Chrome oder Edge auf dem Desktop.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS nicht verfügbar auf $browserName$ + $chatbotName$. Spracheingabe funktioniert! Versuchen Sie Chrome Desktop für TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS -Stimme"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Mikrofon aktivieren ..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "VAD-Detail, wenn sprachähnliches Audio erkannt wurde, aber zu leise/mit zu geringer Sicherheit zum Transkribieren war (clientseitiger Admission-Gate-Drop).",
+    "message": "Audio zu leise zum Transkribieren"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD -Service geschlossen."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "VAD-Detail, das erklärt, dass der Anruf beendet wurde, weil das Mikrofon von einem neueren Tab übernommen wurde.",
+    "message": "Spracheingabe in anderen Tab verschoben"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Warten auf Sprache"
@@ -1227,41 +1531,9 @@
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Stimme nicht verfügbar. \nVersuchen Sie Chrome oder Firefox auf dem Desktop."
   },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Achtung! Sprachwiedergabe ist auf $browserName$ mit $chatbotName$ noch nicht verfügbar. Die gute Nachricht? Spracheingabe funktioniert großartig! Für TTS versuchen Sie Chrome oder Edge auf dem Desktop.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS nicht verfügbar auf $browserName$ + $chatbotName$. Spracheingabe funktioniert! Versuchen Sie Chrome Desktop für TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Verstanden",
-    "description": "Button text to dismiss a notification or dialog."
-  },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
-    "message": "Sprachfunktionen werden bei mobilen Browsern möglicherweise nicht vollständig unterstützt. \nBitte verwenden Sie einen Desktop -Browser für die beste Erfahrung.",
+    "message": "Sprachfunktionen werden in mobilen Browsern mit $chatbotName$ möglicherweise nicht vollständig unterstützt. Bitte versuchen Sie für das beste Erlebnis einen Desktop-Browser zu verwenden.",
     "placeholders": {
       "chatbotName": {
         "content": "$1",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Fehlzündung"
   },
+  "vadStatusPreempted": {
+    "description": "VAD-Status, der in einem Tab angezeigt wird, dessen Spracheingabe von einem anderen Tab übernommen wurde.",
+    "message": "Pausiert"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Verarbeitung"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Details anzeigen"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Generische gesprochene Einführung, die abgespielt wird, wenn eine ausgewählte SayPi-Stimme kein stimmenspezifisches Einführungsskript hat (und es keine aktuelle Nachricht zum Vorlesen gibt).",
+    "message": "Hi, ich bin $voice$. So klinge ich. Ich hoffe, dir gefällt diese Stimme.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hola! \nBitte! \nJa! \nIch bin Pi, Ihr polyglotter KI-Assistent. \nDa ich 32 Sprachen beherrsche, können wir Ideen und Kulturen aus der ganzen Welt erkunden. \nWas halten Sie von dieser Stimme?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Spracheinstellungen"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Ersatz-Untertitel für eine Stimmzeile im Stimmkatalog der Einstellungen, wenn die Stimme keine Beschreibung hat; $count$ ist die Anzahl der Sprachen, die die Stimme unterstützt.",
+    "message": "Spricht $count$ Sprachen",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Addison“ (Einstellungen: Voices-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Sonnig und wortgewandt"
+  },
+  "voiceTagline_alloy": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Alloy“ (Stimmen-Studio in den Einstellungen; clientseitige Zuordnung der Stimmenidentität).",
+    "message": "Ausgewogen und vielseitig"
+  },
+  "voiceTagline_ash": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Ash“ (Stimmen-Studio in den Einstellungen; clientseitige Zuordnung der Stimmenidentität).",
+    "message": "Tief, nachdenklich, ruhig"
+  },
+  "voiceTagline_ballad": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Ballad“ (Stimmen-Studio in den Einstellungen; clientseitige Zuordnung der Stimmenidentität).",
+    "message": "Sanft und melodisch"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Cassidy“ (Einstellungen: Voices-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Freundlich und sachlich"
+  },
+  "voiceTagline_cedar": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Cedar“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Ruhig und beruhigend"
+  },
+  "voiceTagline_coral": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Coral“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Hell und beschwingt"
+  },
+  "voiceTagline_echo": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Echo“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Klar und neutral"
+  },
+  "voiceTagline_fable": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Fable“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Erzählerischer Tonfall"
+  },
+  "voiceTagline_finn": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Finn“ (Einstellungen: Voices-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Frisch und energiegeladen"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Jamahal“ (Einstellungen: Voices-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Kräftig und anziehend"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Jarnathan“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Samtiger Spätabend-Bariton"
+  },
+  "voiceTagline_jeff": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Jeff“ (Einstellungen: Voices-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Bodenständig und gelassen"
+  },
+  "voiceTagline_jessica": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Jessica“ (Einstellungen: Voices-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Warm und souverän"
+  },
+  "voiceTagline_joey": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Joey“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Entspanntes amerikanisches Gespräch"
+  },
+  "voiceTagline_juniper": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Juniper“ (Einstellungen: Voices-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Präzise, hell, lebendig"
+  },
+  "voiceTagline_lucy": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Lucy“ (Einstellungen: Voices-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Sanft und leuchtend"
+  },
+  "voiceTagline_marin": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Marin“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Warm und radiomorgens ruhig"
+  },
+  "voiceTagline_mark": {
+    "description": "Verfasster Persönlichkeits-Tagline für die Stimme „Mark“ (Einstellungen: Voices-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Klarer, selbstsicherer Erzähler"
+  },
+  "voiceTagline_nova": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Nova“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Schnell und neugierig"
+  },
+  "voiceTagline_onyx": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Onyx“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Tief und klangvoll"
+  },
+  "voiceTagline_paola": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Paola“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Ausdrucksstarke italienische Wärme"
+  },
+  "voiceTagline_sage": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Sage“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Leise Klarheit"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Verfasster Persönlichkeits-Claim für die Stimme „Shimmer“ (Einstellungen: Stimmen-Studio; clientseitige Zuordnung der Stimmidentität).",
+    "message": "Leicht und luftig"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Kurze Beschriftung auf dem Pin-Schalter einer Stimmkarte (Aus-Zustand) im Einstellungen‑Stimmenstudio; beim Drücken wird die Stimme dem In-Chat-Menü des Hosts hinzugefügt.",
+    "message": "+ Menü"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Bedienungshilfe-Beschriftung für den Pin-Schalter einer Stimmkarte (Aus-Zustand); $name$ ist die Stimme, $host$ der Assistent.",
+    "message": "$name$ zum Menü von $host$ hinzufügen",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Beschriftung des Schalters in der Stimmen-Steuerleiste, der angibt, ob beim Durchgehen der Liste mit den Pfeiltasten jede Stimme abgespielt wird, sobald der Fokus sie erreicht.",
+    "message": "Beim Navigieren abspielen"
+  },
+  "voicesArrowsLive": {
+    "description": "Screenreader-Bestätigung, die an die erste „<Stimme> wird abgespielt“-Ansage in der Liste „Stimmen“ in den Einstellungen angehängt wird und mitteilt, dass die Pfeiltasten gerade hörbar geworden sind. Spiegelt die Formulierung des Schalters „Beim Wechseln abspielen“.",
+    "message": "Pfeiltasten spielen jetzt beim Wechseln. Esc stoppt."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Hinweis unter den Menüplätzen für Hosts, die native Stimmen mitbringen (z. B. Pis 8 integrierte), die das Studio nicht verwaltet; $host$ ist der Assistent.",
+    "message": "Die integrierten Stimmen von $host$ erscheinen immer auch in seinem Menü.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variante von voicesBuiltinsNote für einen Host ohne In-Chat-Stimmenmenü (Pi hat sein Menü 2026 eingestellt), bei dem das Versprechen des Originals, dass die integrierten Stimmen „in seinem Menü erscheinen“, falsch wäre; $host$ ist der Assistent.",
+    "message": "$host$ hat auch eigene integrierte Stimmen, die hier nicht aufgeführt sind.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Fortschrittsanzeige in der Steuerleiste „Stimmen“ in den Einstellungen: wie viele der gelisteten Stimmen der Nutzer bereits angehört hat. Nur Zahlen, sodass es bei 1 ebenso korrekt klingt – Chrome i18n hat keine Pluralformen.",
+    "message": "$heard$ von $total$ gehört",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Teil des barrierefreien Namens einer Stimmenzeile in der Liste „Stimmen“ in den Einstellungen, der eine Stimme markiert, die dieses Profil bereits angehört hat. Visuell wird dies als Farbdichte im Klangabdruck der Stimme dargestellt, was ein Screenreader nicht sehen kann.",
+    "message": "Gehört"
+  },
+  "voicesInHostMenu": {
+    "description": "Abschnittsüberschrift über der Menü-Slots-Zeile im Einstellungen‑Stimmenstudio; $host$ ist der Assistent.",
+    "message": "Im Menü von $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Kurze Beschriftung auf dem Pin-Schalter einer Stimmkarte (Ein-Zustand) im Einstellungen‑Stimmenstudio.",
+    "message": "✓ Im Menü"
+  },
+  "voicesInUse": {
+    "description": "Dauerhaftes Badge bei der aktuell ausgewählten Stimme des Hosts in der Einstellungen‑Stimmenliste, wird in Großbuchstaben dargestellt. Absichtlich NICHT „Spricht gerade“: Auf dieser Seite spielen Zeilen ihre Beispielclips ab, daher darf eine ausgewählte, aber stumme Stimme nicht behaupten zu sprechen, während eine andere Zeile es tut.",
+    "message": "In Verwendung"
+  },
+  "voicesKeyboardHint": {
+    "description": "Einzeiliger Tastaturhinweis in der Steuerleiste „Stimmen“ in den Einstellungen. Die Symbole sind Tasten: Leertaste, die Pfeile nach oben/unten und Umschalt+Leertaste.",
+    "message": "Leertaste zum Anhören, ↑↓ zum Wechseln, ⇧Leertaste zum Zurückwechseln."
+  },
+  "voicesLoadError": {
+    "description": "Fehlerzustand innerhalb des Studios eines Hosts, wenn der Stimmkatalog dieses Hosts nicht geladen werden konnte; $host$ ist der Assistent.",
+    "message": "Die Stimmen von $host$ konnten nicht geladen werden. Bitte versuche es später noch einmal.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/Hinweis auf einem deaktivierten „+ Menü“-Schalter, wenn das In-Chat-Menü des Hosts bereits die maximale Anzahl an Stimmen hat.",
+    "message": "Menü voll, entferne eine Stimme, um eine andere hinzuzufügen"
+  },
+  "voicesMenuHint": {
+    "description": "Einzeiliger Hinweis neben der Überschrift „Im Menü von {host}“, der erklärt, dass die Slots-Zeile das Stimmenmenü im Chat widerspiegelt.",
+    "message": "Das siehst du im Chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Hinweis unter den Menüplätzen, wenn der Nutzer mehr angepinnte Stimmen hat, als das In-Chat-Menü anzeigen kann (Altzustand); $count$ ist die Anzahl, die nicht hineinpasst, $cap$ ist die Menügröße.",
+    "message": "Weitere $count$ angepinnte Stimmen warten außerhalb der $cap$ Menüplätze.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Singular von voicesMenuOverflow, verwendet, wenn genau eine angepinnte Stimme nicht ins In-Chat-Menü passt; $cap$ ist die Menügröße.",
+    "message": "1 weitere angepinnte Stimme wartet außerhalb der $cap$ Menüplätze.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Zusammenfassungszeile unter der Liste „Stimmen“ in den Einstellungen, die zeigt, wie voll das In-Chat-Stimmenmenü des Hosts ist; $host$ ist der Assistent, $used$ die belegten Plätze, $cap$ die Gesamtzahl. So formuliert, dass es bei 1 ebenso korrekt klingt – Chrome i18n hat keine Pluralformen.",
+    "message": "Menü von $host$: $used$ von $cap$ Plätzen",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Überschrift für die Gruppe am Ende der Liste „Stimmen“ in den Einstellungen, die Stimmen ohne abspielbaren Probe-Clip enthält; $count$ ist die Anzahl. So formuliert, dass es bei 1 ebenso korrekt klingt – Chrome i18n hat keine Pluralformen.",
+    "message": "Noch keine Probe ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Wird im Stimmkatalog der Einstellungen angezeigt, wenn die Stimmenliste für einen angemeldeten Nutzer leer ist (z. B. bei einem Netzwerkproblem).",
+    "message": "Stimmen konnten gerade nicht geladen werden. Bitte versuche es später noch einmal."
+  },
+  "voicesNowPlaying": {
+    "description": "Screenreader-Ansage, wenn der Probe-Clip einer Stimme in der Liste „Stimmen“ in den Einstellungen startet; $name$ ist die Stimme.",
+    "message": "$name$ wird abgespielt",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Schaltfläche in der Steuerleiste „Stimmen“ in den Einstellungen, die jede aktuell gelistete Stimme nacheinander abspielt; $count$ ist die Anzahl. So formuliert, dass es bei 1 ebenso korrekt klingt – Chrome i18n hat keine Pluralformen.",
+    "message": "Alle abspielen ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Schaltfläche in der Steuerleiste „Stimmen“ in den Einstellungen bei einem erneuten Besuch: spielt nur die gelisteten Stimmen ab, die noch nicht angehört wurden; $count$ ist die Anzahl. So formuliert, dass es bei 1 ebenso korrekt klingt – Chrome i18n hat keine Pluralformen.",
+    "message": "Neue abspielen ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Zeile in der Stimmen-Steuerleiste der Einstellungen, wenn der Browser das Abspielen eines Samples verweigert hat, weil es auf der Seite noch keine Nutzerinteraktion gab.",
+    "message": "Klicke eine Stimme an, um Ton zu aktivieren."
+  },
+  "voicesPreview": {
+    "description": "Barrierefreie Beschriftung für die Play-Schaltfläche (▶), die den kostenlosen Beispielclip einer Stimme in einer Stimmzeile abspielt; $name$ ist der Name der Stimme.",
+    "message": "Ein Beispiel von $name$ abspielen",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Barrierefreier Name der Stimmenliste in den Einstellungen (eine Listbox mit jeder Stimme, eine Zeile pro Stimme).",
+    "message": "Stimmen, von tief bis hell geordnet"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Bedienungshilfe-Beschriftung für den Pin-Schalter einer Stimmkarte (Ein-Zustand) und den Entfernen-Button eines Menü-Slots; $name$ ist die Stimme, $host$ der Assistent.",
+    "message": "$name$ aus dem Menü von $host$ entfernen",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Zeile in der Stimmen-Steuerleiste der Einstellungen, wenn der Sample-Clip einer Stimme nicht geladen oder abgespielt werden konnte; $name$ ist diese Stimme. Nicht modal – eine Reihe von Samples läuft darüber hinweg weiter.",
+    "message": "Konnte das Sample von $name$ nicht abspielen.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Unterüberschrift für den Abschnitt des Stimmenkatalogs in den Einstellungen im Tab „AI Chat“",
+    "message": "Wähle die Stimme, die auf jeder Website Antworten vorliest."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Unterüberschrift unter der Überschrift „Voices“, für die nach Tonhöhe sortierte Leiste der Stimmen.",
+    "message": "Jede Stimme, von tief bis hell. Hör zu, dann wähle."
+  },
+  "voicesSectionTitle": {
+    "description": "Überschrift für den Abschnitt des Stimmenkatalogs in den Einstellungen im Tab „AI Chat“",
+    "message": "Stimmen"
+  },
+  "voicesShelfEveryday": {
+    "description": "Gruppenüberschrift für Stimmen der Value-Stufe im Stimmenkatalog der Einstellungen. Wird per CSS in Großbuchstaben dargestellt.",
+    "message": "Alltagsstimmen"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Einzeiliger Hinweis neben der Gruppenüberschrift „Everyday“ im Einstellungen-Bereich „Stimmen“; die einzige Stelle im Studio, die angibt, wie viel weiter diese Stufe als HD reicht.",
+    "message": "Natürlich und klar — du kannst etwa 20× länger zuhören als mit HD."
+  },
+  "voicesShelfHd": {
+    "description": "Gruppenüberschrift für Premium- (HD-)Stimmen im Stimmenkatalog der Einstellungen. Wird per CSS in Großbuchstaben dargestellt.",
+    "message": "HD-Stimmen"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Einzeiliger Hinweis neben der HD-Gruppenüberschrift im Einstellungen-Bereich „Stimmen“.",
+    "message": "Unser klangvollster, ausdrucksstärkster Sound."
+  },
+  "voicesShowAll": {
+    "description": "Option im „Anzeigen“-Filter der Stimmen-Einstellungen: keine Filterung, jede Stimme wird aufgelistet.",
+    "message": "Alle Stimmen"
+  },
+  "voicesShowEveryday": {
+    "description": "Option im „Anzeigen“-Filter der Stimmen-Einstellungen: listet nur die Standard- (nicht HD-)Stimmen auf.",
+    "message": "Nur Standard"
+  },
+  "voicesShowHd": {
+    "description": "Option im „Anzeigen“-Filter der Stimmen-Einstellungen: listet nur die Premium- (HD-)Stimmen auf.",
+    "message": "Nur HD"
+  },
+  "voicesShowLabel": {
+    "description": "Beschriftung am Filter in der Stimmen-Steuerleiste der Einstellungen, der eingrenzt, welche Stimmen die Liste anzeigt.",
+    "message": "Anzeigen"
+  },
+  "voicesShowUnheard": {
+    "description": "Option im „Anzeigen“-Filter der Stimmen-Einstellungen: listet nur Stimmen auf, die der Nutzer noch nicht angehört hat.",
+    "message": "Noch nicht angehört"
+  },
+  "voicesSpeakingNow": {
+    "description": "Statusbeschriftung bei der aktuell ausgewählten Stimme des Hosts im Einstellungen‑Stimmenstudio (Menü-Slot und Stimmkarte).",
+    "message": "Spricht gerade"
+  },
+  "voicesSpeaksWith": {
+    "description": "Eyebrow-Zeile über dem Namen der aktuellen Stimme auf der Einstellungen‑Bühne des Stimmen‑Studios; $host$ ist der Assistent (z. B. Pi). Wird per CSS in Großbuchstaben dargestellt.",
+    "message": "$host$ spricht mit",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Hinweis auf der Bühne, wenn der Host sein eigenes Audio liefert (z. B. Pi), sodass die Auswahl einer Say, Pi-Stimme die Stimme des Hosts ersetzt.",
+    "message": "$host$ nutzt seine eigene Stimme, bis du unten eine auswählst.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Hinweis auf der Bühne, wenn der Host keine eigene Stimme hat (z. B. Claude), sodass nichts laut vorgelesen wird, bis eine Say, Pi-Stimme ausgewählt ist.",
+    "message": "$host$ liest Antworten nicht laut vor, bis du unten eine auswählst.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Überschrift auf der Bühne der Einstellungen im Stimmen-Studio, wenn für den Host keine SayPi-Stimme ausgewählt ist; $host$ ist der Assistent (z. B. Pi, Claude). Wird in Namensgröße gerendert.",
+    "message": "Wähle, wie $host$ klingt",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Schaltfläche auf der Bühne im Stimmen-Studio der Einstellungen, die den kostenlosen Beispiel-Clip der aktuellen Stimme abspielt.",
+    "message": "Hör dir ein Beispiel an"
+  },
+  "voicesStopPlayback": {
+    "description": "Schaltfläche in der Steuerleiste „Stimmen“ in den Einstellungen, die die durch „Alle abspielen“ gestartete Abfolge von Proben stoppt.",
+    "message": "Stopp"
+  },
+  "voicesSweepPosition": {
+    "description": "Live-Positionsanzeige in der Stimmen-Steuerleiste der Einstellungen, während „Alle abspielen“ die Liste durchläuft; $index$ ist die Stimme, die gerade abgespielt wird, und $total$ wie viele in der Warteschlange sind.",
+    "message": "$index$ von $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Barrierefreie Beschriftung für das Vergleichs-Steuerelement in der Steuerleiste „Stimmen“ in den Einstellungen, das die jeweils andere der zuletzt zwei gehörten Stimmen erneut abspielt; $name$ ist diese Stimme.",
+    "message": "Zurück zu $name$ wechseln",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Zeile in der Stimmen-Steuerleiste der Einstellungen, wenn „Alle abspielen“ bei einer zu langen Liste gedrückt wird; $count$ ist die Anzahl der Stimmen und $minutes$ ungefähr die Minuten, die sie dauern würden. Abgekürzt „min“, damit es bei 1 korrekt ist – Chrome i18n hat keine Pluralformen.",
+    "message": "Das sind $count$ Stimmen – etwa $minutes$ min. Grenze die Liste zuerst ein.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Bedienungshilfe-Beschriftung für den Button „diese Stimme verwenden“ pro Host im Einstellungen‑Stimmkatalog; $name$ ist die Stimme, $host$ ist der Assistent (z. B. Pi, Claude).",
+    "message": "$name$ bei $host$ verwenden",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Kurze Beschriftung auf der Buttonbeschriftung „diese Stimme verwenden“ pro Host im einheitlichen Einstellungen‑Stimmkatalog (der Host wird daneben angezeigt).",
+    "message": "Verwenden"
+  },
+  "voicesYourVoice": {
+    "description": "Schaltfläche in der Steuerleiste der Liste „Stimmen“ in den Einstellungen, die den Fokus zur Zeile der Stimme verschiebt, die dieser Host aktuell verwendet; $name$ ist diese Stimme.",
+    "message": "Deine Stimme: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Fehler, der ausgelöst wird, wenn der Browser nicht genug WebAssembly-Speicher für das Spracherkennungsmodell zuweisen kann.",
+    "message": "Spracherkennung kann nicht starten: nicht genug WebAssembly-Speicher für das Sprachmodell. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Fehler, der ausgelöst wird, wenn der Browser den initialen WebAssembly-Speicher nicht bereitstellt, der zum Ausführen des Spracherkennungsmodells benötigt wird.",
+    "message": "Spracherkennung kann nicht starten: WebAssembly-Speicher ist in diesem Browser nicht verfügbar."
   }
 }

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Όφελος που εμφανίζεται στο modal σύνδεσης - αυξημένα όρια χρήσης.",
+    "message": "Υψηλότερα όρια χρήσης με δωρεάν λογαριασμό"
+  },
+  "authBenefitPremium": {
+    "description": "Όφελος που εμφανίζεται στο modal σύνδεσης - premium λειτουργίες σε chatbot.",
+    "message": "Premium λειτουργίες και υποστήριξη chatbot"
+  },
+  "authBenefitSupport": {
+    "description": "Όφελος που εμφανίζεται στο modal σύνδεσης - υποστήριξη προτεραιότητας.",
+    "message": "Υποστήριξη προτεραιότητας για προβλήματα"
+  },
+  "authBenefitSync": {
+    "description": "Όφελος που εμφανίζεται στο modal σύνδεσης - συγχρονισμός ρυθμίσεων.",
+    "message": "Συγχρονίστε τις ρυθμίσεις φωνής παντού"
+  },
+  "authBenefitTTS": {
+    "description": "Όφελος που εμφανίζεται στο modal σύνδεσης - λειτουργία TTS.",
+    "message": "Φωνές κειμένου σε ομιλία (επί πληρωμή προγράμματα)"
+  },
+  "authBenefitUsage": {
+    "description": "Όφελος που εμφανίζεται στο modal σύνδεσης - παρακολούθηση χρήσης.",
+    "message": "Παρακολουθήστε τη χρήση φωνής σε όλες τις συσκευές"
+  },
+  "authPromptModalFull": {
+    "description": "Περιγραφή για το πλήρες modal προτροπής σύνδεσης με πρόταση αξίας.",
+    "message": "Χρησιμοποιείτε πολύ το SayPi. Συνδεθείτε για υψηλότερα όρια, φωνές κειμένου σε ομιλία και premium λειτουργίες σε όλα τα υποστηριζόμενα chatbot."
+  },
+  "authPromptModalSoft": {
+    "description": "Περιγραφή για το ήπιο modal προτροπής σύνδεσης.",
+    "message": "Δημιουργήστε έναν δωρεάν λογαριασμό SayPi για υψηλότερα όρια χρήσης και πρόσβαση σε premium λειτουργίες φωνής."
+  },
+  "authPromptTitle": {
+    "description": "Τίτλος για το modal προτροπής σύνδεσης.",
+    "message": "Ξεκλειδώστε περισσότερες λειτουργίες φωνής"
+  },
+  "authPromptToast": {
+    "description": "Ειδοποίηση toast που ενθαρρύνει τον χρήστη να συνδεθεί.",
+    "message": "Συνδεθείτε στο SayPi για υψηλότερα όρια και premium λειτουργίες"
+  },
   "autoReadAloudChatGPT": {
     "description": "Ετικέτα για το πλαίσιο επιλογής που ενεργοποιεί ή απενεργοποιεί την αυτόματη ανάγνωση των απαντήσεων του ChatGPT κατά τη διάρκεια φωνητικών κλήσεων.",
     "message": "Αυτόματη Ανάγνωση (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Απενεργοποιήστε το κείμενο σε ομιλία"
   },
+  "dismiss": {
+    "message": "Το κατάλαβα",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Απορρίπτω"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Εστίαση"
   },
+  "errorVadInitFailed": {
+    "description": "Αναδυόμενο μήνυμα σφάλματος όταν αποτυγχάνει να αρχικοποιηθεί η ανίχνευση φωνητικής δραστηριότητας.",
+    "message": "Αποτυχία αρχικοποίησης ανίχνευσης φωνής"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Αναδυόμενο μήνυμα σφάλματος όταν προκύπτει απρόσμενο σφάλμα κατά τη ρύθμιση της ηχογράφησης φωνής.",
+    "message": "Αποτυχία ρύθμισης ηχογράφησης φωνής"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Αναδυόμενο μήνυμα σφάλματος όταν ο πελάτης ανίχνευσης φωνής αποτυγχάνει να ξεκινήσει την ηχογράφηση.",
+    "message": "Αποτυχία εκκίνησης ηχογράφησης φωνής"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Αναδυόμενο μήνυμα σφάλματος όταν ο πελάτης ανίχνευσης φωνής (VAD) δεν είναι διαθέσιμος, οπότε δεν μπορεί να ξεκινήσει η ηχογράφηση.",
+    "message": "Η ηχογράφηση φωνής δεν είναι διαθέσιμη"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Απενεργοποίηση Λειτουργίας Εστίασης"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Μονόγραμμη σημείωση που εμφανίζεται στα μενού φωνής όταν υπάρχουν διαθέσιμες τόσο premium (HD) όσο και value φωνές",
+    "message": "Οι φωνές HD καταναλώνουν το μηνιαίο όριό σας περίπου 20× πιο γρήγορα."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Τοποθετώντας αυτό μακριά ..."
   },
+  "maybeLater": {
+    "description": "Κείμενο κουμπιού για απόρριψη της προτροπής σύνδεσης.",
+    "message": "Ίσως αργότερα"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Οι ρυθμίσεις του μικροφώνου σας δεν πληρούν τις απαιτούμενες προδιαγραφές. \nΔοκιμάστε να χρησιμοποιήσετε διαφορετικό μικρόφωνο ή να προσαρμόσετε τις ρυθμίσεις ήχου."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Δεν είναι δυνατή η πρόσβαση στο μικρόφωνο. \nΕλέγξτε τις ρυθμίσεις της συσκευής σας και δοκιμάστε ξανά."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Αναδυόμενο μήνυμα σφάλματος όταν η άδεια μικροφώνου απορρίφθηκε μετά τη ροή του παραθύρου προτροπής άδειας.",
+    "message": "Δεν δόθηκε άδεια για το μικρόφωνο. Βεβαιώσου ότι έχεις επιτρέψει την πρόσβαση στο παράθυρο προτροπής και στις ρυθμίσεις της επέκτασης."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "ακρίβεια"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Η ταχύτερη απόκριση, αλλά λιγότερο ακριβής. \nΕπιρρεπής σε διακοπή."
   },
+  "moreVoices": {
+    "description": "Γραμμή μενού που συνδέει από το μενού φωνών στη σελίδα προς τον πλήρη κατάλογο φωνών στις ρυθμίσεις της επέκτασης",
+    "message": "Περισσότερες φωνές…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Ψευδώνυμο βοηθού"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Δεν έχει συνδεθεί"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Ετικέτα κουμπιού που ανοίγει το ChatGPT.",
+    "message": "Άνοιγμα του ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Ετικέτα κουμπιού που ανοίγει το Claude.ai.",
+    "message": "Άνοιγμα Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Ετικέτα κουμπιού που ανοίγει το Pi.ai.",
+    "message": "Άνοιγμα Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Επιλογή περιβάλλοντος: κοντά σε άλλα άτομα.",
+    "message": "Δίπλα σε άλλα άτομα"
+  },
+  "onboarding_envMixed": {
+    "description": "Επιλογή περιβάλλοντος: μίγμα ιδιωτικών και κοινόχρηστων χώρων.",
+    "message": "Σε διάφορα μέρη"
+  },
+  "onboarding_envPrivate": {
+    "description": "Επιλογή περιβάλλοντος: ιδιωτικός χώρος.",
+    "message": "Κάπου ιδιωτικά"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Επιβεβαίωση που εμφανίζεται όταν η απάντηση για το περιβάλλον αφήνει τη λειτουργία ησυχίας απενεργοποιημένη.",
+    "message": "Εντάξει — θα κρατήσουμε τις τυπικές ρυθμίσεις ακρόασης και αναπαραγωγής."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Επιβεβαίωση που εμφανίζεται όταν η απάντηση για το περιβάλλον ενεργοποιεί την ήσυχη λειτουργία.",
+    "message": "Ησυχη λειτουργία ενεργή — θα πιάνουμε πιο χαμηλή ομιλία και θα απαντάμε ήσυχα, για να μιλάς διακριτικά."
+  },
+  "onboarding_envTitle": {
+    "description": "Επικεφαλίδα για την ερώτηση onboarding σχετικά με το περιβάλλον του χρήστη.",
+    "message": "Πού θα μιλάς συνήθως;"
+  },
+  "onboarding_footer": {
+    "description": "Κείμενο υποσέλιδου στη σελίδα onboarding της πρώτης εκτέλεσης.",
+    "message": "Μπορείς να το ξαναδείς όποτε θέλεις από τις ρυθμίσεις του Say, Pi. Το απόρρητό σου έχει σημασία — ο ήχος καταγράφεται μόνο κατά τη διάρκεια μιας ενεργής κλήσης."
+  },
+  "onboarding_heading": {
+    "description": "Κύρια επικεφαλίδα στη σελίδα πρώτης εκτέλεσης του onboarding.",
+    "message": "🗣️ Καλώς ήρθατε στο Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Εισαγωγική παράγραφος στη σελίδα πρώτης εκτέλεσης του onboarding.",
+    "message": "Απέχετε δύο βήματα από την πρώτη σας προφορική συνομιλία με ένα AI. Το να μιλάτε είναι περίπου 3× πιο γρήγορο από το να πληκτρολογείτε — ας το ρυθμίσουμε."
+  },
+  "onboarding_micTestButton": {
+    "description": "Κουμπί που ξεκινά τη δοκιμή μικροφώνου στο onboarding, χωρίς επιπτώσεις.",
+    "message": "🎤 Δοκίμασε το μικρόφωνό σου"
+  },
+  "onboarding_micTestDone": {
+    "description": "Κατάσταση που εμφανίζεται αφού η δοκιμή μικροφώνου στο onboarding ολοκληρωθεί με επιτυχία.",
+    "message": "Ωραία — το μικρόφωνό σου λειτουργεί! 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Κατάσταση που εμφανίζεται όσο η δοκιμή μικροφώνου στο onboarding μετρά την είσοδο.",
+    "message": "Ακούω — πες κάτι! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Κατάσταση που εμφανίζεται όσο η δοκιμή μικροφώνου στο onboarding περιμένει άδεια.",
+    "message": "Ζητείται πρόσβαση στο μικρόφωνο…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Ετικέτα κουμπιού για διακοπή της δοκιμής μικροφώνου στο onboarding ενώ εκτελείται.",
+    "message": "Διακοπή δοκιμής"
+  },
+  "onboarding_step1Body": {
+    "description": "Κείμενο του πρώτου βήματος onboarding που εξηγεί πώς να καρφιτσώσετε την επέκταση.",
+    "message": "Πατήστε το εικονίδιο παζλ 🧩 πάνω δεξιά στο πρόγραμμα περιήγησής σας και μετά την καρφίτσα 📌 δίπλα στο Say, Pi. Έτσι, το κουμπί κλήσης είναι πάντα ένα κλικ μακριά."
+  },
+  "onboarding_step1Title": {
+    "description": "Τίτλος του πρώτου βήματος onboarding (καρφίτσωμα της επέκτασης).",
+    "message": "Καρφιτσώστε το Say, Pi στη γραμμή εργαλείων σας"
+  },
+  "onboarding_step2Body": {
+    "description": "Κείμενο του δεύτερου βήματος onboarding που εξηγεί πώς να ξεκινήσετε μια φωνητική συνομιλία.",
+    "message": "Μεταβείτε σε έναν από τους υποστηριζόμενους βοηθούς παρακάτω, έπειτα πατήστε το κουμπί κλήσης του Say, Pi και πείτε γεια. Την πρώτη φορά θα ζητήσουμε πρόσβαση στο μικρόφωνο — είναι αναμενόμενο, και ακούμε μόνο όσο βρίσκεστε ενεργά σε μια κλήση."
+  },
+  "onboarding_step2Title": {
+    "description": "Τίτλος του δεύτερου βήματος onboarding (έναρξη μιας συνομιλίας).",
+    "message": "Ανοίξτε ένα AI chat και ξεκινήστε να μιλάτε"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Άδεια μικροφώνου"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Οδηγίες ανάκτησης όταν η άδεια μικροφώνου είναι αποκλεισμένη.",
+    "message": "Το πρόγραμμα περιήγησής σας αποκλείει το μικρόφωνο. Κάντε κλικ στο εικονίδιο κάμερας ή λουκέτου στη γραμμή διευθύνσεων, ορίστε το Microphone σε \"Allow\" και μετά δοκιμάστε ξανά. Σε macOS, ελέγξτε επίσης: System Settings → Privacy & Security → Microphone."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Τίτλος του πίνακα ανάκτησης όταν η άδεια μικροφώνου απορρίφθηκε/αποκλείστηκε.",
+    "message": "Η πρόσβαση στο μικρόφωνο είναι αποκλεισμένη"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Οδηγίες ανάκτησης όταν το μικρόφωνο χρησιμοποιείται αλλού.",
+    "message": "Κάποια άλλη εφαρμογή ή καρτέλα μπορεί να χρησιμοποιεί το μικρόφωνό σας. Κλείστε οτιδήποτε άλλο μπορεί να κάνει εγγραφή (βιντεοκλήσεις, φωνητικές σημειώσεις) και μετά δοκιμάστε ξανά."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Τίτλος του πίνακα ανάκτησης όταν το μικρόφωνο χρησιμοποιείται από άλλη εφαρμογή.",
+    "message": "Το μικρόφωνό σας χρησιμοποιείται"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Οδηγίες ανάκτησης όταν δεν είναι διαθέσιμη συσκευή μικροφώνου.",
+    "message": "Δεν μπορέσαμε να βρούμε μικρόφωνο. Συνδέστε ένα (ή συνδέστε το headset σας), βεβαιωθείτε ότι είναι επιλεγμένο ως συσκευή εισόδου και μετά δοκιμάστε ξανά."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Τίτλος του πίνακα ανάκτησης όταν δεν είναι διαθέσιμη συσκευή μικροφώνου.",
+    "message": "Δεν βρέθηκε μικρόφωνο"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Οδηγίες ανάκτησης για άγνωστο σφάλμα μικροφώνου.",
+    "message": "Κάτι πήγε στραβά με την πρόσβαση στο μικρόφωνό σας. Ελέγξτε ότι είναι συνδεδεμένο και ότι επιτρέπεται στις ρυθμίσεις του προγράμματος περιήγησής σας, και μετά δοκιμάστε ξανά."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Τίτλος του πίνακα ανάκτησης για άγνωστο σφάλμα μικροφώνου.",
+    "message": "Δεν μπορέσαμε να αποκτήσουμε πρόσβαση στο μικρόφωνό σας"
+  },
+  "permissions_retryButton": {
+    "description": "Ετικέτα για το κουμπί που ζητά ξανά άδεια πρόσβασης στο μικρόφωνο.",
+    "message": "Δοκιμάστε ξανά"
+  },
+  "permissions_revokedHeading": {
+    "description": "Επικεφαλίδα που εμφανίζεται όταν η πρόσβαση στο μικρόφωνο είχε δοθεί προηγουμένως αλλά έκτοτε έχει ανακληθεί.",
+    "message": "🎙️ Ας συνδέσουμε ξανά το μικρόφωνό σας"
+  },
+  "permissions_revokedInfo": {
+    "description": "Ενημερωτικό κείμενο που εμφανίζεται όταν η πρόσβαση στο μικρόφωνο ανακλήθηκε αφού είχε δοθεί.",
+    "message": "Η πρόσβαση στο μικρόφωνό σας απενεργοποιήθηκε — αυτό συχνά συμβαίνει μετά από ενημέρωση του προγράμματος περιήγησης ή του συστήματος. Επιτρέψτε την ξανά παρακάτω και το $productName$ θα ξανακούει όταν είστε σε κλήση.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Προφίλ"
+  },
+  "quietModeLabel": {
+    "description": "Ετικέτα για τον διακόπτη που ενεργοποιεί την αθόρυβη/ψιθυριστή λειτουργία.",
+    "message": "Αθόρυβη λειτουργία"
+  },
+  "quietModeTooltip": {
+    "description": "Υπόδειξη εργαλείου που εξηγεί τι κάνει η αθόρυβη/ψιθυριστή λειτουργία.",
+    "message": "Μίλα χαμηλόφωνα — ανιχνεύει πιο ήσυχη ομιλία και μειώνει την ένταση της απάντησης του βοηθού, ώστε να χρησιμοποιείς φωνή κοντά σε άλλους."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Κείμενο για το κουμπί σύνδεσης όσο η ταυτοποίηση βρίσκεται σε εξέλιξη.",
+    "message": "Γίνεται σύνδεση..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Ηχητικά εφέ"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Τα ηχητικά εφέ είναι απενεργοποιημένα στον Firefox για την αποφυγή προβλημάτων με τα ηχητικά σχόλια."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Τίτλος της εφάπαξ ειδοποίησης για το όφελος ταχύτητας που εμφανίζεται μετά την πρώτη προφορική ανταλλαγή.",
+    "message": "Ωραία — η ομιλία είναι περίπου 3× πιο γρήγορη από την πληκτρολόγηση."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Προαιρετική δεύτερη γραμμή της ειδοποίησης για το όφελος ταχύτητας που δείχνει ολόκληρα λεπτά που εξοικονομήθηκαν.",
+    "message": "Έχεις ήδη μιλήσει περίπου $minutes$ λεπτά πιο γρήγορα από ό,τι θα το πληκτρολογούσες.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Υποβολή μόνο όταν πατήσετε το κουμπί"
   },
+  "surveyQuestion": {
+    "description": "Η μοναδική ερώτηση του εφάπαξ micro-survey μετά το win.",
+    "message": "Πώς σου φαίνεται η φωνή μέχρι τώρα;"
+  },
+  "surveyRatingLabel": {
+    "description": "Προσβάσιμη ετικέτα για ένα κουμπί βαθμολόγησης της έρευνας.",
+    "message": "Βαθμολόγησε $rating$ στα 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Ευχαριστήριο μήνυμα που εμφανίζεται αφού ο χρήστης απαντήσει στην έρευνα μετά το win.",
+    "message": "Ευχαριστούμε — αυτό μας βοηθά να κάνουμε το Say, Pi καλύτερο. 🙏"
+  },
   "tabAIChat": {
     "description": "Ετικέτα καρτέλας για τις ρυθμίσεις συνομιλίας AI.",
     "message": "Συνομιλία AI"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Ετικέτα καρτέλας για τις γενικές ρυθμίσεις.",
     "message": "Γενικά"
+  },
+  "tabVoices": {
+    "description": "Ετικέτα καρτέλας για την ενότητα ρυθμίσεων φωνών (κατάλογος φωνών ανά ιστότοπο).",
+    "message": "Φωνές"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "πιστώσεις"
   },
+  "ttsCreditsRemaining": {
+    "description": "Κείμενο που δείχνει το υπόλοιπο του ορίου TTS ως σύνολο πιστώσεων ανά φωνή (saypi-api #181 Stage 2), όχι ως ακατέργαστους χαρακτήρες.",
+    "message": "Απομένουν $credits$ πιστώσεις",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Οι πολύγλωσσες φωνές δεν υποστηρίζονται αυτήν τη στιγμή στο Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Παραγωγή φωνής"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Προσοχή! Η αναπαραγωγή ομιλίας δεν είναι ακόμη διαθέσιμη στο $browserName$ με το $chatbotName$. Τα καλά νέα; Η φωνητική είσοδος λειτουργεί τέλεια! Για TTS, δοκιμάστε το Chrome ή το Edge στην επιφάνεια εργασίας.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS μη διαθέσιμο στο $browserName$ + $chatbotName$. Η φωνητική είσοδος λειτουργεί! Δοκιμάστε το Chrome desktop για TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Φωνή TTS"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Λεπτομέρεια VAD όταν ανιχνεύτηκε ήχος που μοιάζει με ομιλία αλλά ήταν πολύ αδύναμος / χαμηλής βεβαιότητας για απομαγνητοφώνηση (απόρριψη στην πύλη εισαγωγής από την πλευρά του πελάτη).",
+    "message": "Ο ήχος είναι πολύ αδύναμος για απομαγνητοφώνηση"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Λεπτομέρεια VAD που εξηγεί ότι η κλήση τερματίστηκε επειδή το μικρόφωνο δεσμεύτηκε από νεότερη καρτέλα.",
+    "message": "Η φωνητική είσοδος μεταφέρθηκε σε άλλη καρτέλα"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Η φωνή δεν είναι διαθέσιμη. \nΔοκιμάστε το Chrome ή τον Firefox στην επιφάνεια εργασίας."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Προσοχή! Η αναπαραγωγή ομιλίας δεν είναι ακόμη διαθέσιμη στο $browserName$ με το $chatbotName$. Τα καλά νέα; Η φωνητική είσοδος λειτουργεί τέλεια! Για TTS, δοκιμάστε το Chrome ή το Edge στην επιφάνεια εργασίας.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS μη διαθέσιμο στο $browserName$ + $chatbotName$. Η φωνητική είσοδος λειτουργεί! Δοκιμάστε το Chrome desktop για TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Το κατάλαβα",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Κατάσταση VAD που εμφανίζεται σε καρτέλα της οποίας η φωνητική είσοδος παραλήφθηκε από άλλη καρτέλα.",
+    "message": "Σε παύση"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Προβολή λεπτομερειών"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Γενική προφορική εισαγωγή που αναπαράγεται όταν μια επιλεγμένη φωνή του SayPi δεν έχει εισαγωγικό σενάριο ειδικό για τη φωνή (και δεν υπάρχει πρόσφατο μήνυμα για ανάγνωση).",
+    "message": "Γεια, είμαι ο/η $voice$. Έτσι ακούγομαι. Ελπίζω να σου αρέσει αυτή η φωνή.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hola! \nΣυμβουλή! \nεσυ! \nΕίμαι ο Πι, ο πολυγλωσσικός σας βοηθός τεχνητής νοημοσύνης. \nΜε 32 γλώσσες υπό τις διαταγές μου, μπορούμε να εξερευνήσουμε ιδέες και πολιτισμούς από όλο τον κόσμο. \nΠώς σας φαίνεται αυτή η φωνή;"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Ρυθμίσεις φωνής"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Εφεδρικός υπότιτλος για μια σειρά φωνής στον κατάλογο φωνών των ρυθμίσεων όταν η φωνή δεν έχει περιγραφή· το $count$ είναι ο αριθμός των γλωσσών που υποστηρίζει η φωνή.",
+    "message": "Μιλά $count$ γλώσσες",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Σύντομο κείμενο προσωπικότητας που έχει γραφτεί για τη φωνή «Addison» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Φωτεινός και εύγλωττος"
+  },
+  "voiceTagline_alloy": {
+    "description": "Σύντομο tagline προσωπικότητας για τη φωνή «Alloy» (στούντιο Φωνές στις ρυθμίσεις· χάρτης ταυτότητας φωνών στην πλευρά του πελάτη).",
+    "message": "Ισορροπημένη και για κάθε χρήση"
+  },
+  "voiceTagline_ash": {
+    "description": "Σύντομο tagline προσωπικότητας για τη φωνή «Ash» (στούντιο Φωνές στις ρυθμίσεις· χάρτης ταυτότητας φωνών στην πλευρά του πελάτη).",
+    "message": "Χαμηλή, στοχαστική, ήρεμη"
+  },
+  "voiceTagline_ballad": {
+    "description": "Σύντομο tagline προσωπικότητας για τη φωνή «Ballad» (στούντιο Φωνές στις ρυθμίσεις· χάρτης ταυτότητας φωνών στην πλευρά του πελάτη).",
+    "message": "Απαλή και μελωδική"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Σύντομο κείμενο προσωπικότητας που έχει γραφτεί για τη φωνή «Cassidy» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Φιλικός και απλός"
+  },
+  "voiceTagline_cedar": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Cedar» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Σταθερή και καθησυχαστική"
+  },
+  "voiceTagline_coral": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Coral» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Φωτεινή, ανεβασμένη ενέργεια"
+  },
+  "voiceTagline_echo": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Echo» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Καθαρή και ουδέτερη"
+  },
+  "voiceTagline_fable": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Fable» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Με αφηγηματική χροιά"
+  },
+  "voiceTagline_finn": {
+    "description": "Σύντομο κείμενο προσωπικότητας που έχει γραφτεί για τη φωνή «Finn» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Φρέσκος και γεμάτος ενέργεια"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Σύντομο κείμενο προσωπικότητας που έχει γραφτεί για τη φωνή «Jamahal» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Πλούσιος και μαγνητικός"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Jarnathan» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Βελούδινο, νυχτερινό μπάσο"
+  },
+  "voiceTagline_jeff": {
+    "description": "Σύντομο κείμενο προσωπικότητας που έχει γραφτεί για τη φωνή «Jeff» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Απλός και σταθερός"
+  },
+  "voiceTagline_jessica": {
+    "description": "Σύντομο κείμενο προσωπικότητας που έχει γραφτεί για τη φωνή «Jessica» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Ζεστή, με κομψή ισορροπία"
+  },
+  "voiceTagline_joey": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Joey» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Άνετη, αμερικανική κουβεντιαστή χροιά"
+  },
+  "voiceTagline_juniper": {
+    "description": "Σύντομο κείμενο προσωπικότητας που έχει γραφτεί για τη φωνή «Juniper» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Κοφτερός, φωτεινός, ζωντανός"
+  },
+  "voiceTagline_lucy": {
+    "description": "Σύντομο κείμενο προσωπικότητας που έχει γραφτεί για τη φωνή «Lucy» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Απαλός και φωτεινός"
+  },
+  "voiceTagline_marin": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Marin» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Ζεστή, πρωινή ραδιοφωνική ηρεμία"
+  },
+  "voiceTagline_mark": {
+    "description": "Σύντομο κείμενο προσωπικότητας που έχει γραφτεί για τη φωνή «Mark» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Καθαρός, με αυτοπεποίθηση αφηγητής"
+  },
+  "voiceTagline_nova": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Nova» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Γρήγορη και περίεργη"
+  },
+  "voiceTagline_onyx": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Onyx» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Βαθιά, ηχηρή επιβλητικότητα"
+  },
+  "voiceTagline_paola": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Paola» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Εκφραστική ιταλική ζεστασιά"
+  },
+  "voiceTagline_sage": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Sage» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Ήπια, καθαρή άρθρωση"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Επιμελημένο σλόγκαν προσωπικότητας για τη φωνή «Shimmer» (ρυθμίσεις Voices studio· αντιστοίχιση ταυτότητας φωνής στην πλευρά του πελάτη).",
+    "message": "Ελαφριά και αέρινη"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Σύντομη ετικέτα στον διακόπτη καρφίτσας μιας κάρτας φωνής (κατάσταση off) στο Voices studio των ρυθμίσεων· πατώντας προσθέτει τη φωνή στο μενού του host μέσα στη συνομιλία.",
+    "message": "+ Μενού"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Ετικέτα προσβασιμότητας για τον διακόπτη καρφίτσας μιας κάρτας φωνής (κατάσταση off)· το $name$ είναι η φωνή, το $host$ ο βοηθός.",
+    "message": "Προσθήκη του/της $name$ στο μενού του $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Ετικέτα στον διακόπτη στη γραμμή ελέγχου Φωνές που δηλώνει αν, όταν κινείστε στη λίστα με τα πλήκτρα βέλους, παίζει κάθε φωνή μόλις αποκτήσει εστίαση.",
+    "message": "Αναπαραγωγή καθώς μετακινείστε"
+  },
+  "voicesArrowsLive": {
+    "description": "Επιβεβαίωση για αναγνώστη οθόνης, που προστίθεται στην πρώτη ανακοίνωση «Αναπαραγωγή <φωνή>» στη λίστα Φωνών στις ρυθμίσεις, λέγοντας ότι τα πλήκτρα βελών μόλις έγιναν ακουστά. Αντιγράφει τη διατύπωση του διακόπτη «Αναπαραγωγή καθώς μετακινείστε».",
+    "message": "Τα βέλη παίζουν καθώς μετακινείστε. Το Esc σταματά."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Σημείωση κάτω από τις θέσεις του μενού για hosts που διαθέτουν εγγενείς φωνές (π.χ. οι 8 ενσωματωμένες του Pi), τις οποίες δεν διαχειρίζεται το στούντιο· το $host$ είναι ο βοηθός.",
+    "message": "Οι ενσωματωμένες φωνές του $host$ εμφανίζονται πάντα και στο μενού του.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Παραλλαγή του voicesBuiltinsNote για host χωρίς μενού φωνής μέσα στη συνομιλία (το Pi απέσυρε το μενού του το 2026), όπου η υπόσχεση του αρχικού ότι οι ενσωματωμένες «εμφανίζονται στο μενού του» θα ήταν αναληθής· το $host$ είναι ο βοηθός.",
+    "message": "Ο $host$ έχει επίσης τις δικές του ενσωματωμένες φωνές, που δεν εμφανίζονται εδώ.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Ένδειξη προόδου στη γραμμή ελέγχου Φωνών στις ρυθμίσεις: πόσες από τις φωνές που εμφανίζονται έχει ήδη ακούσει ο χρήστης. Γυμνοί αριθμοί, ώστε να διαβάζεται σωστά και στο 1 — το Chrome i18n δεν έχει πληθυντικούς τύπους.",
+    "message": "Ακούστηκαν $heard$ από $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Μέρος του προσβάσιμου ονόματος μιας γραμμής φωνής στη λίστα Φωνών στις ρυθμίσεις, που επισημαίνει μια φωνή που αυτό το προφίλ έχει ήδη ακούσει. Οπτικά αυτό σχεδιάζεται ως πυκνότητα μελανιού στο ηχητικό αποτύπωμα της φωνής, κάτι που ένας αναγνώστης οθόνης δεν μπορεί να δει.",
+    "message": "Ακούστηκε"
+  },
+  "voicesInHostMenu": {
+    "description": "Επικεφαλίδα ενότητας πάνω από τη σειρά θέσεων μενού στο Voices studio των ρυθμίσεων· το $host$ είναι ο βοηθός.",
+    "message": "Στο μενού του $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Σύντομη ετικέτα στον διακόπτη καρφίτσας μιας κάρτας φωνής (κατάσταση on) στο Voices studio των ρυθμίσεων.",
+    "message": "✓ Στο μενού"
+  },
+  "voicesInUse": {
+    "description": "Μόνιμο σήμα στην τρέχουσα επιλεγμένη φωνή του host στη λίστα Voices στις ρυθμίσεις, αποδίδεται με κεφαλαία. Σκόπιμα ΔΕΝ είναι «Μιλάει τώρα»: σε αυτή τη σελίδα οι γραμμές αναπαράγουν τα δείγματά τους, οπότε μια επιλεγμένη αλλά σιωπηλή φωνή δεν πρέπει να ισχυρίζεται ότι μιλάει ενώ μια άλλη γραμμή αναπαράγεται.",
+    "message": "Σε χρήση"
+  },
+  "voicesKeyboardHint": {
+    "description": "Υπόδειξη πληκτρολογίου μίας γραμμής στη γραμμή ελέγχου Φωνών στις ρυθμίσεις. Τα σύμβολα είναι πλήκτρα: Space, τα βέλη πάνω/κάτω και Shift+Space.",
+    "message": "Πατήστε Space για ακρόαση, ↑↓ για μετακίνηση μεταξύ φωνών, ⇧Space για επιστροφή."
+  },
+  "voicesLoadError": {
+    "description": "Κατάσταση σφάλματος μέσα στο στούντιο ενός host όταν απέτυχε να φορτώσει ο κατάλογος φωνών αυτού του host· το $host$ είναι ο βοηθός.",
+    "message": "Δεν ήταν δυνατή η φόρτωση των φωνών του $host$. Δοκιμάστε ξανά αργότερα.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/υπόδειξη σε απενεργοποιημένο διακόπτη «+ Μενού» όταν το μενού μέσα στη συνομιλία του host έχει ήδη τον μέγιστο αριθμό φωνών.",
+    "message": "Το μενού είναι πλήρες — αφαίρεσε μια φωνή για να προσθέσεις άλλη"
+  },
+  "voicesMenuHint": {
+    "description": "Μονογραμμική υπόδειξη δίπλα στην επικεφαλίδα «Στο μενού του {host}», που εξηγεί ότι η σειρά θέσεων αντιστοιχεί στο μενού φωνών μέσα στη συνομιλία.",
+    "message": "Τι θα βλέπεις στη συνομιλία"
+  },
+  "voicesMenuOverflow": {
+    "description": "Σημείωση κάτω από τις θέσεις του μενού όταν ο χρήστης έχει περισσότερες καρφιτσωμένες φωνές από όσες μπορεί να δείξει το μενού μέσα στη συνομιλία (παλαιά κατάσταση)· το $count$ είναι πόσες δεν χωρούν, το $cap$ είναι το μέγεθος του μενού.",
+    "message": "Άλλες $count$ καρφιτσωμένες φωνές περιμένουν πέρα από τις $cap$ θέσεις του μενού.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Ενικός του voicesMenuOverflow, χρησιμοποιείται όταν ακριβώς μία καρφιτσωμένη φωνή δεν χωρά στο μενού μέσα στη συνομιλία· το $cap$ είναι το μέγεθος του μενού.",
+    "message": "Άλλη 1 καρφιτσωμένη φωνή περιμένει πέρα από τις $cap$ θέσεις του μενού.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Γραμμή σύνοψης κάτω από τη λίστα Φωνών στις ρυθμίσεις που λέει πόσο γεμάτο είναι το μενού φωνών εντός συνομιλίας του host· το $host$ είναι ο βοηθός, το $used$ πόσες θέσεις είναι κατειλημμένες, το $cap$ πόσες υπάρχουν. Διατυπωμένο ώστε να διαβάζεται σωστά και στο 1 — το Chrome i18n δεν έχει πληθυντικούς τύπους.",
+    "message": "Μενού του/της $host$: $used$ από $cap$ θέσεις",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Κεφαλίδα για την ομάδα στο τέλος της λίστας Φωνών στις ρυθμίσεις που περιέχει φωνές χωρίς κλιπ δείγματος για αναπαραγωγή· το $count$ είναι πόσες. Διατυπωμένο ώστε να διαβάζεται σωστά και στο 1 — το Chrome i18n δεν έχει πληθυντικούς τύπους.",
+    "message": "Χωρίς δείγμα ακόμη ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Εμφανίζεται στον κατάλογο φωνών των ρυθμίσεων όταν η λίστα φωνών είναι κενή για έναν συνδεδεμένο χρήστη (π.χ. πρόβλημα δικτύου)",
+    "message": "Οι φωνές δεν μπόρεσαν να φορτωθούν αυτή τη στιγμή. Δοκιμάστε ξανά αργότερα."
+  },
+  "voicesNowPlaying": {
+    "description": "Ανακοίνωση για αναγνώστη οθόνης όταν ξεκινά να παίζει το κλιπ δείγματος μιας φωνής στη λίστα Φωνών στις ρυθμίσεις· το $name$ είναι η φωνή.",
+    "message": "Αναπαραγωγή $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Κουμπί στη γραμμή ελέγχου Φωνών στις ρυθμίσεις που αναπαράγει κάθε φωνή που εμφανίζεται αυτή τη στιγμή, τη μία μετά την άλλη· το $count$ είναι πόσες. Διατυπωμένο ώστε να διαβάζεται σωστά και στο 1 — το Chrome i18n δεν έχει πληθυντικούς τύπους.",
+    "message": "Αναπαραγωγή όλων ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Κουμπί στη γραμμή ελέγχου Φωνών στις ρυθμίσεις σε επόμενη επίσκεψη: αναπαράγει μόνο τις φωνές που εμφανίζονται και δεν έχετε ακούσει ακόμη· το $count$ είναι πόσες. Διατυπωμένο ώστε να διαβάζεται σωστά και στο 1 — το Chrome i18n δεν έχει πληθυντικούς τύπους.",
+    "message": "Αναπαραγωγή νέων ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Γραμμή στη μπάρα ελέγχου Φωνές στις ρυθμίσεις όταν το πρόγραμμα περιήγησης αρνήθηκε να παίξει δείγμα επειδή η σελίδα δεν είχε ακόμη αλληλεπίδραση χρήστη.",
+    "message": "Κάντε κλικ σε οποιαδήποτε φωνή για να ενεργοποιήσετε τον ήχο."
+  },
+  "voicesPreview": {
+    "description": "Ετικέτα προσβασιμότητας για το κουμπί αναπαραγωγής (▶) που δοκιμάζει το δωρεάν δείγμα κλιπ μιας φωνής σε μια σειρά φωνής· το $name$ είναι το όνομα της φωνής.",
+    "message": "Αναπαραγωγή δείγματος του/της $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Προσβάσιμο όνομα της λίστας Φωνές στις ρυθμίσεις (ένα listbox με κάθε φωνή, μία ανά γραμμή).",
+    "message": "Φωνές, με σειρά από τη βαθύτερη ως την πιο φωτεινή"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Ετικέτα προσβασιμότητας για τον διακόπτη καρφίτσας μιας κάρτας φωνής (κατάσταση on) και για το κουμπί αφαίρεσης μιας θέσης μενού· το $name$ είναι η φωνή, το $host$ ο βοηθός.",
+    "message": "Αφαίρεση του/της $name$ από το μενού του $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Γραμμή στη μπάρα ελέγχου Φωνές στις ρυθμίσεις όταν απέτυχε η φόρτωση ή η αναπαραγωγή του δείγματος μιας φωνής· το $name$ είναι αυτή η φωνή. Μη modal — η ακολουθία δειγμάτων συνεχίζει μετά από αυτό.",
+    "message": "Δεν ήταν δυνατή η αναπαραγωγή του δείγματος της φωνής $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Υποεπικεφαλίδα για την ενότητα καταλόγου φωνών στις ρυθμίσεις, καρτέλα AI Chat",
+    "message": "Διάλεξε τη φωνή που διαβάζει τις απαντήσεις δυνατά σε κάθε ιστότοπο."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Υποεπικεφαλίδα κάτω από την επικεφαλίδα ρυθμίσεων Φωνές, για τη ράγα φωνών ταξινομημένων κατά ύψος.",
+    "message": "Κάθε φωνή, από τη βαθύτερη ως την πιο φωτεινή. Ακούστε και διαλέξτε."
+  },
+  "voicesSectionTitle": {
+    "description": "Επικεφαλίδα για την ενότητα καταλόγου φωνών στις ρυθμίσεις, καρτέλα AI Chat",
+    "message": "Φωνές"
+  },
+  "voicesShelfEveryday": {
+    "description": "Επικεφαλίδα ομάδας για φωνές κατηγορίας value στον κατάλογο φωνών των ρυθμίσεων. Εμφανίζεται με κεφαλαία μέσω CSS.",
+    "message": "Καθημερινές φωνές"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Σύντομη σημείωση μίας γραμμής δίπλα στην επικεφαλίδα της ομάδας Everyday στο στούντιο Φωνές των ρυθμίσεων· το μοναδικό σημείο όπου το στούντιο αναφέρει πόσο περισσότερο διαρκεί αυτή η κατηγορία σε σχέση με τις HD.",
+    "message": "Φυσικές και καθαρές — μπορείς να ακούς περίπου 20× περισσότερο απ’ ό,τι με τις HD."
+  },
+  "voicesShelfHd": {
+    "description": "Επικεφαλίδα ομάδας για premium (HD) φωνές στον κατάλογο φωνών των ρυθμίσεων. Εμφανίζεται με κεφαλαία μέσω CSS.",
+    "message": "Φωνές HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Σύντομη σημείωση μίας γραμμής δίπλα στην επικεφαλίδα της ομάδας HD στο στούντιο Φωνές των ρυθμίσεων.",
+    "message": "Ο πιο πλούσιος, πιο εκφραστικός μας ήχος."
+  },
+  "voicesShowAll": {
+    "description": "Επιλογή στο φίλτρο «Εμφάνιση» των Φωνών στις ρυθμίσεις: χωρίς φιλτράρισμα, εμφανίζονται όλες οι φωνές.",
+    "message": "Όλες οι φωνές"
+  },
+  "voicesShowEveryday": {
+    "description": "Επιλογή στο φίλτρο «Εμφάνιση» των Φωνών στις ρυθμίσεις: εμφάνιση μόνο των τυπικών (μη HD) φωνών.",
+    "message": "Μόνο καθημερινές"
+  },
+  "voicesShowHd": {
+    "description": "Επιλογή στο φίλτρο «Εμφάνιση» των Φωνών στις ρυθμίσεις: εμφάνιση μόνο των premium (HD) φωνών.",
+    "message": "Μόνο HD"
+  },
+  "voicesShowLabel": {
+    "description": "Ετικέτα στο φίλτρο στη μπάρα ελέγχου Φωνές στις ρυθμίσεις που περιορίζει ποιες φωνές εμφανίζει η λίστα.",
+    "message": "Εμφάνιση"
+  },
+  "voicesShowUnheard": {
+    "description": "Επιλογή στο φίλτρο «Εμφάνιση» των Φωνών στις ρυθμίσεις: εμφάνιση μόνο των φωνών που ο χρήστης δεν έχει ακούσει ακόμα.",
+    "message": "Δεν έχουν ακουστεί ακόμα"
+  },
+  "voicesSpeakingNow": {
+    "description": "Ετικέτα κατάστασης στην τρέχουσα επιλεγμένη φωνή του host στο Voices studio των ρυθμίσεων (θέση μενού και κάρτα φωνής).",
+    "message": "Μιλάει τώρα"
+  },
+  "voicesSpeaksWith": {
+    "description": "Γραμμή-επικεφαλίδα πάνω από το όνομα της τρέχουσας φωνής στη σκηνή του Voices studio στις ρυθμίσεις· το $host$ είναι ο βοηθός (π.χ. Pi). Αποδίδεται με κεφαλαία από CSS.",
+    "message": "Το $host$ μιλάει με",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Σημείωση σκηνής όταν ο host παρέχει δικό του ήχο (π.χ. Pi), οπότε η επιλογή μιας φωνής Say, Pi αντικαθιστά τη φωνή του host.",
+    "message": "Ο $host$ χρησιμοποιεί τη δική του φωνή μέχρι να διαλέξετε μία παρακάτω.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Σημείωση σκηνής όταν ο host δεν έχει δική του φωνή (π.χ. Claude), οπότε δεν διαβάζεται τίποτα δυνατά μέχρι να επιλεγεί μια φωνή Say, Pi.",
+    "message": "Ο $host$ δεν θα διαβάζει τις απαντήσεις δυνατά μέχρι να διαλέξετε μία παρακάτω.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Επικεφαλίδα στη σκηνή του στούντιο Φωνές στις ρυθμίσεις όταν ο host δεν έχει επιλεγμένη φωνή SayPi· το $host$ είναι ο βοηθός (π.χ. Pi, Claude). Αποδίδεται σε μέγεθος ονόματος.",
+    "message": "Διαλέξτε πώς ακούγεται ο $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Κουμπί στη σκηνή του στούντιο Φωνές στις ρυθμίσεις που αναπαράγει το δωρεάν δείγμα κλιπ της τρέχουσας φωνής.",
+    "message": "Ακούστε ένα δείγμα"
+  },
+  "voicesStopPlayback": {
+    "description": "Κουμπί στη γραμμή ελέγχου Φωνών στις ρυθμίσεις που σταματά τη σειρά δειγμάτων που ξεκίνησε από το «Αναπαραγωγή όλων».",
+    "message": "Διακοπή"
+  },
+  "voicesSweepPosition": {
+    "description": "Ζωντανή ένδειξη θέσης στη μπάρα ελέγχου Φωνές στις ρυθμίσεις, όσο το «Αναπαραγωγή όλων» διατρέχει τη λίστα· το $index$ είναι η φωνή που παίζει τώρα και το $total$ πόσες είναι σε ουρά.",
+    "message": "$index$ από $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Ετικέτα προσβασιμότητας για το στοιχείο σύγκρισης στη γραμμή ελέγχου Φωνών στις ρυθμίσεις, που αναπαράγει ξανά την άλλη φωνή από τις δύο τελευταίες που ακούστηκαν· το $name$ είναι αυτή η φωνή.",
+    "message": "Επιστροφή στο $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Γραμμή στη μπάρα ελέγχου Φωνές στις ρυθμίσεις όταν πατιέται το «Αναπαραγωγή όλων» σε λίστα πολύ μεγάλη για να την ακούσει κανείς· το $count$ είναι πόσες φωνές και το $minutes$ περίπου πόσα λεπτά θα έπαιρναν. Συντομογραφία «min» ώστε να διαβάζεται σωστά στο 1 — το Chrome i18n δεν έχει πληθυντικούς.",
+    "message": "Είναι $count$ φωνές — περίπου $minutes$ min. Περιορίστε πρώτα τη λίστα.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Ετικέτα προσβασιμότητας για το κουμπί «χρήση αυτής της φωνής» ανά host στον κατάλογο φωνών στις ρυθμίσεις· το $name$ είναι η φωνή, το $host$ είναι ο βοηθός (π.χ. Pi, Claude).",
+    "message": "Χρήση του/της $name$ στο $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Σύντομη ετικέτα στο κουμπί «χρήση αυτής της φωνής» ανά host στον ενοποιημένο κατάλογο φωνών στις ρυθμίσεις (ο host εμφανίζεται δίπλα).",
+    "message": "Χρήση"
+  },
+  "voicesYourVoice": {
+    "description": "Κουμπί στη γραμμή ελέγχου στη λίστα Φωνών των ρυθμίσεων που μεταφέρει την εστίαση στη γραμμή της φωνής που χρησιμοποιεί αυτή τη στιγμή αυτός ο host· το $name$ είναι αυτή η φωνή.",
+    "message": "Η φωνή σας: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Σφάλμα που προκύπτει όταν το πρόγραμμα περιήγησης δεν μπορεί να δεσμεύσει αρκετή μνήμη WebAssembly για το μοντέλο ανίχνευσης φωνής.",
+    "message": "Η ανίχνευση φωνής δεν μπορεί να ξεκινήσει: δεν υπάρχει αρκετή μνήμη WebAssembly για το μοντέλο φωνής. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Σφάλμα που προκύπτει όταν το πρόγραμμα περιήγησης δεν εκθέτει την αρχική μνήμη WebAssembly που απαιτείται για την εκτέλεση του μοντέλου ανίχνευσης φωνής.",
+    "message": "Η ανίχνευση φωνής δεν μπορεί να ξεκινήσει: η μνήμη WebAssembly δεν είναι διαθέσιμη σε αυτό το πρόγραμμα περιήγησης."
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Beneficio que se muestra en el modal de autenticación: aumento de límites de uso.",
+    "message": "Límites de uso más altos con cuenta gratuita"
+  },
+  "authBenefitPremium": {
+    "description": "Beneficio que se muestra en el modal de autenticación: funciones premium en chatbots.",
+    "message": "Funciones premium y compatibilidad con chatbots"
+  },
+  "authBenefitSupport": {
+    "description": "Beneficio que se muestra en el modal de autenticación: soporte prioritario.",
+    "message": "Soporte prioritario para incidencias"
+  },
+  "authBenefitSync": {
+    "description": "Beneficio que se muestra en el modal de autenticación: sincronización de ajustes.",
+    "message": "Sincroniza los ajustes de voz en todas partes"
+  },
+  "authBenefitTTS": {
+    "description": "Beneficio que se muestra en el modal de autenticación: función de texto a voz.",
+    "message": "Voces de texto a voz (planes de pago)"
+  },
+  "authBenefitUsage": {
+    "description": "Beneficio que se muestra en el modal de autenticación: seguimiento del uso.",
+    "message": "Controla tu uso de voz en todos tus dispositivos"
+  },
+  "authPromptModalFull": {
+    "description": "Descripción del modal completo de solicitud de autenticación con propuesta de valor.",
+    "message": "Estás aprovechando mucho Say, Pi. Inicia sesión para tener límites más altos, voces de texto a voz y funciones premium en todos los chatbots compatibles."
+  },
+  "authPromptModalSoft": {
+    "description": "Descripción del modal suave de solicitud de autenticación.",
+    "message": "Crea una cuenta gratuita de Say, Pi para tener límites de uso más altos y acceso a funciones de voz premium."
+  },
+  "authPromptTitle": {
+    "description": "Título del modal de solicitud de autenticación.",
+    "message": "Desbloquea más funciones de voz"
+  },
+  "authPromptToast": {
+    "description": "Notificación tipo toast que anima al usuario a iniciar sesión.",
+    "message": "Inicia sesión en Say, Pi para tener límites más altos y funciones premium"
+  },
   "autoReadAloudChatGPT": {
     "description": "Etiqueta para la casilla que permite activar o desactivar la lectura automática de las respuestas de ChatGPT durante las llamadas de voz.",
     "message": "Lectura Automática (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Desactivar texto a voz"
   },
+  "dismiss": {
+    "message": "Entendido",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Despedir"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Enfocar"
   },
+  "errorVadInitFailed": {
+    "description": "Toast de error que se muestra cuando la detección de actividad de voz no se puede inicializar.",
+    "message": "No se pudo inicializar la detección de voz"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Toast de error que se muestra cuando ocurre un error inesperado al configurar la grabación de voz.",
+    "message": "No se pudo configurar la grabación de voz"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Toast de error que se muestra cuando el cliente de detección de voz no puede iniciar la grabación.",
+    "message": "No se pudo iniciar la grabación de voz"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Toast de error que se muestra cuando el cliente de detección de voz (VAD) no está disponible, por lo que la grabación no puede iniciarse.",
+    "message": "Grabación de voz no disponible"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Salir del modo de concentración"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Nota de una línea que se muestra en los menús de voz cuando están disponibles tanto voces premium (HD) como voces económicas",
+    "message": "Las voces HD consumen tu asignación mensual unas 20× más rápido."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Alegando esto ..."
   },
+  "maybeLater": {
+    "description": "Texto del botón para descartar la solicitud de autenticación.",
+    "message": "Quizá más tarde"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "La configuración de su micrófono no cumple con las especificaciones requeridas. \nIntente usar un micrófono diferente o ajustar la configuración de audio."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "No se puede acceder al micrófono. \nVerifique la configuración de su dispositivo e inténtelo nuevamente."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Toast de error que se muestra cuando se denegó el permiso del micrófono después del flujo del aviso de permisos.",
+    "message": "No se concedió el permiso del micrófono. Asegúrate de haber permitido el acceso en el aviso y en la configuración de la extensión."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "exactitud"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Respuesta más rápida, pero menos precisa. \nPropenso a interrumpir."
   },
+  "moreVoices": {
+    "description": "Fila del menú que enlaza desde el menú de voces en la página al catálogo completo de voces en los ajustes de la extensión.",
+    "message": "Más voces…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Apodo del asistente"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "No firmado en"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Etiqueta del botón que abre ChatGPT.",
+    "message": "Abrir ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Etiqueta del botón que abre Claude.ai.",
+    "message": "Abrir Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Etiqueta del botón que abre Pi.ai.",
+    "message": "Abrir Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Opción de entorno: con otras personas alrededor.",
+    "message": "Con otras personas cerca"
+  },
+  "onboarding_envMixed": {
+    "description": "Opción de entorno: una mezcla de espacios privados y compartidos.",
+    "message": "En varios sitios"
+  },
+  "onboarding_envPrivate": {
+    "description": "Opción de entorno: un espacio privado.",
+    "message": "En un lugar privado"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Confirmación que se muestra cuando la respuesta sobre el entorno deja el modo silencioso desactivado.",
+    "message": "Entendido: mantendremos los ajustes estándar de escucha y reproducción."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Confirmación que se muestra cuando la respuesta sobre el entorno activa el modo silencioso.",
+    "message": "Modo silencioso activado: captaremos una voz más suave y responderemos en voz baja para que puedas hablar discretamente."
+  },
+  "onboarding_envTitle": {
+    "description": "Título de la pregunta de incorporación sobre el entorno del usuario.",
+    "message": "¿Dónde sueles hablar?"
+  },
+  "onboarding_footer": {
+    "description": "Texto del pie de página en la pantalla de incorporación del primer uso.",
+    "message": "Puedes volver a verlo cuando quieras desde los ajustes de Say, Pi. Tu privacidad importa: el audio solo se captura durante una llamada activa."
+  },
+  "onboarding_heading": {
+    "description": "Encabezado principal en la página de incorporación de la primera ejecución.",
+    "message": "🗣️ Te damos la bienvenida a Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Párrafo de introducción en la página de incorporación de la primera ejecución.",
+    "message": "Estás a dos pasos de tu primera conversación hablada con una IA. Hablar es unas 3× más rápido que escribir, vamos a configurarlo."
+  },
+  "onboarding_micTestButton": {
+    "description": "Botón que inicia la prueba de micrófono de incorporación, sin consecuencias.",
+    "message": "🎤 Probar tu micrófono"
+  },
+  "onboarding_micTestDone": {
+    "description": "Estado que se muestra cuando la prueba de micrófono finaliza correctamente.",
+    "message": "Bien, tu micrófono funciona 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Estado que se muestra mientras la prueba de micrófono mide la entrada.",
+    "message": "Escuchando: di algo 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Estado que se muestra mientras la prueba de micrófono espera el permiso.",
+    "message": "Solicitando el micrófono…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Etiqueta del botón para detener la prueba de micrófono mientras se está ejecutando.",
+    "message": "Detener prueba"
+  },
+  "onboarding_step1Body": {
+    "description": "Texto del primer paso de incorporación que explica cómo fijar la extensión.",
+    "message": "Haz clic en el icono de pieza de rompecabezas 🧩 en la esquina superior derecha del navegador y luego en la chincheta 📌 junto a Say, Pi. Así el botón de llamada queda a un clic."
+  },
+  "onboarding_step1Title": {
+    "description": "Título del primer paso de incorporación (fijar la extensión).",
+    "message": "Fija Say, Pi en la barra de herramientas"
+  },
+  "onboarding_step2Body": {
+    "description": "Texto del segundo paso de incorporación que explica cómo iniciar una conversación por voz.",
+    "message": "Ve a uno de los asistentes compatibles de abajo, luego toca el botón de llamada de Say, Pi y di hola. Te pediremos acceso al micrófono la primera vez, es normal, y solo escuchamos mientras estés en una llamada."
+  },
+  "onboarding_step2Title": {
+    "description": "Título del segundo paso de incorporación (iniciar una conversación).",
+    "message": "Abre un chat de IA y empieza a hablar"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Permiso de micrófono"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Guía de recuperación cuando el permiso del micrófono está bloqueado.",
+    "message": "Tu navegador está bloqueando el micrófono. Haz clic en el icono de la cámara o del candado en la barra de direcciones, configura Micrófono en \"Permitir\" y vuelve a intentarlo. En macOS, comprueba también Ajustes del sistema → Privacidad y seguridad → Micrófono."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Título del panel de recuperación cuando el permiso del micrófono fue denegado/bloqueado.",
+    "message": "El acceso al micrófono está bloqueado"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Guía de recuperación cuando el micrófono está en uso en otro lugar.",
+    "message": "Puede que otra app o pestaña esté usando tu micrófono. Cierra cualquier cosa que pueda estar grabando (videollamadas, notas de voz) y vuelve a intentarlo."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Título del panel de recuperación cuando el micrófono está siendo usado por otra app.",
+    "message": "Tu micrófono está en uso"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Guía de recuperación cuando no hay ningún dispositivo de micrófono disponible.",
+    "message": "No pudimos encontrar un micrófono. Conecta uno (o conecta tus auriculares con micrófono), asegúrate de que esté seleccionado como dispositivo de entrada y vuelve a intentarlo."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Título del panel de recuperación cuando no hay ningún dispositivo de micrófono disponible.",
+    "message": "No se encontró ningún micrófono"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Guía de recuperación para un error desconocido del micrófono.",
+    "message": "Algo salió mal al acceder a tu micrófono. Comprueba que esté conectado y permitido en la configuración del navegador, y vuelve a intentarlo."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Título del panel de recuperación para un error desconocido del micrófono.",
+    "message": "No pudimos acceder a tu micrófono"
+  },
+  "permissions_retryButton": {
+    "description": "Etiqueta del botón que vuelve a solicitar el permiso del micrófono.",
+    "message": "Volver a intentarlo"
+  },
+  "permissions_revokedHeading": {
+    "description": "Encabezado que se muestra cuando el acceso al micrófono se concedió antes, pero desde entonces se ha revocado.",
+    "message": "🎙️ Volvamos a conectar tu micrófono"
+  },
+  "permissions_revokedInfo": {
+    "description": "Texto informativo que se muestra cuando se revoca el acceso al micrófono después de haberse concedido.",
+    "message": "El acceso a tu micrófono se desactivó; esto suele ocurrir tras una actualización del navegador o del sistema. Vuelve a permitirlo abajo y $productName$ volverá a escucharte cuando estés en una llamada.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Perfil"
+  },
+  "quietModeLabel": {
+    "description": "Etiqueta del interruptor que activa el modo silencioso/susurro.",
+    "message": "Modo silencioso"
+  },
+  "quietModeTooltip": {
+    "description": "Tooltip que explica qué hace el modo silencioso/susurro.",
+    "message": "Habla en voz baja: capta el habla más suave y baja el volumen de la respuesta del asistente, para que puedas usar la voz cerca de otras personas."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Texto del botón de iniciar sesión mientras la autenticación está en curso.",
+    "message": "Iniciando sesión..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Efectos sonoros"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Los efectos de sonido están deshabilitados en Firefox para evitar problemas de respuesta de audio."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Titular del aviso único de beneficio de velocidad posterior al primer logro, mostrado después del primer intercambio hablado.",
+    "message": "Bien, hablar es unas 3× veces más rápido que escribir."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Segunda línea opcional del aviso de beneficio de velocidad que muestra los minutos enteros ahorrados.",
+    "message": "Ya has hablado aproximadamente $minutes$ min más rápido que si lo hubieras escrito.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Envíe solo cuando presione el botón"
   },
+  "surveyQuestion": {
+    "description": "La única pregunta de la microencuesta puntual posterior a la primera experiencia positiva.",
+    "message": "¿Qué tal te está funcionando la voz hasta ahora?"
+  },
+  "surveyRatingLabel": {
+    "description": "Etiqueta accesible para un botón de valoración de la encuesta.",
+    "message": "Valora $rating$ de 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Agradecimiento que se muestra después de que el usuario responde la encuesta posterior a la primera experiencia positiva.",
+    "message": "Gracias, esto nos ayuda a mejorar Say, Pi. 🙏"
+  },
   "tabAIChat": {
     "description": "Etiqueta de pestaña para la sección de configuración de chat de IA.",
     "message": "Chat de IA"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Etiqueta de pestaña para la sección de configuración general.",
     "message": "General"
+  },
+  "tabVoices": {
+    "description": "Etiqueta de pestaña para la sección de ajustes de voces (catálogo de voces por sitio).",
+    "message": "Voces"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "créditos"
   },
+  "ttsCreditsRemaining": {
+    "description": "Texto que muestra la cuota de TTS restante como un conjunto de créditos por voz (saypi-api #181 Stage 2), no como caracteres sin procesar.",
+    "message": "Quedan $credits$ créditos",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Actualmente, Safari no admite voces multilingües."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Generación de voz"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "¡Atención! La reproducción de voz no está disponible en $browserName$ con $chatbotName$ todavía. ¿La buena noticia? ¡La entrada de voz funciona genial! Para TTS, pruebe Chrome o Edge en el escritorio.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS no disponible en $browserName$ + $chatbotName$. ¡La entrada de voz funciona! Pruebe Chrome en el escritorio para TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS Voice"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Detalle de VAD cuando se detectó audio similar al habla pero era demasiado tenue o de baja confianza para transcribir (descartado por la puerta de admisión del lado del cliente).",
+    "message": "Audio demasiado tenue para transcribir"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Detalle de VAD que explica que la llamada terminó porque el micrófono fue reclamado por una pestaña más reciente.",
+    "message": "La entrada de voz se movió a otra pestaña"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Voz no disponible. \nPruebe Chrome o Firefox en el escritorio."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "¡Atención! La reproducción de voz no está disponible en $browserName$ con $chatbotName$ todavía. ¿La buena noticia? ¡La entrada de voz funciona genial! Para TTS, pruebe Chrome o Edge en el escritorio.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS no disponible en $browserName$ + $chatbotName$. ¡La entrada de voz funciona! Pruebe Chrome en el escritorio para TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Entendido",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Estado de VAD que se muestra en una pestaña cuyo input de voz fue tomado por otra pestaña.",
+    "message": "En pausa"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Ver detalles"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Introducción genérica hablada que se reproduce cuando una voz de SayPi seleccionada no tiene un guion de introducción específico (y no hay un mensaje reciente para leer).",
+    "message": "Hola, soy $voice$. Así sueno. Espero que te guste esta voz.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "¡Hola! \n¡Привет! \n¡你好! \nSoy Pi, tu asistente de IA políglota. \nCon 32 idiomas a mi disposición, podemos explorar ideas y culturas de todo el mundo. \n¿Qué opinas de esta voz?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Configuración de voz"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Subtítulo alternativo para una fila de voz en el catálogo de voces de ajustes cuando la voz no tiene descripción; $count$ es el número de idiomas que admite la voz.",
+    "message": "Habla $count$ idiomas",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Lema de personalidad escrito para la voz \"Addison\" (ajustes > estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Luminoso y elocuente"
+  },
+  "voiceTagline_alloy": {
+    "description": "Eslogan de personalidad redactado para la voz \"Alloy\" (estudio de Voces en ajustes; mapa de identidad de voz del lado del cliente).",
+    "message": "Equilibrada y versátil"
+  },
+  "voiceTagline_ash": {
+    "description": "Eslogan de personalidad redactado para la voz \"Ash\" (estudio de Voces en ajustes; mapa de identidad de voz del lado del cliente).",
+    "message": "Grave, reflexiva, serena"
+  },
+  "voiceTagline_ballad": {
+    "description": "Eslogan de personalidad redactado para la voz \"Ballad\" (estudio de Voces en ajustes; mapa de identidad de voz del lado del cliente).",
+    "message": "Suave y melódica"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Lema de personalidad escrito para la voz \"Cassidy\" (ajustes > estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Amable y sin rodeos"
+  },
+  "voiceTagline_cedar": {
+    "description": "Eslogan de personalidad redactado para la voz \"Cedar\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Serena y tranquilizadora"
+  },
+  "voiceTagline_coral": {
+    "description": "Eslogan de personalidad redactado para la voz \"Coral\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Energía brillante y animada"
+  },
+  "voiceTagline_echo": {
+    "description": "Eslogan de personalidad redactado para la voz \"Echo\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Clara y neutra"
+  },
+  "voiceTagline_fable": {
+    "description": "Eslogan de personalidad redactado para la voz \"Fable\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Cadencia de narrador"
+  },
+  "voiceTagline_finn": {
+    "description": "Lema de personalidad escrito para la la voz \"Finn\" (ajustes > estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Fresco y enérgico"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Lema de personalidad escrito para la voz \"Jamahal\" (ajustes > estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Con cuerpo y magnético"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Eslogan de personalidad redactado para la voz \"Jarnathan\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Barítono aterciopelado de madrugada"
+  },
+  "voiceTagline_jeff": {
+    "description": "Lema de personalidad escrito para la voz \"Jeff\" (ajustes > estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Directo y sereno"
+  },
+  "voiceTagline_jessica": {
+    "description": "Lema de personalidad escrito para la voz \"Jessica\" (ajustes > estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Calidez y aplomo pulido"
+  },
+  "voiceTagline_joey": {
+    "description": "Eslogan de personalidad redactado para la voz \"Joey\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Estilo estadounidense, conversacional y natural"
+  },
+  "voiceTagline_juniper": {
+    "description": "Lema de personalidad escrito para la voz \"Juniper\" (ajustes > estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Nítido, luminoso, animado"
+  },
+  "voiceTagline_lucy": {
+    "description": "Lema de personalidad escrito para la voz \"Lucy\" (ajustes > estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Suave y luminoso"
+  },
+  "voiceTagline_marin": {
+    "description": "Eslogan de personalidad redactado para la voz \"Marin\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Cálida, con calma de radio matinal"
+  },
+  "voiceTagline_mark": {
+    "description": "Lema de personalidad escrito para la voz \"Mark\" (ajustes > estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Narrador claro y seguro"
+  },
+  "voiceTagline_nova": {
+    "description": "Eslogan de personalidad redactado para la voz \"Nova\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Rápida y curiosa"
+  },
+  "voiceTagline_onyx": {
+    "description": "Eslogan de personalidad redactado para la voz \"Onyx\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Grave, con resonancia y aplomo"
+  },
+  "voiceTagline_paola": {
+    "description": "Eslogan de personalidad redactado para la voz \"Paola\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Calidez italiana expresiva"
+  },
+  "voiceTagline_sage": {
+    "description": "Eslogan de personalidad redactado para la voz \"Sage\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Claridad serena"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Eslogan de personalidad redactado para la voz \"Shimmer\" (configuración del estudio de Voces; mapa de identidad de voz del lado del cliente).",
+    "message": "Ligera y etérea"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Etiqueta corta en el interruptor de anclaje de una tarjeta de voz (estado desactivado) en el estudio de Voces de ajustes; al pulsarlo añade la voz al menú dentro del chat del host.",
+    "message": "+ Menú"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Etiqueta accesible para el interruptor de anclaje de una tarjeta de voz (estado desactivado); $name$ es la voz, $host$ el asistente.",
+    "message": "Añadir $name$ al menú de $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Etiqueta del interruptor en la barra de control de Voces que indica si al recorrer la lista con las teclas de flecha se reproduce cada voz cuando el foco llega a ella.",
+    "message": "Reproducir al moverte"
+  },
+  "voicesArrowsLive": {
+    "description": "Confirmación del lector de pantalla, añadida al primer anuncio de \"Reproduciendo <voz>\" en la lista de Voces en ajustes, que indica que las teclas de flecha acaban de volverse audibles. Repite la redacción del interruptor \"Reproducir al moverte\".",
+    "message": "Las flechas ahora reproducen al moverte. Esc detiene."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Nota bajo los espacios del menú para hosts que incluyen voces nativas (p. ej., las 8 integradas de Pi), que el estudio no gestiona; $host$ es el asistente.",
+    "message": "Las voces integradas de $host$ también aparecen siempre en su menú.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variante de voicesBuiltinsNote para un host sin menú de voz en el chat (Pi retiró su menú en 2026), donde la promesa del original de que las integradas 'aparecen en su menú' sería falsa; $host$ es el asistente.",
+    "message": "$host$ también tiene sus propias voces integradas, que no se muestran aquí.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Lectura de progreso en la barra de control de Voces en ajustes: cuántas de las voces listadas el usuario ya ha escuchado. Números sin más, para que se lea bien con 1 — Chrome i18n no tiene formas plurales.",
+    "message": "$heard$ de $total$ escuchadas",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Parte del nombre accesible de una fila de voz en la lista de Voces en ajustes, que marca una voz que este perfil ya ha escuchado. Visualmente se dibuja como densidad de tinta en la huella sonora de la voz, que un lector de pantalla no puede ver.",
+    "message": "Escuchada"
+  },
+  "voicesInHostMenu": {
+    "description": "Encabezado de sección encima de la fila de ranuras del menú en el estudio de Voces de ajustes; $host$ es el asistente.",
+    "message": "En el menú de $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Etiqueta corta en el interruptor de anclaje de una tarjeta de voz (estado activado) en el estudio de Voces de ajustes.",
+    "message": "✓ En menú"
+  },
+  "voicesInUse": {
+    "description": "Insignia persistente en la voz seleccionada actualmente del host en la lista de Voces de ajustes, mostrada en mayúsculas. Deliberadamente NO es \"Hablando ahora\": en esta página las filas reproducen sus clips de muestra, por lo que una voz seleccionada pero en silencio no debe afirmar que está hablando mientras otra fila distinta lo está.",
+    "message": "En uso"
+  },
+  "voicesKeyboardHint": {
+    "description": "Sugerencia de teclado de una línea en la barra de control de Voces en ajustes. Los glifos son teclas: Espacio, las flechas arriba/abajo y Mayús+Espacio.",
+    "message": "Pulsa Espacio para escuchar, ↑↓ para moverte entre voces, ⇧Espacio para volver."
+  },
+  "voicesLoadError": {
+    "description": "Estado de error dentro del estudio de un host cuando no se pudo cargar el catálogo de voces de ese host; $host$ es el asistente.",
+    "message": "No se pudieron cargar las voces de $host$. Inténtalo de nuevo más tarde.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Información sobre herramienta/pista en un interruptor \"+ Menú\" desactivado cuando el menú dentro del chat del host ya tiene su número máximo de voces.",
+    "message": "Menú lleno, quita una voz para añadir otra"
+  },
+  "voicesMenuHint": {
+    "description": "Pista de una línea junto al encabezado \"En el menú de {host}\", explicando que la fila de ranuras refleja el menú de voz dentro del chat.",
+    "message": "Lo que verás en el chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Nota bajo los espacios del menú cuando el usuario tiene más voces fijadas de las que el menú en el chat puede mostrar (estado heredado); $count$ es cuántas no caben, $cap$ es el tamaño del menú.",
+    "message": "Hay $count$ voz(es) fijada(s) más esperando más allá de los $cap$ espacios del menú.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Singular de voicesMenuOverflow, usado cuando exactamente una voz fijada no cabe en el menú en el chat; $cap$ es el tamaño del menú.",
+    "message": "Hay 1 voz fijada más esperando más allá de los $cap$ espacios del menú.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Línea de resumen bajo la lista de Voces en ajustes que indica cuánto del menú de voces en el chat del host está ocupado; $host$ es el asistente, $used$ cuántas plazas están ocupadas, $cap$ cuántas hay. Redactado para leerse bien con 1 — Chrome i18n no tiene formas plurales.",
+    "message": "Menú de $host$: $used$ de $cap$ plazas",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Encabezado del grupo al final de la lista de Voces en ajustes que contiene voces sin clip de muestra para reproducir; $count$ es cuántas. Redactado para leerse bien con 1 — Chrome i18n no tiene formas plurales.",
+    "message": "Aún sin muestra ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Se muestra en el catálogo de voces de ajustes cuando la lista de voces está vacía para un usuario con sesión iniciada (p. ej., un problema de red).",
+    "message": "No se pudieron cargar las voces en este momento. Vuelve a intentarlo más tarde."
+  },
+  "voicesNowPlaying": {
+    "description": "Anuncio del lector de pantalla cuando empieza a reproducirse el clip de muestra de una voz en la lista de Voces en ajustes; $name$ es la voz.",
+    "message": "Reproduciendo $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Botón en la barra de control de Voces en ajustes que reproduce todas las voces mostradas actualmente, una tras otra; $count$ es cuántas. Redactado para leerse bien con 1 — Chrome i18n no tiene formas plurales.",
+    "message": "Reproducir todas ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Botón en la barra de control de Voces en ajustes en una visita de vuelta: reproduce solo las voces listadas que aún no has escuchado; $count$ es cuántas. Redactado para leerse bien con 1 — Chrome i18n no tiene formas plurales.",
+    "message": "Reproducir nuevas ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Línea en la barra de control de Voces de ajustes cuando el navegador se negó a reproducir una muestra porque la página aún no ha tenido interacción del usuario.",
+    "message": "Haz clic en cualquier voz para activar el sonido."
+  },
+  "voicesPreview": {
+    "description": "Etiqueta accesible para el botón de reproducir (▶) que permite escuchar el clip de muestra gratuito de una voz en su fila; $name$ es el nombre de la voz.",
+    "message": "Reproducir una muestra de $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Nombre accesible de la lista de Voces en ajustes (un listbox de todas las voces, una fila por cada voz).",
+    "message": "Voces, ordenadas de las más graves a las más brillantes"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Etiqueta accesible para el interruptor de anclaje de una tarjeta de voz (estado activado) y el botón de quitar de una ranura del menú; $name$ es la voz, $host$ el asistente.",
+    "message": "Quitar $name$ del menú de $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Línea en la barra de control de Voces de ajustes cuando el clip de muestra de una voz no se pudo cargar o reproducir; $name$ es esa voz. No modal: una secuencia de muestras continúa más allá de ella.",
+    "message": "No se pudo reproducir la muestra de $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Subencabezado de la sección del catálogo de voces en la pestaña de ajustes AI Chat.",
+    "message": "Elige la voz que lee las respuestas en voz alta en cada sitio."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Subtítulo bajo el encabezado de ajustes de Voces, para el carril de voces ordenadas por tono.",
+    "message": "Todas las voces, de las más graves a las más brillantes. Escucha y elige."
+  },
+  "voicesSectionTitle": {
+    "description": "Encabezado de la sección del catálogo de voces en la pestaña de ajustes AI Chat.",
+    "message": "Voces"
+  },
+  "voicesShelfEveryday": {
+    "description": "Encabezado de grupo para voces de nivel económico en el catálogo de voces de ajustes. Se muestra en mayúsculas mediante CSS.",
+    "message": "Voces de diario"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Nota de una línea junto al encabezado del grupo Everyday en el estudio de Voces de ajustes; el único lugar donde el estudio indica cuánto más rinde este nivel frente a HD.",
+    "message": "Natural y clara: puedes escuchar unas 20× veces más que con HD."
+  },
+  "voicesShelfHd": {
+    "description": "Encabezado de grupo para voces premium (HD) en el catálogo de voces de ajustes. Se muestra en mayúsculas mediante CSS.",
+    "message": "Voces HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Nota de una línea junto al encabezado del grupo HD en el estudio de Voces de ajustes.",
+    "message": "Nuestro sonido más rico y expresivo."
+  },
+  "voicesShowAll": {
+    "description": "Opción en el filtro \"Mostrar\" de Voces en ajustes: sin filtro, se listan todas las voces.",
+    "message": "Todas las voces"
+  },
+  "voicesShowEveryday": {
+    "description": "Opción en el filtro \"Mostrar\" de Voces en ajustes: muestra solo las voces estándar (no HD).",
+    "message": "Solo cotidianas"
+  },
+  "voicesShowHd": {
+    "description": "Opción en el filtro \"Mostrar\" de Voces en ajustes: muestra solo las voces premium (HD).",
+    "message": "Solo HD"
+  },
+  "voicesShowLabel": {
+    "description": "Etiqueta del filtro en la barra de control de Voces de ajustes que acota qué voces muestra la lista.",
+    "message": "Mostrar"
+  },
+  "voicesShowUnheard": {
+    "description": "Opción en el filtro \"Mostrar\" de Voces en ajustes: muestra solo las voces que el usuario aún no ha escuchado.",
+    "message": "Aún no escuchadas"
+  },
+  "voicesSpeakingNow": {
+    "description": "Etiqueta de estado en la voz seleccionada actualmente del host en el estudio de Voces de ajustes (ranura del menú y tarjeta de voz).",
+    "message": "Hablando ahora"
+  },
+  "voicesSpeaksWith": {
+    "description": "Línea de ceja encima del nombre de la voz actual en el escenario del estudio de Voces de ajustes; $host$ es el asistente (p. ej., Pi). Se muestra en mayúsculas mediante CSS.",
+    "message": "$host$ habla con",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Nota del escenario cuando el host sirve su propio audio (p. ej., Pi), así que elegir una voz de Say, Pi reemplaza la del host.",
+    "message": "$host$ usa su propia voz hasta que elijas una abajo.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Nota del escenario cuando el host no tiene voz propia (p. ej., Claude), así que no se lee nada en voz alta hasta que se elija una voz de Say, Pi.",
+    "message": "$host$ no leerá las respuestas en voz alta hasta que elijas una abajo.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Titular en el escenario del estudio de Voces en ajustes cuando el host no tiene ninguna voz de Say, Pi seleccionada; $host$ es el asistente (p. ej., Pi, Claude). Se muestra con tamaño de nombre.",
+    "message": "Elige cómo suena $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Botón en el escenario del estudio de Voces en ajustes que reproduce el clip de muestra gratuito de la voz actual.",
+    "message": "Escuchar una muestra"
+  },
+  "voicesStopPlayback": {
+    "description": "Botón en la barra de control de Voces en ajustes que detiene la secuencia de muestras iniciada por \"Reproducir todas\".",
+    "message": "Detener"
+  },
+  "voicesSweepPosition": {
+    "description": "Lectura de posición en vivo en la barra de control de Voces de ajustes mientras \"Reproducir todo\" recorre la lista; $index$ es la voz que se está reproduciendo y $total$ cuántas están en cola.",
+    "message": "$index$ de $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Etiqueta accesible para el control de comparación en la barra de control de Voces en ajustes, que reproduce la otra voz de las dos últimas escuchadas; $name$ es esa voz.",
+    "message": "Volver a $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Línea en la barra de control de Voces de ajustes cuando se pulsa \"Reproducir todo\" en una lista demasiado larga como para escucharla entera; $count$ es cuántas voces y $minutes$ aproximadamente cuántos minutos tardarían. \"min\" abreviado para que se lea correctamente con 1 — Chrome i18n no tiene formas plurales.",
+    "message": "Son $count$ voces — aprox. $minutes$ min. Primero reduce la lista.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Etiqueta accesible para el botón por host de \"usar esta voz\" en el catálogo de voces de ajustes; $name$ es la voz, $host$ es el asistente (p. ej., Pi, Claude).",
+    "message": "Usar $name$ en $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Etiqueta corta en el botón por host de \"usar esta voz\" en el catálogo unificado de voces de ajustes (el host se muestra junto a él).",
+    "message": "Usar"
+  },
+  "voicesYourVoice": {
+    "description": "Botón de la barra de control en la lista de Voces de ajustes que mueve el foco a la fila de la voz que usa actualmente este host; $name$ es esa voz.",
+    "message": "Tu voz: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Error que se lanza cuando el navegador no puede asignar suficiente memoria de WebAssembly para el modelo de detección de voz.",
+    "message": "No se puede iniciar la detección de voz: no hay suficiente memoria de WebAssembly para el modelo de voz. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Error que se lanza cuando el navegador no expone la memoria inicial de WebAssembly necesaria para ejecutar el modelo de detección de voz.",
+    "message": "No se puede iniciar la detección de voz: la memoria de WebAssembly no está disponible en este navegador."
   }
 }

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Etu kirjautumismodaalissa – suuremmat käyttörajat.",
+    "message": "Korkeammat käyttörajat ilmaisella tilillä"
+  },
+  "authBenefitPremium": {
+    "description": "Etu kirjautumismodaalissa – premium-ominaisuudet eri chatboteissa.",
+    "message": "Premium-ominaisuudet ja chatbot-tuki"
+  },
+  "authBenefitSupport": {
+    "description": "Etu kirjautumismodaalissa – ensisijainen tuki.",
+    "message": "Ensisijainen tuki ongelmatilanteissa"
+  },
+  "authBenefitSync": {
+    "description": "Etu kirjautumismodaalissa – asetusten synkronointi.",
+    "message": "Synkronoi ääniasetukset kaikkialle"
+  },
+  "authBenefitTTS": {
+    "description": "Etu kirjautumismodaalissa – TTS-ominaisuus.",
+    "message": "Tekstistä puheeksi -äänet (maksulliset paketit)"
+  },
+  "authBenefitUsage": {
+    "description": "Etu kirjautumismodaalissa – käytön seuranta.",
+    "message": "Seuraa äänen käyttöäsi laitteiden välillä"
+  },
+  "authPromptModalFull": {
+    "description": "Kuvaus täydelle modaalille kirjautumiskehotteelle, jossa kerrotaan arvolupaus.",
+    "message": "Saat Say, Pi:stä paljon irti. Kirjaudu sisään saadaksesi korkeammat rajat, tekstistä puheeksi -äänet ja premium-ominaisuudet kaikissa tuetuissa chatboteissa."
+  },
+  "authPromptModalSoft": {
+    "description": "Kuvaus pehmeälle modaalille kirjautumiskehotteelle.",
+    "message": "Luo ilmainen Say, Pi -tili saadaksesi korkeammat käyttörajat ja premium-ääniominaisuudet."
+  },
+  "authPromptTitle": {
+    "description": "Otsikko kirjautumiskehotteen modaalissa.",
+    "message": "Avaa lisää ääniominaisuuksia"
+  },
+  "authPromptToast": {
+    "description": "Toast-ilmoitus, joka kannustaa käyttäjää kirjautumaan sisään.",
+    "message": "Kirjaudu Say, Pi -palveluun, niin saat korkeammat rajat ja premium-ominaisuudet"
+  },
   "autoReadAloudChatGPT": {
     "description": "Valintaruutu ChatGPT-vastausten automaattisen ääneenlukemisen ottamiseksi käyttöön tai pois käytöstä puheluiden aikana.",
     "message": "Automaattinen ääneenlukeminen (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Poista tekstistä puheeksi"
   },
+  "dismiss": {
+    "message": "Selvä",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Hylkää"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Keskity"
   },
+  "errorVadInitFailed": {
+    "description": "Virheilmoitus, joka näytetään, kun puheaktiivisuuden tunnistus ei onnistu alustamaan.",
+    "message": "Puheentunnistuksen alustus epäonnistui"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Virheilmoitus, joka näytetään, kun äänitallennusta määritettäessä tapahtuu odottamaton virhe.",
+    "message": "Äänitallennuksen määritys epäonnistui"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Virheilmoitus, joka näytetään, kun puheentunnistuksen asiakas ei onnistu käynnistämään tallennusta.",
+    "message": "Äänitallennuksen käynnistys epäonnistui"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Virheilmoitus, joka näytetään, kun puheentunnistuksen (VAD) asiakas ei ole käytettävissä, joten tallennusta ei voida aloittaa.",
+    "message": "Äänitallennus ei ole käytettävissä"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Poistu keskittymismoodista"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Yhden rivin huomautus, joka näytetään ääni-valikoissa, kun sekä premium- (HD) että value-äänet ovat saatavilla",
+    "message": "HD-äänet kuluttavat kuukausikiintiötäsi noin 20× nopeammin."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Tämän työntäminen ..."
   },
+  "maybeLater": {
+    "description": "Painiketeksti kirjautumiskehotteen sulkemiseen.",
+    "message": "Ehkä myöhemmin"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Mikrofoniasetukset eivät täytä vaadittuja määrityksiä. \nKokeile käyttää toista mikrofonia tai säätää ääniasetuksiasi."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Mikrofonia ei voi käyttää. \nTarkista laitteesi asetukset ja yritä uudelleen."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Virheilmoitus, joka näytetään, kun mikrofonin käyttöoikeus evättiin käyttöoikeuspyyntöprosessin jälkeen.",
+    "message": "Mikrofonin käyttöoikeutta ei myönnetty. Varmista, että olet sallinut pääsyn ponnahdusikkunassa ja laajennuksen asetuksissa."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "tarkkuus"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Nopein vastaus, mutta vähemmän tarkka. \nTaipuvainen keskeyttämään."
   },
+  "moreVoices": {
+    "description": "Valikkorivi, joka linkittää sivun sisäisestä äänivalikosta laajaan äänikatalogiin laajennuksen asetuksissa",
+    "message": "Lisää ääniä…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Assistentin lempinimi"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Ei allekirjoitettu"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Painikkeen teksti, joka avaa ChatGPT:n.",
+    "message": "Avaa ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Painiketeksti, joka avaa Claude.ai:n.",
+    "message": "Avaa Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Painiketeksti, joka avaa Pi.ai:n.",
+    "message": "Avaa Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Ympäristövaihtoehto: muiden ihmisten lähellä.",
+    "message": "Muiden ihmisten lähellä"
+  },
+  "onboarding_envMixed": {
+    "description": "Ympäristövaihtoehto: sekoitus yksityisiä ja jaettuja tiloja.",
+    "message": "Eri paikoissa"
+  },
+  "onboarding_envPrivate": {
+    "description": "Ympäristövaihtoehto: yksityinen tila.",
+    "message": "Jossain yksityisessä paikassa"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Vahvistus, joka näytetään, kun ympäristökysymykseen annettu vastaus jättää hiljaisen tilan pois päältä.",
+    "message": "Selvä — pidämme vakio kuuntelu- ja toistoasetukset."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Vahvistus, joka näytetään, kun ympäristövalinta ottaa hiljaisen tilan käyttöön.",
+    "message": "Hiljainen tila päällä — kuulemme myös hiljaisemman puheen ja vastaamme hiljaa, jotta voit puhua huomaamattomasti."
+  },
+  "onboarding_envTitle": {
+    "description": "Otsikko käyttöönoton kysymykselle käyttäjän ympäristöstä.",
+    "message": "Missä yleensä puhut?"
+  },
+  "onboarding_footer": {
+    "description": "Alateksti ensimmäisen käynnistyksen opastussivun alareunassa.",
+    "message": "Voit palata tähän milloin tahansa Say, Pi -asetuksista. Yksityisyytesi on tärkeää — ääntä tallennetaan vain aktiivisen puhelun aikana."
+  },
+  "onboarding_heading": {
+    "description": "Pääotsikko ensimmäisen käynnistyksen opastussivulla.",
+    "message": "🗣️ Tervetuloa käyttämään Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Johdantokappale ensimmäisen käynnistyksen opastussivulla.",
+    "message": "Olet kahden vaiheen päässä ensimmäisestä puhutusta AI-keskustelustasi. Puhuminen on noin 3× nopeampaa kuin kirjoittaminen — laitetaan kaikki valmiiksi."
+  },
+  "onboarding_micTestButton": {
+    "description": "Painike, joka käynnistää riskittömän mikrofonitestin käyttöönoton yhteydessä.",
+    "message": "🎤 Testaa mikrofonisi"
+  },
+  "onboarding_micTestDone": {
+    "description": "Tila, joka näytetään, kun käyttöönoton mikrofonitesti valmistuu onnistuneesti.",
+    "message": "Hyvä — mikrofonisi toimii. 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Tila, joka näytetään, kun käyttöönoton mikrofonitesti mittaa sisääntuloa.",
+    "message": "Kuunnellaan — sano jotain. 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Tila, joka näytetään, kun käyttöönoton mikrofonitesti odottaa lupaa.",
+    "message": "Pyydetään mikrofonin käyttöoikeutta…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Painikkeen teksti, jolla käyttöönoton mikrofonitesti pysäytetään sen ollessa käynnissä.",
+    "message": "Lopeta testi"
+  },
+  "onboarding_step1Body": {
+    "description": "Ensimmäisen opastusvaiheen leipäteksti, joka selittää, miten laajennus kiinnitetään.",
+    "message": "Napsauta selaimen oikeassa yläkulmassa olevaa palapeli 🧩 -kuvaketta ja sitten Say, Pi:n vieressä olevaa nastaa 📌. Näin puhelupainike on yhden klikkauksen päässä."
+  },
+  "onboarding_step1Title": {
+    "description": "Ensimmäisen opastusvaiheen otsikko (laajennuksen kiinnittäminen).",
+    "message": "Kiinnitä Say, Pi työkalupalkkiin"
+  },
+  "onboarding_step2Body": {
+    "description": "Toisen opastusvaiheen leipäteksti, joka selittää, miten äänikeskustelu aloitetaan.",
+    "message": "Siirry johonkin alla olevista tuetuista avustajista, napauta sitten Say, Pi:n puhelupainiketta ja tervehdi. Pyydämme ensimmäisellä kerralla mikrofonin käyttöoikeutta — se kuuluu asiaan, ja kuuntelemme vain silloin, kun olet aktiivisesti puhelussa."
+  },
+  "onboarding_step2Title": {
+    "description": "Toisen opastusvaiheen otsikko (keskustelun aloittaminen).",
+    "message": "Avaa AI-chat ja ala puhua"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Mikrofonin lupa"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Palautusohjeet, kun mikrofonin käyttöoikeus on estetty.",
+    "message": "Selaimesi estää mikrofonin. Napsauta osoiterivillä kamera- tai lukkokuvaketta, aseta Microphone arvoon \"Allow\" ja yritä sitten uudelleen. macOS:ssä tarkista myös Järjestelmäasetukset → Tietosuoja ja suojaus → Mikrofoni."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Palautuspaneelin otsikko, kun mikrofonin lupa on hylätty/estetty.",
+    "message": "Mikrofonin käyttöoikeus on estetty"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Palautusohjeet, kun mikrofoni on muualla käytössä.",
+    "message": "Toinen sovellus tai välilehti saattaa käyttää mikrofoniasi. Sulje kaikki muu, joka voi nauhoittaa (videopuhelut, äänimuistiot), ja yritä sitten uudelleen."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Palautuspaneelin otsikko, kun mikrofoni on toisen sovelluksen käytössä.",
+    "message": "Mikrofoni on varattuna"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Palautusohjeet, kun mikrofonilaitetta ei ole saatavilla.",
+    "message": "Emme löytäneet mikrofonia. Liitä sellainen (tai kytke kuulokemikrofoni), varmista että se on valittu syöttölaitteeksi ja yritä sitten uudelleen."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Palautuspaneelin otsikko, kun mikrofonilaitetta ei ole saatavilla.",
+    "message": "Mikrofonia ei löytynyt"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Palautusohjeet tuntemattomaan mikrofonivirheeseen.",
+    "message": "Mikrofoniin yhdistämisessä meni jokin pieleen. Tarkista, että se on kytketty ja sallittu selaimen asetuksissa, ja yritä sitten uudelleen."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Palautuspaneelin otsikko tuntemattomalle mikrofonivirheelle.",
+    "message": "Emme saaneet mikrofonia käyttöön"
+  },
+  "permissions_retryButton": {
+    "description": "Painikkeen teksti, joka pyytää mikrofonin käyttöoikeutta uudelleen.",
+    "message": "Yritä uudelleen"
+  },
+  "permissions_revokedHeading": {
+    "description": "Otsikko, joka näytetään, kun mikrofonin käyttöoikeus oli aiemmin myönnetty mutta on sittemmin poistettu.",
+    "message": "Yhdistetään mikrofoni uudelleen"
+  },
+  "permissions_revokedInfo": {
+    "description": "Infoteksti, joka näytetään, kun mikrofonin käyttöoikeus on peruttu sen jälkeen kun se oli myönnetty.",
+    "message": "Mikrofonin käyttöoikeus on poistettu käytöstä — näin käy usein selaimen tai järjestelmän päivityksen jälkeen. Salli se uudelleen alta, niin $productName$ kuuntelee taas, kun olet puhelussa.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profiili"
+  },
+  "quietModeLabel": {
+    "description": "Selite valintakytkimelle, joka ottaa käyttöön hiljaisen/kuiskaustilan.",
+    "message": "Hiljainen tila"
+  },
+  "quietModeTooltip": {
+    "description": "Työkaluvihje, joka selittää mitä hiljainen/kuiskaustila tekee.",
+    "message": "Puhu hiljaa — tunnistaa hiljaisemman puheen ja laskee avustajan vastausäänenvoimakkuutta, jotta voit käyttää ääntä muiden lähellä."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Teksti kirjautumispainikkeessa, kun tunnistautuminen on käynnissä.",
+    "message": "Kirjaudutaan sisään…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Ääniefektit"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Äänitehosteet on poistettu käytöstä Firefoxissa äänipalauteongelmien estämiseksi."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Otsikko kertaluonteisessa nopeushyödyn ilmoituksessa, joka näytetään ensimmäisen puhutun keskustelun jälkeen.",
+    "message": "Hyvä — puhuminen on noin 3× nopeampaa kuin kirjoittaminen."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Nopeushyödyn ilmoituksen valinnainen toinen rivi, joka näyttää säästetyt kokonaiset minuutit.",
+    "message": "Olet jo puhunut noin $minutes$ min nopeammin kuin olisit kirjoittanut sen.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Lähetä vain, kun painat painiketta"
   },
+  "surveyQuestion": {
+    "description": "Kertaluonteisen, onnistumisen jälkeen näytettävän mikrokyselyn ainoa kysymys.",
+    "message": "Miten ääni on toiminut tähän asti?"
+  },
+  "surveyRatingLabel": {
+    "description": "Saavutettava nimike kyselyn arviointipainikkeelle.",
+    "message": "Arvioi $rating$ / 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Kuittaus, joka näytetään käyttäjän vastattua onnistumisen jälkeiseen kyselyyn.",
+    "message": "Kiitos — tämä auttaa meitä parantamaan Say, Pi:tä. 🙏"
+  },
   "tabAIChat": {
     "description": "Välilehden kansi AI-keskusteluasetuksille.",
     "message": "AI Keskustelu"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Välilehden kansi yleisille asetuksille.",
     "message": "Yleiset"
+  },
+  "tabVoices": {
+    "description": "Välilehden nimi ääniasetusten osiolle (sivustokohtainen ääniluettelo).",
+    "message": "Äänet"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "hyvitykset"
   },
+  "ttsCreditsRemaining": {
+    "description": "Teksti, joka näyttää jäljellä olevan TTS-kiintiön ääni-kohtaisena krediittipoolina (saypi-api #181 Stage 2), ei raakoina merkkeinä.",
+    "message": "$credits$ krediittiä jäljellä",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Monikielisiä ääniä ei tällä hetkellä tueta Safarissa."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Äänen sukupolvi"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Huomio! Puheen toisto ei ole vielä saatavilla $browserName$:lla $chatbotName$:n kanssa. Hyvät uutiset? Äänisyöte toimii loistavasti! TTS:ää varten kokeile Chromea tai Edgeä työpöydällä.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS ei saatavilla $browserName$ + $chatbotName$. Äänisyöte toimii! Kokeile Chrome työpöytää TTS:ää varten.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS -ääni"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "VAD-yksityiskohta, kun puheelta kuulostavaa ääntä havaittiin, mutta se oli liian hiljainen / luottamus liian matala litterointiin (asiakaspään admission-gate drop).",
+    "message": "Ääni on liian hiljainen litteroitavaksi"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "VAD-yksityiskohta, joka selittää, että puhelu päättyi, koska mikrofoni varattiin uudemmalle välilehdelle.",
+    "message": "Äänisyöttö siirrettiin toiseen välilehteen"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Ääni ei ole saatavilla. \nKokeile Chromea tai Firefoxia työpöydällä."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Huomio! Puheen toisto ei ole vielä saatavilla $browserName$:lla $chatbotName$:n kanssa. Hyvät uutiset? Äänisyöte toimii loistavasti! TTS:ää varten kokeile Chromea tai Edgeä työpöydällä.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS ei saatavilla $browserName$ + $chatbotName$. Äänisyöte toimii! Kokeile Chrome työpöytää TTS:ää varten.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Selvä",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "VAD-tila, joka näytetään välilehdellä, jonka äänisyötön toinen välilehti otti haltuunsa.",
+    "message": "Tauolla"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Katso yksityiskohdat"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Yleinen puhuttu esittely, joka soitetaan, kun valitulla Say, Pi -äänellä ei ole ääneen sidottua esittelytekstiä (eikä ole tuoretta viestiä luettavaksi).",
+    "message": "Hei, olen $voice$. Tältä kuulostan. Toivottavasti pidät tästä äänestä.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hei! \nПривет! \n你好! \nOlen Pi, polyglotti tekoälyavustajasi. \nHallitsemani 32 kielellä voimme tutustua ideoihin ja kulttuureihin ympäri maailmaa. \nMitä mieltä olet tästä äänestä?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Ääni -asetukset"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Varateksti äänen riville asetusten äänikatalogissa, kun äänellä ei ole kuvausta; $count$ on niiden kielten määrä, joita ääni tukee.",
+    "message": "Puhuu $count$ kieltä",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Kirjoitettu persoonallisuustunnuslause 'Addison'-äänelle (asetukset > Voices studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Aurinkoinen ja selkeä"
+  },
+  "voiceTagline_alloy": {
+    "description": "Kirjoitettu persoonallisuustunnuslause \"Alloy\"-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Tasapainoinen ja monikäyttöinen"
+  },
+  "voiceTagline_ash": {
+    "description": "Kirjoitettu persoonallisuustunnuslause \"Ash\"-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Matala, harkitseva, rauhallinen"
+  },
+  "voiceTagline_ballad": {
+    "description": "Kirjoitettu persoonallisuustunnuslause \"Ballad\"-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Pehmeä ja melodinen"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Kirjoitettu persoonallisuustunnuslause 'Cassidy'-äänelle (asetukset > Voices studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Ystävällinen ja asiallinen"
+  },
+  "voiceTagline_cedar": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Cedar'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Tyyni ja rauhoittava"
+  },
+  "voiceTagline_coral": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Coral'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Kirkas ja pirteä energia"
+  },
+  "voiceTagline_echo": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Echo'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Selkeä ja neutraali"
+  },
+  "voiceTagline_fable": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Fable'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Tarinankertojan sointi"
+  },
+  "voiceTagline_finn": {
+    "description": "Kirjoitettu persoonallisuustunnuslause 'Finn'-äänelle (asetukset > Voices studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Raikas ja energinen"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Kirjoitettu persoonallisuustunnuslause 'Jamahal'-äänelle (asetukset > Voices studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Täyteläinen ja vetovoimainen"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Jarnathan'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Samettinen myöhäisillan baritoni"
+  },
+  "voiceTagline_jeff": {
+    "description": "Kirjoitettu persoonallisuustunnuslause 'Jeff'-äänelle (asetukset > Voices studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Selkeä ja rauhallinen"
+  },
+  "voiceTagline_jessica": {
+    "description": "Kirjoitettu persoonallisuustunnuslause 'Jessica'-äänelle (asetukset > Voices studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Lämmin, huoliteltu olemus"
+  },
+  "voiceTagline_joey": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Joey'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Vaivaton, keskusteleva amerikkalainen"
+  },
+  "voiceTagline_juniper": {
+    "description": "Kirjoitettu persoonallisuustunnuslause 'Juniper'-äänelle (asetukset > Voices studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Napakka, kirkas, eloisa"
+  },
+  "voiceTagline_lucy": {
+    "description": "Kirjoitettu persoonallisuustunnuslause 'Lucy'-äänelle (asetukset > Voices studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Lempeä ja hehkuva"
+  },
+  "voiceTagline_marin": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Marin'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Lämmin, aamujuontajan rauha"
+  },
+  "voiceTagline_mark": {
+    "description": "Kirjoitettu persoonallisuustunnuslause 'Mark'-äänelle (asetukset > Voices studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Selkeä, itsevarma kertoja"
+  },
+  "voiceTagline_nova": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Nova'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Nopea ja utelias"
+  },
+  "voiceTagline_onyx": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Onyx'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Syvä ja arvokas sointi"
+  },
+  "voiceTagline_paola": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Paola'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Ilmeikäs italialainen lämpö"
+  },
+  "voiceTagline_sage": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Sage'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Hiljainen selkeys"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Kirjoittajan laatima persoonallisuustagi 'Shimmer'-äänelle (asetusten Äänet-studio; asiakaspuolen ääni-identiteettikartta).",
+    "message": "Kevyt ja ilmava"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Lyhyt teksti äänikortin kiinnityskytkimessä (pois päältä) asetusten Voices-studiossa; painaminen lisää äänen isännän chatin valikkoon.",
+    "message": "+ Valikko"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Saavutettava nimi äänikortin kiinnityskytkimelle (pois päältä); $name$ on ääni, $host$ avustaja.",
+    "message": "Lisää $name$ $host$:n valikkoon",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Selite Voices-ohjauspalkin kytkimessä, joka kertoo, toistetaanko jokainen ääni, kun listaa selataan nuolinäppäimillä ja kohdistus siirtyy siihen.",
+    "message": "Toista liikuessa"
+  },
+  "voicesArrowsLive": {
+    "description": "Ruudunlukijan vahvistus, joka lisätään ensimmäiseen \"Toistetaan <ääni>\" -ilmoitukseen asetusten Äänet-luettelossa ja kertoo, että nuolinäppäimistä on juuri tullut kuultavia. Toistaa \"Toista siirtyessä\" -valitsimen omaa sanamuotoa.",
+    "message": "Nuolinäppäimet toistavat nyt siirtyessäsi. Esc lopettaa."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Huomautus valikkopaikkojen alla isännille, joilla on omat natiivit äänet (esim. Pin 8 sisäänrakennettua), joita studio ei hallitse; $host$ on avustaja.",
+    "message": "Myös $host$in omat sisäänrakennetut äänet näkyvät aina sen valikossa.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "voicesBuiltinsNote-tekstin muunnelma isännälle, jolla ei ole chatin sisäistä äänivalikkoa (Pi poisti valikkonsa vuonna 2026), jolloin alkuperäisen lupaus siitä, että sisäänrakennetut äänet 'näkyvät sen valikossa', olisi virheellinen; $host$ on avustaja.",
+    "message": "$host$illa on myös omat sisäänrakennetut äänet, joita ei luetella tässä.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Edistymisnäyttö asetusten Äänet-ohjauspalkissa: kuinka monta luetelluista äänistä käyttäjä on jo kuunnellut. Pelkät numerot, jotta se toimii oikein myös arvolla 1 — Chrome i18n:ssa ei ole monikkoja.",
+    "message": "Kuunneltu $heard$/$total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Osa äänen rivin saavutettavaa nimeä asetusten Äänet-luettelossa; merkitsee äänen, jota tämä profiili on jo kuunnellut. Visuaalisesti tämä piirretään mustetiheytenä äänen äänijäljessä, jota ruudunlukija ei näe.",
+    "message": "Kuunneltu"
+  },
+  "voicesInHostMenu": {
+    "description": "Osion otsikko valikkopaikkarivin yläpuolella asetusten Voices-studiossa; $host$ on avustaja.",
+    "message": "$host$:n valikossa",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Lyhyt teksti äänikortin kiinnityskytkimessä (päällä) asetusten Voices-studiossa.",
+    "message": "✓ Valikossa"
+  },
+  "voicesInUse": {
+    "description": "Pysyvä merkki asetusten Voices-listassa isännän tällä hetkellä valitulle äänelle, näytetään isoilla kirjaimilla. Tarkoituksella EI ”Puhuu nyt”: tällä sivulla rivit soittavat esimerkkipätkiä, joten valittu mutta hiljainen ääni ei saa väittää puhuvansa, kun eri rivi soi.",
+    "message": "Käytössä"
+  },
+  "voicesKeyboardHint": {
+    "description": "Yhden rivin pikanäppäinvihje asetusten Äänet-ohjauspalkissa. Merkit ovat näppäimiä: välilyönti, ylös/alas-nuolet ja Shift+välilyönti.",
+    "message": "Paina välilyöntiä kuunnellaksesi, ↑↓ siirtyäksesi äänien välillä, ⇧Välilyönti palataksesi takaisin."
+  },
+  "voicesLoadError": {
+    "description": "Virhetila yhden isännän studiossa, kun kyseisen isännän ääniluetteloa ei saatu ladattua; $host$ on avustaja.",
+    "message": "Ei voitu ladata avustajan $host$ ääniä. Yritä myöhemmin uudelleen.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Vihjeteksti/ohjeteksti pois käytöstä olevalle ”+ Valikko” -kytkimelle, kun isännän chatin valikossa on jo enimmäismäärä ääniä.",
+    "message": "Valikko täynnä — poista yksi ääni lisätäksesi toisen"
+  },
+  "voicesMenuHint": {
+    "description": "Yhden rivin vihje ”In {host}'s menu” -otsikon vieressä, selittää että paikkarivi vastaa chatin äänivalikkoa.",
+    "message": "Näin se näkyy chatissa"
+  },
+  "voicesMenuOverflow": {
+    "description": "Huomautus valikkopaikkojen alla, kun käyttäjällä on enemmän kiinnitettyjä ääniä kuin chatin valikko voi näyttää (perintötila); $count$ on niiden määrä, jotka eivät mahdu, $cap$ on valikon koko.",
+    "message": "Vielä $count$ kiinnitettyä ääntä odottaa valikon $cap$ paikan ulkopuolella.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "voicesMenuOverflow-tekstin yksikkömuoto, käytetään kun täsmälleen yksi kiinnitetty ääni ei mahdu chatin valikkoon; $cap$ on valikon koko.",
+    "message": "Vielä 1 kiinnitetty ääni odottaa valikon $cap$ paikan ulkopuolella.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Yhteenvetorivi asetusten Äänet-luettelon alla: kuinka täynnä isännän chatin sisäinen äänivalikko on; $host$ on avustaja, $used$ on varattujen paikkojen määrä, $cap$ paikkojen kokonaismäärä. Muotoiltu toimimaan oikein myös arvolla 1 — Chrome i18n:ssa ei ole monikkoja.",
+    "message": "$host$-valikko: $used$/$cap$ paikkaa käytössä",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Otsikko ryhmälle asetusten Äänet-luettelon lopussa, jossa ovat äänet, joilla ei ole toistettavaa näyteleikettä; $count$ on määrä. Muotoiltu toimimaan oikein myös arvolla 1 — Chrome i18n:ssa ei ole monikkoja.",
+    "message": "Ei vielä näytettä ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Näytetään asetusten äänikatalogissa, kun ääniluettelo on tyhjä sisäänkirjautuneella käyttäjällä (esim. verkkohäiriö).",
+    "message": "Ääniä ei voitu ladata juuri nyt. Yritä myöhemmin uudelleen."
+  },
+  "voicesNowPlaying": {
+    "description": "Ruudunlukijan ilmoitus, kun äänen näyteleike alkaa toistua asetusten Äänet-luettelossa; $name$ on ääni.",
+    "message": "Toistetaan: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Painike asetusten Äänet-ohjauspalkissa, joka toistaa kaikki tällä hetkellä luetellut äänet peräkkäin; $count$ on määrä. Muotoiltu toimimaan oikein myös arvolla 1 — Chrome i18n:ssa ei ole monikkoja.",
+    "message": "Toista kaikki ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Painike asetusten Äänet-ohjauspalkissa paluukäynnillä: toistaa vain luetellut äänet, joita et ole vielä kuunnellut; $count$ on määrä. Muotoiltu toimimaan oikein myös arvolla 1 — Chrome i18n:ssa ei ole monikkoja.",
+    "message": "Toista uudet ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Rivi asetusten Äänet-ohjauspalkissa, kun selain kieltäytyi toistamasta näytettä, koska sivulla ei ole vielä ollut käyttäjän vuorovaikutusta.",
+    "message": "Ota ääni käyttöön klikkaamalla mitä tahansa ääntä."
+  },
+  "voicesPreview": {
+    "description": "Saavutettava nimike toisto (▶) -painikkeelle, joka kuuntelee äänen ilmaisen esimerkkileikkeen äänen rivillä; $name$ on äänen nimi.",
+    "message": "Toista äänen $name$ esimerkki",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Asetusten Voices-listan saavutettava nimi (listbox, jossa jokainen ääni on omalla rivillään).",
+    "message": "Äänet, järjestetty matalimmasta kirkkaimpaan"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Saavutettava nimi äänikortin kiinnityskytkimelle (päällä) ja valikkopaikan poistopainikkeelle; $name$ on ääni, $host$ avustaja.",
+    "message": "Poista $name$ $host$:n valikosta",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Rivi asetusten Äänet-ohjauspalkissa, kun yhden äänen näyteklippiä ei saatu ladattua tai toistettua; $name$ on kyseinen ääni. Ei-modaalinen — näytteiden sarja jatkuu siitä huolimatta.",
+    "message": "Äänen $name$ näytettä ei voitu toistaa.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Alaotsikko äänikatalogiosioon asetusten AI Chat -välilehdessä",
+    "message": "Valitse ääni, joka lukee vastaukset ääneen kullekin sivustolle."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Alaotsikko Voices-asetusten otsikon alla, sävelkorkeuden mukaan järjestetylle ääniriville.",
+    "message": "Jokainen ääni, matalimmasta kirkkaimpaan. Kuuntele ja valitse."
+  },
+  "voicesSectionTitle": {
+    "description": "Otsikko äänikatalogiosioon asetusten AI Chat -välilehdessä",
+    "message": "Äänet"
+  },
+  "voicesShelfEveryday": {
+    "description": "Ryhmäotsikko edullisemman tason äänille asetusten äänikatalogissa. CSS muuntaa isoiksi kirjaimiksi.",
+    "message": "Jokapäiväiset äänet"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Yhden rivin huomautus Everyday-ryhmäotsikon vieressä asetusten Äänet-studiossa; ainoa kohta, jossa studio kertoo, kuinka paljon pidemmälle tämä taso riittää verrattuna HD:hen.",
+    "message": "Luonnollinen ja selkeä — voit kuunnella noin 20× pidempään kuin HD:llä."
+  },
+  "voicesShelfHd": {
+    "description": "Ryhmäotsikko premium- (HD-)äänille asetusten äänikatalogissa. CSS muuntaa isoiksi kirjaimiksi.",
+    "message": "HD-äänet"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Yhden rivin huomautus HD-ryhmäotsikon vieressä asetusten Äänet-studiossa.",
+    "message": "Rikkain ja ilmeikkäin äänemme."
+  },
+  "voicesShowAll": {
+    "description": "Valinta asetusten Äänet-näkymän \"Näytä\"-suodattimessa: ei suodatusta, kaikki äänet listataan.",
+    "message": "Kaikki äänet"
+  },
+  "voicesShowEveryday": {
+    "description": "Valinta asetusten Äänet-näkymän \"Näytä\"-suodattimessa: listaa vain tavalliset (ei-HD) äänet.",
+    "message": "Vain perusäänet"
+  },
+  "voicesShowHd": {
+    "description": "Valinta asetusten Äänet-näkymän \"Näytä\"-suodattimessa: listaa vain premium- (HD-) äänet.",
+    "message": "Vain HD"
+  },
+  "voicesShowLabel": {
+    "description": "Selite asetusten Äänet-ohjauspalkin suodattimessa, joka rajaa, mitkä äänet luettelo näyttää.",
+    "message": "Näytä"
+  },
+  "voicesShowUnheard": {
+    "description": "Valinta asetusten Äänet-näkymän \"Näytä\"-suodattimessa: listaa vain äänet, joita käyttäjä ei ole vielä kuunnellut.",
+    "message": "Ei vielä kuunneltu"
+  },
+  "voicesSpeakingNow": {
+    "description": "Tilan ilmaiseva teksti asetusten Voices-studiossa isännän tällä hetkellä valitulle äänelle (valikkopaikka ja äänikortti).",
+    "message": "Puhuu nyt"
+  },
+  "voicesSpeaksWith": {
+    "description": "Pieni otsakerivi nykyisen äänen nimen yläpuolella asetusten Voices-studiossa; $host$ on avustaja (esim. Pi). CSS muuntaa tekstin isoiksi kirjaimiksi.",
+    "message": "$host$ puhuu äänellä",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Vaihemuistiinpano, kun isäntä tuottaa oman äänensä (esim. Pi), joten Say, Pi -äänen valinta korvaa isännän äänen.",
+    "message": "$host$ käyttää omaa ääntään, kunnes valitset alta.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Vaihemuistiinpano, kun isännällä ei ole omaa ääntä (esim. Claude), joten mitään ei lueta ääneen ennen kuin Say, Pi -ääni on valittu.",
+    "message": "$host$ ei lue vastauksia ääneen, ennen kuin valitset alta.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Otsikko Asetukset > Voices -studion vaiheessa, kun isännälle ei ole valittu SayPi-ääntä; $host$ on avustaja (esim. Pi, Claude). Renderöidään nimikoolla.",
+    "message": "Valitse, miltä $host$ kuulostaa",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Painike Asetukset > Voices -studion vaiheessa, joka toistaa nykyisen äänen ilmaisen näytepätkän.",
+    "message": "Kuuntele näyte"
+  },
+  "voicesStopPlayback": {
+    "description": "Painike asetusten Äänet-ohjauspalkissa, joka pysäyttää \"Toista kaikki\" -toiminnolla aloitetun näytteiden sarjan.",
+    "message": "Pysäytä"
+  },
+  "voicesSweepPosition": {
+    "description": "Reaaliaikainen sijaintinäyttö asetusten Äänet-ohjauspalkissa, kun \"Toista kaikki\" käy luetteloa läpi; $index$ on nyt soiva ääni ja $total$ kertoo, montako ääntä on jonossa.",
+    "message": "$index$ / $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Saavutettava nimi vertailuohjaimelle asetusten Äänet-ohjauspalkissa. Toistaa uudelleen toisen kahdesta viimeksi kuullusta äänestä; $name$ on kyseinen ääni.",
+    "message": "Vaihda takaisin: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Rivi asetusten Äänet-ohjauspalkissa, kun \"Toista kaikki\" painetaan liian pitkälle listalle; $count$ on äänien määrä ja $minutes$ on karkea arvio minuuteissa. Lyhennetty \"min\", jotta se toimii oikein myös arvolla 1 — Chrome i18n:ssä ei ole monikkomuotoja.",
+    "message": "Se on $count$ ääntä — noin $minutes$ min. Rajaa lista ensin.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Saavutettava nimi asetusten ääniluettelon isäntäkohtaiselle ”käytä tätä ääntä” -painikkeelle; $name$ on ääni, $host$ on avustaja (esim. Pi, Claude).",
+    "message": "Käytä ääntä $name$ kohteessa $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Lyhyt teksti yhtenäisen asetusten ääniluettelon isäntäkohtaisessa ”käytä tätä ääntä” -painikkeessa (isäntä näkyy sen vieressä).",
+    "message": "Käytä"
+  },
+  "voicesYourVoice": {
+    "description": "Ohjauspalkin painike asetusten Äänet-luettelossa, joka siirtää kohdistuksen sen äänen riville, jota tämä isäntä käyttää tällä hetkellä; $name$ on kyseinen ääni.",
+    "message": "Äänesi: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Virhe, joka heitetään, kun selain ei pysty varaamaan riittävästi WebAssembly-muistia puheentunnistusmallille.",
+    "message": "Puheentunnistus ei voi käynnistyä: WebAssembly-muistia ei ole riittävästi äänimallille. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Virhe, joka heitetään, kun selain ei tarjoa alkuperäistä WebAssembly-muistia, jota tarvitaan puheentunnistusmallin ajamiseen.",
+    "message": "Puheentunnistus ei voi käynnistyä: WebAssembly-muisti ei ole käytettävissä tässä selaimessa."
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Avantage listé dans la fenêtre modale d’authentification : limites d’utilisation augmentées.",
+    "message": "Limites d’utilisation plus élevées avec un compte gratuit"
+  },
+  "authBenefitPremium": {
+    "description": "Avantage listé dans la fenêtre modale d’authentification : fonctionnalités premium sur les chatbots.",
+    "message": "Fonctionnalités premium et prise en charge des chatbots"
+  },
+  "authBenefitSupport": {
+    "description": "Avantage listé dans la fenêtre modale d’authentification : support prioritaire.",
+    "message": "Support prioritaire en cas de problème"
+  },
+  "authBenefitSync": {
+    "description": "Avantage listé dans la fenêtre modale d’authentification : synchronisation des paramètres.",
+    "message": "Synchronisez les paramètres de voix partout"
+  },
+  "authBenefitTTS": {
+    "description": "Avantage listé dans la fenêtre modale d’authentification : fonctionnalité de synthèse vocale.",
+    "message": "Voix de synthèse vocale (offres payantes)"
+  },
+  "authBenefitUsage": {
+    "description": "Avantage listé dans la fenêtre modale d’authentification : suivi d’utilisation.",
+    "message": "Suivez votre utilisation de la voix sur tous vos appareils"
+  },
+  "authPromptModalFull": {
+    "description": "Description de la fenêtre modale complète d’invite d’authentification avec proposition de valeur.",
+    "message": "Vous utilisez beaucoup Say, Pi. Connectez-vous pour des limites plus élevées, des voix de synthèse vocale et des fonctionnalités premium sur tous les chatbots pris en charge."
+  },
+  "authPromptModalSoft": {
+    "description": "Description de la fenêtre modale légère d’invite d’authentification.",
+    "message": "Créez un compte gratuit Say, Pi pour des limites d’utilisation plus élevées et l’accès à des fonctionnalités vocales premium."
+  },
+  "authPromptTitle": {
+    "description": "Titre de la fenêtre modale d’invite d’authentification.",
+    "message": "Débloquer plus de fonctionnalités vocales"
+  },
+  "authPromptToast": {
+    "description": "Notification toast encourageant l’utilisateur à se connecter.",
+    "message": "Connectez-vous à Say, Pi pour des limites plus élevées et des fonctionnalités premium"
+  },
   "autoReadAloudChatGPT": {
     "description": "Libellé pour la case à cocher permettant d'activer ou de désactiver la lecture automatique des réponses de ChatGPT lors des appels vocaux.",
     "message": "Lecture automatique à voix haute (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Désactiver le texte vocal"
   },
+  "dismiss": {
+    "message": "Compris",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Rejeter"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Concentration"
   },
+  "errorVadInitFailed": {
+    "description": "Notification d’erreur affichée lorsque la détection d’activité vocale ne parvient pas à s’initialiser.",
+    "message": "Impossible d’initialiser la détection vocale"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Notification d’erreur affichée lorsqu’une erreur inattendue se produit pendant la configuration de l’enregistrement vocal.",
+    "message": "Impossible de configurer l’enregistrement vocal"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Notification d’erreur affichée lorsque le client de détection vocale n’arrive pas à démarrer l’enregistrement.",
+    "message": "Impossible de démarrer l’enregistrement vocal"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Notification d’erreur affichée lorsque le client de détection vocale (VAD) est indisponible et que l’enregistrement ne peut pas démarrer.",
+    "message": "Enregistrement vocal indisponible"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Quitter le mode Concentration"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Note d’une ligne affichée dans les menus de voix lorsque des voix premium (HD) et des voix économiques sont toutes deux disponibles",
+    "message": "Les voix HD consomment votre quota mensuel environ 20× plus vite."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Gucking ça ..."
   },
+  "maybeLater": {
+    "description": "Texte du bouton pour fermer l’invite d’authentification.",
+    "message": "Peut-être plus tard"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Les paramètres de votre microphone ne répondent pas aux spécifications requises. \nEssayez d'utiliser un autre microphone ou d'ajuster vos paramètres audio."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Impossible d'accéder au micro. \nVeuillez vérifier les paramètres de votre appareil et réessayer."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Notification d’erreur affichée lorsque l’autorisation du micro a été refusée après le flux d’invite d’autorisation.",
+    "message": "L’autorisation du micro n’a pas été accordée. Vérifie que tu as autorisé l’accès dans l’invite et dans les paramètres de l’extension."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "précision"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Réponse la plus rapide, mais moins précise. \nEnclin à interrompre."
   },
+  "moreVoices": {
+    "description": "Ligne de menu reliant le menu des voix dans la page au catalogue complet de voix dans les paramètres de l’extension.",
+    "message": "Plus de voix…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Surnom de l'assistant"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Non signé"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Libellé du bouton qui ouvre ChatGPT.",
+    "message": "Ouvrir ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Libellé du bouton qui ouvre Claude.ai.",
+    "message": "Ouvrir Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Libellé du bouton qui ouvre Pi.ai.",
+    "message": "Ouvrir Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Option d’environnement : autour d’autres personnes.",
+    "message": "Avec d’autres personnes autour"
+  },
+  "onboarding_envMixed": {
+    "description": "Option d’environnement : un mélange d’espaces privés et partagés.",
+    "message": "Un mélange d’endroits"
+  },
+  "onboarding_envPrivate": {
+    "description": "Option d’environnement : un espace privé.",
+    "message": "Quelque part en privé"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Confirmation affichée lorsque la réponse sur l’environnement laisse le mode silencieux désactivé.",
+    "message": "D’accord, nous garderons les réglages d’écoute et de lecture par défaut."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Confirmation affichée lorsque la réponse sur l’environnement active le mode discret.",
+    "message": "Mode discret activé : nous capterons une voix plus douce et répondrons à voix basse, pour que vous puissiez parler discrètement."
+  },
+  "onboarding_envTitle": {
+    "description": "Titre de la question d’onboarding sur l’environnement de l’utilisateur.",
+    "message": "Où parlerez-vous le plus souvent ?"
+  },
+  "onboarding_footer": {
+    "description": "Texte de pied de page sur la page d’onboarding de première utilisation.",
+    "message": "Vous pouvez revenir à tout moment à cette page depuis les paramètres de Say, Pi. Votre confidentialité compte : l’audio n’est capturé que pendant un appel actif."
+  },
+  "onboarding_heading": {
+    "description": "Titre principal sur la page d’onboarding au premier lancement.",
+    "message": "🗣️ Bienvenue dans Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Paragraphe d’introduction sur la page d’onboarding au premier lancement.",
+    "message": "Vous êtes à deux étapes de votre première conversation parlée avec une IA. Parler est environ 3× plus rapide que taper — on s’occupe de la configuration."
+  },
+  "onboarding_micTestButton": {
+    "description": "Bouton qui lance le test de micro d’onboarding, sans enjeu.",
+    "message": "🎤 Tester votre micro"
+  },
+  "onboarding_micTestDone": {
+    "description": "Statut affiché après la fin réussie du test micro d’onboarding.",
+    "message": "Parfait, votre micro fonctionne 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Statut affiché pendant que le test micro d’onboarding mesure l’entrée.",
+    "message": "Écoute — dites quelque chose 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Statut affiché pendant que le test micro d’onboarding attend l’autorisation.",
+    "message": "Demande d’accès au micro…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Libellé du bouton pour arrêter le test micro d’onboarding pendant qu’il est en cours.",
+    "message": "Arrêter le test"
+  },
+  "onboarding_step1Body": {
+    "description": "Texte de la première étape d’onboarding expliquant comment épingler l’extension.",
+    "message": "Cliquez sur l’icône pièce de puzzle 🧩 en haut à droite de votre navigateur, puis sur l’épingle 📌 à côté de Say, Pi. Le bouton d’appel reste ainsi à un clic."
+  },
+  "onboarding_step1Title": {
+    "description": "Titre de la première étape d’onboarding (épingler l’extension).",
+    "message": "Épinglez Say, Pi à votre barre d’outils"
+  },
+  "onboarding_step2Body": {
+    "description": "Texte de la deuxième étape d’onboarding expliquant comment démarrer une conversation vocale.",
+    "message": "Allez sur l’un des assistants pris en charge ci-dessous, puis appuyez sur le bouton d’appel Say, Pi et dites bonjour. Nous demanderons l’accès au micro la première fois — c’est normal, et nous n’écoutons que pendant un appel actif."
+  },
+  "onboarding_step2Title": {
+    "description": "Titre de la deuxième étape d’onboarding (démarrer une conversation).",
+    "message": "Ouvrez un chat IA et commencez à parler"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Permission de microphone"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Consignes de récupération lorsque l’autorisation du micro est bloquée.",
+    "message": "Votre navigateur bloque le micro. Cliquez sur l’icône de caméra ou de cadenas dans la barre d’adresse, réglez Microphone sur « Autoriser », puis réessayez. Sur macOS, vérifiez aussi Réglages Système → Confidentialité et sécurité → Microphone."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Titre du panneau de récupération lorsque l’autorisation du micro a été refusée/bloquée.",
+    "message": "L’accès au micro est bloqué"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Consignes de récupération lorsque le micro est utilisé ailleurs.",
+    "message": "Une autre application ou un autre onglet utilise peut-être votre micro. Fermez tout ce qui pourrait enregistrer (appels vidéo, mémos vocaux), puis réessayez."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Titre du panneau de récupération lorsque le micro est utilisé par une autre application.",
+    "message": "Votre micro est utilisé"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Consignes de récupération lorsqu’aucun appareil microphone n’est disponible.",
+    "message": "Nous n’avons trouvé aucun micro. Branchez-en un (ou connectez votre casque), assurez-vous qu’il est sélectionné comme périphérique d’entrée, puis réessayez."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Titre du panneau de récupération lorsqu’aucun appareil microphone n’est disponible.",
+    "message": "Aucun micro détecté"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Consignes de récupération pour une erreur de micro inconnue.",
+    "message": "Un problème est survenu lors de l’accès à votre micro. Vérifiez qu’il est connecté et autorisé dans les réglages de votre navigateur, puis réessayez."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Titre du panneau de récupération pour une erreur de micro inconnue.",
+    "message": "Nous n’avons pas pu accéder à votre micro"
+  },
+  "permissions_retryButton": {
+    "description": "Libellé du bouton qui redemande l’autorisation du micro.",
+    "message": "Réessayer"
+  },
+  "permissions_revokedHeading": {
+    "description": "Titre affiché lorsque l’accès au micro a déjà été accordé, mais a ensuite été révoqué.",
+    "message": "🎙️ Reconnectons votre micro"
+  },
+  "permissions_revokedInfo": {
+    "description": "Texte informatif affiché lorsque l’accès au micro a été révoqué après avoir été accordé.",
+    "message": "L’accès à votre micro a été désactivé — cela arrive souvent après une mise à jour du navigateur ou du système. Réautorisez-le ci-dessous et $productName$ écoutera à nouveau lorsque vous serez en appel.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Libellé pour l’interrupteur qui active le mode discret/chuchoté.",
+    "message": "Mode discret"
+  },
+  "quietModeTooltip": {
+    "description": "Infobulle expliquant ce que fait le mode discret/chuchoté.",
+    "message": "Parle doucement : capte une voix plus faible et baisse le volume des réponses de l’assistant, pour utiliser la voix près d’autres personnes."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Texte du bouton de connexion pendant l’authentification.",
+    "message": "Connexion…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Effets sonores"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Les effets sonores sont désactivés dans Firefox pour éviter les problèmes de retour audio."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Titre de l’avis unique sur le gain de vitesse affiché après le premier échange vocal.",
+    "message": "Bien vu, parler est environ 3× plus rapide que taper."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Deuxième ligne optionnelle de l’avis sur le gain de vitesse indiquant le nombre de minutes entières gagnées.",
+    "message": "Tu as déjà parlé environ $minutes$ min plus vite que si tu l’avais tapé.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Soumettez uniquement lorsque vous appuyez sur le bouton"
   },
+  "surveyQuestion": {
+    "description": "L’unique question du micro-sondage unique après une victoire.",
+    "message": "Comment la voix fonctionne-t-elle pour vous jusqu’à présent ?"
+  },
+  "surveyRatingLabel": {
+    "description": "Libellé accessible pour un bouton de note du sondage.",
+    "message": "Noter $rating$ sur 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Remerciement affiché après la réponse de l’utilisateur au sondage post-victoire.",
+    "message": "Merci — cela nous aide à améliorer Say, Pi. 🙏"
+  },
   "tabAIChat": {
     "description": "Étiquette d'onglet pour la section des paramètres de chat IA.",
     "message": "Chat IA"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Étiquette d'onglet pour la section des paramètres généraux.",
     "message": "Général"
+  },
+  "tabVoices": {
+    "description": "Libellé d’onglet pour la section des paramètres de voix (catalogue de voix par site).",
+    "message": "Voix"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "crédits"
   },
+  "ttsCreditsRemaining": {
+    "description": "Texte indiquant le quota TTS restant sous forme de réserve de crédits par voix (saypi-api #181 étape 2), et non en nombre de caractères.",
+    "message": "$credits$ crédits restants",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Les voix multilingues ne sont actuellement pas prises en charge dans Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Génération de voix"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Attention ! La lecture vocale n'est pas encore disponible sur $browserName$ avec $chatbotName$. La bonne nouvelle ? L'entrée vocale fonctionne très bien ! Pour le TTS, essayez Chrome ou Edge sur le bureau.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS indisponible sur $browserName$ + $chatbotName$. L'entrée vocale fonctionne ! Essayez Chrome sur le bureau pour le TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Voix tts"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Détail VAD lorsque de l’audio semblable à de la parole a été détecté mais était trop faible / avec une confiance trop basse pour être transcrit (suppression côté client via la porte d’admission).",
+    "message": "Audio trop faible pour être transcrit"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Détail VAD expliquant que l’appel s’est terminé car le microphone a été revendiqué par un onglet plus récent.",
+    "message": "Entrée vocale déplacée vers un autre onglet"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Voix non disponible. \nEssayez Chrome ou Firefox sur le bureau."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Attention ! La lecture vocale n'est pas encore disponible sur $browserName$ avec $chatbotName$. La bonne nouvelle ? L'entrée vocale fonctionne très bien ! Pour le TTS, essayez Chrome ou Edge sur le bureau.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS indisponible sur $browserName$ + $chatbotName$. L'entrée vocale fonctionne ! Essayez Chrome sur le bureau pour le TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Compris",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Statut VAD affiché sur un onglet dont l’entrée vocale a été prise en charge par un autre onglet.",
+    "message": "En pause"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Afficher les détails"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Introduction générique lue quand une voix SayPi sélectionnée n’a pas de script d’introduction spécifique (et qu’il n’y a pas de message récent à relire).",
+    "message": "Salut, je suis $voice$. Voilà comment je sonne. J’espère que cette voix te plaira.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Holà ! \nPrivé! \nEh bien! \nJe m'appelle Pi, votre assistant IA polyglotte. \nAvec 32 langues à ma disposition, nous pouvons explorer des idées et des cultures du monde entier. \nQue pensez-vous de cette voix ?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Paramètres vocaux"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Sous-titre de secours pour une ligne de voix dans le catalogue des voix des paramètres quand la voix n’a pas de description ; $count$ est le nombre de langues prises en charge par la voix.",
+    "message": "Parle $count$ langues",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Slogan de personnalité rédigé pour la voix « Addison » (paramètres > studio des voix ; mappage d’identité de voix côté client).",
+    "message": "Solaire et articulé"
+  },
+  "voiceTagline_alloy": {
+    "description": "Slogan de personnalité rédigé pour la voix « Alloy » (studio Voix des paramètres ; carte d’identité des voix côté client).",
+    "message": "Équilibrée et polyvalente"
+  },
+  "voiceTagline_ash": {
+    "description": "Slogan de personnalité rédigé pour la voix « Ash » (studio Voix des paramètres ; carte d’identité des voix côté client).",
+    "message": "Grave, réfléchie, calme"
+  },
+  "voiceTagline_ballad": {
+    "description": "Slogan de personnalité rédigé pour la voix « Ballad » (studio Voix des paramètres ; carte d’identité des voix côté client).",
+    "message": "Douce et mélodieuse"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Slogan de personnalité rédigé pour la voix « Cassidy » (paramètres > studio des voix ; mappage d’identité de voix côté client).",
+    "message": "Sympathique et factuel"
+  },
+  "voiceTagline_cedar": {
+    "description": "Accroche de personnalité rédigée pour la voix « Cedar » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Stable et rassurant"
+  },
+  "voiceTagline_coral": {
+    "description": "Accroche de personnalité rédigée pour la voix « Coral » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Énergie vive et positive"
+  },
+  "voiceTagline_echo": {
+    "description": "Accroche de personnalité rédigée pour la voix « Echo » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Clair et neutre"
+  },
+  "voiceTagline_fable": {
+    "description": "Accroche de personnalité rédigée pour la voix « Fable » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Une intonation de conteur"
+  },
+  "voiceTagline_finn": {
+    "description": "Slogan de personnalité rédigé pour la voix « Finn » (paramètres > studio des voix ; mappage d’identité de voix côté client).",
+    "message": "Frais et énergique"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Slogan de personnalité rédigé pour la voix « Jamahal » (paramètres > studio des voix ; mappage d’identité de voix côté client).",
+    "message": "Riche et magnétique"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Accroche de personnalité rédigée pour la voix « Jarnathan » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Baryton velouté de fin de soirée"
+  },
+  "voiceTagline_jeff": {
+    "description": "Slogan de personnalité rédigé pour la voix « Jeff » (paramètres > studio des voix ; mappage d’identité de voix côté client).",
+    "message": "Direct et posé"
+  },
+  "voiceTagline_jessica": {
+    "description": "Slogan de personnalité rédigé pour la voix « Jessica » (paramètres > studio des voix ; mappage d’identité de voix côté client).",
+    "message": "Chaleureuse, posée, soignée"
+  },
+  "voiceTagline_joey": {
+    "description": "Accroche de personnalité rédigée pour la voix « Joey » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Américain naturel et conversationnel"
+  },
+  "voiceTagline_juniper": {
+    "description": "Slogan de personnalité rédigé pour la voix « Juniper » (paramètres > studio des voix ; mappage d’identité de voix côté client).",
+    "message": "Net, lumineux, animé"
+  },
+  "voiceTagline_lucy": {
+    "description": "Slogan de personnalité rédigé pour la voix « Lucy » (paramètres > studio des voix ; mappage d’identité de voix côté client).",
+    "message": "Douce et lumineuse"
+  },
+  "voiceTagline_marin": {
+    "description": "Accroche de personnalité rédigée pour la voix « Marin » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Chaleureux, calme de radio du matin"
+  },
+  "voiceTagline_mark": {
+    "description": "Slogan de personnalité rédigé pour la voix « Mark » (paramètres > studio des voix ; mappage d’identité de voix côté client).",
+    "message": "Narrateur clair et sûr de lui"
+  },
+  "voiceTagline_nova": {
+    "description": "Accroche de personnalité rédigée pour la voix « Nova » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Rapide et curieux"
+  },
+  "voiceTagline_onyx": {
+    "description": "Accroche de personnalité rédigée pour la voix « Onyx » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Gravité profonde et résonnante"
+  },
+  "voiceTagline_paola": {
+    "description": "Accroche de personnalité rédigée pour la voix « Paola » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Chaleur italienne expressive"
+  },
+  "voiceTagline_sage": {
+    "description": "Accroche de personnalité rédigée pour la voix « Sage » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Clarté tout en douceur"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Accroche de personnalité rédigée pour la voix « Shimmer » (paramètres, studio Voix ; carte d’identité de voix côté client).",
+    "message": "Léger et aérien"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Libellé court sur le bouton d’épinglage d’une carte de voix (état désactivé) dans le studio Voix des paramètres ; l’action ajoute la voix au menu dans le chat de l’hôte.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Libellé accessible pour le bouton d’épinglage d’une carte de voix (état désactivé) ; $name$ est la voix, $host$ l’assistant.",
+    "message": "Ajouter $name$ au menu de $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Libellé du bouton bascule dans la barre de contrôle Voix qui indique si parcourir la liste avec les flèches du clavier lit chaque voix lorsque le focus l’atteint.",
+    "message": "Lire pendant le déplacement"
+  },
+  "voicesArrowsLive": {
+    "description": "Confirmation du lecteur d’écran, ajoutée à la première annonce « Lecture de <voix> » dans la liste Voix des paramètres, indiquant que les touches fléchées viennent de devenir audibles. Reprend le libellé du bouton « Lire au fil du déplacement ».",
+    "message": "Les flèches jouent maintenant au fil du déplacement. Échap arrête."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Note sous les emplacements du menu pour les hôtes qui proposent des voix natives (p. ex. les 8 voix intégrées de Pi), que le studio ne gère pas ; $host$ est l’assistant.",
+    "message": "Les voix intégrées de $host$ apparaissent toujours aussi dans son menu.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variante de voicesBuiltinsNote pour un hôte sans menu de voix dans la discussion (Pi a supprimé son menu en 2026), où la promesse de l’original selon laquelle les voix intégrées « apparaissent dans son menu » serait fausse ; $host$ est l’assistant.",
+    "message": "$host$ a aussi ses propres voix intégrées, qui ne sont pas listées ici.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Indicateur de progression dans la barre de contrôle Voix des paramètres : combien de voix listées l’utilisateur a déjà écoutées. Nombres seuls, pour que cela se lise correctement avec 1 — Chrome i18n n’a pas de formes plurielles.",
+    "message": "$heard$ sur $total$ écoutées",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Partie du nom accessible d’une ligne de voix dans la liste Voix des paramètres, marquant une voix déjà écoutée par ce profil. Visuellement, cela est rendu par la densité d’encre sur l’empreinte sonore de la voix, ce qu’un lecteur d’écran ne peut pas voir.",
+    "message": "Écoutée"
+  },
+  "voicesInHostMenu": {
+    "description": "Titre de section au-dessus de la rangée des emplacements de menu dans le studio Voix des paramètres ; $host$ est l’assistant.",
+    "message": "Dans le menu de $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Libellé court sur le bouton d’épinglage d’une carte de voix (état activé) dans le studio Voix des paramètres.",
+    "message": "✓ Dans le menu"
+  },
+  "voicesInUse": {
+    "description": "Badge persistant sur la voix actuellement sélectionnée de l’hôte dans la liste Voix des paramètres, affiché en majuscules. Délibérément PAS « Parle maintenant » : sur cette page, les lignes lisent leurs extraits, donc une voix sélectionnée mais silencieuse ne doit pas prétendre parler pendant qu’une autre ligne est en cours.",
+    "message": "Utilisée"
+  },
+  "voicesKeyboardHint": {
+    "description": "Astuce clavier sur une ligne dans la barre de contrôle Voix des paramètres. Les glyphes sont des touches : Espace, les flèches haut/bas et Maj+Espace.",
+    "message": "Appuyez sur Espace pour écouter, ↑↓ pour passer d’une voix à l’autre, ⇧Espace pour revenir."
+  },
+  "voicesLoadError": {
+    "description": "État d’erreur dans le studio d’un hôte lorsque le catalogue de voix de cet hôte n’a pas pu être chargé ; $host$ est l’assistant.",
+    "message": "Impossible de charger les voix de $host$. Veuillez réessayer plus tard.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Info-bulle/indice sur un bouton « + Menu » désactivé quand le menu dans le chat de l’hôte contient déjà le nombre maximal de voix.",
+    "message": "Menu complet — retirez une voix pour en ajouter une autre"
+  },
+  "voicesMenuHint": {
+    "description": "Indice sur une ligne à côté du titre « Dans le menu de {host} », expliquant que la rangée d’emplacements reflète le menu des voix dans le chat.",
+    "message": "Ce que vous verrez dans le chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Note sous les emplacements du menu lorsque l’utilisateur a plus de voix épinglées que le menu dans la discussion ne peut en afficher (état hérité) ; $count$ correspond au nombre qui ne tient pas, $cap$ à la taille du menu.",
+    "message": "$count$ voix épinglée en plus attend au-delà des $cap$ emplacements du menu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Singulier de voicesMenuOverflow, utilisé lorsqu’exactement une voix épinglée ne tient pas dans le menu dans la discussion ; $cap$ est la taille du menu.",
+    "message": "1 voix épinglée en plus attend au-delà des $cap$ emplacements du menu.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Ligne de résumé sous la liste Voix des paramètres indiquant quelle part du menu vocal dans le chat de l’hôte est remplie ; $host$ est l’assistant, $used$ le nombre de places occupées, $cap$ le total. Formulé pour se lire correctement avec 1 — Chrome i18n n’a pas de formes plurielles.",
+    "message": "Menu de $host$ : $used$ sur $cap$ places",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Titre du groupe à la fin de la liste Voix des paramètres contenant les voix sans extrait à lire ; $count$ indique combien. Formulé pour se lire correctement avec 1 — Chrome i18n n’a pas de formes plurielles.",
+    "message": "Pas encore d’extrait ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Affiché dans le catalogue des voix des paramètres quand la liste des voix est vide pour un utilisateur connecté (par ex. un problème réseau).",
+    "message": "Impossible de charger les voix pour le moment. Veuillez réessayer plus tard."
+  },
+  "voicesNowPlaying": {
+    "description": "Annonce du lecteur d’écran quand l’extrait d’une voix commence à être lu dans la liste Voix des paramètres ; $name$ est la voix.",
+    "message": "Lecture de $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Bouton dans la barre de contrôle Voix des paramètres qui lit toutes les voix actuellement listées, les unes après les autres ; $count$ indique combien. Formulé pour se lire correctement avec 1 — Chrome i18n n’a pas de formes plurielles.",
+    "message": "Tout lire ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Bouton dans la barre de contrôle Voix des paramètres lors d’une visite de retour : lit uniquement les voix listées que vous n’avez pas encore écoutées ; $count$ indique combien. Formulé pour se lire correctement avec 1 — Chrome i18n n’a pas de formes plurielles.",
+    "message": "Lire les nouvelles ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Ligne dans la barre de contrôle Voix des paramètres lorsque le navigateur a refusé de lire un extrait car la page n’a pas encore eu d’interaction utilisateur.",
+    "message": "Cliquez sur une voix pour activer le son."
+  },
+  "voicesPreview": {
+    "description": "Libellé accessible pour le bouton lecture (▶) qui permet d’écouter l’extrait gratuit d’une voix sur une ligne de voix ; $name$ est le nom de la voix.",
+    "message": "Écouter un extrait de $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Nom accessible de la liste Voix dans les paramètres (une listbox de toutes les voix, une ligne par voix).",
+    "message": "Voix, classées de la plus grave à la plus claire"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Libellé accessible pour le bouton d’épinglage d’une carte de voix (état activé) et le bouton de suppression d’un emplacement de menu ; $name$ est la voix, $host$ l’assistant.",
+    "message": "Retirer $name$ du menu de $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Ligne dans la barre de contrôle Voix des paramètres lorsqu’un extrait d’une voix n’a pas pu être chargé ou lu ; $name$ est cette voix. Non modal — la lecture en série continue malgré tout.",
+    "message": "Impossible de lire l’extrait de $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Sous-titre de la section du catalogue de voix dans l’onglet de paramètres IA Chat.",
+    "message": "Choisissez la voix qui lit les réponses à voix haute sur chaque site."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Sous-titre sous l’en-tête des paramètres Voix, pour le rail de voix ordonné par hauteur.",
+    "message": "Chaque voix, de la plus grave à la plus claire. Écoutez, puis choisissez."
+  },
+  "voicesSectionTitle": {
+    "description": "Titre de la section du catalogue de voix dans l’onglet de paramètres IA Chat.",
+    "message": "Voix"
+  },
+  "voicesShelfEveryday": {
+    "description": "Titre de groupe pour les voix d’entrée de gamme dans le catalogue de voix des paramètres. Affiché en majuscules par CSS.",
+    "message": "Voix du quotidien"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Note d’une ligne à côté du titre de groupe du quotidien dans le studio Voix des paramètres ; le seul endroit où le studio indique de combien ce palier va plus loin que HD.",
+    "message": "Naturel et clair — vous pouvez écouter environ 20× plus longtemps qu’avec les voix HD."
+  },
+  "voicesShelfHd": {
+    "description": "Titre de groupe pour les voix premium (HD) dans le catalogue de voix des paramètres. Affiché en majuscules par CSS.",
+    "message": "Voix HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Note d’une ligne à côté du titre de groupe HD dans le studio Voix des paramètres.",
+    "message": "Notre son le plus riche et le plus expressif."
+  },
+  "voicesShowAll": {
+    "description": "Option du filtre « Afficher » des Voix (paramètres) : aucun filtrage, toutes les voix sont listées.",
+    "message": "Toutes les voix"
+  },
+  "voicesShowEveryday": {
+    "description": "Option du filtre « Afficher » des Voix (paramètres) : n’affiche que les voix standard (non HD).",
+    "message": "Standard uniquement"
+  },
+  "voicesShowHd": {
+    "description": "Option du filtre « Afficher » des Voix (paramètres) : n’affiche que les voix premium (HD).",
+    "message": "HD uniquement"
+  },
+  "voicesShowLabel": {
+    "description": "Libellé du filtre dans la barre de contrôle Voix des paramètres qui réduit les voix affichées dans la liste.",
+    "message": "Afficher"
+  },
+  "voicesShowUnheard": {
+    "description": "Option du filtre « Afficher » des Voix (paramètres) : n’affiche que les voix que l’utilisateur n’a pas encore écoutées.",
+    "message": "Pas encore écoutées"
+  },
+  "voicesSpeakingNow": {
+    "description": "Libellé d’état sur la voix actuellement sélectionnée de l’hôte dans le studio Voix des paramètres (emplacement de menu et carte de voix).",
+    "message": "Parle maintenant"
+  },
+  "voicesSpeaksWith": {
+    "description": "Ligne de surtitre au-dessus du nom de la voix actuelle sur la scène du studio Voix des paramètres ; $host$ est l’assistant (p. ex. Pi). Affiché en majuscules par le CSS.",
+    "message": "$host$ parle avec",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Note de scène lorsque l’hôte fournit son propre audio (p. ex. Pi), donc choisir une voix Say, Pi remplace celle de l’hôte.",
+    "message": "$host$ utilise sa propre voix jusqu’à ce que vous en choisissiez une ci-dessous.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Note de scène lorsque l’hôte n’a pas de voix propre (p. ex. Claude), donc rien n’est lu à voix haute tant qu’une voix Say, Pi n’est pas choisie.",
+    "message": "$host$ ne lira pas les réponses à voix haute tant que vous n’en choisirez pas une ci-dessous.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Titre sur la scène du studio Voix dans les paramètres lorsque l’hôte n’a pas de voix SayPi sélectionnée ; $host$ est l’assistant (p. ex. Pi, Claude). Affiché en taille de nom.",
+    "message": "Choisissez comment $host$ sonne",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Bouton sur la scène du studio Voix dans les paramètres qui lit l’extrait gratuit de la voix actuelle.",
+    "message": "Écouter un extrait"
+  },
+  "voicesStopPlayback": {
+    "description": "Bouton dans la barre de contrôle Voix des paramètres qui arrête la suite d’extraits lancée par « Tout lire ».",
+    "message": "Arrêter"
+  },
+  "voicesSweepPosition": {
+    "description": "Indication de position en direct dans la barre de contrôle Voix des paramètres pendant que « Tout lire » parcourt la liste ; $index$ est la voix en cours de lecture et $total$ le nombre de voix en file d’attente.",
+    "message": "$index$ sur $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Libellé accessible pour le contrôle de comparaison dans la barre de contrôle Voix des paramètres, qui rejoue l’autre voix parmi les deux dernières entendues ; $name$ est cette voix.",
+    "message": "Revenir à $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Ligne dans la barre de contrôle Voix des paramètres lorsque « Tout lire » est pressé sur une liste trop longue ; $count$ est le nombre de voix et $minutes$ le nombre approximatif de minutes. « min » est abrégé pour que cela reste correct à 1 — Chrome i18n n’a pas de formes plurielles.",
+    "message": "Cela fait $count$ voix — environ $minutes$ min. Affinez d’abord la liste.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Libellé accessible pour le bouton « utiliser cette voix » par hôte dans le catalogue de voix des paramètres ; $name$ est la voix, $host$ est l’assistant (p. ex. Pi, Claude).",
+    "message": "Utiliser $name$ sur $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Libellé court sur le bouton « utiliser cette voix » par hôte dans le catalogue de voix des paramètres unifiés (l’hôte est affiché à côté).",
+    "message": "Utiliser"
+  },
+  "voicesYourVoice": {
+    "description": "Bouton de la barre de contrôle dans la liste Voix des paramètres qui déplace le focus vers la ligne de la voix actuellement utilisée par cet hôte ; $name$ est cette voix.",
+    "message": "Votre voix : $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Erreur levée lorsque le navigateur ne peut pas allouer suffisamment de mémoire WebAssembly pour le modèle de détection vocale.",
+    "message": "La détection vocale ne peut pas démarrer : pas assez de mémoire WebAssembly pour le modèle vocal. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Erreur levée lorsque le navigateur n’expose pas la mémoire WebAssembly initiale nécessaire pour exécuter le modèle de détection vocale.",
+    "message": "La détection vocale ne peut pas démarrer : la mémoire WebAssembly n’est pas disponible dans ce navigateur."
   }
 }

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "ऑथ मोडल में सूचीबद्ध लाभ - बढ़ी हुई उपयोग सीमाएँ।",
+    "message": "मुफ्त अकाउंट के साथ ज़्यादा उपयोग लिमिट"
+  },
+  "authBenefitPremium": {
+    "description": "ऑथ मोडल में सूचीबद्ध लाभ - चैटबॉट्स में प्रीमियम सुविधाएँ।",
+    "message": "प्रीमियम सुविधाएँ और चैटबॉट सपोर्ट"
+  },
+  "authBenefitSupport": {
+    "description": "ऑथ मोडल में सूचीबद्ध लाभ - प्राथमिकता सहायता।",
+    "message": "समस्याओं के लिए प्राथमिकता सहायता"
+  },
+  "authBenefitSync": {
+    "description": "ऑथ मोडल में सूचीबद्ध लाभ - सेटिंग्स सिंक।",
+    "message": "हर जगह वॉइस सेटिंग्स सिंक करें"
+  },
+  "authBenefitTTS": {
+    "description": "ऑथ मोडल में सूचीबद्ध लाभ - TTS सुविधा।",
+    "message": "टेक्स्ट-टू-स्पीच आवाज़ें (पेड प्लान)"
+  },
+  "authBenefitUsage": {
+    "description": "ऑथ मोडल में सूचीबद्ध लाभ - उपयोग ट्रैकिंग।",
+    "message": "डिवाइसों पर अपने वॉइस उपयोग को ट्रैक करें"
+  },
+  "authPromptModalFull": {
+    "description": "वैल्यू प्रपोज़िशन के साथ फुल मोडल ऑथ प्रॉम्प्ट का विवरण।",
+    "message": "आप SayPi का बढ़िया उपयोग कर रहे हैं। ज़्यादा लिमिट, टेक्स्ट-टू-स्पीच आवाज़ें, और सभी समर्थित चैटबॉट्स में प्रीमियम सुविधाओं के लिए साइन इन करें।"
+  },
+  "authPromptModalSoft": {
+    "description": "सॉफ्ट मोडल ऑथ प्रॉम्प्ट का विवरण।",
+    "message": "ज़्यादा उपयोग लिमिट और प्रीमियम वॉइस सुविधाओं तक पहुँच के लिए एक मुफ्त SayPi अकाउंट बनाएँ।"
+  },
+  "authPromptTitle": {
+    "description": "ऑथ प्रॉम्प्ट मोडल का शीर्षक।",
+    "message": "और वॉइस सुविधाएँ अनलॉक करें"
+  },
+  "authPromptToast": {
+    "description": "उपयोगकर्ता को साइन इन करने के लिए प्रोत्साहित करने वाली टोस्ट सूचना।",
+    "message": "ज़्यादा लिमिट और प्रीमियम सुविधाओं के लिए SayPi में साइन इन करें"
+  },
   "autoReadAloudChatGPT": {
     "description": "वॉयस कॉल के दौरान ChatGPT के उत्तरों को स्वत: पढ़ने के विकल्प को चालू या बंद करने के लिए चेकबॉक्स का लेबल।",
     "message": "स्वत: पढ़ें (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "पाठ-से-भाषण अक्षम करें"
   },
+  "dismiss": {
+    "message": "समझ गए",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "खारिज करें"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "ध्यान केन्द्रित करें"
   },
+  "errorVadInitFailed": {
+    "description": "एरर टोस्ट, जब वॉइस-एक्टिविटी डिटेक्शन इनिशियलाइज़ नहीं हो पाता।",
+    "message": "वॉइस डिटेक्शन शुरू नहीं हो सका"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "एरर टोस्ट, जब वॉइस रिकॉर्डिंग सेट अप करते समय कोई अप्रत्याशित त्रुटि होती है।",
+    "message": "वॉइस रिकॉर्डिंग सेट अप नहीं हो सका"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "एरर टोस्ट, जब वॉइस-डिटेक्शन क्लाइंट रिकॉर्डिंग शुरू नहीं कर पाता।",
+    "message": "वॉइस रिकॉर्डिंग शुरू नहीं हो सकी"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "एरर टोस्ट, जब वॉइस-डिटेक्शन (VAD) क्लाइंट उपलब्ध नहीं होता, इसलिए रिकॉर्डिंग शुरू नहीं हो सकती।",
+    "message": "वॉइस रिकॉर्डिंग उपलब्ध नहीं है"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "फोकस मोड से बाहर निकलें"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "प्रीमियम (HD) और वैल्यू वॉइस दोनों उपलब्ध होने पर वॉइस मेनू में दिखाया जाने वाला एक-पंक्ति नोट",
+    "message": "HD वॉइस आपकी मासिक सीमा को लगभग 20× तेज़ी से उपयोग करती हैं।"
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "इस दूर टक ..."
   },
+  "maybeLater": {
+    "description": "ऑथ प्रॉम्प्ट को बंद करने के लिए बटन टेक्स्ट।",
+    "message": "शायद बाद में"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "आपकी माइक्रोफ़ोन सेटिंग्स आवश्यक विशिष्टताओं को पूरा नहीं करती हैं। \nकिसी भिन्न माइक्रोफ़ोन का उपयोग करने या अपनी ऑडियो सेटिंग समायोजित करने का प्रयास करें।"
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "माइक्रोफ़ोन तक पहुँचने में असमर्थ. \nकृपया अपनी डिवाइस सेटिंग जांचें और पुनः प्रयास करें।"
   },
+  "microphonePermissionDeniedError": {
+    "description": "एरर टोस्ट, जब अनुमति प्रॉम्प्ट फ्लो के बाद माइक्रोफ़ोन अनुमति अस्वीकार कर दी जाती है।",
+    "message": "माइक्रोफ़ोन की अनुमति नहीं मिली। कृपया सुनिश्चित करें कि आपने प्रॉम्प्ट में और एक्सटेंशन सेटिंग्स में एक्सेस की अनुमति दी है।"
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "सटीकता"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "सबसे तेज़ प्रतिक्रिया, लेकिन कम सटीक। \nव्यवधान उत्पन्न करने वाला।"
   },
+  "moreVoices": {
+    "description": "इन-पेज आवाज़ मेन्यू से एक्सटेंशन सेटिंग्स में पूरी आवाज़ कैटलॉग तक ले जाने वाली मेन्यू पंक्ति",
+    "message": "और आवाज़ें…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "सहायक उपनाम"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "प्रवेश नहीं किया"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "बटन लेबल जो ChatGPT खोलता है।",
+    "message": "ChatGPT खोलें"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Claude.ai खोलने वाला बटन लेबल।",
+    "message": "Claude खोलें"
+  },
+  "onboarding_ctaPi": {
+    "description": "Pi.ai खोलने वाला बटन लेबल।",
+    "message": "Pi खोलें"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "माहौल विकल्प: दूसरे लोगों के आसपास।",
+    "message": "दूसरे लोगों के आसपास"
+  },
+  "onboarding_envMixed": {
+    "description": "माहौल विकल्प: निजी और साझा जगहों का मिश्रण।",
+    "message": "अलग-अलग जगहों पर"
+  },
+  "onboarding_envPrivate": {
+    "description": "माहौल विकल्प: एक निजी स्थान।",
+    "message": "किसी निजी जगह पर"
+  },
+  "onboarding_envQuietOff": {
+    "description": "पुष्टिकरण संदेश, जब पर्यावरण वाला उत्तर शांत मोड को बंद ही रखता है।",
+    "message": "ठीक है — हम मानक सुनने और प्लेबैक सेटिंग्स ही रखेंगे।"
+  },
+  "onboarding_envQuietOn": {
+    "description": "माहौल का जवाब क्वाइट मोड चालू करे तो दिखने वाली पुष्टि।",
+    "message": "क्वाइट मोड चालू — हम धीमी आवाज़ भी पकड़ लेंगे और धीरे जवाब देंगे, ताकि आप चुपचाप बात कर सकें।"
+  },
+  "onboarding_envTitle": {
+    "description": "उपयोगकर्ता के माहौल के बारे में ऑनबोर्डिंग सवाल के लिए शीर्षक।",
+    "message": "आप आम तौर पर कहाँ बात करेंगे?"
+  },
+  "onboarding_footer": {
+    "description": "पहली बार चलने वाले ऑनबोर्डिंग पेज पर फ़ूटर टेक्स्ट।",
+    "message": "आप इसे कभी भी Say, Pi की सेटिंग्स से फिर से देख सकते हैं। आपकी निजता मायने रखती है — ऑडियो सिर्फ़ सक्रिय कॉल के दौरान ही कैप्चर होता है।"
+  },
+  "onboarding_heading": {
+    "description": "पहली बार चलाने पर ऑनबोर्डिंग पेज का मुख्य शीर्षक।",
+    "message": "🗣️ Say, Pi में आपका स्वागत है"
+  },
+  "onboarding_intro": {
+    "description": "पहली बार चलाने पर ऑनबोर्डिंग पेज का परिचय पैराग्राफ।",
+    "message": "AI के साथ अपनी पहली बोली हुई बातचीत से आप बस दो कदम दूर हैं। बोलना टाइप करने से लगभग 3× तेज़ है — चलिए सेट अप करते हैं।"
+  },
+  "onboarding_micTestButton": {
+    "description": "बटन जो बिना किसी दबाव वाले ऑनबोर्डिंग माइक्रोफ़ोन टेस्ट को शुरू करता है।",
+    "message": "🎤 अपना माइक्रोफ़ोन टेस्ट करें"
+  },
+  "onboarding_micTestDone": {
+    "description": "ऑनबोर्डिंग माइक टेस्ट सफलतापूर्वक पूरा होने के बाद दिखने वाली स्थिति।",
+    "message": "अच्छा — आपका माइक्रोफ़ोन काम कर रहा है 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "ऑनबोर्डिंग माइक टेस्ट के इनपुट मापते समय दिखने वाली स्थिति।",
+    "message": "सुन रहे हैं — कुछ बोलिए 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "ऑनबोर्डिंग माइक टेस्ट में अनुमति का इंतज़ार करते समय दिखने वाली स्थिति।",
+    "message": "माइक्रोफ़ोन की अनुमति मांग रहे हैं…"
+  },
+  "onboarding_micTestStop": {
+    "description": "ऑनबोर्डिंग माइक टेस्ट चल रहा हो तब उसे रोकने के लिए बटन लेबल।",
+    "message": "टेस्ट रोकें"
+  },
+  "onboarding_step1Body": {
+    "description": "एक्सटेंशन को पिन करने का तरीका समझाने वाला पहले ऑनबोर्डिंग चरण का मुख्य पाठ।",
+    "message": "अपने ब्राउज़र के ऊपर-दाईं ओर पज़ल-पीस 🧩 आइकन पर क्लिक करें, फिर Say, Pi के पास पिन 📌 पर क्लिक करें। इससे कॉल बटन एक क्लिक की दूरी पर रहता है।"
+  },
+  "onboarding_step1Title": {
+    "description": "पहले ऑनबोर्डिंग चरण का शीर्षक (एक्सटेंशन को पिन करना)।",
+    "message": "Say, Pi को अपनी टूलबार में पिन करें"
+  },
+  "onboarding_step2Body": {
+    "description": "वॉइस बातचीत शुरू करने का तरीका समझाने वाला दूसरे ऑनबोर्डिंग चरण का मुख्य पाठ।",
+    "message": "नीचे दिए गए समर्थित असिस्टेंट में से किसी एक पर जाएँ, फिर Say, Pi कॉल बटन दबाएँ और नमस्ते कहें। पहली बार हम माइक्रोफोन की अनुमति माँगेंगे — यह सामान्य है, और हम केवल तभी सुनते हैं जब आप सक्रिय रूप से कॉल में हों।"
+  },
+  "onboarding_step2Title": {
+    "description": "दूसरे ऑनबोर्डिंग चरण का शीर्षक (बातचीत शुरू करना)।",
+    "message": "AI चैट खोलें और बोलना शुरू करें"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "माइक्रोफोन अनुमति"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "रिकवरी मार्गदर्शन, जब माइक्रोफ़ोन अनुमति ब्लॉक हो।",
+    "message": "आपका ब्राउज़र माइक्रोफ़ोन को ब्लॉक कर रहा है। एड्रेस बार में कैमरा या लॉक आइकन पर क्लिक करें, Microphone को \"Allow\" पर सेट करें, फिर दोबारा कोशिश करें। macOS पर, System Settings → Privacy & Security → Microphone भी जाँचें।"
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "रिकवरी पैनल का शीर्षक, जब माइक्रोफ़ोन अनुमति अस्वीकार/ब्लॉक कर दी गई हो।",
+    "message": "माइक्रोफ़ोन एक्सेस ब्लॉक है"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "रिकवरी मार्गदर्शन, जब माइक्रोफ़ोन कहीं और उपयोग में हो।",
+    "message": "कोई दूसरा ऐप या टैब आपका माइक्रोफ़ोन इस्तेमाल कर रहा हो सकता है। जो भी रिकॉर्ड कर रहा हो सकता है उसे बंद करें (वीडियो कॉल, वॉइस मेमो), फिर दोबारा कोशिश करें।"
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "रिकवरी पैनल का शीर्षक, जब माइक्रोफ़ोन किसी अन्य ऐप द्वारा उपयोग में हो।",
+    "message": "आपका माइक्रोफ़ोन व्यस्त है"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "रिकवरी मार्गदर्शन, जब कोई माइक्रोफ़ोन डिवाइस उपलब्ध न हो।",
+    "message": "हमें कोई माइक्रोफ़ोन नहीं मिला। एक प्लग इन करें (या अपना हेडसेट कनेक्ट करें), सुनिश्चित करें कि वह आपके इनपुट डिवाइस के रूप में चुना गया है, फिर दोबारा कोशिश करें।"
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "रिकवरी पैनल का शीर्षक, जब कोई माइक्रोफ़ोन डिवाइस उपलब्ध न हो।",
+    "message": "कोई माइक्रोफ़ोन नहीं मिला"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "किसी अज्ञात माइक्रोफ़ोन त्रुटि के लिए रिकवरी मार्गदर्शन।",
+    "message": "आपके माइक्रोफ़ोन तक पहुँचने में कुछ गड़बड़ हो गई। जाँचें कि वह कनेक्ट है और आपकी ब्राउज़र सेटिंग्स में अनुमति दी गई है, फिर दोबारा कोशिश करें।"
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "किसी अज्ञात माइक्रोफ़ोन त्रुटि के लिए रिकवरी पैनल का शीर्षक।",
+    "message": "हम आपके माइक्रोफ़ोन तक नहीं पहुँच पाए"
+  },
+  "permissions_retryButton": {
+    "description": "उस बटन का लेबल जो माइक्रोफ़ोन अनुमति के लिए दोबारा अनुरोध करता है।",
+    "message": "फिर से कोशिश करें"
+  },
+  "permissions_revokedHeading": {
+    "description": "शीर्षक, जब माइक्रोफ़ोन एक्सेस पहले दिया गया था लेकिन बाद में वापस ले लिया गया।",
+    "message": "🎙️ आइए आपका माइक्रोफ़ोन फिर से कनेक्ट करें"
+  },
+  "permissions_revokedInfo": {
+    "description": "जानकारी वाला पाठ, जब माइक्रोफ़ोन एक्सेस अनुमति मिलने के बाद रद्द/वापस ले लिया गया हो।",
+    "message": "आपका माइक्रोफ़ोन एक्सेस बंद कर दिया गया था — यह अक्सर ब्राउज़र या सिस्टम अपडेट के बाद होता है। नीचे फिर से अनुमति दें और जब आप कॉल में होंगे, $productName$ फिर से सुनने लगेगा।",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "प्रोफ़ाइल"
+  },
+  "quietModeLabel": {
+    "description": "उस टॉगल के लिए लेबल जो शांत/फुसफुसाहट मोड सक्षम करता है।",
+    "message": "शांत मोड"
+  },
+  "quietModeTooltip": {
+    "description": "समझाने के लिए टूलटिप कि शांत/फुसफुसाहट मोड क्या करता है।",
+    "message": "धीरे बोलें — यह धीमी आवाज़ भी पकड़ता है और असिस्टेंट के जवाब की आवाज़ कम करता है, ताकि आप दूसरों के आसपास भी वॉइस इस्तेमाल कर सकें।"
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "प्रमाणीकरण जारी होने के दौरान साइन इन बटन के लिए टेक्स्ट।",
+    "message": "साइन इन हो रहा है..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "ध्वनि प्रभाव"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "ऑडियो फीडबैक समस्याओं को रोकने के लिए फ़ायरफ़ॉक्स में ध्वनि प्रभाव अक्षम हैं।"
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "पहले बोले गए एक्सचेंज के बाद दिखने वाली एक-बार वाली speed-payoff सूचना की हेडलाइन।",
+    "message": "अच्छा — बोलना टाइप करने से लगभग 3× तेज़ है।"
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "speed-payoff सूचना की वैकल्पिक दूसरी पंक्ति, जो बचाए गए पूरे मिनट दिखाती है।",
+    "message": "आपने इसे टाइप करने के बजाय लगभग $minutes$ मिनट तेज़ बोल लिया।",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "जब आप बटन दबाएँ तभी सबमिट करें"
   },
+  "surveyQuestion": {
+    "description": "एक बार दिखने वाले पोस्ट-विन माइक्रो-सर्वे का एकमात्र सवाल।",
+    "message": "अब तक आवाज़ आपके लिए कैसी काम कर रही है?"
+  },
+  "surveyRatingLabel": {
+    "description": "सर्वे रेटिंग बटन के लिए सुलभ लेबल।",
+    "message": "5 में से $rating$ रेट करें",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "यूज़र के पोस्ट-विन सर्वे का जवाब देने के बाद दिखाया जाने वाला आभार संदेश।",
+    "message": "धन्यवाद — इससे हमें Say, Pi को बेहतर बनाने में मदद मिलती है। 🙏"
+  },
   "tabAIChat": {
     "description": "एआई चैट सेटिंग्स अनुभाग के लिए टैब लेबल।",
     "message": "एआई चैट"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "सामान्य सेटिंग्स अनुभाग के लिए टैब लेबल।",
     "message": "सामान्य"
+  },
+  "tabVoices": {
+    "description": "आवाज़ों की सेटिंग्स सेक्शन (प्रति साइट वॉइस कैटलॉग) के लिए टैब लेबल।",
+    "message": "आवाज़ें"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "क्रेडिट"
   },
+  "ttsCreditsRemaining": {
+    "description": "बची हुई TTS कोटा दिखाने वाला टेक्स्ट, प्रति-आवाज़ क्रेडिट पूल के रूप में (saypi-api #181 Stage 2), कच्चे अक्षरों के रूप में नहीं।",
+    "message": "$credits$ क्रेडिट शेष",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "सफ़ारी में वर्तमान में बहुभाषी आवाज़ें समर्थित नहीं हैं।"
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "आवाज"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "ध्यान दें! $browserName$ पर $chatbotName$ के साथ स्पीच प्लेबैक अभी उपलब्ध नहीं है। अच्छी खबर? वॉयस इनपुट बहुत अच्छा काम करता है! TTS के लिए, डेस्कटॉप पर Chrome या Edge आज़माएं।",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "$browserName$ + $chatbotName$ पर TTS उपलब्ध नहीं है। वॉयस इनपुट काम करता है! TTS के लिए Chrome डेस्कटॉप आज़माएं।",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "टीटीएस आवाज"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "जब बोलने जैसा ऑडियो मिला लेकिन वह ट्रांसक्राइब करने के लिए बहुत धीमा / कम भरोसे वाला था (क्लाइंट-साइड एडमिशन-गेट ड्रॉप), तब दिखने वाला VAD विवरण।",
+    "message": "ऑडियो ट्रांसक्राइब करने के लिए बहुत धीमा है"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "VAD विवरण जो बताता है कि माइक्रोफोन को नए टैब ने क्लेम कर लिया, इसलिए कॉल खत्म हो गई।",
+    "message": "वॉइस इनपुट दूसरे टैब में चला गया"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "आवाज उपलब्ध नहीं है। \nडेस्कटॉप पर क्रोम या फ़ायरफ़ॉक्स का प्रयास करें।"
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "ध्यान दें! $browserName$ पर $chatbotName$ के साथ स्पीच प्लेबैक अभी उपलब्ध नहीं है। अच्छी खबर? वॉयस इनपुट बहुत अच्छा काम करता है! TTS के लिए, डेस्कटॉप पर Chrome या Edge आज़माएं।",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "$browserName$ + $chatbotName$ पर TTS उपलब्ध नहीं है। वॉयस इनपुट काम करता है! TTS के लिए Chrome डेस्कटॉप आज़माएं।",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "समझ गए",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "उस टैब पर दिखाया जाने वाला VAD स्टेटस, जिसकी वॉइस इनपुट को किसी दूसरे टैब ने अपने नियंत्रण में ले लिया हो।",
+    "message": "रोका गया"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "विवरण देखें"
   },
+  "voiceIntroductionGeneric": {
+    "description": "सामान्य बोला गया परिचय, जब चुनी गई SayPi वॉइस के पास वॉइस-विशेष परिचय स्क्रिप्ट नहीं होती (और पढ़कर सुनाने के लिए कोई हालिया संदेश भी नहीं होता)।",
+    "message": "नमस्ते, मैं $voice$ हूँ। मेरी आवाज़ ऐसी है। उम्मीद है आपको यह आवाज़ पसंद आएगी।",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "होला! \nПривет! \nठीक है! \nमैं पाई हूं, आपका बहुभाषी एआई सहायक। \nमेरे नियंत्रण में 32 भाषाओं के साथ, हम दुनिया भर के विचारों और संस्कृतियों का पता लगा सकते हैं। \nआप इस आवाज़ के बारे में क्या सोचते हैं?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "आवाज सेटिंग्स"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "सेटिंग्स वॉइस कैटलॉग में किसी वॉइस पंक्ति के लिए फ़ॉलबैक सबटाइटल, जब वॉइस का कोई विवरण नहीं होता; $count$ उन भाषाओं की संख्या है जिन्हें वॉइस सपोर्ट करती है।",
+    "message": "$count$ भाषाएँ बोलता है",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "'Addison' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "खुशनुमा और स्पष्ट वक्ता"
+  },
+  "voiceTagline_alloy": {
+    "description": "'Alloy' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "संतुलित और हर काम के लिए"
+  },
+  "voiceTagline_ash": {
+    "description": "'Ash' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "गहरी, विचारशील, शांत"
+  },
+  "voiceTagline_ballad": {
+    "description": "'Ballad' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "मुलायम और मधुर"
+  },
+  "voiceTagline_cassidy": {
+    "description": "'Cassidy' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "मिलनसार और साफ़-साफ़"
+  },
+  "voiceTagline_cedar": {
+    "description": "'Cedar' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "स्थिर और भरोसा जगाने वाली"
+  },
+  "voiceTagline_coral": {
+    "description": "'Coral' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "उज्ज्वल, उत्साहपूर्ण ऊर्जा"
+  },
+  "voiceTagline_echo": {
+    "description": "'Echo' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "साफ़ और तटस्थ"
+  },
+  "voiceTagline_fable": {
+    "description": "'Fable' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "कहानीकार जैसी लय"
+  },
+  "voiceTagline_finn": {
+    "description": "'Finn' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "ताज़ा और ऊर्जावान"
+  },
+  "voiceTagline_jamahal": {
+    "description": "'Jamahal' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "समृद्ध और आकर्षक"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "'Jarnathan' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "मखमली देर-रात वाला बैरिटोन"
+  },
+  "voiceTagline_jeff": {
+    "description": "'Jeff' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "सीधी और स्थिर"
+  },
+  "voiceTagline_jessica": {
+    "description": "'Jessica' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "गर्मजोशी भरा, तराशा हुआ ठहराव"
+  },
+  "voiceTagline_joey": {
+    "description": "'Joey' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "आसान, संवादात्मक अमेरिकी अंदाज़"
+  },
+  "voiceTagline_juniper": {
+    "description": "'Juniper' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "सटीक, उजला, जीवंत"
+  },
+  "voiceTagline_lucy": {
+    "description": "'Lucy' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "मृदु और उज्ज्वल"
+  },
+  "voiceTagline_marin": {
+    "description": "'Marin' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "गरमजोशी भरा, सुबह-रेडियो जैसा सुकून"
+  },
+  "voiceTagline_mark": {
+    "description": "'Mark' वॉइस के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस पहचान मैप)।",
+    "message": "स्पष्ट, आत्मविश्वासी कथावाचक"
+  },
+  "voiceTagline_nova": {
+    "description": "'Nova' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "तेज़ और जिज्ञासु"
+  },
+  "voiceTagline_onyx": {
+    "description": "'Onyx' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "गहरी, गूंजती गरिमा"
+  },
+  "voiceTagline_paola": {
+    "description": "'Paola' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "अभिव्यक्तिपूर्ण इतालवी गरमजोशी"
+  },
+  "voiceTagline_sage": {
+    "description": "'Sage' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "धीमे स्वर की स्पष्टता"
+  },
+  "voiceTagline_shimmer": {
+    "description": "'Shimmer' आवाज़ के लिए लिखी गई व्यक्तित्व टैगलाइन (सेटिंग्स Voices स्टूडियो; क्लाइंट-साइड वॉइस आइडेंटिटी मैप)।",
+    "message": "हल्की और हवादार"
+  },
+  "voicesAddToMenuShort": {
+    "description": "सेटिंग्स Voices स्टूडियो में वॉइस कार्ड के पिन टॉगल (ऑफ़ स्थिति) पर छोटा लेबल; दबाने पर आवाज़ होस्ट के चैट-इन मेनू में जुड़ जाती है।",
+    "message": "+ मेनू"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "वॉइस कार्ड के पिन टॉगल (ऑफ़ स्थिति) के लिए सुलभ लेबल; $name$ आवाज़ है, $host$ असिस्टेंट।",
+    "message": "$host$ के मेनू में $name$ जोड़ें",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Voices कंट्रोल बार में टॉगल का लेबल, जो बताता है कि एरो कीज़ से सूची में आगे बढ़ने पर फोकस पहुँचते ही हर आवाज़ चलती है या नहीं।",
+    "message": "जैसे-जैसे आप जाएँ, वैसे ही चलाएँ"
+  },
+  "voicesArrowsLive": {
+    "description": "सेटिंग्स के Voices सूची में पहली 'Playing <voice>' घोषणा के साथ जोड़ा गया स्क्रीन-रीडर पुष्टिकरण, जो बताता है कि तीर कुंजियाँ अभी सुनाई देने लगी हैं। 'Play as you move' टॉगल के शब्दों को दोहराता है।",
+    "message": "अब चलते समय तीर कुंजियाँ चलाएँगी। Esc रोकता है।"
+  },
+  "voicesBuiltinsNote": {
+    "description": "उन होस्ट्स के लिए मेनू स्लॉट्स के नीचे नोट जिनमें नेटिव आवाज़ें आती हैं (जैसे Pi की 8 बिल्ट-इन), जिन्हें स्टूडियो मैनेज नहीं करता; $host$ असिस्टेंट है।",
+    "message": "$host$ की अपनी बिल्ट-इन आवाज़ें उसके मेनू में भी हमेशा दिखती हैं।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "voicesBuiltinsNote का रूपांतर उस होस्ट के लिए जिसमें इन-चैट वॉइस मेनू नहीं है (Pi ने 2026 में अपना मेनू हटाया), जहाँ मूल वाक्य का यह कहना कि बिल्ट-इन आवाज़ें 'उसके मेनू में दिखती हैं' गलत हो जाएगा; $host$ असिस्टेंट है।",
+    "message": "$host$ की अपनी बिल्ट-इन आवाज़ें भी हैं, जो यहाँ सूचीबद्ध नहीं हैं।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार में प्रगति रीडआउट: सूचीबद्ध आवाज़ों में से कितनी को उपयोगकर्ता पहले ही सुन चुका है। सिर्फ़ संख्याएँ, ताकि 1 पर भी सही पढ़े — Chrome i18n में बहुवचन रूप नहीं हैं।",
+    "message": "$total$ में से $heard$ सुना गया",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "सेटिंग्स के Voices सूची में आवाज़ की पंक्ति के सुलभ नाम का हिस्सा, जो बताता है कि इस प्रोफ़ाइल ने यह आवाज़ पहले ही सुन ली है। दृश्य रूप से यह आवाज़ के साउंडप्रिंट पर स्याही की घनता के रूप में दिखता है, जिसे स्क्रीन रीडर नहीं देख सकता।",
+    "message": "सुना गया"
+  },
+  "voicesInHostMenu": {
+    "description": "सेटिंग्स Voices स्टूडियो में मेनू स्लॉट्स वाली पंक्ति के ऊपर सेक्शन हेडिंग; $host$ असिस्टेंट है।",
+    "message": "$host$ के मेनू में",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "सेटिंग्स Voices स्टूडियो में वॉइस कार्ड के पिन टॉगल (ऑन स्थिति) पर छोटा लेबल।",
+    "message": "✓ मेनू में"
+  },
+  "voicesInUse": {
+    "description": "सेटिंग्स Voices सूची में होस्ट की वर्तमान में चुनी गई आवाज़ पर स्थायी बैज, uppercase में रेंडर होता है। जानबूझकर 'अभी बोल रहा है' नहीं: इस पेज पर पंक्तियाँ अपने सैंपल क्लिप चलाती हैं, इसलिए चुनी हुई लेकिन शांत आवाज़ को बोलने का दावा नहीं करना चाहिए जब कोई दूसरी पंक्ति चल रही हो।",
+    "message": "उपयोग में"
+  },
+  "voicesKeyboardHint": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार में एक लाइन का कीबोर्ड संकेत। ये चिन्ह कुंजियाँ हैं: Space, ऊपर/नीचे वाले तीर, और Shift+Space।",
+    "message": "सुनने के लिए Space दबाएँ, आवाज़ों में जाने के लिए ↑↓, वापस स्विच करने के लिए ⇧Space"
+  },
+  "voicesLoadError": {
+    "description": "किसी एक होस्ट के स्टूडियो के अंदर त्रुटि स्थिति, जब उस होस्ट का वॉइस कैटलॉग लोड नहीं हो पाया; $host$ असिस्टेंट है।",
+    "message": "$host$ की आवाज़ें लोड नहीं हो सकीं। कृपया बाद में फिर कोशिश करें।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "जब होस्ट के चैट-इन मेनू में आवाज़ों की अधिकतम संख्या पहले से हो, तब निष्क्रिय '+ मेनू' टॉगल पर टूलटिप/संकेत।",
+    "message": "मेनू भर गया है — दूसरा जोड़ने के लिए कोई आवाज़ हटाएँ"
+  },
+  "voicesMenuHint": {
+    "description": "'In {host}'s menu' हेडिंग के पास एक लाइन का संकेत, जो बताता है कि स्लॉट्स वाली पंक्ति चैट के अंदर वाले वॉइस मेनू को प्रतिबिंबित करती है।",
+    "message": "चैट में आपको यही दिखेगा"
+  },
+  "voicesMenuOverflow": {
+    "description": "जब उपयोगकर्ता के पास जितनी पिन की गई आवाज़ें हैं वे इन-चैट मेनू में दिखने वाली संख्या से ज़्यादा हों (पुरानी स्थिति), तब मेनू स्लॉट्स के नीचे दिखने वाला नोट; $count$ बताता है कितनी आवाज़ें फिट नहीं हुईं, $cap$ मेनू का आकार है।",
+    "message": "$count$ और पिन की गई आवाज़ें मेनू के $cap$ स्लॉट्स से आगे इंतज़ार कर रही हैं।",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "voicesMenuOverflow का एकवचन रूप, जब ठीक एक पिन की गई आवाज़ इन-चैट मेनू में फिट नहीं होती; $cap$ मेनू का आकार है।",
+    "message": "1 और पिन की गई आवाज़ मेनू के $cap$ स्लॉट्स से आगे इंतज़ार कर रही है।",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "सेटिंग्स के Voices सूची के नीचे सार पंक्ति जो बताती है कि होस्ट के इन-चैट वॉइस मेनू में कितना भरा है; $host$ सहायक है, $used$ कितनी सीटें भरी हैं, $cap$ कुल कितनी हैं। इसे 1 पर भी सही पढ़ने लायक लिखा गया है — Chrome i18n में बहुवचन रूप नहीं हैं।",
+    "message": "$host$ का मेनू: $cap$ में से $used$ सीटें",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "सेटिंग्स के Voices सूची के अंत में उस समूह के लिए शीर्षक जिसमें चलाने के लिए कोई सैंपल क्लिप नहीं है; $count$ कितनी हैं। इसे 1 पर भी सही पढ़ने लायक लिखा गया है — Chrome i18n में बहुवचन रूप नहीं हैं।",
+    "message": "अभी तक कोई सैंपल नहीं ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "सेटिंग्स वॉइस कैटलॉग में तब दिखाया जाता है जब साइन-इन उपयोगकर्ता के लिए वॉइस सूची खाली हो (जैसे नेटवर्क समस्या)।",
+    "message": "अभी वॉइस लोड नहीं हो सकीं. कृपया बाद में फिर से कोशिश करें."
+  },
+  "voicesNowPlaying": {
+    "description": "सेटिंग्स के Voices सूची में किसी आवाज़ का सैंपल क्लिप चलना शुरू होने पर स्क्रीन रीडर की घोषणा; $name$ वह आवाज़ है।",
+    "message": "$name$ चल रहा है",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार में बटन जो अभी सूचीबद्ध हर आवाज़ को एक-एक करके चलाता है; $count$ कितनी हैं। इसे 1 पर भी सही पढ़ने लायक लिखा गया है — Chrome i18n में बहुवचन रूप नहीं हैं।",
+    "message": "सब चलाएँ ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "वापसी पर सेटिंग्स के Voices कंट्रोल बार में बटन: सिर्फ़ वे सूचीबद्ध आवाज़ें चलाता है जिन्हें आपने अभी तक नहीं सुना; $count$ कितनी हैं। इसे 1 पर भी सही पढ़ने लायक लिखा गया है — Chrome i18n में बहुवचन रूप नहीं हैं।",
+    "message": "नई चलाएँ ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार की पंक्ति, जब पेज पर अभी तक उपयोगकर्ता इंटरैक्शन न होने के कारण ब्राउज़र ने सैंपल चलाने से मना कर दिया।",
+    "message": "ध्वनि चालू करने के लिए किसी भी वॉइस पर क्लिक करें।"
+  },
+  "voicesPreview": {
+    "description": "प्ले (▶) बटन के लिए सुलभ लेबल, जो वॉइस पंक्ति पर किसी वॉइस की निःशुल्क नमूना क्लिप चलाता है; $name$ वॉइस का नाम है।",
+    "message": "$name$ का नमूना चलाएँ",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "सेटिंग्स की Voices सूची का सुलभ नाम (हर आवाज़ के लिए एक पंक्ति, सभी आवाज़ों की सूचीबॉक्स)।",
+    "message": "आवाज़ें, सबसे गहरी से सबसे चमकीली तक क्रम में"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "वॉइस कार्ड के पिन टॉगल (ऑन स्थिति) और मेनू स्लॉट के हटाने वाले बटन के लिए सुलभ लेबल; $name$ आवाज़ है, $host$ असिस्टेंट।",
+    "message": "$host$ के मेनू से $name$ हटाएँ",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार की पंक्ति, जब किसी एक वॉइस का सैंपल क्लिप लोड या प्ले नहीं हो पाया; $name$ वही वॉइस है। यह मोडल नहीं है — सैंपलों की श्रृंखला इसके बाद भी चलती रहती है।",
+    "message": "$name$ का सैंपल नहीं चल पाया।",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "सेटिंग्स के AI Chat टैब में आवाज़ कैटलॉग सेक्शन के लिए उपशीर्षक",
+    "message": "हर साइट पर जवाबों को ज़ोर से पढ़ने वाली आवाज़ चुनें।"
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Voices सेटिंग्स शीर्षक के नीचे उपशीर्षक, पिच-क्रम वाली आवाज़ों की रेल के लिए।",
+    "message": "हर आवाज़, सबसे गहरी से सबसे चमकीली तक। सुनें, फिर चुनें।"
+  },
+  "voicesSectionTitle": {
+    "description": "सेटिंग्स के AI Chat टैब में आवाज़ कैटलॉग सेक्शन के लिए शीर्षक",
+    "message": "आवाज़ें"
+  },
+  "voicesShelfEveryday": {
+    "description": "सेटिंग्स आवाज़ कैटलॉग में वैल्यू-टियर आवाज़ों के लिए समूह शीर्षक। CSS द्वारा अपरकेस में रेंडर होता है।",
+    "message": "रोज़मर्रा की आवाज़ें"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "सेटिंग्स के Voices स्टूडियो में Everyday समूह शीर्षक के पास एक-पंक्ति नोट; स्टूडियो में यही एक जगह है जहाँ बताया जाता है कि यह टियर HD से कितना आगे तक जाता है।",
+    "message": "प्राकृतिक और स्पष्ट — HD की तुलना में आप लगभग 20× ज़्यादा देर सुन सकते हैं।"
+  },
+  "voicesShelfHd": {
+    "description": "सेटिंग्स आवाज़ कैटलॉग में प्रीमियम (HD) आवाज़ों के लिए समूह शीर्षक। CSS द्वारा अपरकेस में रेंडर होता है।",
+    "message": "HD आवाज़ें"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "सेटिंग्स के Voices स्टूडियो में HD समूह शीर्षक के पास एक-पंक्ति नोट।",
+    "message": "हमारी सबसे समृद्ध, सबसे अभिव्यंजक ध्वनि।"
+  },
+  "voicesShowAll": {
+    "description": "सेटिंग्स के Voices 'Show' फ़िल्टर में विकल्प: कोई फ़िल्टर नहीं, हर वॉइस सूचीबद्ध होती है।",
+    "message": "सभी वॉइस"
+  },
+  "voicesShowEveryday": {
+    "description": "सेटिंग्स के Voices 'Show' फ़िल्टर में विकल्प: केवल मानक (non-HD) वॉइस सूचीबद्ध करें।",
+    "message": "केवल रोज़मर्रा"
+  },
+  "voicesShowHd": {
+    "description": "सेटिंग्स के Voices 'Show' फ़िल्टर में विकल्प: केवल प्रीमियम (HD) वॉइस सूचीबद्ध करें।",
+    "message": "केवल HD"
+  },
+  "voicesShowLabel": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार में फ़िल्टर का लेबल, जो सूची में दिखने वाली वॉइसों को सीमित करता है।",
+    "message": "दिखाएँ"
+  },
+  "voicesShowUnheard": {
+    "description": "सेटिंग्स के Voices 'Show' फ़िल्टर में विकल्प: केवल वे वॉइस सूचीबद्ध करें जिन्हें उपयोगकर्ता ने अभी तक नहीं सुना है।",
+    "message": "अभी तक नहीं सुनी"
+  },
+  "voicesSpeakingNow": {
+    "description": "सेटिंग्स Voices स्टूडियो में होस्ट की वर्तमान में चुनी गई आवाज़ पर स्टेट लेबल (मेनू स्लॉट और वॉइस कार्ड)।",
+    "message": "अभी बोल रहा है"
+  },
+  "voicesSpeaksWith": {
+    "description": "सेटिंग्स Voices स्टूडियो स्टेज में वर्तमान आवाज़ के नाम के ऊपर आइब्रो लाइन; $host$ असिस्टेंट है (जैसे Pi)। CSS द्वारा uppercase में रेंडर होता है।",
+    "message": "$host$ बोलता है",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "स्टेज नोट जब होस्ट अपना ही ऑडियो देता है (जैसे Pi), इसलिए Say, Pi की कोई आवाज़ चुनने पर होस्ट की आवाज़ बदल जाती है।",
+    "message": "जब तक आप नीचे से कोई आवाज़ नहीं चुनते, $host$ अपनी ही आवाज़ इस्तेमाल करेगा।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "स्टेज नोट जब होस्ट के पास अपनी कोई आवाज़ नहीं होती (जैसे Claude), इसलिए Say, Pi की आवाज़ चुने बिना कुछ भी ज़ोर से नहीं पढ़ा जाता।",
+    "message": "जब तक आप नीचे से कोई आवाज़ नहीं चुनते, $host$ जवाबों को ज़ोर से नहीं पढ़ेगा।",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Voices स्टूडियो स्टेज पर सेटिंग्स में शीर्षक, जब होस्ट के लिए कोई SayPi आवाज़ चुनी नहीं गई हो; $host$ असिस्टेंट है (जैसे Pi, Claude)। नाम के आकार में रेंडर होता है।",
+    "message": "चुनें कि $host$ की आवाज़ कैसी लगे",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Voices स्टूडियो स्टेज पर बटन, जो वर्तमान आवाज़ का मुफ्त सैंपल क्लिप चलाता है।",
+    "message": "सैंपल सुनें"
+  },
+  "voicesStopPlayback": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार में बटन जो 'Play all' से शुरू हुए सैंपल्स के क्रम को रोकता है।",
+    "message": "रोकें"
+  },
+  "voicesSweepPosition": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार में लाइव स्थिति दिखाने वाला पाठ, जब 'Play all' सूची में आगे बढ़ता है; $index$ अभी चल रही वॉइस है और $total$ कतार में कुल कितनी हैं।",
+    "message": "$total$ में से $index$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार में compare कंट्रोल के लिए सुलभ लेबल, जो पिछली दो सुनी गई आवाज़ों में से दूसरी वाली को फिर चलाता है; $name$ वही आवाज़ है।",
+    "message": "$name$ पर वापस स्विच करें",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "सेटिंग्स के Voices कंट्रोल बार की पंक्ति, जब बहुत लंबी सूची पर 'Play all' दबाया जाता है; $count$ वॉइसों की संख्या है और $minutes$ लगभग कितने मिनट लगेंगे। 'min' संक्षिप्त रखा है ताकि 1 पर भी सही लगे — Chrome i18n में बहुवचन रूप नहीं हैं।",
+    "message": "ये $count$ वॉइस हैं — लगभग $minutes$ min. पहले सूची को सीमित करें।",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "सेटिंग्स वॉइस कैटलॉग में प्रति-होस्ट 'इस आवाज़ का उपयोग करें' बटन के लिए सुलभ लेबल; $name$ आवाज़ है, $host$ असिस्टेंट है (जैसे Pi, Claude)।",
+    "message": "$host$ पर $name$ उपयोग करें",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "यूनिफ़ाइड सेटिंग्स वॉइस कैटलॉग में प्रति-होस्ट 'इस आवाज़ का उपयोग करें' बटन पर छोटा लेबल (होस्ट इसके साथ दिखाया जाता है)।",
+    "message": "उपयोग करें"
+  },
+  "voicesYourVoice": {
+    "description": "सेटिंग्स के Voices सूची में कंट्रोल-बार बटन जो फ़ोकस को उस आवाज़ की पंक्ति पर ले जाता है जिसे यह होस्ट अभी उपयोग कर रहा है; $name$ वही आवाज़ है।",
+    "message": "आपकी आवाज़: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "एरर, जब ब्राउज़र वॉइस-डिटेक्शन मॉडल के लिए पर्याप्त WebAssembly मेमोरी आवंटित नहीं कर पाता।",
+    "message": "वॉइस डिटेक्शन शुरू नहीं हो सकता: वॉइस मॉडल के लिए पर्याप्त WebAssembly मेमोरी नहीं है। $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "एरर, जब ब्राउज़र वॉइस-डिटेक्शन मॉडल चलाने के लिए ज़रूरी शुरुआती WebAssembly मेमोरी उपलब्ध नहीं कराता।",
+    "message": "वॉइस डिटेक्शन शुरू नहीं हो सकता: इस ब्राउज़र में WebAssembly मेमोरी उपलब्ध नहीं है।"
   }
 }

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Prednost navedena u modalu za prijavu - povećana ograničenja korištenja.",
+    "message": "Veća ograničenja korištenja uz besplatan račun"
+  },
+  "authBenefitPremium": {
+    "description": "Prednost navedena u modalu za prijavu - premium značajke u chatbotovima.",
+    "message": "Premium značajke i podrška za chatbotove"
+  },
+  "authBenefitSupport": {
+    "description": "Prednost navedena u modalu za prijavu - prioritetna podrška.",
+    "message": "Prioritetna podrška za probleme"
+  },
+  "authBenefitSync": {
+    "description": "Prednost navedena u modalu za prijavu - sinkronizacija postavki.",
+    "message": "Sinkronizirajte postavke glasova posvuda"
+  },
+  "authBenefitTTS": {
+    "description": "Prednost navedena u modalu za prijavu - značajka TTS.",
+    "message": "Glasovi za pretvorbu teksta u govor (plaćeni planovi)"
+  },
+  "authBenefitUsage": {
+    "description": "Prednost navedena u modalu za prijavu - praćenje korištenja.",
+    "message": "Pratite korištenje glasova na svim uređajima"
+  },
+  "authPromptModalFull": {
+    "description": "Opis za puni modalni upit za prijavu/autentifikaciju s vrijednosnom ponudom.",
+    "message": "Vidimo da često koristite Say, Pi. Prijavite se za veća ograničenja, glasove za pretvorbu teksta u govor i premium značajke u svim podržanim chatbotovima."
+  },
+  "authPromptModalSoft": {
+    "description": "Opis za blagi modalni upit za prijavu/autentifikaciju.",
+    "message": "Izradite besplatan Say, Pi račun za veća ograničenja korištenja i pristup premium glasovnim značajkama."
+  },
+  "authPromptTitle": {
+    "description": "Naslov za modal za prijavu/autentifikaciju.",
+    "message": "Otključajte više glasovnih značajki"
+  },
+  "authPromptToast": {
+    "description": "Toast obavijest koja potiče korisnika da se prijavi.",
+    "message": "Prijavite se u Say, Pi za veća ograničenja i premium značajke"
+  },
   "autoReadAloudChatGPT": {
     "description": "Oznaka za okvir za potvrdu kojim se omogućuje ili onemogućuje automatsko čitanje ChatGPT odgovora tijekom glasovnih poziva.",
     "message": "Automatsko glasno čitanje (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Onemogućite tekst u govor"
   },
+  "dismiss": {
+    "message": "Razumijem",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Odbaci"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Usredotoči se"
   },
+  "errorVadInitFailed": {
+    "description": "Poruka o pogrešci prikazana kada se detekcija glasovne aktivnosti ne uspije pokrenuti.",
+    "message": "Nije uspjelo pokretanje detekcije glasa"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Poruka o pogrešci prikazana kada dođe do neočekivane pogreške tijekom postavljanja snimanja glasa.",
+    "message": "Nije uspjelo postavljanje snimanja glasa"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Poruka o pogrešci prikazana kada klijent za detekciju glasa ne uspije pokrenuti snimanje.",
+    "message": "Nije uspjelo pokretanje snimanja glasa"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Poruka o pogrešci prikazana kada klijent za detekciju glasa (VAD) nije dostupan, pa snimanje ne može započeti.",
+    "message": "Snimanje glasa nije dostupno"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Izađi iz fokusiranog načina"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Jednoredna napomena prikazana u izbornicima glasova kada su dostupni i premium (HD) i value glasovi",
+    "message": "HD glasovi troše vašu mjesečnu kvotu oko 20× brže."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Uguravanje ovoga ..."
   },
+  "maybeLater": {
+    "description": "Tekst gumba za odbacivanje upita za prijavu/autentifikaciju.",
+    "message": "Možda poslije"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Vaše postavke mikrofona ne zadovoljavaju potrebne specifikacije. \nPokušajte upotrijebiti drugi mikrofon ili prilagoditi postavke zvuka."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Nije moguće pristupiti mikrofonu. \nProvjerite postavke uređaja i pokušajte ponovno."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Poruka o pogrešci prikazana kada je dopuštenje za mikrofon odbijeno nakon tijeka upita za dopuštenje.",
+    "message": "Dopuštenje za mikrofon nije odobreno. Provjerite jeste li dopustili pristup u upitu i u postavkama proširenja."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "točnost"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Najbrži odgovor, ali manje točan. \nSklon prekidanju."
   },
+  "moreVoices": {
+    "description": "Redak izbornika koji vodi iz izbornika glasova na stranici na puni katalog glasova u postavkama proširenja.",
+    "message": "Više glasova…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Nadimak asistenta"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Nije prijavljen"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Oznaka gumba koja otvara ChatGPT.",
+    "message": "Otvori ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Oznaka gumba koji otvara Claude.ai.",
+    "message": "Otvori Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Oznaka gumba koji otvara Pi.ai.",
+    "message": "Otvori Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Opcija okruženja: u blizini drugih ljudi.",
+    "message": "U blizini drugih ljudi"
+  },
+  "onboarding_envMixed": {
+    "description": "Opcija okruženja: kombinacija privatnih i zajedničkih prostora.",
+    "message": "Malo ovdje, malo tamo"
+  },
+  "onboarding_envPrivate": {
+    "description": "Opcija okruženja: privatni prostor.",
+    "message": "Negdje privatno"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Potvrda koja se prikazuje kada odgovor o okruženju ostavlja tihi način isključenim.",
+    "message": "U redu — zadržat ćemo standardne postavke slušanja i reprodukcije."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Potvrda prikazana kada odgovor o okruženju uključi tihi način.",
+    "message": "Tihi način je uključen — prepoznat ćemo tiši govor i odgovarati tiho, pa možeš razgovarati diskretno."
+  },
+  "onboarding_envTitle": {
+    "description": "Naslov za uvodno pitanje o korisnikovom okruženju.",
+    "message": "Gdje ćeš najčešće razgovarati?"
+  },
+  "onboarding_footer": {
+    "description": "Tekst u podnožju na stranici uvodnog prikaza pri prvom pokretanju.",
+    "message": "Ovo možeš ponovno otvoriti bilo kada u postavkama za Say, Pi. Tvoja privatnost je važna — zvuk se snima samo tijekom aktivnog poziva."
+  },
+  "onboarding_heading": {
+    "description": "Glavni naslov na onboarding stranici pri prvom pokretanju.",
+    "message": "🗣️ Dobro došli u Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Uvodni odlomak na onboarding stranici pri prvom pokretanju.",
+    "message": "Dva ste koraka udaljeni od svog prvog razgovora s AI-jem. Govor je oko 3× brži od tipkanja — postavimo sve kako treba."
+  },
+  "onboarding_micTestButton": {
+    "description": "Gumb koji pokreće bezopasni uvodni test mikrofona.",
+    "message": "🎤 Testiraj mikrofon"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status prikazan nakon uspješnog završetka uvodnog testa mikrofona.",
+    "message": "Super — mikrofon radi. 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status prikazan dok uvodni test mikrofona mjeri ulaz.",
+    "message": "Slušam — reci nešto. 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status prikazan dok uvodni test mikrofona čeka dopuštenje.",
+    "message": "Tražim pristup mikrofonu…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Oznaka gumba za zaustavljanje uvodnog testa mikrofona dok je u tijeku.",
+    "message": "Zaustavi test"
+  },
+  "onboarding_step1Body": {
+    "description": "Tekst prvog onboarding koraka koji objašnjava kako prikvačiti proširenje.",
+    "message": "Kliknite ikonu slagalice 🧩 u gornjem desnom kutu preglednika, zatim pribadaču 📌 pokraj Say, Pi. Tako je gumb za poziv uvijek na jedan klik."
+  },
+  "onboarding_step1Title": {
+    "description": "Naslov prvog onboarding koraka (prikvačivanje proširenja).",
+    "message": "Prikvačite Say, Pi na alatnu traku"
+  },
+  "onboarding_step2Body": {
+    "description": "Tekst drugog onboarding koraka koji objašnjava kako započeti glasovni razgovor.",
+    "message": "Idite na jednog od podržanih asistenata u nastavku, zatim dodirnite gumb za poziv Say, Pi i pozdravite se. Prvi put ćemo zatražiti pristup mikrofonu — to je očekivano, a slušamo samo dok ste aktivno u pozivu."
+  },
+  "onboarding_step2Title": {
+    "description": "Naslov drugog onboarding koraka (započinjanje razgovora).",
+    "message": "Otvorite AI chat i počnite govoriti"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Odobrenje mikrofona"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Upute za oporavak kada je dopuštenje za mikrofon blokirano.",
+    "message": "Vaš preglednik blokira mikrofon. Kliknite ikonu kamere ili lokota u adresnoj traci, postavite Mikrofon na \"Dopusti\", a zatim pokušajte ponovno. Na macOS-u također provjerite Postavke sustava → Privatnost i sigurnost → Mikrofon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Naslov panela za oporavak kada je dopuštenje za mikrofon odbijeno/blokirano.",
+    "message": "Pristup mikrofonu je blokiran"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Upute za oporavak kada se mikrofon koristi na drugom mjestu.",
+    "message": "Druga aplikacija ili kartica možda koristi vaš mikrofon. Zatvorite sve što bi moglo snimati (videopozivi, glasovne bilješke), a zatim pokušajte ponovno."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Naslov panela za oporavak kada mikrofon koristi druga aplikacija.",
+    "message": "Vaš mikrofon je zauzet"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Upute za oporavak kada nije dostupan nijedan uređaj mikrofona.",
+    "message": "Nismo pronašli mikrofon. Priključite ga (ili povežite slušalice), provjerite je li odabran kao ulazni uređaj, a zatim pokušajte ponovno."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Naslov panela za oporavak kada nije dostupan nijedan uređaj mikrofona.",
+    "message": "Nije pronađen mikrofon"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Upute za oporavak za nepoznatu pogrešku mikrofona.",
+    "message": "Nešto je pošlo po zlu pri pristupu vašem mikrofonu. Provjerite je li povezan i dopušten u postavkama preglednika, a zatim pokušajte ponovno."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Naslov panela za oporavak za nepoznatu pogrešku mikrofona.",
+    "message": "Nismo mogli pristupiti vašem mikrofonu"
+  },
+  "permissions_retryButton": {
+    "description": "Oznaka gumba koji ponovno traži dopuštenje za mikrofon.",
+    "message": "Pokušaj ponovno"
+  },
+  "permissions_revokedHeading": {
+    "description": "Naslov koji se prikazuje kada je pristup mikrofonu ranije bio odobren, ali je u međuvremenu opozvan.",
+    "message": "🎙️ Ponovno povežimo vaš mikrofon"
+  },
+  "permissions_revokedInfo": {
+    "description": "Informativni tekst koji se prikazuje kada je pristup mikrofonu opozvan nakon što je bio odobren.",
+    "message": "Pristup vašem mikrofonu je isključen — to se često dogodi nakon ažuriranja preglednika ili sustava. Ponovno ga odobrite u nastavku i $productName$ će opet slušati kada ste u pozivu.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Oznaka za prekidač koji uključuje tihi/šaputajući način.",
+    "message": "Tihi način"
+  },
+  "quietModeTooltip": {
+    "description": "Opis alata koji objašnjava što radi tihi/šaputajući način.",
+    "message": "Govori tiho — hvata tiši govor i smanjuje glasnoću odgovora asistenta, kako biste mogli koristiti glas u blizini drugih."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Tekst za gumb za prijavu dok je provjera autentičnosti u tijeku.",
+    "message": "Prijava u tijeku..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Zvučni efekti"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Zvučni efekti su onemogućeni u Firefoxu kako bi se spriječili problemi sa zvučnim povratnim informacijama."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Naslov jednokratne obavijesti o dobitku u brzini prikazane nakon prve izgovorene razmjene.",
+    "message": "Lijepo — govor je oko 3× brži od tipkanja."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Neobavezni drugi redak obavijesti o dobitku u brzini koji prikazuje ušteđene cijele minute.",
+    "message": "Već ste govorili otprilike $minutes$ min brže nego da ste to tipkali.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Pošaljite samo kada pritisnete gumb"
   },
+  "surveyQuestion": {
+    "description": "Jedino pitanje jednokratne mikro-ankete nakon uspjeha.",
+    "message": "Kako ti zasad radi glas?"
+  },
+  "surveyRatingLabel": {
+    "description": "Pristupačna oznaka za gumb ocjene u anketi.",
+    "message": "Ocijeni $rating$ od 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Zahvala prikazana nakon što korisnik odgovori na anketu nakon uspjeha.",
+    "message": "Hvala — to nam pomaže da Say, Pi bude bolji. 🙏"
+  },
   "tabAIChat": {
     "description": "Oznaka kartice za odjeljak postavki AI chata.",
     "message": "AI Chat"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Oznaka kartice za odjeljak općih postavki.",
     "message": "Općenito"
+  },
+  "tabVoices": {
+    "description": "Oznaka kartice za odjeljak postavki glasova (katalog glasova po web-mjestu).",
+    "message": "Glasovi"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "zasluga"
   },
+  "ttsCreditsRemaining": {
+    "description": "Tekst koji prikazuje preostalu TTS kvotu kao skup kredita po glasu (saypi-api #181 Stage 2), a ne sirove znakove.",
+    "message": "Preostalo kredita: $credits$",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Višejezični glasovi trenutno nisu podržani u Safariju."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Generacija glasa"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Pozor! Reprodukcija govora još nije dostupna na $browserName$ s $chatbotName$. Dobre vijesti? Glasovni unos radi odlično! Za TTS, isprobajte Chrome ili Edge na radnoj površini.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS nije dostupan na $browserName$ + $chatbotName$. Glasovni unos radi! Isprobajte Chrome radnu površinu za TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS glas"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "VAD detalj kada je otkriven audio nalik govoru, ali je bio preslab / s preniskom pouzdanošću za transkripciju (odbačeno na strani klijenta na admission-gateu).",
+    "message": "Zvuk je preslab za transkripciju"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "VAD detalj koji objašnjava da je poziv završio jer je mikrofon preuzela novija kartica.",
+    "message": "Glasovni unos premješten je na drugu karticu"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Glas nije dostupan. \nIsprobajte Chrome ili Firefox na radnoj površini."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Pozor! Reprodukcija govora još nije dostupna na $browserName$ s $chatbotName$. Dobre vijesti? Glasovni unos radi odlično! Za TTS, isprobajte Chrome ili Edge na radnoj površini.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS nije dostupan na $browserName$ + $chatbotName$. Glasovni unos radi! Isprobajte Chrome radnu površinu za TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Razumijem",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "VAD status prikazan na kartici kojoj je unos glasa preuzela druga kartica.",
+    "message": "Pauzirano"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Pogledajte detalje"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Generički izgovoreni uvod koji se pušta kada odabrani glas u Say, Pi nema uvodnu skriptu specifičnu za taj glas (i nema nedavne poruke za pročitati).",
+    "message": "Bok, ja sam $voice$. Ovako zvučim. Nadam se da vam se sviđa ovaj glas.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Zdravo! \nPrivet! \n你好! \nJa sam Pi, vaš poliglot AI pomoćnik. \nS 32 jezika kojima upravljam, možemo istraživati ​​ideje i kulture iz cijelog svijeta. \nŠto mislite o ovom glasu?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Glasovne postavke"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Rezervni podnaslov za redak glasa u katalogu glasova u postavkama kada glas nema opis; $count$ je broj jezika koje glas podržava.",
+    "message": "Govori $count$ jezika",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Autorski slogan osobnosti za glas 'Addison' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Vedra i razgovijetna"
+  },
+  "voiceTagline_alloy": {
+    "description": "Autorski slogan osobnosti za glas 'Alloy' (studio Glasova u postavkama; mapa identiteta glasa na strani klijenta).",
+    "message": "Uravnotežen i svestran"
+  },
+  "voiceTagline_ash": {
+    "description": "Autorski slogan osobnosti za glas 'Ash' (studio Glasova u postavkama; mapa identiteta glasa na strani klijenta).",
+    "message": "Dubok, promišljen, smiren"
+  },
+  "voiceTagline_ballad": {
+    "description": "Autorski slogan osobnosti za glas 'Ballad' (studio Glasova u postavkama; mapa identiteta glasa na strani klijenta).",
+    "message": "Ugodan i melodičan"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Autorski slogan osobnosti za glas 'Cassidy' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Srdačan i konkretan"
+  },
+  "voiceTagline_cedar": {
+    "description": "Napisani slogan osobnosti za glas 'Cedar' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Postojan i umirujući"
+  },
+  "voiceTagline_coral": {
+    "description": "Napisani slogan osobnosti za glas 'Coral' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Vedra, poletna energija"
+  },
+  "voiceTagline_echo": {
+    "description": "Napisani slogan osobnosti za glas 'Echo' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Čist i neutralan"
+  },
+  "voiceTagline_fable": {
+    "description": "Napisani slogan osobnosti za glas 'Fable' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Pripovjedački šarm"
+  },
+  "voiceTagline_finn": {
+    "description": "Autorski slogan osobnosti za glas 'Finn' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Svjež i energičan"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Autorski slogan osobnosti za glas 'Jamahal' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Pun i magnetičan"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Napisani slogan osobnosti za glas 'Jarnathan' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Baršunasti noćni bariton"
+  },
+  "voiceTagline_jeff": {
+    "description": "Autorski slogan osobnosti za glas 'Jeff' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Izravan i staložen"
+  },
+  "voiceTagline_jessica": {
+    "description": "Autorski slogan osobnosti za glas 'Jessica' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Topla, uglađena smirenost"
+  },
+  "voiceTagline_joey": {
+    "description": "Napisani slogan osobnosti za glas 'Joey' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Ležeran, razgovorni američki stil"
+  },
+  "voiceTagline_juniper": {
+    "description": "Autorski slogan osobnosti za glas 'Juniper' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Jasan, vedar, živahan"
+  },
+  "voiceTagline_lucy": {
+    "description": "Autorski slogan osobnosti za glas 'Lucy' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Nježna i blistava"
+  },
+  "voiceTagline_marin": {
+    "description": "Napisani slogan osobnosti za glas 'Marin' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Topla, jutarnje-radijska smirenost"
+  },
+  "voiceTagline_mark": {
+    "description": "Autorski slogan osobnosti za glas 'Mark' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Jasan, samouvjeren pripovjedač"
+  },
+  "voiceTagline_nova": {
+    "description": "Napisani slogan osobnosti za glas 'Nova' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Brz i znatiželjan"
+  },
+  "voiceTagline_onyx": {
+    "description": "Napisani slogan osobnosti za glas 'Onyx' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Duboka, rezonantna ozbiljnost"
+  },
+  "voiceTagline_paola": {
+    "description": "Napisani slogan osobnosti za glas 'Paola' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Izražajna talijanska toplina"
+  },
+  "voiceTagline_sage": {
+    "description": "Napisani slogan osobnosti za glas 'Sage' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Tiha jasnoća"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Napisani slogan osobnosti za glas 'Shimmer' (postavke Voices studio; mapiranje identiteta glasa na strani klijenta).",
+    "message": "Lagan i prozračan"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Kratka oznaka na prekidaču pribadače na kartici glasa (isključeno stanje) u studiju Glasovi u postavkama; pritiskom se glas dodaje u hostov izbornik u chatu.",
+    "message": "+ Izbornik"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Oznaka za pristupačnost za prekidač pribadače na kartici glasa (isključeno stanje); $name$ je glas, $host$ je asistent.",
+    "message": "Dodaj $name$ u izbornik za $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Oznaka na prekidaču u kontrolnoj traci Glasova koja kaže hoće li kretanje popisom strelicama reproducirati svaki glas kad fokus dođe do njega.",
+    "message": "Reproduciraj dok se krećete"
+  },
+  "voicesArrowsLive": {
+    "description": "Potvrda čitaču zaslona, dodana prvoj najavi \"Reproducira se <glas>\" u popisu Glasovi u postavkama, koja kaže da su tipke strelica upravo postale zvučne. Odražava formulaciju preklopnika \"Reproduciraj tijekom kretanja\".",
+    "message": "Strelice sada reproduciraju dok se krećete. Esc zaustavlja."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Napomena ispod mjesta u izborniku za hostove koji dolaze s izvornim glasovima (npr. Pi-jevih 8 ugrađenih), kojima studio ne upravlja; $host$ je asistent.",
+    "message": "$host$ovi ugrađeni glasovi uvijek se također pojavljuju u njegovu izborniku.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Varijanta voicesBuiltinsNote za host bez izbornika glasova u chatu (Pi je 2026. ukinuo svoj izbornik), gdje bi obećanje iz originala da se ugrađeni glasovi 'pojavljuju u njegovu izborniku' bilo netočno; $host$ je asistent.",
+    "message": "$host$ također ima vlastite ugrađene glasove, koji ovdje nisu navedeni.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Prikaz napretka u traci kontrola Glasovi u postavkama: koliko je navedenih glasova korisnik već preslušao. Goli brojevi, pa se ispravno čita i za 1 — Chrome i18n nema oblike množine.",
+    "message": "Preslušano: $heard$ od $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Dio pristupačnog naziva retka glasa u popisu Glasovi u postavkama, kojim se označava glas koji je ovaj profil već poslušao. Vizualno je to prikazano gustoćom tinte na zvučnom otisku glasa, što čitač zaslona ne može vidjeti.",
+    "message": "Preslušano"
+  },
+  "voicesInHostMenu": {
+    "description": "Naslov odjeljka iznad retka s mjestima u izborniku u studiju Glasovi u postavkama; $host$ je asistent.",
+    "message": "U izborniku za $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Kratka oznaka na prekidaču pribadače na kartici glasa (uključeno stanje) u studiju Glasovi u postavkama.",
+    "message": "✓ U izborniku"
+  },
+  "voicesInUse": {
+    "description": "Trajna oznaka na trenutačno odabranom glasu hosta na popisu Glasovi u postavkama, prikazana velikim slovima. Namjerno NIJE 'Sada govori': na ovoj stranici redci reproduciraju svoje ogledne isječke, pa odabrani, ali tihi glas ne smije tvrditi da govori dok je odabran drugi redak.",
+    "message": "U upotrebi"
+  },
+  "voicesKeyboardHint": {
+    "description": "Jednoredni savjet za tipkovnicu u traci kontrola Glasovi u postavkama. Znakovi su tipke: razmaknica, strelice gore/dolje i Shift+Razmak.",
+    "message": "Pritisnite razmaknicu za slušanje, ↑↓ za kretanje među glasovima, ⇧Razmak za povratak."
+  },
+  "voicesLoadError": {
+    "description": "Stanje pogreške unutar studija jednog hosta kada se katalog glasova tog hosta nije uspio učitati; $host$ je asistent.",
+    "message": "Nije moguće učitati glasove za $host$. Pokušajte ponovno kasnije.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Opis alata/savjet na onemogućenom prekidaču '+ Izbornik' kada hostov izbornik u chatu već ima maksimalan broj glasova.",
+    "message": "Izbornik je pun, ukloni glas da dodaš drugi"
+  },
+  "voicesMenuHint": {
+    "description": "Jednoredni savjet uz naslov 'U {host}ovom izborniku', koji objašnjava da redak s mjestima preslikava izbornik glasova u chatu.",
+    "message": "Što ćeš vidjeti u chatu"
+  },
+  "voicesMenuOverflow": {
+    "description": "Napomena ispod mjesta u izborniku kada korisnik ima više prikvačenih glasova nego što izbornik u chatu može prikazati (naslijeđeno stanje); $count$ je koliko ih ne stane, $cap$ je veličina izbornika.",
+    "message": "Još $count$ prikvačenih glasova čeka izvan $cap$ mjesta u izborniku.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Jednina za voicesMenuOverflow, koristi se kada točno jedan prikvačeni glas ne stane u izbornik u chatu; $cap$ je veličina izbornika.",
+    "message": "Još 1 prikvačeni glas čeka izvan $cap$ mjesta u izborniku.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Sažetak ispod popisa Glasovi u postavkama koji govori koliko je popunjen hostov izbornik glasova u chatu; $host$ je asistent, $used$ koliko je mjesta zauzeto, $cap$ koliko ih ima. Sročeno tako da se ispravno čita i za 1 — Chrome i18n nema oblike množine.",
+    "message": "Izbornik za $host$: $used$ od $cap$ mjesta",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Naslov za grupu na kraju popisa Glasovi u postavkama koja sadrži glasove bez isječka uzorka za reprodukciju; $count$ je koliko ih je. Sročeno tako da se ispravno čita i za 1 — Chrome i18n nema oblike množine.",
+    "message": "Još nema uzorka ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Prikazuje se u katalogu glasova u postavkama kada je popis glasova prazan za prijavljenog korisnika (npr. problem s mrežom).",
+    "message": "Glasovi se trenutačno ne mogu učitati. Pokušajte ponovno kasnije."
+  },
+  "voicesNowPlaying": {
+    "description": "Najava čitaču zaslona kada se u popisu Glasovi u postavkama počne reproducirati isječak uzorka glasa; $name$ je glas.",
+    "message": "Reproducira se $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Gumb u traci kontrola Glasovi u postavkama koji reproducira svaki trenutno prikazani glas, jedan za drugim; $count$ je koliko ih je. Sročeno tako da se ispravno čita i za 1 — Chrome i18n nema oblike množine.",
+    "message": "Reproduciraj sve ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Gumb u traci kontrola Glasovi u postavkama pri ponovnom posjetu: reproducira samo navedene glasove koje još niste preslušali; $count$ je koliko ih je. Sročeno tako da se ispravno čita i za 1 — Chrome i18n nema oblike množine.",
+    "message": "Reproduciraj nove ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Redak u traci s kontrolama Glasova u postavkama kada je preglednik odbio reproducirati uzorak jer još nije bilo interakcije korisnika sa stranicom.",
+    "message": "Kliknite bilo koji glas da omogućite zvuk."
+  },
+  "voicesPreview": {
+    "description": "Pristupačna oznaka za gumb za reprodukciju (▶) koji preslušava besplatni ogledni isječak glasa u retku glasa; $name$ je naziv glasa.",
+    "message": "Pusti uzorak za $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Pristupačni naziv popisa Glasovi u postavkama (listbox svih glasova, po jedan redak za svaki).",
+    "message": "Glasovi, poredani od najdubljeg do najsvjetlijeg"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Oznaka za pristupačnost za prekidač pribadače na kartici glasa (uključeno stanje) i gumb za uklanjanje mjesta u izborniku; $name$ je glas, $host$ je asistent.",
+    "message": "Ukloni $name$ iz izbornika za $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Redak u traci s kontrolama Glasova u postavkama kada se uzorak jednog glasa nije uspio učitati ili reproducirati; $name$ je taj glas. Nije modalno — niz uzoraka nastavlja dalje.",
+    "message": "Nije moguće reproducirati uzorak za $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Podnaslov odjeljka kataloga glasova u kartici AI Chat u postavkama.",
+    "message": "Odaberi glas koji naglas čita odgovore na svakoj web-lokaciji."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Podnaslov ispod naslova postavki Glasovi, za traku glasova poredanih po visini tona.",
+    "message": "Svaki glas, od najdubljeg do najsvjetlijeg. Poslušajte pa odaberite."
+  },
+  "voicesSectionTitle": {
+    "description": "Naslov odjeljka kataloga glasova u kartici AI Chat u postavkama.",
+    "message": "Glasovi"
+  },
+  "voicesShelfEveryday": {
+    "description": "Naslov grupe za glasove povoljnije razine u katalogu glasova u postavkama. CSS prikazuje velikim slovima.",
+    "message": "Svakodnevni glasovi"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Jednoredna napomena uz naslov grupe Svakodnevni glasovi u studiju Glasovi u postavkama; jedino mjesto gdje studio navodi koliko ova razina traje dulje od HD.",
+    "message": "Prirodno i jasno — možeš slušati oko 20× dulje nego s HD glasovima."
+  },
+  "voicesShelfHd": {
+    "description": "Naslov grupe za premium (HD) glasove u katalogu glasova u postavkama. CSS prikazuje velikim slovima.",
+    "message": "HD glasovi"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Jednoredna napomena uz naslov HD grupe u studiju Glasovi u postavkama.",
+    "message": "Naš najbogatiji i najizražajniji zvuk."
+  },
+  "voicesShowAll": {
+    "description": "Opcija u filtru 'Prikaži' u postavkama Glasovi: bez filtriranja, naveden je svaki glas.",
+    "message": "Svi glasovi"
+  },
+  "voicesShowEveryday": {
+    "description": "Opcija u filtru 'Prikaži' u postavkama Glasovi: navedi samo standardne (ne-HD) glasove.",
+    "message": "Samo standardni"
+  },
+  "voicesShowHd": {
+    "description": "Opcija u filtru 'Prikaži' u postavkama Glasovi: navedi samo premium (HD) glasove.",
+    "message": "Samo HD"
+  },
+  "voicesShowLabel": {
+    "description": "Oznaka na filtru u traci s kontrolama Glasova u postavkama koji sužava koje glasove popis prikazuje.",
+    "message": "Prikaži"
+  },
+  "voicesShowUnheard": {
+    "description": "Opcija u filtru 'Prikaži' u postavkama Glasovi: navedi samo glasove koje korisnik još nije poslušao.",
+    "message": "Još nije poslušano"
+  },
+  "voicesSpeakingNow": {
+    "description": "Oznaka stanja na trenutačno odabranom glasu hosta u studiju Glasovi u postavkama (mjesto u izborniku i kartica glasa).",
+    "message": "Sada govori"
+  },
+  "voicesSpeaksWith": {
+    "description": "Redak iznad naziva trenutačnog glasa na pozornici studija Glasovi u postavkama; $host$ je asistent (npr. Pi). CSS ga prikazuje velikim slovima.",
+    "message": "$host$ govori s",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Napomena na pozornici kada host pruža vlastiti zvuk (npr. Pi), pa odabir glasa Say, Pi zamjenjuje hostov.",
+    "message": "$host$ koristi vlastiti glas dok dolje ne odaberete jedan.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Napomena na pozornici kada host nema vlastiti glas (npr. Claude), pa se ništa ne čita naglas dok se ne odabere glas Say, Pi.",
+    "message": "$host$ neće čitati odgovore naglas dok dolje ne odaberete jedan.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Naslov na pozornici studija Glasovi u postavkama kada host nema odabran SayPi glas; $host$ je asistent (npr. Pi, Claude). Prikazuje se u veličini teksta za naziv.",
+    "message": "Odaberite kako $host$ zvuči",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Gumb na pozornici studija Glasovi u postavkama koji reproducira besplatni uzorak isječka trenutačnog glasa.",
+    "message": "Poslušajte uzorak"
+  },
+  "voicesStopPlayback": {
+    "description": "Gumb u traci kontrola Glasovi u postavkama koji zaustavlja niz uzoraka pokrenut naredbom \"Reproduciraj sve\".",
+    "message": "Zaustavi"
+  },
+  "voicesSweepPosition": {
+    "description": "Prikaz trenutačne pozicije u traci s kontrolama Glasova u postavkama dok opcija 'Reproduciraj sve' prolazi popis; $index$ je glas koji se trenutačno reproducira, a $total$ koliko ih je u redu.",
+    "message": "$index$ od $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Pristupačna oznaka za kontrolu usporedbe u traci kontrola Glasovi u postavkama, koja ponovno reproducira drugi glas od posljednja dva preslušana; $name$ je taj glas.",
+    "message": "Vrati se na $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Redak u traci s kontrolama Glasova u postavkama kada se pritisne 'Reproduciraj sve' na predugom popisu; $count$ je broj glasova, a $minutes$ približno broj minuta koliko bi trajali. Skraćeno 'min' kako bi ispravno glasilo i za 1 — Chrome i18n nema množinske oblike.",
+    "message": "To je $count$ glasova — oko $minutes$ min. Prvo suzite popis.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Oznaka za pristupačnost za gumb 'koristi ovaj glas' po hostu u katalogu glasova u postavkama; $name$ je glas, $host$ je asistent (npr. Pi, Claude).",
+    "message": "Koristi $name$ na $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Kratka oznaka na gumbu 'koristi ovaj glas' po hostu u objedinjenom katalogu glasova u postavkama (host je prikazan uz njega).",
+    "message": "Koristi"
+  },
+  "voicesYourVoice": {
+    "description": "Gumb u traci kontrola na popisu Glasovi u postavkama koji prebacuje fokus na redak glasa koji ovaj host trenutačno koristi; $name$ je taj glas.",
+    "message": "Vaš glas: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Pogreška koja se javlja kada preglednik ne može dodijeliti dovoljno WebAssembly memorije za model za detekciju glasa.",
+    "message": "Detekcija glasa se ne može pokrenuti: nema dovoljno WebAssembly memorije za glasovni model. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Pogreška koja se javlja kada preglednik ne izlaže početnu WebAssembly memoriju potrebnu za pokretanje modela za detekciju glasa.",
+    "message": "Detekcija glasa se ne može pokrenuti: WebAssembly memorija nije dostupna u ovom pregledniku."
   }
 }

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Előny a bejelentkezési ablakban – magasabb használati korlátok.",
+    "message": "Magasabb használati korlátok ingyenes fiókkal"
+  },
+  "authBenefitPremium": {
+    "description": "Előny a bejelentkezési ablakban – prémium funkciók több chatbotban.",
+    "message": "Prémium funkciók és chatbot-támogatás"
+  },
+  "authBenefitSupport": {
+    "description": "Előny a bejelentkezési ablakban – elsőbbségi támogatás.",
+    "message": "Elsőbbségi támogatás problémák esetén"
+  },
+  "authBenefitSync": {
+    "description": "Előny a bejelentkezési ablakban – beállítások szinkronizálása.",
+    "message": "Hangbeállítások szinkronizálása mindenhol"
+  },
+  "authBenefitTTS": {
+    "description": "Előny a bejelentkezési ablakban – TTS funkció.",
+    "message": "Szövegfelolvasó hangok (fizetős csomagokban)"
+  },
+  "authBenefitUsage": {
+    "description": "Előny a bejelentkezési ablakban – használatkövetés.",
+    "message": "Kövesd a hanghasználatodat több eszközön"
+  },
+  "authPromptModalFull": {
+    "description": "Leírás a teljes bejelentkezési felugró ablakhoz, értékajánlattal.",
+    "message": "Úgy tűnik, sokat használod a Say, Pi-t. Jelentkezz be a magasabb korlátokért, a szövegfelolvasó hangokért és a prémium funkciókért az összes támogatott chatbotban."
+  },
+  "authPromptModalSoft": {
+    "description": "Leírás a bejelentkezést kérő, enyhébb felugró ablakhoz.",
+    "message": "Hozz létre egy ingyenes Say, Pi-fiókot a magasabb használati korlátokért és a prémium hangfunkciók eléréséhez."
+  },
+  "authPromptTitle": {
+    "description": "Cím a bejelentkezési felugró ablakhoz.",
+    "message": "További hangfunkciók feloldása"
+  },
+  "authPromptToast": {
+    "description": "Toast értesítés, amely bejelentkezésre ösztönzi a felhasználót.",
+    "message": "Jelentkezz be a Say, Pi-ba a magasabb korlátokért és a prémium funkciókért"
+  },
   "autoReadAloudChatGPT": {
     "description": "Jelölőnégyzet felirat az automatikus válaszolvasás engedélyezéséhez vagy letiltásához hanghívások alatt ChatGPT válaszainak esetén.",
     "message": "Automatikus felolvasás (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Tiltsa le a szöveges beszédet"
   },
+  "dismiss": {
+    "message": "Értem",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Elutasít"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Fókusz"
   },
+  "errorVadInitFailed": {
+    "description": "Hiba toast, amely akkor jelenik meg, ha a hangaktivitás-érzékelést nem sikerül inicializálni.",
+    "message": "Nem sikerült inicializálni a hangérzékelést"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Hiba toast, amely akkor jelenik meg, ha váratlan hiba történik a hangrögzítés beállítása közben.",
+    "message": "Nem sikerült beállítani a hangrögzítést"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Hiba toast, amely akkor jelenik meg, ha a hangérzékelő kliens nem tudja elindítani a rögzítést.",
+    "message": "Nem sikerült elindítani a hangrögzítést"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Hiba toast, amely akkor jelenik meg, ha a hangérzékelő (VAD) kliens nem érhető el, ezért nem lehet elindítani a rögzítést.",
+    "message": "A hangrögzítés nem érhető el"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Fókusz mód kikapcsolása"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Egysoros megjegyzés, amely a hangmenükben jelenik meg, amikor prémium (HD) és value hangok is elérhetők",
+    "message": "A HD hangok kb. 20× gyorsabban fogyasztják a havi keretedet."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Ezt eldobva ..."
   },
+  "maybeLater": {
+    "description": "Gombszöveg a bejelentkezési kérés elutasításához.",
+    "message": "Talán később"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "A mikrofon beállításai nem felelnek meg a szükséges előírásoknak. \nPróbáljon meg másik mikrofont használni, vagy módosítsa a hangbeállításokat."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Nem lehet hozzáférni a mikrofonhoz. \nKérjük, ellenőrizze az eszköz beállításait, és próbálja újra."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Hiba toast, amely akkor jelenik meg, ha a mikrofonengedélyt elutasították az engedélykérési folyamat után.",
+    "message": "A mikrofonengedélyt nem adtad meg. Ellenőrizd, hogy engedélyezted-e a hozzáférést a felugró kérésnél és a bővítmény beállításaiban."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "pontosság"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "A leggyorsabb válasz, de kevésbé pontos. \nHajlamos a megszakításra."
   },
+  "moreVoices": {
+    "description": "Menüsor, amely az oldalon belüli hangmenüből a bővítmény beállításaiban található teljes hangkatalógusra mutat.",
+    "message": "További hangok…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Segédfelhasználónév"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Nem jelentkezett be"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Gombfelirat, amely megnyitja a ChatGPT-t.",
+    "message": "ChatGPT megnyitása"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Gombfelirat, amely megnyitja a Claude.ai-t.",
+    "message": "Claude megnyitása"
+  },
+  "onboarding_ctaPi": {
+    "description": "Gombfelirat, amely megnyitja a Pi.ai-t.",
+    "message": "Pi megnyitása"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Környezeti opció: mások között.",
+    "message": "Mások között"
+  },
+  "onboarding_envMixed": {
+    "description": "Környezeti opció: privát és közös terek keveréke.",
+    "message": "Különféle helyeken"
+  },
+  "onboarding_envPrivate": {
+    "description": "Környezeti opció: privát tér.",
+    "message": "Valahol privát helyen"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Megerősítés, amikor a környezeti válasz alapján a csendes mód ki van kapcsolva.",
+    "message": "Rendben, maradnak az alapértelmezett figyelési és lejátszási beállítások."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Megerősítés, amely akkor jelenik meg, amikor a környezeti válasz bekapcsolja a csendes módot.",
+    "message": "Csendes mód bekapcsolva — a halkabb beszédet is felvesszük, és halkan válaszolunk, hogy diszkréten beszélhess."
+  },
+  "onboarding_envTitle": {
+    "description": "Címsor az onboarding kérdéshez a felhasználó környezetéről.",
+    "message": "Hol szoktál általában beszélni?"
+  },
+  "onboarding_footer": {
+    "description": "Láblécszöveg az első indításkor megjelenő onboarding oldalon.",
+    "message": "Bármikor újra megnyithatod ezt a Say, Pi beállításaiból. Fontos a magánszférád — hangot csak aktív hívás közben rögzítünk."
+  },
+  "onboarding_heading": {
+    "description": "Főcím az első indításkor megjelenő bevezető oldalon.",
+    "message": "🗣️ Üdv a Say, Pi-ban"
+  },
+  "onboarding_intro": {
+    "description": "Bevezető bekezdés az első indításkor megjelenő bevezető oldalon.",
+    "message": "Már csak két lépésre vagy az első, AI-jal folytatott beszélgetésedtől. Beszélni kb. 3× gyorsabb, mint gépelni, állítsuk be."
+  },
+  "onboarding_micTestButton": {
+    "description": "Gomb, amely elindítja a tét nélküli onboarding mikrofontesztet.",
+    "message": "🎤 Mikrofon tesztelése"
+  },
+  "onboarding_micTestDone": {
+    "description": "Állapot, amely az onboarding mikrofonteszt sikeres befejezése után jelenik meg.",
+    "message": "Szuper — működik a mikrofonod. 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Állapot, amely akkor jelenik meg, amikor az onboarding mikrofonteszt méri a bemenetet.",
+    "message": "Figyelek — mondj valamit! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Állapot, amely akkor jelenik meg, amikor az onboarding mikrofonteszt engedélyre vár.",
+    "message": "Mikrofon engedély kérése…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Gombfelirat az onboarding mikrofonteszt leállításához, miközben fut.",
+    "message": "Teszt leállítása"
+  },
+  "onboarding_step1Body": {
+    "description": "Az első bevezető lépés szövege, amely elmagyarázza, hogyan kell kitűzni a bővítményt.",
+    "message": "Kattints a böngésző jobb felső sarkában a kirakós 🧩 ikonra, majd a Say, Pi melletti kitűzés 📌 ikonra. Így a hívásgomb egy kattintásra lesz."
+  },
+  "onboarding_step1Title": {
+    "description": "Az első bevezető lépés címe (a bővítmény kitűzése).",
+    "message": "Rögzítsd a Say, Pi-t az eszköztáradra"
+  },
+  "onboarding_step2Body": {
+    "description": "A második bevezető lépés szövege, amely elmagyarázza, hogyan kell hangos beszélgetést indítani.",
+    "message": "Menj az alábbi támogatott asszisztensek egyikéhez, majd nyomd meg a Say, Pi hívásgombját, és köszönj. Az első alkalommal mikrofonhozzáférést kérünk, ez rendben van, és csak akkor figyelünk, amikor aktív hívásban vagy."
+  },
+  "onboarding_step2Title": {
+    "description": "A második bevezető lépés címe (beszélgetés indítása).",
+    "message": "Nyiss meg egy AI chatet, és kezdj el beszélni"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Mikrofon engedély"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Helyreállítási útmutató, amikor a mikrofonengedély le van tiltva.",
+    "message": "A böngésződ blokkolja a mikrofont. Kattints a kamera vagy a lakat ikonra a címsorban, állítsd a Mikrofon beállítást „Engedélyezés”-re, majd próbáld újra. macOS-en ellenőrizd a Rendszerbeállítások → Adatvédelem és biztonság → Mikrofon részt is."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "A helyreállítási panel címe, amikor a mikrofonengedélyt elutasították/letiltották.",
+    "message": "A mikrofonhozzáférés le van tiltva"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Helyreállítási útmutató, amikor a mikrofont máshol használják.",
+    "message": "Lehet, hogy egy másik alkalmazás vagy lap használja a mikrofonodat. Zárj be mindent, ami rögzíthet (videóhívás, hangjegyzet), majd próbáld újra."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "A helyreállítási panel címe, amikor a mikrofont egy másik alkalmazás használja.",
+    "message": "A mikrofonod foglalt"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Helyreállítási útmutató, amikor nem érhető el mikrofon eszköz.",
+    "message": "Nem találtunk mikrofont. Csatlakoztass egyet (vagy a headsetedet), ellenőrizd, hogy bemeneti eszközként van kiválasztva, majd próbáld újra."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "A helyreállítási panel címe, amikor nem érhető el mikrofon eszköz.",
+    "message": "Nem található mikrofon"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Helyreállítási útmutató ismeretlen mikrofonhiba esetén.",
+    "message": "Hiba történt a mikrofon elérésekor. Ellenőrizd, hogy csatlakoztatva van-e, és hogy engedélyezve van a böngésző beállításaiban, majd próbáld újra."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "A helyreállítási panel címe ismeretlen mikrofonhiba esetén.",
+    "message": "Nem tudtunk hozzáférni a mikrofonodhoz"
+  },
+  "permissions_retryButton": {
+    "description": "A gomb felirata, amely újra kéri a mikrofonengedélyt.",
+    "message": "Próbáld újra"
+  },
+  "permissions_revokedHeading": {
+    "description": "Címsor, amikor a mikrofonhozzáférés korábban engedélyezve volt, de azóta visszavonták.",
+    "message": "Csatlakoztassuk újra a mikrofonodat"
+  },
+  "permissions_revokedInfo": {
+    "description": "Tájékoztató szöveg, amikor a mikrofonhozzáférést az engedélyezés után visszavonták.",
+    "message": "A mikrofonhozzáférés ki lett kapcsolva, ez gyakran böngésző- vagy rendszerfrissítés után történik. Engedélyezd újra lent, és $productName$ ismét figyelni fog, amikor hívásban vagy.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Címke a kapcsolóhoz, amely bekapcsolja a csendes/suttogó módot.",
+    "message": "Csendes mód"
+  },
+  "quietModeTooltip": {
+    "description": "Súgó, amely elmagyarázza, mit csinál a csendes/suttogó mód.",
+    "message": "Halkan beszél — a halkabb beszédet is érzékeli, és csökkenti az asszisztens válaszának hangerejét, így mások mellett is használhatod a hangot."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Szöveg a bejelentkezés gombon, amíg a hitelesítés folyamatban van.",
+    "message": "Bejelentkezés…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Hanghatások"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "A hangeffektusok le vannak tiltva a Firefoxban a hangvisszajelzéssel kapcsolatos problémák elkerülése érdekében."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Címsor az egyszer megjelenő, „sebesség-nyereség” értesítéshez, amely az első elhangzott váltás után jelenik meg.",
+    "message": "Klassz, beszélni nagyjából 3× gyorsabb, mint gépelni."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "A „sebesség-nyereség” értesítés opcionális második sora, amely a megtakarított egész perceket mutatja.",
+    "message": "Eddig nagyjából $minutes$ percet spóroltál a gépeléshez képest.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Csak akkor küldje el, ha megnyomja a gombot"
   },
+  "surveyQuestion": {
+    "description": "Az egyszeri, nyerés utáni mikro-felmérés egyetlen kérdése.",
+    "message": "Hogy működik eddig a hang?"
+  },
+  "surveyRatingLabel": {
+    "description": "Akadálymentes címke a felmérés értékelő gombjához.",
+    "message": "Értékelés: $rating$ / 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "A felhasználó válasza után megjelenő köszönetnyilvánítás a nyerés utáni felmérésben.",
+    "message": "Köszönjük, ez segít, hogy jobbá tegyük a Say, Pi-t. 🙏"
+  },
   "tabAIChat": {
     "description": "Fül címke az AI chat beállítások szekcióhoz.",
     "message": "AI Chat"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Fül címke az általános beállítások szekcióhoz.",
     "message": "Általános"
+  },
+  "tabVoices": {
+    "description": "Fül felirata a hangbeállítások szakaszához (webhelyenkénti hangkatalógus).",
+    "message": "Hangok"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "jóváírás"
   },
+  "ttsCreditsRemaining": {
+    "description": "A fennmaradó TTS-kvótát megjelenítő szöveg, hangonkénti kreditkeretként (saypi-api #181 2. szakasz), nem nyers karakterként.",
+    "message": "Hátralévő kreditek: $credits$",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "A Safari jelenleg nem támogatja a többnyelvű hangokat."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Hangtermelés"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Figyelem! A beszéd lejátszás még nem elérhető a $browserName$ böngészőben a $chatbotName$ használatával. A jó hír? A hangbemenet remekül működik! A TTS-hez próbálja ki a Chrome-ot vagy az Edge-et asztali gépen.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "A TTS nem érhető el a $browserName$ + $chatbotName$ esetén. A hangbemenet működik! Próbálja ki a Chrome asztali verziót a TTS-hez.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS hang"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "VAD-részlet, amikor beszédszerű hangot észleltünk, de túl halk / túl alacsony megbízhatóságú volt a leiratozáshoz (kliensoldali admission-gate eldobás).",
+    "message": "A hang túl halk a leirathoz"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "VAD-részlet, amely elmagyarázza, hogy a hívás azért ért véget, mert a mikrofont egy újabb lap foglalta le.",
+    "message": "A hangbemenet átkerült egy másik lapra"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "A hang nem érhető el. \nPróbálja ki a Chrome -t vagy a Firefoxot az asztalon."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Figyelem! A beszéd lejátszás még nem elérhető a $browserName$ böngészőben a $chatbotName$ használatával. A jó hír? A hangbemenet remekül működik! A TTS-hez próbálja ki a Chrome-ot vagy az Edge-et asztali gépen.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "A TTS nem érhető el a $browserName$ + $chatbotName$ esetén. A hangbemenet működik! Próbálja ki a Chrome asztali verziót a TTS-hez.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Értem",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "VAD-állapot egy olyan lapon, amelynek hangbemenetét egy másik lap vette át.",
+    "message": "Szüneteltetve"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "A részletek megtekintése"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Általános, felolvasott bemutatkozás, amely akkor szólal meg, ha a kiválasztott SayPi hanghoz nincs hangspecifikus bemutatkozó szöveg (és nincs friss üzenet, amit fel lehetne olvasni).",
+    "message": "Szia, én vagyok $voice$. Így szólok. Remélem, tetszik ez a hang.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hola! \nПривет! \n你好! \nPi vagyok, a poliglott mesterséges intelligencia asszisztense. \nA rendelkezésemre álló 32 nyelv segítségével felfedezhetünk ötleteket és kultúrákat a világ minden tájáról. \nmit gondolsz erről a hangról?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Hangbeállítások"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Tartalék felirat egy hang sorához a beállítások hangkatalógusában, amikor a hanghoz nincs leírás; a $count$ a hang által támogatott nyelvek száma.",
+    "message": "$count$ nyelven beszél",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Szerző által írt személyiségszlogen az „Addison” hanghoz (Beállítások > Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Derűs és választékos"
+  },
+  "voiceTagline_alloy": {
+    "description": "Megírt személyiség-jelmondat az „Alloy” hanghoz (Beállítások Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Kiegyensúlyozott, mindenre jó"
+  },
+  "voiceTagline_ash": {
+    "description": "Megírt személyiség-jelmondat az „Ash” hanghoz (Beállítások Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Mély, elgondolkodó, nyugodt"
+  },
+  "voiceTagline_ballad": {
+    "description": "Megírt személyiség-jelmondat a „Ballad” hanghoz (Beállítások Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Sima és dallamos"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Szerző által írt személyiségszlogen a „Cassidy” hanghoz (Beállítások > Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Barátságos és tárgyilagos"
+  },
+  "voiceTagline_cedar": {
+    "description": "A 'Cedar' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Nyugodt és megnyugtató"
+  },
+  "voiceTagline_coral": {
+    "description": "A 'Coral' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Fényes, lendületes energia"
+  },
+  "voiceTagline_echo": {
+    "description": "Az 'Echo' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Tiszta és semleges"
+  },
+  "voiceTagline_fable": {
+    "description": "A 'Fable' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Mesélős dallamosság"
+  },
+  "voiceTagline_finn": {
+    "description": "Szerző által írt személyiségszlogen a „Finn” hanghoz (Beállítások > Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Friss és energikus"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Szerző által írt személyiségszlogen a „Jamahal” hanghoz (Beállítások > Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Gazdag és magával ragadó"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "A 'Jarnathan' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Bársonyos, késő esti bariton"
+  },
+  "voiceTagline_jeff": {
+    "description": "Szerző által írt személyiségszlogen a „Jeff” hanghoz (Beállítások > Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Egyszerű, egyenes és kiegyensúlyozott"
+  },
+  "voiceTagline_jessica": {
+    "description": "Szerző által írt személyiségszlogen a „Jessica” hanghoz (Beállítások > Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Meleg, kifinomult elegancia"
+  },
+  "voiceTagline_joey": {
+    "description": "A 'Joey' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Laza, társalgós amerikai"
+  },
+  "voiceTagline_juniper": {
+    "description": "Szerző által írt személyiségszlogen a „Juniper” hanghoz (Beállítások > Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Éles, derűs, élénk"
+  },
+  "voiceTagline_lucy": {
+    "description": "Szerző által írt személyiségszlogen a „Lucy” hanghoz (Beállítások > Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Lágy és ragyogó"
+  },
+  "voiceTagline_marin": {
+    "description": "A 'Marin' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Meleg, reggeli rádiós nyugalom"
+  },
+  "voiceTagline_mark": {
+    "description": "Szerző által írt személyiségszlogen a „Mark” hanghoz (Beállítások > Hangok stúdió; kliensoldali hangazonosság-térkép).",
+    "message": "Tiszta, magabiztos narrátor"
+  },
+  "voiceTagline_nova": {
+    "description": "A 'Nova' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Gyors és kíváncsi"
+  },
+  "voiceTagline_onyx": {
+    "description": "Az 'Onyx' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Mély, zengő komolyság"
+  },
+  "voiceTagline_paola": {
+    "description": "A 'Paola' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Kifejező olasz melegség"
+  },
+  "voiceTagline_sage": {
+    "description": "A 'Sage' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Halk szavú tisztaság"
+  },
+  "voiceTagline_shimmer": {
+    "description": "A 'Shimmer' hanghoz írt személyiségjelmondat (Beállítások > Hangok stúdió; kliensoldali hangidentitás-térkép).",
+    "message": "Könnyed és légies"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Rövid címke egy hangkártya rögzítéskapcsolóján (kikapcsolt állapot) a beállítások Hangok stúdiójában; megnyomásra hozzáadja a hangot a gazdagép csevegésbeli menüjéhez.",
+    "message": "+ Menü"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Akadálymentes címke egy hangkártya rögzítéskapcsolójához (kikapcsolt állapot); $name$ a hang, $host$ az asszisztens.",
+    "message": "$name$ hozzáadása $host$ menüjéhez",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "A Hangok vezérlősáv kapcsolójának felirata, amely jelzi, hogy a lista nyílbillentyűkkel történő bejárásakor lejátszódik-e minden hang, amikor a fókusz ráér.",
+    "message": "Lejátszás léptetés közben"
+  },
+  "voicesArrowsLive": {
+    "description": "Képernyőolvasós megerősítés, amely az első „Lejátszás <hang>” bejelentéshez van hozzáfűzve a Beállítások Hangok listában, jelezve, hogy a nyílbillentyűk mostantól hallhatóak. A „Lejátszás mozgás közben” kapcsoló saját megfogalmazását tükrözi.",
+    "message": "A nyilak most már lépés közben lejátszanak. Esc leállítja."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Megjegyzés a menühelyek alatt azoknál a hosztoknál, amelyek natív hangokkal érkeznek (pl. Pi 8 beépített hangja), amelyeket a stúdió nem kezel; $host$ az asszisztens.",
+    "message": "$host$ saját beépített hangjai is mindig megjelennek a menüjében.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "A voicesBuiltinsNote változata olyan hoszthoz, amelynek nincs chaten belüli hangmenüje (Pi 2026-ban kivezette a menüjét), ahol az eredeti ígérete, hogy a beépített hangok „megjelennek a menüjében”, nem lenne igaz; $host$ az asszisztens.",
+    "message": "$host$-nak saját beépített hangjai is vannak, amelyek itt nem szerepelnek.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Állapotjelző a Beállítások Hangok vezérlősávjában: hány hangot hallgatott már meg a felhasználó a listából. Csak számok, így 1-nél is helyesen olvasható — a Chrome i18n nem támogat többes számot.",
+    "message": "$heard$ / $total$ meghallgatva",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "A Beállítások Hangok listában egy hang sorának akadálymentes nevének része, amely jelöli, hogy ezt a profilt használva a felhasználó már meghallgatta. Vizuálisan ez a hang hanglenyomatán megjelenő tinta-sűrűség, amit a képernyőolvasó nem lát.",
+    "message": "Meghallgatva"
+  },
+  "voicesInHostMenu": {
+    "description": "Szakaszcím a menühelyek sora felett a beállítások Hangok stúdiójában; $host$ az asszisztens.",
+    "message": "$host$ menüjében",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Rövid címke egy hangkártya rögzítéskapcsolóján (bekapcsolt állapot) a beállítások Hangok stúdiójában.",
+    "message": "✓ Menüben"
+  },
+  "voicesInUse": {
+    "description": "Tartós jelvény a beállítások Hangok listájában a gazdagép által jelenleg kiválasztott hangon, nagybetűsítve. Szándékosan NEM „Most beszél”: ezen az oldalon a sorok mintaklipjei lejátszhatók, ezért a kiválasztott, de néma hang nem állíthatja, hogy beszél, miközben egy másik sor épp szól.",
+    "message": "Használatban"
+  },
+  "voicesKeyboardHint": {
+    "description": "Egysoros billentyűzetes súgó a Beállítások Hangok vezérlősávjában. A jelek billentyűk: Szóköz, fel/le nyilak és Shift+Szóköz.",
+    "message": "Nyomj szóközt a meghallgatáshoz, ↑↓ a hangok közti lépkedéshez, ⇧Szóköz a visszaváltáshoz."
+  },
+  "voicesLoadError": {
+    "description": "Hibaállapot egy hoszt stúdióján belül, amikor a hoszt hangkatalógusát nem sikerült betölteni; $host$ az asszisztens.",
+    "message": "Nem sikerült betölteni $host$ hangjait. Próbáld újra később.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Eszköztipp/tájékoztató egy letiltott „+ Menü” kapcsolón, amikor a gazdagép csevegésbeli menüje már elérte a maximális hangszámot.",
+    "message": "A menü tele van, távolíts el egy hangot a másik hozzáadásához"
+  },
+  "voicesMenuHint": {
+    "description": "Egysoros tipp az „A(z) {host} menüjében” cím mellett, amely elmagyarázza, hogy a helyek sora tükrözi a csevegésbeli hangmenüt.",
+    "message": "Ezt fogod látni a csevegésben"
+  },
+  "voicesMenuOverflow": {
+    "description": "Megjegyzés a menühelyek alatt, amikor a felhasználónak több rögzített hangja van, mint amennyit a chaten belüli menü meg tud jeleníteni (örökölt állapot); $count$ az, hogy mennyi nem fér be, $cap$ a menü mérete.",
+    "message": "Még $count$ rögzített hang vár a menü $cap$ helyén túl.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "A voicesMenuOverflow egyes számú alakja, amikor pontosan egy rögzített hang nem fér be a chaten belüli menübe; $cap$ a menü mérete.",
+    "message": "Még 1 rögzített hang vár a menü $cap$ helyén túl.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Összegző sor a Beállítások Hangok lista alatt, amely jelzi, mennyire van feltöltve a host csevegésen belüli hangmenüje; $host$ az asszisztens, $used$ a foglalt helyek száma, $cap$ a teljes férőhely. Úgy megfogalmazva, hogy 1-nél is helyesen olvasható legyen — a Chrome i18n nem támogat többes számot.",
+    "message": "$host$ menüje: $used$ / $cap$ hely foglalt",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Címsor a Beállítások Hangok lista végén lévő csoporthoz, amely a lejátszható mintaklip nélküli hangokat tartalmazza; $count$ a darabszám. Úgy megfogalmazva, hogy 1-nél is helyesen olvasható legyen — a Chrome i18n nem támogat többes számot.",
+    "message": "Még nincs minta ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "A beállítások hangkatalógusában jelenik meg, amikor a hanglista üres bejelentkezett felhasználónál (pl. hálózati probléma esetén).",
+    "message": "A hangokat most nem sikerült betölteni. Próbáld meg később."
+  },
+  "voicesNowPlaying": {
+    "description": "Képernyőolvasó-bejelentés, amikor elindul egy hang mintaklipje a Beállítások Hangok listában; $name$ a hang.",
+    "message": "$name$ lejátszása",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Gomb a Beállítások Hangok vezérlősávjában, amely egymás után lejátssza az összes jelenleg listázott hangot; $count$ a darabszám. Úgy megfogalmazva, hogy 1-nél is helyesen olvasható legyen — a Chrome i18n nem támogat többes számot.",
+    "message": "Összes lejátszása ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Gomb a Beállítások Hangok vezérlősávjában visszatérő látogatáskor: csak azokat a listázott hangokat játssza le, amelyeket még nem hallgattál meg; $count$ a darabszám. Úgy megfogalmazva, hogy 1-nél is helyesen olvasható legyen — a Chrome i18n nem támogat többes számot.",
+    "message": "Újak lejátszása ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Sor a Beállítások Hangok vezérlősávjában, amikor a böngésző megtagadta egy minta lejátszását, mert az oldalon még nem történt felhasználói interakció.",
+    "message": "Kattints bármelyik hangra a hang engedélyezéséhez."
+  },
+  "voicesPreview": {
+    "description": "Akadálymentes címke a lejátszás (▶) gombhoz, amely egy hang ingyenes mintaklipjét játssza le a hang sorában; a $name$ a hang neve.",
+    "message": "$name$ mintájának lejátszása",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "A Beállítások Hangok listájának akadálymentes neve (egy listadoboz az összes hanggal, soronként egy).",
+    "message": "Hangok, a legmélyebbtől a legvilágosabbig rendezve"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Akadálymentes címke egy hangkártya rögzítéskapcsolójához (bekapcsolt állapot) és egy menühely eltávolítás gombjához; $name$ a hang, $host$ az asszisztens.",
+    "message": "$name$ eltávolítása $host$ menüjéből",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Sor a Beállítások Hangok vezérlősávjában, amikor egy hang mintaklipje nem töltődött be vagy nem játszható le; $name$ az adott hang neve. Nem modális — a minták sorozata továbbhalad.",
+    "message": "Nem sikerült lejátszani $name$ mintáját.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Alcím a hangkatalógus szakaszához a beállítások AI Chat lapján.",
+    "message": "Válaszd ki, melyik hang olvassa fel az adott oldalon a válaszokat."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Alcím a Hangok beállítások címsora alatt, a hangok magasság szerint rendezett sávjához.",
+    "message": "Minden hang, a legmélyebbtől a legvilágosabbig. Hallgasd meg, majd válassz."
+  },
+  "voicesSectionTitle": {
+    "description": "Címsor a hangkatalógus szakaszához a beállítások AI Chat lapján.",
+    "message": "Hangok"
+  },
+  "voicesShelfEveryday": {
+    "description": "Csoportcím a kedvezőbb árú hangokhoz a beállítások hangkatalógusában. CSS nagybetűssé alakítja.",
+    "message": "Mindennapi hangok"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Egysoros megjegyzés a Mindennapi csoportcím mellett a Hangok stúdiójában; az egyetlen hely, ahol a stúdió megadja, mennyivel tart tovább ez a szint a HD-nál.",
+    "message": "Természetes és tiszta, kb. 20× tovább hallgatható, mint a HD."
+  },
+  "voicesShelfHd": {
+    "description": "Csoportcím a prémium (HD) hangokhoz a beállítások hangkatalógusában. CSS nagybetűssé alakítja.",
+    "message": "HD hangok"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Egysoros megjegyzés a HD csoportcím mellett a Hangok stúdiójában.",
+    "message": "A leggazdagabb, legkifejezőbb hangzásunk."
+  },
+  "voicesShowAll": {
+    "description": "Opció a Beállítások Hangok „Megjelenítés” szűrőjében: nincs szűrés, minden hang listázva van.",
+    "message": "Összes hang"
+  },
+  "voicesShowEveryday": {
+    "description": "Opció a Beállítások Hangok „Megjelenítés” szűrőjében: csak a standard (nem HD) hangokat listázza.",
+    "message": "Csak alap"
+  },
+  "voicesShowHd": {
+    "description": "Opció a Beállítások Hangok „Megjelenítés” szűrőjében: csak a prémium (HD) hangokat listázza.",
+    "message": "Csak HD"
+  },
+  "voicesShowLabel": {
+    "description": "Felirat a Beállítások Hangok vezérlősávjában lévő szűrőn, amely leszűkíti, hogy a lista mely hangokat mutassa.",
+    "message": "Megjelenítés"
+  },
+  "voicesShowUnheard": {
+    "description": "Opció a Beállítások Hangok „Megjelenítés” szűrőjében: csak azokat a hangokat listázza, amelyeket a felhasználó még nem hallgatott meg.",
+    "message": "Még nem meghallgatott"
+  },
+  "voicesSpeakingNow": {
+    "description": "Állapotcímke a gazdagép beállítások Hangok stúdiójában jelenleg kiválasztott hangján (menühely és hangkártya).",
+    "message": "Most beszél"
+  },
+  "voicesSpeaksWith": {
+    "description": "Szemöldöksor a jelenlegi hang neve felett a beállítások Hangok stúdió nézetében; $host$ az asszisztens (pl. Pi). CSS nagybetűsítve jeleníti meg.",
+    "message": "$host$ ezzel beszél",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Színpadi megjegyzés, amikor a hoszt a saját hangját szolgáltatja (pl. Pi), így egy Say, Pi hang kiválasztása lecseréli a hoszt hangját.",
+    "message": "$host$ a saját hangját használja, amíg nem választasz lent egyet.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Színpadi megjegyzés, amikor a hosztnak nincs saját hangja (pl. Claude), így addig semmi nem hangzik el, amíg nem választanak egy Say, Pi hangot.",
+    "message": "$host$ nem olvassa fel a válaszokat, amíg nem választasz lent egyet.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Címsor a Beállítások Hangok stúdiójának színpadán, amikor a hoszthoz nincs kiválasztva Say, Pi hang; $host$ az asszisztens (pl. Pi, Claude). Név méretben jelenik meg.",
+    "message": "Válaszd ki, hogyan szóljon $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Gomb a Beállítások Hangok stúdiójának színpadán, amely lejátsza az aktuális hang ingyenes mintaklipjét.",
+    "message": "Minta meghallgatása"
+  },
+  "voicesStopPlayback": {
+    "description": "Gomb a Beállítások Hangok vezérlősávjában, amely leállítja az „Összes lejátszása” által elindított mintasorozatot.",
+    "message": "Leállítás"
+  },
+  "voicesSweepPosition": {
+    "description": "Élő pozíciókijelzés a Beállítások Hangok vezérlősávjában, miközben a „Lejátszás mind” végiglépked a listán; $index$ az épp lejátszott hang, $total$ pedig a sorban lévők száma.",
+    "message": "$index$ / $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Akadálymentes címke a Beállítások Hangok vezérlősávjában lévő összehasonlítás vezérlőhöz, amely a legutóbb meghallgatott két hang közül a másikat játssza le; $name$ az a hang.",
+    "message": "Visszaváltás erre: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Sor a Beállítások Hangok vezérlősávjában, amikor a „Lejátszás mind” túl hosszú listán lett megnyomva; $count$ a hangok száma, $minutes$ pedig nagyjából az, hány percig tartana. A „min” rövidítés azért van, hogy 1-nél is helyesen olvasható legyen — a Chrome i18n nem kezeli a többes számot.",
+    "message": "Ez $count$ hang, kb. $minutes$ min. Előbb szűkítsd a listát.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Akadálymentes címke a beállítások hangkatalógusában található, gazdagépenkénti „használd ezt a hangot” gombhoz; $name$ a hang, $host$ az asszisztens (pl. Pi, Claude).",
+    "message": "$name$ használata itt: $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Rövid címke az egységes beállítások hangkatalógusában található, gazdagépenkénti „használd ezt a hangot” gombon (a gazdagép mellette látható).",
+    "message": "Használat"
+  },
+  "voicesYourVoice": {
+    "description": "Vezérlősáv gomb a Beállítások Hangok listában, amely a fókuszt arra a sorra viszi, amelyik hangot ez a host jelenleg használja; $name$ az a hang.",
+    "message": "A te hangod: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Hiba, amely akkor keletkezik, ha a böngésző nem tud elegendő WebAssembly-memóriát lefoglalni a hangérzékelő modellhez.",
+    "message": "A hangérzékelés nem indítható el: nincs elég WebAssembly-memória a hangmodellhez. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Hiba, amely akkor keletkezik, ha a böngésző nem teszi elérhetővé a hangérzékelő modell futtatásához szükséges kezdeti WebAssembly-memóriát.",
+    "message": "A hangérzékelés nem indítható el: ebben a böngészőben nem érhető el a WebAssembly-memória."
   }
 }

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Manfaat yang tercantum di modal autentikasi - peningkatan batas penggunaan.",
+    "message": "Batas penggunaan lebih tinggi dengan akun gratis"
+  },
+  "authBenefitPremium": {
+    "description": "Manfaat yang tercantum di modal autentikasi - fitur premium di berbagai chatbot.",
+    "message": "Fitur premium dan dukungan chatbot"
+  },
+  "authBenefitSupport": {
+    "description": "Manfaat yang tercantum di modal autentikasi - dukungan prioritas.",
+    "message": "Dukungan prioritas untuk masalah"
+  },
+  "authBenefitSync": {
+    "description": "Manfaat yang tercantum di modal autentikasi - sinkronisasi pengaturan.",
+    "message": "Sinkronkan pengaturan suara di mana saja"
+  },
+  "authBenefitTTS": {
+    "description": "Manfaat yang tercantum di modal autentikasi - fitur TTS.",
+    "message": "Suara text-to-speech (paket berbayar)"
+  },
+  "authBenefitUsage": {
+    "description": "Manfaat yang tercantum di modal autentikasi - pelacakan penggunaan.",
+    "message": "Lacak penggunaan suara Anda di semua perangkat"
+  },
+  "authPromptModalFull": {
+    "description": "Deskripsi untuk prompt autentikasi modal penuh dengan proposisi nilai.",
+    "message": "Anda sering memakai Say, Pi. Masuk untuk batas lebih tinggi, suara text-to-speech, dan fitur premium di semua chatbot yang didukung."
+  },
+  "authPromptModalSoft": {
+    "description": "Deskripsi untuk prompt autentikasi modal ringan.",
+    "message": "Buat akun Say, Pi gratis untuk batas penggunaan lebih tinggi dan akses ke fitur suara premium."
+  },
+  "authPromptTitle": {
+    "description": "Judul untuk modal prompt autentikasi.",
+    "message": "Buka lebih banyak fitur suara"
+  },
+  "authPromptToast": {
+    "description": "Notifikasi toast yang mendorong pengguna untuk masuk.",
+    "message": "Masuk ke Say, Pi untuk batas lebih tinggi dan fitur premium"
+  },
   "autoReadAloudChatGPT": {
     "description": "Label untuk kotak centang yang mengaktifkan atau menonaktifkan pembacaan otomatis tanggapan ChatGPT selama panggilan suara.",
     "message": "Pembacaan Otomatis (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Nonaktifkan teks-ke-pidato"
   },
+  "dismiss": {
+    "message": "Paham",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Membubarkan"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Fokus"
   },
+  "errorVadInitFailed": {
+    "description": "Toast error yang ditampilkan saat pendeteksian aktivitas suara gagal diinisialisasi.",
+    "message": "Gagal menginisialisasi pendeteksi suara"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Toast error yang ditampilkan saat terjadi kesalahan tak terduga ketika menyiapkan perekaman suara.",
+    "message": "Gagal menyiapkan perekaman suara"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Toast error yang ditampilkan saat klien pendeteksi suara gagal memulai perekaman.",
+    "message": "Gagal memulai perekaman suara"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Toast error yang ditampilkan saat klien pendeteksi suara (VAD) tidak tersedia, sehingga perekaman tidak dapat dimulai.",
+    "message": "Perekaman suara tidak tersedia"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Keluar dari Mode Fokus"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Catatan satu baris yang ditampilkan di menu suara saat suara premium (HD) dan suara value sama-sama tersedia",
+    "message": "Suara HD memakai jatah bulanan Anda sekitar 20× lebih cepat."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Menyelipkan ini ..."
   },
+  "maybeLater": {
+    "description": "Teks tombol untuk menutup prompt autentikasi.",
+    "message": "Mungkin nanti"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Setelan mikrofon Anda tidak memenuhi spesifikasi yang diperlukan. \nCoba gunakan mikrofon lain atau sesuaikan pengaturan audio Anda."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Tidak dapat mengakses mikrofon. \nSilakan periksa pengaturan perangkat Anda dan coba lagi."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Toast error yang ditampilkan ketika izin mikrofon ditolak setelah alur prompt perizinan.",
+    "message": "Izin mikrofon tidak diberikan. Pastikan kamu sudah mengizinkan akses di prompt dan di pengaturan ekstensi."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "ketepatan"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Respon tercepat, namun kurang akurat. \nCenderung mengganggu."
   },
+  "moreVoices": {
+    "description": "Baris menu yang menautkan dari menu suara di halaman ke katalog suara lengkap di setelan ekstensi",
+    "message": "Suara lainnya…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Nama panggilan asisten"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Tidak masuk"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Label tombol yang membuka ChatGPT.",
+    "message": "Buka ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Label tombol yang membuka Claude.ai.",
+    "message": "Buka Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Label tombol yang membuka Pi.ai.",
+    "message": "Buka Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Opsi lingkungan: di sekitar orang lain.",
+    "message": "Di sekitar orang lain"
+  },
+  "onboarding_envMixed": {
+    "description": "Opsi lingkungan: campuran ruang privat dan bersama.",
+    "message": "Campuran beberapa tempat"
+  },
+  "onboarding_envPrivate": {
+    "description": "Opsi lingkungan: ruang privat.",
+    "message": "Di tempat yang privat"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Konfirmasi yang ditampilkan saat jawaban lingkungan membiarkan mode senyap tetap mati.",
+    "message": "Baik, kami akan tetap memakai pengaturan standar untuk mendengarkan dan pemutaran."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Konfirmasi yang ditampilkan saat jawaban lingkungan mengaktifkan mode senyap.",
+    "message": "Mode senyap aktif — kami akan menangkap suara yang lebih pelan dan membalas dengan pelan, agar Anda bisa berbicara dengan lebih discreet."
+  },
+  "onboarding_envTitle": {
+    "description": "Judul untuk pertanyaan onboarding tentang lingkungan pengguna.",
+    "message": "Biasanya Anda akan berbicara di mana?"
+  },
+  "onboarding_footer": {
+    "description": "Teks footer pada halaman onboarding saat pertama kali dijalankan.",
+    "message": "Anda bisa melihat ini lagi kapan saja dari pengaturan Say, Pi. Privasi Anda penting — audio hanya direkam selama panggilan aktif."
+  },
+  "onboarding_heading": {
+    "description": "Judul utama pada halaman onboarding saat pertama kali dijalankan.",
+    "message": "🗣️ Selamat datang di Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Paragraf pengantar pada halaman onboarding saat pertama kali dijalankan.",
+    "message": "Anda tinggal dua langkah lagi dari percakapan lisan pertama Anda dengan AI. Berbicara sekitar 3× lebih cepat daripada mengetik — mari kita siapkan."
+  },
+  "onboarding_micTestButton": {
+    "description": "Tombol yang memulai uji mikrofon onboarding tanpa risiko.",
+    "message": "🎤 Uji mikrofon Anda"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status yang ditampilkan setelah uji mikrofon onboarding selesai dengan sukses.",
+    "message": "Bagus — mikrofon Anda berfungsi. 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status yang ditampilkan saat uji mikrofon onboarding mengukur input.",
+    "message": "Mendengarkan — coba bicara sesuatu. 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status yang ditampilkan saat uji mikrofon onboarding menunggu izin.",
+    "message": "Meminta akses mikrofon…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Label tombol untuk menghentikan uji mikrofon onboarding saat sedang berjalan.",
+    "message": "Hentikan uji"
+  },
+  "onboarding_step1Body": {
+    "description": "Isi langkah onboarding pertama yang menjelaskan cara menyematkan ekstensi.",
+    "message": "Klik ikon kepingan puzzle 🧩 di kanan atas browser Anda, lalu ikon semat 📌 di sebelah Say, Pi. Itu membuat tombol panggilan selalu satu klik saja."
+  },
+  "onboarding_step1Title": {
+    "description": "Judul langkah onboarding pertama (menyematkan ekstensi).",
+    "message": "Sematkan Say, Pi ke toolbar Anda"
+  },
+  "onboarding_step2Body": {
+    "description": "Isi langkah onboarding kedua yang menjelaskan cara memulai percakapan suara.",
+    "message": "Buka salah satu asisten yang didukung di bawah ini, lalu ketuk tombol panggilan Say, Pi dan sapa. Kami akan meminta akses mikrofon pada kali pertama — itu wajar, dan kami hanya mendengarkan saat Anda sedang dalam panggilan."
+  },
+  "onboarding_step2Title": {
+    "description": "Judul langkah onboarding kedua (memulai percakapan).",
+    "message": "Buka chat AI dan mulai bicara"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Izin mikrofon"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Panduan pemulihan saat izin mikrofon diblokir.",
+    "message": "Browser Anda memblokir mikrofon. Klik ikon kamera atau gembok di bilah alamat, setel Mikrofon ke \"Izinkan\", lalu coba lagi. Di macOS, periksa juga Pengaturan Sistem → Privasi & Keamanan → Mikrofon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Judul panel pemulihan saat izin mikrofon ditolak/diblokir.",
+    "message": "Akses mikrofon diblokir"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Panduan pemulihan saat mikrofon sedang digunakan di tempat lain.",
+    "message": "Aplikasi atau tab lain mungkin sedang menggunakan mikrofon Anda. Tutup apa pun yang mungkin sedang merekam (panggilan video, memo suara), lalu coba lagi."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Judul panel pemulihan saat mikrofon sedang dipakai oleh aplikasi lain.",
+    "message": "Mikrofon Anda sedang digunakan"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Panduan pemulihan saat tidak ada perangkat mikrofon yang tersedia.",
+    "message": "Kami tidak dapat menemukan mikrofon. Colokkan (atau sambungkan headset Anda), pastikan mikrofon dipilih sebagai perangkat input, lalu coba lagi."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Judul panel pemulihan saat tidak ada perangkat mikrofon yang tersedia.",
+    "message": "Tidak ada mikrofon yang ditemukan"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Panduan pemulihan untuk kesalahan mikrofon yang tidak diketahui.",
+    "message": "Ada masalah saat mengakses mikrofon Anda. Pastikan mikrofon tersambung dan diizinkan di pengaturan browser Anda, lalu coba lagi."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Judul panel pemulihan untuk kesalahan mikrofon yang tidak diketahui.",
+    "message": "Kami tidak dapat mengakses mikrofon Anda"
+  },
+  "permissions_retryButton": {
+    "description": "Label untuk tombol yang meminta ulang izin mikrofon.",
+    "message": "Coba lagi"
+  },
+  "permissions_revokedHeading": {
+    "description": "Judul yang ditampilkan saat akses mikrofon sebelumnya sudah diberikan tetapi kemudian dicabut.",
+    "message": "🎙️ Mari hubungkan kembali mikrofon Anda"
+  },
+  "permissions_revokedInfo": {
+    "description": "Teks informasi yang ditampilkan saat akses mikrofon dicabut setelah sebelumnya diberikan.",
+    "message": "Akses mikrofon Anda dimatikan — ini sering terjadi setelah pembaruan browser atau sistem. Izinkan lagi di bawah ini dan $productName$ akan kembali mendengarkan saat Anda sedang dalam panggilan.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Label untuk tombol yang mengaktifkan mode senyap/bisik.",
+    "message": "Mode senyap"
+  },
+  "quietModeTooltip": {
+    "description": "Tooltip yang menjelaskan fungsi mode senyap/bisik.",
+    "message": "Bicara lebih pelan — menangkap suara yang lebih pelan dan menurunkan volume balasan asisten, jadi kamu bisa pakai suara di sekitar orang lain."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Teks untuk tombol masuk saat autentikasi sedang berlangsung.",
+    "message": "Sedang masuk..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Efek suara"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Efek suara dinonaktifkan di Firefox untuk mencegah masalah umpan balik audio."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Judul pemberitahuan satu kali tentang keuntungan kecepatan yang ditampilkan setelah pertukaran suara pertama.",
+    "message": "Bagus — berbicara sekitar 3× lebih cepat daripada mengetik."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Baris kedua opsional dari pemberitahuan keuntungan kecepatan yang menampilkan total menit yang dihemat.",
+    "message": "Kamu sudah berbicara kira-kira $minutes$ menit lebih cepat daripada mengetiknya.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Hanya kirimkan ketika Anda menekan tombol"
   },
+  "surveyQuestion": {
+    "description": "Pertanyaan tunggal untuk mikro-survei sekali saja setelah kemenangan.",
+    "message": "Sejauh ini, bagaimana menurutmu fitur suara?"
+  },
+  "surveyRatingLabel": {
+    "description": "Label aksesibel untuk tombol penilaian survei.",
+    "message": "Beri nilai $rating$ dari 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Ucapan terima kasih yang ditampilkan setelah pengguna menjawab survei pasca-kemenangan.",
+    "message": "Terima kasih — ini membantu kami membuat Say, Pi lebih baik. 🙏"
+  },
   "tabAIChat": {
     "description": "Label tab untuk bagian pengaturan obrolan AI.",
     "message": "Obrolan AI"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Label tab untuk bagian pengaturan umum.",
     "message": "Umum"
+  },
+  "tabVoices": {
+    "description": "Label tab untuk bagian pengaturan suara (katalog suara per situs).",
+    "message": "Suara"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "kredit"
   },
+  "ttsCreditsRemaining": {
+    "description": "Teks yang menampilkan sisa kuota TTS sebagai kumpulan kredit per suara (saypi-api #181 Stage 2), bukan karakter mentah.",
+    "message": "Sisa $credits$ kredit",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Suara multibahasa saat ini tidak didukung di Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Generasi suara"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Perhatian! Pemutaran ucapan belum tersedia di $browserName$ dengan $chatbotName$. Kabar baiknya? Input suara berfungsi dengan baik! Untuk TTS, coba Chrome atau Edge di desktop.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS tidak tersedia di $browserName$ + $chatbotName$. Input suara berfungsi! Coba Chrome desktop untuk TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Suara tts"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Detail VAD saat audio mirip ucapan terdeteksi tetapi terlalu pelan / tingkat keyakinan terlalu rendah untuk ditranskripsikan (penolakan admission-gate di sisi klien).",
+    "message": "Audio terlalu pelan untuk ditranskripsikan"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Detail VAD yang menjelaskan panggilan berakhir karena mikrofon diklaim oleh tab yang lebih baru.",
+    "message": "Input suara dipindahkan ke tab lain"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Suara tidak tersedia. \nCoba chrome atau firefox di desktop."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Perhatian! Pemutaran ucapan belum tersedia di $browserName$ dengan $chatbotName$. Kabar baiknya? Input suara berfungsi dengan baik! Untuk TTS, coba Chrome atau Edge di desktop.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS tidak tersedia di $browserName$ + $chatbotName$. Input suara berfungsi! Coba Chrome desktop untuk TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Paham",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Status VAD yang ditampilkan pada tab yang input suaranya diambil alih oleh tab lain.",
+    "message": "Dijeda"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Lihat detail"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Perkenalan umum yang diputar ketika suara SayPi yang dipilih tidak memiliki skrip perkenalan khusus (dan tidak ada pesan terbaru untuk dibacakan ulang).",
+    "message": "Hai, saya $voice$. Ini suara saya. Semoga kamu suka suara ini.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Halo! \nTerima kasih! \ntidak! \nSaya Pi, asisten AI poliglot Anda. \nDengan 32 bahasa yang saya kuasai, kita dapat mengeksplorasi ide dan budaya dari seluruh dunia. \nApa pendapat Anda tentang suara ini?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Pengaturan Suara"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Subjudul cadangan untuk baris suara di katalog suara pengaturan saat suara tidak memiliki deskripsi; $count$ adalah jumlah bahasa yang didukung suara.",
+    "message": "Berbicara dalam $count$ bahasa",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Addison' (pengaturan Voices studio; peta identitas suara sisi klien).",
+    "message": "Ceria dan artikulatif"
+  },
+  "voiceTagline_alloy": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Alloy' (studio Suara di setelan; peta identitas suara sisi klien).",
+    "message": "Seimbang dan serbaguna"
+  },
+  "voiceTagline_ash": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Ash' (studio Suara di setelan; peta identitas suara sisi klien).",
+    "message": "Rendah, bijak, tenang"
+  },
+  "voiceTagline_ballad": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Ballad' (studio Suara di setelan; peta identitas suara sisi klien).",
+    "message": "Lembut dan melodis"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Cassidy' (pengaturan Voices studio; peta identitas suara sisi klien).",
+    "message": "Ramah dan lugas"
+  },
+  "voiceTagline_cedar": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Cedar' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Stabil dan meyakinkan"
+  },
+  "voiceTagline_coral": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Coral' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Cerah, berenergi positif"
+  },
+  "voiceTagline_echo": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Echo' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Bersih dan netral"
+  },
+  "voiceTagline_fable": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Fable' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Irama khas pendongeng"
+  },
+  "voiceTagline_finn": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Finn' (pengaturan Voices studio; peta identitas suara sisi klien).",
+    "message": "Segar dan berenergi"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Jamahal' (pengaturan Voices studio; peta identitas suara sisi klien).",
+    "message": "Kaya dan memikat"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Jarnathan' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Bariton lembut ala larut malam"
+  },
+  "voiceTagline_jeff": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Jeff' (pengaturan Voices studio; peta identitas suara sisi klien).",
+    "message": "Terus terang dan stabil"
+  },
+  "voiceTagline_jessica": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Jessica' (pengaturan Voices studio; peta identitas suara sisi klien).",
+    "message": "Hangat dan berwibawa"
+  },
+  "voiceTagline_joey": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Joey' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Gaya Amerika yang santai dan komunikatif"
+  },
+  "voiceTagline_juniper": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Juniper' (pengaturan Voices studio; peta identitas suara sisi klien).",
+    "message": "Jernih, cerah, ekspresif"
+  },
+  "voiceTagline_lucy": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Lucy' (pengaturan Voices studio; peta identitas suara sisi klien).",
+    "message": "Lembut dan bercahaya"
+  },
+  "voiceTagline_marin": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Marin' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Hangat, tenang ala radio pagi"
+  },
+  "voiceTagline_mark": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Mark' (pengaturan Voices studio; peta identitas suara sisi klien).",
+    "message": "Narator yang jelas dan percaya diri"
+  },
+  "voiceTagline_nova": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Nova' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Cepat dan ingin tahu"
+  },
+  "voiceTagline_onyx": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Onyx' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Dalam, bergema, dan berwibawa"
+  },
+  "voiceTagline_paola": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Paola' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Kehangatan Italia yang ekspresif"
+  },
+  "voiceTagline_sage": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Sage' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Jelas dengan tutur lembut"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Tagline kepribadian yang ditulis untuk suara 'Shimmer' (pengaturan Voices studio; peta identitas suara di sisi klien).",
+    "message": "Ringan dan lapang"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Label singkat pada tombol semat kartu suara (status mati) di studio Suara pengaturan; menekan akan menambahkan suara ke menu di chat untuk host.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Label aksesibel untuk tombol semat kartu suara (status mati); $name$ adalah suara, $host$ adalah asisten.",
+    "message": "Tambahkan $name$ ke menu $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Label pada toggle di bilah kontrol Suara yang menunjukkan apakah menelusuri daftar dengan tombol panah akan memutar tiap suara saat fokus mencapainya.",
+    "message": "Putar saat Anda berpindah"
+  },
+  "voicesArrowsLive": {
+    "description": "Konfirmasi pembaca layar, ditambahkan ke pengumuman pertama 'Memutar <suara>' di daftar Suara pada setelan, yang menyatakan tombol panah baru saja menjadi terdengar. Menggemakan kata-kata dari sakelar 'Putar saat Anda bergerak'.",
+    "message": "Panah kini memutar saat Anda bergerak. Esc menghentikan."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Catatan di bawah slot menu untuk host yang menyertakan suara asli (mis. 8 suara bawaan Pi), yang tidak dikelola studio; $host$ adalah asisten.",
+    "message": "Suara bawaan $host$ juga selalu muncul di menunya.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Varian dari voicesBuiltinsNote untuk host tanpa menu suara dalam chat (Pi menghentikan menunya pada 2026), ketika janji versi asli bahwa suara bawaan 'muncul di menunya' akan tidak benar; $host$ adalah asisten.",
+    "message": "$host$ juga punya suara bawaan sendiri, yang tidak tercantum di sini.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Tampilan progres di bilah kontrol Suara pada setelan: berapa banyak dari suara yang terdaftar sudah didengarkan pengguna. Angka tanpa kata, sehingga terbaca benar saat 1 — Chrome i18n tidak memiliki bentuk jamak.",
+    "message": "$heard$ dari $total$ sudah didengar",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Bagian dari nama aksesibel pada baris suara di daftar Suara pada setelan, menandai suara yang sudah didengarkan profil ini. Secara visual ini digambar sebagai kepadatan tinta pada jejak suara, yang tidak dapat dilihat pembaca layar.",
+    "message": "Sudah didengar"
+  },
+  "voicesInHostMenu": {
+    "description": "Judul bagian di atas deretan slot menu di studio Suara pengaturan; $host$ adalah asisten.",
+    "message": "Di menu $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Label singkat pada tombol semat kartu suara (status nyala) di studio Suara pengaturan.",
+    "message": "✓ Di menu"
+  },
+  "voicesInUse": {
+    "description": "Lencana tetap pada suara yang saat ini dipilih untuk host di daftar Suara pengaturan, dirender huruf besar. Sengaja BUKAN 'Sedang berbicara': di halaman ini baris memutar klip contoh, jadi suara yang dipilih tetapi diam tidak boleh mengklaim sedang berbicara ketika baris lain yang sedang berbunyi.",
+    "message": "Digunakan"
+  },
+  "voicesKeyboardHint": {
+    "description": "Petunjuk keyboard satu baris di bilah kontrol Suara pada setelan. Glif adalah tombol: Space, panah atas/bawah, dan Shift+Space.",
+    "message": "Tekan Space untuk mendengarkan, ↑↓ untuk berpindah antar suara, ⇧Space untuk beralih kembali."
+  },
+  "voicesLoadError": {
+    "description": "Status error di dalam studio milik satu host saat katalog suara host tersebut gagal dimuat; $host$ adalah asisten.",
+    "message": "Tidak dapat memuat suara $host$. Silakan coba lagi nanti.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/petunjuk pada tombol '+ Menu' yang dinonaktifkan ketika menu di chat untuk host sudah mencapai jumlah maksimum suara.",
+    "message": "Menu penuh — hapus satu suara untuk menambahkan yang lain"
+  },
+  "voicesMenuHint": {
+    "description": "Petunjuk satu baris di samping judul 'Di menu {host}', menjelaskan bahwa deretan slot mencerminkan menu suara di dalam chat.",
+    "message": "Yang akan Anda lihat di chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Catatan di bawah slot menu saat pengguna memiliki lebih banyak suara tersemat daripada yang bisa ditampilkan menu dalam chat (status lama); $count$ adalah jumlah yang tidak muat, $cap$ adalah ukuran menu.",
+    "message": "Ada $count$ suara tersemat lagi yang menunggu di luar $cap$ slot menu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Bentuk tunggal dari voicesMenuOverflow, digunakan saat tepat satu suara tersemat tidak muat di menu dalam chat; $cap$ adalah ukuran menu.",
+    "message": "Ada 1 suara tersemat lagi yang menunggu di luar $cap$ slot menu.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Baris ringkasan di bawah daftar Suara pada setelan yang menyatakan seberapa penuh menu suara dalam chat milik host; $host$ adalah asisten, $used$ berapa slot terisi, $cap$ berapa totalnya. Dirumuskan agar terbaca benar saat 1 — Chrome i18n tidak memiliki bentuk jamak.",
+    "message": "Menu $host$: $used$ dari $cap$ slot",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Judul untuk grup di akhir daftar Suara pada setelan yang berisi suara tanpa klip sampel untuk diputar; $count$ adalah jumlahnya. Dirumuskan agar terbaca benar saat 1 — Chrome i18n tidak memiliki bentuk jamak.",
+    "message": "Belum ada sampel ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Ditampilkan di katalog suara pengaturan saat daftar suara kosong untuk pengguna yang sudah masuk (mis. masalah jaringan).",
+    "message": "Suara tidak dapat dimuat saat ini. Silakan coba lagi nanti."
+  },
+  "voicesNowPlaying": {
+    "description": "Pengumuman pembaca layar saat klip sampel suara mulai diputar di daftar Suara pada setelan; $name$ adalah suara tersebut.",
+    "message": "Memutar $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Tombol di bilah kontrol Suara pada setelan yang memutar setiap suara yang sedang terdaftar, satu demi satu; $count$ adalah jumlahnya. Dirumuskan agar terbaca benar saat 1 — Chrome i18n tidak memiliki bentuk jamak.",
+    "message": "Putar semua ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Tombol di bilah kontrol Suara pada setelan saat kunjungan ulang: hanya memutar suara terdaftar yang belum Anda dengarkan; $count$ adalah jumlahnya. Dirumuskan agar terbaca benar saat 1 — Chrome i18n tidak memiliki bentuk jamak.",
+    "message": "Putar yang baru ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Baris di bilah kontrol Suara pada setelan saat browser menolak memutar sampel karena halaman belum ada interaksi pengguna.",
+    "message": "Klik suara mana pun untuk mengaktifkan audio."
+  },
+  "voicesPreview": {
+    "description": "Label aksesibel untuk tombol putar (▶) yang memutar klip contoh gratis sebuah suara pada baris suara; $name$ adalah nama suara.",
+    "message": "Putar contoh $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Nama aksesibel untuk daftar Suara di pengaturan (listbox berisi semua suara, satu baris tiap suara).",
+    "message": "Suara, diurutkan dari terdalam sampai terjernih"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Label aksesibel untuk tombol semat kartu suara (status nyala) dan tombol hapus pada slot menu; $name$ adalah suara, $host$ adalah asisten.",
+    "message": "Hapus $name$ dari menu $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Baris di bilah kontrol Suara pada setelan saat klip sampel satu suara gagal dimuat atau diputar; $name$ adalah suara tersebut. Non-modal — rangkaian sampel tetap berlanjut melewatinya.",
+    "message": "Tidak bisa memutar sampel $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Subjudul untuk bagian katalog suara di tab setelan AI Chat",
+    "message": "Pilih suara yang membacakan balasan dengan lantang di setiap situs."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Subjudul di bawah judul pengaturan Suara, untuk deretan suara yang diurutkan berdasarkan tinggi nada.",
+    "message": "Semua suara, dari terdalam sampai terjernih. Dengarkan, lalu pilih."
+  },
+  "voicesSectionTitle": {
+    "description": "Judul untuk bagian katalog suara di tab setelan AI Chat",
+    "message": "Suara"
+  },
+  "voicesShelfEveryday": {
+    "description": "Judul grup untuk suara tingkat hemat di katalog suara setelan. Dirender huruf besar oleh CSS.",
+    "message": "Suara sehari-hari"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Catatan satu baris di samping judul grup Sehari-hari di studio Suara setelan; satu-satunya tempat studio menyatakan seberapa jauh tier ini dibandingkan HD.",
+    "message": "Alami dan jernih — bisa didengarkan sekitar 20× lebih lama dibandingkan HD."
+  },
+  "voicesShelfHd": {
+    "description": "Judul grup untuk suara premium (HD) di katalog suara setelan. Dirender huruf besar oleh CSS.",
+    "message": "Suara HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Catatan satu baris di samping judul grup HD di studio Suara setelan.",
+    "message": "Suara kami yang paling kaya dan paling ekspresif."
+  },
+  "voicesShowAll": {
+    "description": "Opsi pada filter 'Tampilkan' Suara di setelan: tanpa pemfilteran, setiap suara ditampilkan.",
+    "message": "Semua suara"
+  },
+  "voicesShowEveryday": {
+    "description": "Opsi pada filter 'Tampilkan' Suara di setelan: hanya tampilkan suara standar (non-HD).",
+    "message": "Hanya standar"
+  },
+  "voicesShowHd": {
+    "description": "Opsi pada filter 'Tampilkan' Suara di setelan: hanya tampilkan suara premium (HD).",
+    "message": "Hanya HD"
+  },
+  "voicesShowLabel": {
+    "description": "Label pada filter di bilah kontrol Suara pada setelan yang mempersempit suara mana yang ditampilkan daftar.",
+    "message": "Tampilkan"
+  },
+  "voicesShowUnheard": {
+    "description": "Opsi pada filter 'Tampilkan' Suara di setelan: hanya tampilkan suara yang belum didengarkan pengguna.",
+    "message": "Belum didengar"
+  },
+  "voicesSpeakingNow": {
+    "description": "Label status pada suara yang saat ini dipilih untuk host di studio Suara pengaturan (slot menu dan kartu suara).",
+    "message": "Sedang berbicara"
+  },
+  "voicesSpeaksWith": {
+    "description": "Baris kecil di atas nama suara saat ini pada panggung studio Suara di pengaturan; $host$ adalah asisten (misalnya Pi). Dirender huruf besar oleh CSS.",
+    "message": "$host$ berbicara dengan",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Catatan panggung saat host menyediakan audionya sendiri (mis. Pi), sehingga memilih suara Say, Pi menggantikan suara host.",
+    "message": "$host$ memakai suaranya sendiri sampai Anda memilih satu di bawah.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Catatan panggung saat host tidak punya suara sendiri (mis. Claude), sehingga tidak ada yang dibacakan sampai suara Say, Pi dipilih.",
+    "message": "$host$ tidak akan membacakan balasan dengan suara sampai Anda memilih satu di bawah.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Judul pada panggung studio Suara di pengaturan saat host belum memiliki suara Say, Pi yang dipilih; $host$ adalah asisten (mis. Pi, Claude). Dirender pada ukuran nama.",
+    "message": "Pilih bagaimana suara $host$ terdengar",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Tombol pada panggung studio Suara di pengaturan yang memutar klip contoh gratis dari suara saat ini.",
+    "message": "Dengarkan contoh"
+  },
+  "voicesStopPlayback": {
+    "description": "Tombol di bilah kontrol Suara pada setelan yang menghentikan rangkaian sampel yang dimulai oleh 'Putar semua'.",
+    "message": "Hentikan"
+  },
+  "voicesSweepPosition": {
+    "description": "Pembacaan posisi langsung di bilah kontrol Suara pada setelan saat 'Putar semua' menelusuri daftar; $index$ adalah suara yang sedang diputar dan $total$ berapa banyak yang masuk antrean.",
+    "message": "$index$ dari $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Label aksesibel untuk kontrol perbandingan di bilah kontrol Suara pada setelan, yang memutar ulang suara lain dari dua suara terakhir yang didengar; $name$ adalah suara tersebut.",
+    "message": "Beralih kembali ke $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Baris di bilah kontrol Suara pada setelan saat 'Putar semua' ditekan pada daftar yang terlalu panjang untuk didengarkan; $count$ adalah jumlah suara dan $minutes$ kira-kira berapa menit durasinya. Disingkat 'min' agar tetap terbaca benar pada 1 — Chrome i18n tidak punya bentuk jamak.",
+    "message": "Itu $count$ suara — sekitar $minutes$ min. Persempit daftar dulu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Label aksesibel untuk tombol per-host 'gunakan suara ini' di katalog suara pengaturan; $name$ adalah suara, $host$ adalah asisten (misalnya Pi, Claude).",
+    "message": "Gunakan $name$ di $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Label singkat pada tombol per-host 'gunakan suara ini' di katalog suara pengaturan terpadu (host ditampilkan di sebelahnya).",
+    "message": "Gunakan"
+  },
+  "voicesYourVoice": {
+    "description": "Tombol bilah kontrol di daftar Suara pada setelan yang memindahkan fokus ke baris suara yang saat ini digunakan host ini; $name$ adalah suara tersebut.",
+    "message": "Suara Anda: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Error yang muncul ketika browser tidak dapat mengalokasikan memori WebAssembly yang cukup untuk model pendeteksi suara.",
+    "message": "Pendeteksian suara tidak dapat dimulai: memori WebAssembly tidak cukup untuk model suara. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Error yang muncul ketika browser tidak menyediakan memori WebAssembly awal yang diperlukan untuk menjalankan model pendeteksi suara.",
+    "message": "Pendeteksian suara tidak dapat dimulai: memori WebAssembly tidak tersedia di browser ini."
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Vantaggio elencato nella modale di autenticazione - aumento dei limiti di utilizzo.",
+    "message": "Limiti di utilizzo più alti con un account gratuito"
+  },
+  "authBenefitPremium": {
+    "description": "Vantaggio elencato nella modale di autenticazione - funzionalità premium su più chatbot.",
+    "message": "Funzionalità premium e supporto chatbot"
+  },
+  "authBenefitSupport": {
+    "description": "Vantaggio elencato nella modale di autenticazione - supporto prioritario.",
+    "message": "Supporto prioritario per i problemi"
+  },
+  "authBenefitSync": {
+    "description": "Vantaggio elencato nella modale di autenticazione - sincronizzazione delle impostazioni.",
+    "message": "Sincronizza ovunque le impostazioni vocali"
+  },
+  "authBenefitTTS": {
+    "description": "Vantaggio elencato nella modale di autenticazione - funzionalità TTS.",
+    "message": "Voci di sintesi vocale (piani a pagamento)"
+  },
+  "authBenefitUsage": {
+    "description": "Vantaggio elencato nella modale di autenticazione - tracciamento dell’utilizzo.",
+    "message": "Tieni traccia dell’utilizzo vocale su più dispositivi"
+  },
+  "authPromptModalFull": {
+    "description": "Descrizione per la richiesta di autenticazione nella modale completa con proposta di valore.",
+    "message": "Stai usando molto Say, Pi. Accedi per limiti più alti, voci di sintesi vocale e funzionalità premium su tutti i chatbot supportati."
+  },
+  "authPromptModalSoft": {
+    "description": "Descrizione per la richiesta di autenticazione nella modale leggera.",
+    "message": "Crea un account Say, Pi gratuito per limiti di utilizzo più alti e l’accesso a funzioni vocali premium."
+  },
+  "authPromptTitle": {
+    "description": "Titolo per la finestra modale della richiesta di autenticazione.",
+    "message": "Sblocca più funzioni vocali"
+  },
+  "authPromptToast": {
+    "description": "Notifica toast che incoraggia l’utente ad accedere.",
+    "message": "Accedi a Say, Pi per limiti più alti e funzionalità premium"
+  },
   "autoReadAloudChatGPT": {
     "description": "Etichetta per la casella di controllo che abilita o disabilita la lettura automatica delle risposte di ChatGPT durante le chiamate vocali.",
     "message": "Lettura Automatica (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Disabilita il testo-Speech"
   },
+  "dismiss": {
+    "message": "Ho capito",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Congedare"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Concentra"
   },
+  "errorVadInitFailed": {
+    "description": "Toast di errore mostrato quando il rilevamento dell'attività vocale non riesce a inizializzarsi.",
+    "message": "Impossibile inizializzare il rilevamento vocale"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Toast di errore mostrato quando si verifica un errore imprevisto durante la configurazione della registrazione vocale.",
+    "message": "Impossibile configurare la registrazione vocale"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Toast di errore mostrato quando il client di rilevamento vocale non riesce ad avviare la registrazione.",
+    "message": "Impossibile avviare la registrazione vocale"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Toast di errore mostrato quando il client di rilevamento vocale (VAD) non è disponibile, quindi la registrazione non può iniziare.",
+    "message": "Registrazione vocale non disponibile"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Esci dalla Modalità Focus"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Nota su una riga mostrata nei menu delle voci quando sono disponibili sia voci premium (HD) sia voci value",
+    "message": "Le voci HD consumano l’allocazione mensile circa 20× più in fretta."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Trancandolo ..."
   },
+  "maybeLater": {
+    "description": "Testo del pulsante per chiudere la richiesta di autenticazione.",
+    "message": "Magari più tardi"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Le impostazioni del microfono non soddisfano le specifiche richieste. \nProva a utilizzare un microfono diverso o a modificare le impostazioni audio."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Impossibile accedere al microfono. \nControlla le impostazioni del tuo dispositivo e riprova."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Toast di errore mostrato quando il permesso per il microfono è stato negato dopo il flusso di richiesta del permesso.",
+    "message": "Il permesso per il microfono non è stato concesso. Assicurati di aver consentito l'accesso nella richiesta e nelle impostazioni dell'estensione."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "precisione"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Risposta più rapida, ma meno precisa. \nIncline a interrompere."
   },
+  "moreVoices": {
+    "description": "Riga di menu che collega dal menu voci nella pagina al catalogo completo delle voci nelle impostazioni dell’estensione.",
+    "message": "Altre voci…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Nickname dell'assistente"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Non firmato"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Etichetta del pulsante che apre ChatGPT.",
+    "message": "Apri ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Etichetta del pulsante che apre Claude.ai.",
+    "message": "Apri Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Etichetta del pulsante che apre Pi.ai.",
+    "message": "Apri Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Opzione ambiente: in presenza di altre persone.",
+    "message": "In mezzo ad altre persone"
+  },
+  "onboarding_envMixed": {
+    "description": "Opzione ambiente: un mix di spazi privati e condivisi.",
+    "message": "In luoghi diversi"
+  },
+  "onboarding_envPrivate": {
+    "description": "Opzione ambiente: uno spazio privato.",
+    "message": "In un luogo privato"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Conferma mostrata quando la risposta sull'ambiente lascia la modalità silenziosa disattivata.",
+    "message": "Va bene, manterremo le impostazioni standard di ascolto e riproduzione."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Conferma mostrata quando la risposta sull'ambiente attiva la modalità silenziosa.",
+    "message": "Modalità silenziosa attiva: rileveremo anche una voce più bassa e risponderemo a bassa voce, così puoi parlare con discrezione."
+  },
+  "onboarding_envTitle": {
+    "description": "Titolo della domanda dell'onboarding sull'ambiente dell'utente.",
+    "message": "Dove parlerai di solito?"
+  },
+  "onboarding_footer": {
+    "description": "Testo del piè di pagina nella pagina di onboarding al primo avvio.",
+    "message": "Puoi rivederlo in qualsiasi momento dalle impostazioni di Say, Pi. La tua privacy conta: l'audio viene acquisito solo durante una chiamata attiva."
+  },
+  "onboarding_heading": {
+    "description": "Titolo principale nella pagina di onboarding al primo avvio.",
+    "message": "🗣️ Benvenuto in Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Paragrafo introduttivo nella pagina di onboarding al primo avvio.",
+    "message": "Ti mancano due passaggi alla tua prima conversazione parlata con un’IA. Parlare è circa 3× più veloce che scrivere, prepariamoci."
+  },
+  "onboarding_micTestButton": {
+    "description": "Pulsante che avvia il test del microfono nell'onboarding, senza conseguenze.",
+    "message": "🎤 Prova il microfono"
+  },
+  "onboarding_micTestDone": {
+    "description": "Stato mostrato dopo il completamento corretto del test del microfono nell'onboarding.",
+    "message": "Bene, il microfono funziona. 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Stato mostrato mentre il test del microfono nell'onboarding misura l'input.",
+    "message": "In ascolto — di' qualcosa. 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Stato mostrato mentre il test del microfono nell'onboarding attende l'autorizzazione.",
+    "message": "Richiesta del microfono…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Etichetta del pulsante per interrompere il test del microfono nell'onboarding mentre è in corso.",
+    "message": "Interrompi test"
+  },
+  "onboarding_step1Body": {
+    "description": "Testo del primo passaggio di onboarding che spiega come fissare l'estensione.",
+    "message": "Fai clic sull’icona del pezzo di puzzle 🧩 in alto a destra nel browser, poi sulla puntina 📌 accanto a Say, Pi. Così il pulsante di chiamata è a un clic di distanza."
+  },
+  "onboarding_step1Title": {
+    "description": "Titolo del primo passaggio di onboarding (fissare l'estensione).",
+    "message": "Fissa Say, Pi alla barra degli strumenti"
+  },
+  "onboarding_step2Body": {
+    "description": "Testo del secondo passaggio di onboarding che spiega come avviare una conversazione vocale.",
+    "message": "Vai su uno degli assistenti supportati qui sotto, poi tocca il pulsante di chiamata di Say, Pi e saluta. La prima volta chiederemo l’accesso al microfono: è normale, e ascoltiamo solo mentre sei attivamente in chiamata."
+  },
+  "onboarding_step2Title": {
+    "description": "Titolo del secondo passaggio di onboarding (iniziare una conversazione).",
+    "message": "Apri una chat con un’IA e inizia a parlare"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Autorizzazione al microfono"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Indicazioni di ripristino quando l'autorizzazione del microfono è bloccata.",
+    "message": "Il tuo browser sta bloccando il microfono. Fai clic sull'icona della fotocamera o del lucchetto nella barra degli indirizzi, imposta Microfono su \"Consenti\", poi riprova. Su macOS, controlla anche Impostazioni di Sistema → Privacy e Sicurezza → Microfono."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Titolo del pannello di ripristino quando l'autorizzazione del microfono è stata negata/bloccata.",
+    "message": "L'accesso al microfono è bloccato"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Indicazioni di ripristino quando il microfono è in uso altrove.",
+    "message": "Un'altra app o scheda potrebbe usare il microfono. Chiudi tutto ciò che potrebbe registrare (videochiamate, memo vocali), poi riprova."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Titolo del pannello di ripristino quando il microfono è usato da un'altra app.",
+    "message": "Il tuo microfono è in uso"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Indicazioni di ripristino quando non è disponibile alcun dispositivo microfono.",
+    "message": "Non siamo riusciti a trovare un microfono. Collegane uno (o connetti le cuffie con microfono), assicurati che sia selezionato come dispositivo di input, poi riprova."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Titolo del pannello di ripristino quando non è disponibile alcun dispositivo microfono.",
+    "message": "Nessun microfono trovato"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Indicazioni di ripristino per un errore del microfono sconosciuto.",
+    "message": "Qualcosa è andato storto durante l'accesso al microfono. Controlla che sia collegato e consentito nelle impostazioni del browser, poi riprova."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Titolo del pannello di ripristino per un errore del microfono sconosciuto.",
+    "message": "Non siamo riusciti ad accedere al microfono"
+  },
+  "permissions_retryButton": {
+    "description": "Etichetta del pulsante che richiede di nuovo l'autorizzazione al microfono.",
+    "message": "Riprova"
+  },
+  "permissions_revokedHeading": {
+    "description": "Titolo mostrato quando l'accesso al microfono era stato concesso in precedenza ma da allora è stato revocato.",
+    "message": "🎙️ Ricolleghiamo il tuo microfono"
+  },
+  "permissions_revokedInfo": {
+    "description": "Testo informativo mostrato quando l'accesso al microfono è stato revocato dopo essere stato concesso.",
+    "message": "L'accesso al microfono è stato disattivato. Succede spesso dopo un aggiornamento del browser o del sistema. Riabilitalo qui sotto e $productName$ tornerà ad ascoltare quando sei in chiamata.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profilo"
+  },
+  "quietModeLabel": {
+    "description": "Etichetta per l'interruttore che abilita la modalità silenziosa/sussurrata.",
+    "message": "Modalità silenziosa"
+  },
+  "quietModeTooltip": {
+    "description": "Tooltip che spiega cosa fa la modalità silenziosa/sussurrata.",
+    "message": "Parla piano: rileva meglio la voce bassa e riduce il volume della risposta dell'assistente, così puoi usare la voce vicino ad altre persone."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Testo del pulsante di accesso mentre l’autenticazione è in corso.",
+    "message": "Accesso in corso..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Effetti sonori"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Gli effetti sonori sono disabilitati in Firefox per evitare problemi di feedback audio."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Titolo dell'avviso una tantum sul vantaggio di velocità mostrato dopo il primo scambio a voce.",
+    "message": "Bello, parlare è circa 3× più veloce che digitare."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Seconda riga opzionale dell'avviso sul vantaggio di velocità che mostra i minuti interi risparmiati.",
+    "message": "Hai già parlato per circa $minutes$ min più velocemente che digitandolo.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Invia solo quando premi il pulsante"
   },
+  "surveyQuestion": {
+    "description": "L’unica domanda del micro-sondaggio una tantum dopo la prima riuscita.",
+    "message": "Come sta andando la voce finora?"
+  },
+  "surveyRatingLabel": {
+    "description": "Etichetta accessibile per un pulsante di valutazione del sondaggio.",
+    "message": "Valuta $rating$ su 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Ringraziamento mostrato dopo che l’utente risponde al sondaggio post-riuscita.",
+    "message": "Grazie, ci aiuta a rendere Say, Pi migliore."
+  },
   "tabAIChat": {
     "description": "Etichetta della scheda per le impostazioni della chat AI.",
     "message": "Chat AI"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Etichetta della scheda per le impostazioni generali.",
     "message": "Generale"
+  },
+  "tabVoices": {
+    "description": "Etichetta della scheda per la sezione impostazioni delle voci (catalogo delle voci per sito).",
+    "message": "Voci"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "Crediti"
   },
+  "ttsCreditsRemaining": {
+    "description": "Testo che mostra la quota TTS rimanente come pool di crediti per voce (saypi-api #181 Fase 2), non come caratteri grezzi.",
+    "message": "$credits$ crediti rimanenti",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Le voci multilingue non sono attualmente supportate in Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Generazione vocale"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Attenzione! La riproduzione vocale non è ancora disponibile su $browserName$ con $chatbotName$. La buona notizia? L'input vocale funziona benissimo! Per il TTS, prova Chrome o Edge sul desktop.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS non disponibile su $browserName$ + $chatbotName$. L'input vocale funziona! Prova Chrome desktop per il TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Voce di TTS"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Dettaglio VAD quando è stato rilevato audio simile al parlato ma era troppo debole / con bassa confidenza per essere trascritto (scarto lato client al gate di ammissione).",
+    "message": "Audio troppo debole per la trascrizione"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Dettaglio VAD che spiega che la chiamata è terminata perché il microfono è stato acquisito da una scheda più recente.",
+    "message": "Input vocale spostato su un'altra scheda"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Voce non disponibile. \nProva Chrome o Firefox sul desktop."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Attenzione! La riproduzione vocale non è ancora disponibile su $browserName$ con $chatbotName$. La buona notizia? L'input vocale funziona benissimo! Per il TTS, prova Chrome o Edge sul desktop.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS non disponibile su $browserName$ + $chatbotName$. L'input vocale funziona! Prova Chrome desktop per il TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Ho capito",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Stato VAD mostrato su una scheda il cui input vocale è stato preso in carico da un'altra scheda.",
+    "message": "In pausa"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Visualizza i dettagli"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Introduzione vocale generica riprodotta quando una voce di SayPi selezionata non ha uno script di introduzione specifico (e non c'è un messaggio recente da rileggere).",
+    "message": "Ciao, sono $voice$. Questo è come suono. Spero che ti piaccia questa voce.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Ciao! \nGrazie! \nVa bene! \nSono Pi, il tuo assistente AI poliglotta. \nCon 32 lingue a mia disposizione, possiamo esplorare idee e culture da tutto il mondo. \nCosa ne pensi di questa voce?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Impostazioni vocali"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Sottotitolo di fallback per una riga voce nel catalogo voci delle impostazioni quando la voce non ha descrizione; $count$ è il numero di lingue supportate dalla voce.",
+    "message": "Parla $count$ lingue",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Tagline di personalità scritta per la voce \"Addison\" (impostazioni Studio voci; mappa identità voce lato client).",
+    "message": "Solare e articolato"
+  },
+  "voiceTagline_alloy": {
+    "description": "Tagline di personalità scritta per la voce 'Alloy' (studio Voci nelle impostazioni; mappa dell'identità della voce lato client).",
+    "message": "Equilibrata e versatile"
+  },
+  "voiceTagline_ash": {
+    "description": "Tagline di personalità scritta per la voce 'Ash' (studio Voci nelle impostazioni; mappa dell'identità della voce lato client).",
+    "message": "Profonda, riflessiva, calma"
+  },
+  "voiceTagline_ballad": {
+    "description": "Tagline di personalità scritta per la voce 'Ballad' (studio Voci nelle impostazioni; mappa dell'identità della voce lato client).",
+    "message": "Morbida e melodica"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Tagline di personalità scritta per la voce \"Cassidy\" (impostazioni Studio voci; mappa identità voce lato client).",
+    "message": "Cordiale e schietto"
+  },
+  "voiceTagline_cedar": {
+    "description": "Tagline di personalità scritta per la voce \"Cedar\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Stabile e rassicurante"
+  },
+  "voiceTagline_coral": {
+    "description": "Tagline di personalità scritta per la voce \"Coral\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Energia brillante e positiva"
+  },
+  "voiceTagline_echo": {
+    "description": "Tagline di personalità scritta per la voce \"Echo\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Pulita e neutra"
+  },
+  "voiceTagline_fable": {
+    "description": "Tagline di personalità scritta per la voce \"Fable\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Cadenza da narratore"
+  },
+  "voiceTagline_finn": {
+    "description": "Tagline di personalità scritta per la voce \"Finn\" (impostazioni Studio voci; mappa identità voce lato client).",
+    "message": "Fresco ed energico"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Tagline di personalità scritta per la voce \"Jamahal\" (impostazioni Studio voci; mappa identità voce lato client).",
+    "message": "Ricco e magnetico"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Tagline di personalità scritta per la voce \"Jarnathan\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Baritono vellutato da tarda notte"
+  },
+  "voiceTagline_jeff": {
+    "description": "Tagline di personalità scritta per la voce \"Jeff\" (impostazioni Studio voci; mappa identità voce lato client).",
+    "message": "Schietto e costante"
+  },
+  "voiceTagline_jessica": {
+    "description": "Tagline di personalità scritta per la voce \"Jessica\" (impostazioni Studio voci; mappa identità voce lato client).",
+    "message": "Calda, con eleganza impeccabile"
+  },
+  "voiceTagline_joey": {
+    "description": "Tagline di personalità scritta per la voce \"Joey\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Americano facile e colloquiale"
+  },
+  "voiceTagline_juniper": {
+    "description": "Tagline di personalità scritta per la voce \"Juniper\" (impostazioni Studio voci; mappa identità voce lato client).",
+    "message": "Nitido, brillante, vivace"
+  },
+  "voiceTagline_lucy": {
+    "description": "Tagline di personalità scritta per la voce \"Lucy\" (impostazioni Studio voci; mappa identità voce lato client).",
+    "message": "Dolce e luminosa"
+  },
+  "voiceTagline_marin": {
+    "description": "Tagline di personalità scritta per la voce \"Marin\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Calma calda da radio mattutina"
+  },
+  "voiceTagline_mark": {
+    "description": "Tagline di personalità scritta per la voce \"Mark\" (impostazioni Studio voci; mappa identità voce lato client).",
+    "message": "Narratore chiaro e sicuro"
+  },
+  "voiceTagline_nova": {
+    "description": "Tagline di personalità scritta per la voce \"Nova\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Veloce e curiosa"
+  },
+  "voiceTagline_onyx": {
+    "description": "Tagline di personalità scritta per la voce \"Onyx\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Gravità profonda e risonante"
+  },
+  "voiceTagline_paola": {
+    "description": "Tagline di personalità scritta per la voce \"Paola\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Calore italiano espressivo"
+  },
+  "voiceTagline_sage": {
+    "description": "Tagline di personalità scritta per la voce \"Sage\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Chiarezza pacata"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Tagline di personalità scritta per la voce \"Shimmer\" (impostazioni Studio voci; mappa dell’identità vocale lato client).",
+    "message": "Leggera e ariosa"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Etichetta breve sull'interruttore di fissaggio di una scheda voce (stato disattivo) nello Studio voci delle impostazioni; premendolo aggiunge la voce al menu in chat dell'host.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Etichetta accessibile per l'interruttore di fissaggio di una scheda voce (stato disattivo); $name$ è la voce, $host$ l'assistente.",
+    "message": "Aggiungi $name$ al menu di $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Etichetta dell’interruttore nella barra di controllo Voci che indica se scorrere l’elenco con i tasti freccia riproduce ogni voce quando il focus la raggiunge.",
+    "message": "Riproduci mentre ti sposti"
+  },
+  "voicesArrowsLive": {
+    "description": "Conferma per lettori di schermo, aggiunta al primo annuncio \"In riproduzione <voce>\" nell'elenco Voci delle impostazioni, che dice che i tasti freccia sono appena diventati udibili. Ricalca la formulazione dell'interruttore \"Riproduci mentre ti sposti\".",
+    "message": "Le frecce ora riproducono mentre ti sposti. Esc ferma."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Nota sotto gli slot del menu per gli host che includono voci native (es. gli 8 integrati di Pi), che lo studio non gestisce; $host$ è l’assistente.",
+    "message": "Anche le voci integrate di $host$ appaiono sempre nel suo menu.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variante di voicesBuiltinsNote per un host senza menu voci in chat (Pi ha ritirato il menu nel 2026), dove la promessa dell’originale che le voci integrate 'appaiono nel suo menu' sarebbe falsa; $host$ è l’assistente.",
+    "message": "$host$ ha anche voci integrate, che non sono elencate qui.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Indicatore di avanzamento nella barra di controllo Voci delle impostazioni: quante delle voci elencate l'utente ha già ascoltato. Solo numeri, quindi è corretto con 1 — Chrome i18n non ha forme plurali.",
+    "message": "$heard$ di $total$ ascoltate",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Parte del nome accessibile di una riga voce nell'elenco Voci delle impostazioni, che contrassegna una voce che questo profilo ha già ascoltato. Visivamente è rappresentata come densità dell'inchiostro nell'impronta sonora della voce, che un lettore di schermo non può vedere.",
+    "message": "Ascoltata"
+  },
+  "voicesInHostMenu": {
+    "description": "Titolo della sezione sopra la riga degli slot di menu nello Studio voci delle impostazioni; $host$ è l'assistente.",
+    "message": "Nel menu di $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Etichetta breve sull'interruttore di fissaggio di una scheda voce (stato attivo) nello Studio voci delle impostazioni.",
+    "message": "✓ Nel menu"
+  },
+  "voicesInUse": {
+    "description": "Badge persistente sulla voce attualmente selezionata dell'host nell'elenco Voci delle impostazioni, resa in maiuscolo. Deliberatamente NON \"Sta parlando\": in questa pagina le righe riproducono i loro clip di esempio, quindi una voce selezionata ma silenziosa non deve affermare di parlare mentre lo fa una riga diversa.",
+    "message": "In uso"
+  },
+  "voicesKeyboardHint": {
+    "description": "Suggerimento da una riga per la tastiera nella barra di controllo Voci delle impostazioni. I simboli indicano tasti: Spazio, le frecce su/giù e Maiusc+Spazio.",
+    "message": "Premi Spazio per ascoltare, ↑↓ per spostarti tra le voci, ⇧Spazio per tornare indietro."
+  },
+  "voicesLoadError": {
+    "description": "Stato di errore nello studio di un host quando il catalogo voci di quell’host non è riuscito a caricarsi; $host$ è l’assistente.",
+    "message": "Impossibile caricare le voci di $host$. Riprova più tardi.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/suggerimento su un interruttore \"+ Menu\" disabilitato quando il menu in chat dell'host ha già raggiunto il numero massimo di voci.",
+    "message": "Menu pieno, rimuovi una voce per aggiungerne un'altra"
+  },
+  "voicesMenuHint": {
+    "description": "Suggerimento su una riga accanto all'intestazione \"Nel menu di {host}\", che spiega che la riga degli slot rispecchia il menu voci in chat.",
+    "message": "Cosa vedrai in chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Nota sotto gli slot del menu quando l’utente ha più voci fissate di quante il menu in chat possa mostrare (stato legacy); $count$ è quante non ci stanno, $cap$ è la dimensione del menu.",
+    "message": "$count$ altre voci fissate ti aspettano oltre i $cap$ slot del menu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Singolare di voicesMenuOverflow, usato quando esattamente una voce fissata non ci sta nel menu in chat; $cap$ è la dimensione del menu.",
+    "message": "1 altra voce fissata ti aspetta oltre i $cap$ slot del menu.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Riga di riepilogo sotto l'elenco Voci delle impostazioni che indica quanto è pieno il menu vocale in chat dell'host; $host$ è l'assistente, $used$ quanti posti sono occupati, $cap$ quanti ce ne sono. Formulato per essere corretto con 1 — Chrome i18n non ha forme plurali.",
+    "message": "Menu di $host$: $used$ di $cap$ posti",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Intestazione per il gruppo alla fine dell'elenco Voci delle impostazioni che contiene le voci senza clip di esempio da riprodurre; $count$ è quante. Formulato per essere corretto con 1 — Chrome i18n non ha forme plurali.",
+    "message": "Ancora nessun campione ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Mostrato nel catalogo voci delle impostazioni quando l'elenco delle voci è vuoto per un utente connesso (ad es. un problema di rete)",
+    "message": "Le voci non possono essere caricate al momento. Riprova più tardi."
+  },
+  "voicesNowPlaying": {
+    "description": "Annuncio per lettori di schermo quando inizia la riproduzione della clip di esempio di una voce nell'elenco Voci delle impostazioni; $name$ è la voce.",
+    "message": "In riproduzione $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Pulsante nella barra di controllo Voci delle impostazioni che riproduce tutte le voci attualmente elencate, una dopo l'altra; $count$ è quante. Formulato per essere corretto con 1 — Chrome i18n non ha forme plurali.",
+    "message": "Riproduci tutte ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Pulsante nella barra di controllo Voci delle impostazioni in una visita di ritorno: riproduce solo le voci elencate che non hai ancora ascoltato; $count$ è quante. Formulato per essere corretto con 1 — Chrome i18n non ha forme plurali.",
+    "message": "Riproduci nuove ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Riga nella barra di controllo Voci nelle impostazioni quando il browser ha rifiutato di riprodurre un campione perché la pagina non ha ancora avuto interazione da parte dell'utente.",
+    "message": "Fai clic su una voce per attivare l'audio."
+  },
+  "voicesPreview": {
+    "description": "Etichetta accessibile per il pulsante di riproduzione (▶) che fa ascoltare il clip di esempio gratuito di una voce in una riga voce; $name$ è il nome della voce.",
+    "message": "Riproduci un campione di $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Nome accessibile dell’elenco Voci nelle impostazioni (una listbox di ogni voce, una riga ciascuna).",
+    "message": "Voci, ordinate dalla più profonda alla più brillante"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Etichetta accessibile per l'interruttore di fissaggio di una scheda voce (stato attivo) e per il pulsante di rimozione di uno slot del menu; $name$ è la voce, $host$ l'assistente.",
+    "message": "Rimuovi $name$ dal menu di $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Riga nella barra di controllo Voci nelle impostazioni quando il clip di campione di una voce non è riuscito a caricarsi o a essere riprodotto; $name$ è quella voce. Non modale — una sequenza di campioni prosegue oltre.",
+    "message": "Impossibile riprodurre il campione di $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Sottotitolo della sezione del catalogo voci nelle impostazioni, scheda AI Chat.",
+    "message": "Scegli la voce che legge ad alta voce le risposte su ciascun sito."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Sottotitolo sotto l’intestazione delle impostazioni Voci, per la corsia di voci ordinate per altezza.",
+    "message": "Ogni voce, dalla più profonda alla più brillante. Ascolta, poi scegli."
+  },
+  "voicesSectionTitle": {
+    "description": "Titolo della sezione del catalogo voci nelle impostazioni, scheda AI Chat.",
+    "message": "Voci"
+  },
+  "voicesShelfEveryday": {
+    "description": "Titolo del gruppo per le voci di fascia economica nel catalogo voci delle impostazioni. Reso in maiuscolo dal CSS.",
+    "message": "Voci quotidiane"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Nota di una riga accanto al titolo del gruppo Everyday nello studio Voci delle impostazioni; l’unico punto in cui lo studio indica quanto questa fascia duri più a lungo rispetto a HD.",
+    "message": "Naturale e chiaro, puoi ascoltare circa 20× più a lungo rispetto a HD."
+  },
+  "voicesShelfHd": {
+    "description": "Titolo del gruppo per le voci premium (HD) nel catalogo voci delle impostazioni. Reso in maiuscolo dal CSS.",
+    "message": "Voci HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Nota di una riga accanto al titolo del gruppo HD nello studio Voci delle impostazioni.",
+    "message": "Il nostro suono più ricco ed espressivo."
+  },
+  "voicesShowAll": {
+    "description": "Opzione nel filtro 'Mostra' di Voci nelle impostazioni: nessun filtro, vengono elencate tutte le voci.",
+    "message": "Tutte le voci"
+  },
+  "voicesShowEveryday": {
+    "description": "Opzione nel filtro 'Mostra' di Voci nelle impostazioni: elenca solo le voci standard (non HD).",
+    "message": "Solo standard"
+  },
+  "voicesShowHd": {
+    "description": "Opzione nel filtro 'Mostra' di Voci nelle impostazioni: elenca solo le voci premium (HD).",
+    "message": "Solo HD"
+  },
+  "voicesShowLabel": {
+    "description": "Etichetta sul filtro nella barra di controllo Voci nelle impostazioni che limita quali voci vengono mostrate nell'elenco.",
+    "message": "Mostra"
+  },
+  "voicesShowUnheard": {
+    "description": "Opzione nel filtro 'Mostra' di Voci nelle impostazioni: elenca solo le voci che l'utente non ha ancora ascoltato.",
+    "message": "Non ancora ascoltate"
+  },
+  "voicesSpeakingNow": {
+    "description": "Etichetta di stato sulla voce attualmente selezionata dell'host nello Studio voci delle impostazioni (voce di menu e scheda voce).",
+    "message": "Sta parlando"
+  },
+  "voicesSpeaksWith": {
+    "description": "Riga sopra il nome della voce corrente nella schermata Studio voci delle impostazioni; $host$ è l'assistente (ad es. Pi). Resa in maiuscolo dal CSS.",
+    "message": "$host$ parla con",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Nota nella schermata quando l’host fornisce il proprio audio (es. Pi), quindi scegliere una voce di Say, Pi sostituisce quella dell’host.",
+    "message": "$host$ usa la sua voce finché non ne scegli una qui sotto.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Nota nella schermata quando l’host non ha una voce propria (es. Claude), quindi non viene letto nulla ad alta voce finché non viene scelta una voce di Say, Pi.",
+    "message": "$host$ non leggerà le risposte ad alta voce finché non ne scegli una qui sotto.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Titolo nella schermata dello studio Voci nelle impostazioni quando l’host non ha selezionato alcuna voce di SayPi; $host$ è l’assistente (es. Pi, Claude). Reso alla dimensione del nome.",
+    "message": "Scegli come suona $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Pulsante nello studio Voci delle impostazioni che riproduce la clip di campione gratuita della voce corrente.",
+    "message": "Ascolta un campione"
+  },
+  "voicesStopPlayback": {
+    "description": "Pulsante nella barra di controllo Voci delle impostazioni che interrompe la sequenza di campioni avviata da \"Riproduci tutte\".",
+    "message": "Interrompi"
+  },
+  "voicesSweepPosition": {
+    "description": "Indicatore della posizione in tempo reale nella barra di controllo Voci nelle impostazioni mentre 'Riproduci tutto' scorre l'elenco; $index$ è la voce in riproduzione e $total$ quante sono in coda.",
+    "message": "$index$ di $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Etichetta accessibile per il controllo di confronto nella barra di controllo Voci delle impostazioni, che riascolta l'altra voce delle ultime due ascoltate; $name$ è quella voce.",
+    "message": "Torna a $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Riga nella barra di controllo Voci nelle impostazioni quando si preme 'Riproduci tutto' su un elenco troppo lungo da ascoltare; $count$ è quante voci e $minutes$ approssimativamente quanti minuti richiederebbero. 'min' è abbreviato così che si legga correttamente anche con 1 — Chrome i18n non ha forme plurali.",
+    "message": "Sono $count$ voci — circa $minutes$ min. Restringi prima l'elenco.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Etichetta accessibile per il pulsante per host \"usa questa voce\" nel catalogo voci delle impostazioni; $name$ è la voce, $host$ è l'assistente (ad es. Pi, Claude).",
+    "message": "Usa $name$ su $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Etichetta breve sul pulsante per host \"usa questa voce\" nel catalogo voci delle impostazioni unificate (l'host è mostrato accanto).",
+    "message": "Usa"
+  },
+  "voicesYourVoice": {
+    "description": "Pulsante nella barra di controllo nell'elenco Voci delle impostazioni che sposta il focus sulla riga della voce usata attualmente da questo host; $name$ è quella voce.",
+    "message": "La tua voce: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Errore generato quando il browser non riesce ad allocare memoria WebAssembly sufficiente per il modello di rilevamento vocale.",
+    "message": "Impossibile avviare il rilevamento vocale: memoria WebAssembly insufficiente per il modello vocale. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Errore generato quando il browser non espone la memoria WebAssembly iniziale necessaria per eseguire il modello di rilevamento vocale.",
+    "message": "Impossibile avviare il rilevamento vocale: la memoria WebAssembly non è disponibile in questo browser."
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "認証モーダルに表示する特典：利用上限の増加。",
+    "message": "無料アカウントで利用上限アップ"
+  },
+  "authBenefitPremium": {
+    "description": "認証モーダルに表示する特典：チャットボット全体でのプレミアム機能。",
+    "message": "プレミアム機能とチャットボット対応"
+  },
+  "authBenefitSupport": {
+    "description": "認証モーダルに表示する特典：優先サポート。",
+    "message": "問題への優先サポート"
+  },
+  "authBenefitSync": {
+    "description": "認証モーダルに表示する特典：設定の同期。",
+    "message": "音声設定をどこでも同期"
+  },
+  "authBenefitTTS": {
+    "description": "認証モーダルに表示する特典：TTS 機能。",
+    "message": "テキスト読み上げ音声（有料プラン）"
+  },
+  "authBenefitUsage": {
+    "description": "認証モーダルに表示する特典：利用状況の追跡。",
+    "message": "デバイス間の音声利用量を確認"
+  },
+  "authPromptModalFull": {
+    "description": "価値提案を含む、フルモーダル認証プロンプトの説明文。",
+    "message": "Say, Pi をたくさんご利用いただいています。サインインすると、上限の引き上げ、テキスト読み上げ音声、対応するすべてのチャットボットでのプレミアム機能が利用できます。"
+  },
+  "authPromptModalSoft": {
+    "description": "控えめなモーダル認証プロンプトの説明文。",
+    "message": "無料の Say, Pi アカウントを作成すると、利用上限が増えてプレミアム音声機能にアクセスできます。"
+  },
+  "authPromptTitle": {
+    "description": "認証プロンプトのモーダルのタイトル。",
+    "message": "音声機能をもっと使う"
+  },
+  "authPromptToast": {
+    "description": "ユーザーにサインインを促すトースト通知。",
+    "message": "Say, Pi にサインインして上限引き上げとプレミアム機能を利用"
+  },
   "autoReadAloudChatGPT": {
     "description": "音声通話中にChatGPTの回答を自動で読み上げる機能のオン・オフを切り替えるチェックボックスのラベルです。",
     "message": "自動読み上げ（ChatGPT）"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "テキストからスピーチを無効にします"
   },
+  "dismiss": {
+    "message": "了解",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "解散"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "集中"
   },
+  "errorVadInitFailed": {
+    "description": "音声アクティビティ検出の初期化に失敗したときに表示されるエラートースト。",
+    "message": "音声検出を初期化できませんでした"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "音声録音の設定中に予期しないエラーが発生したときに表示されるエラートースト。",
+    "message": "音声録音の設定に失敗しました"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "音声検出クライアントが録音開始に失敗したときに表示されるエラートースト。",
+    "message": "音声録音を開始できませんでした"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "音声検出（VAD）クライアントが利用できず、録音を開始できないときに表示されるエラートースト。",
+    "message": "音声録音は利用できません"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "集中モードを終了"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "プレミアム（HD）音声とバリュー音声の両方が利用できるときに、音声メニューに表示される 1 行の注意書き",
+    "message": "HD 音声は月間利用枠を約 20 倍速く消費します。"
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "これを取り除く..."
   },
+  "maybeLater": {
+    "description": "認証プロンプトを閉じるボタンのテキスト。",
+    "message": "あとで"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "マイクの設定が必要な仕様を満たしていません。\n別のマイクを使用するか、オーディオ設定を調整してみてください。"
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "マイクにアクセスできません。\nデバイスの設定を確認して、もう一度試してください。"
   },
+  "microphonePermissionDeniedError": {
+    "description": "権限プロンプトのフロー後にマイクの権限が拒否されたときに表示されるエラートースト。",
+    "message": "マイクの権限が許可されませんでした。プロンプトと拡張機能の設定でアクセスを許可しているか確認してください。"
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "正確さ"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "応答は最速ですが、精度は低くなります。\n中断しがち。"
   },
+  "moreVoices": {
+    "description": "ページ内の音声メニューから拡張機能の設定にある完全な音声カタログへ移動するメニュー行。",
+    "message": "他の音声…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "アシスタントのニックネーム"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "サインインしていません"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "ChatGPT を開くボタンのラベル。",
+    "message": "ChatGPT を開く"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Claude.ai を開くボタンのラベル。",
+    "message": "Claude を開く"
+  },
+  "onboarding_ctaPi": {
+    "description": "Pi.ai を開くボタンのラベル。",
+    "message": "Pi を開く"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "環境の選択肢: 周りに他の人がいる。",
+    "message": "周りに人がいる場所"
+  },
+  "onboarding_envMixed": {
+    "description": "環境の選択肢: プライベートと共有空間の混在。",
+    "message": "いろいろな場所"
+  },
+  "onboarding_envPrivate": {
+    "description": "環境の選択肢: プライベートな空間。",
+    "message": "プライベートな場所"
+  },
+  "onboarding_envQuietOff": {
+    "description": "環境に関する回答で静音モードをオフのままにする場合に表示される確認。",
+    "message": "了解しました。標準のリスニングと再生の設定のままにします。"
+  },
+  "onboarding_envQuietOn": {
+    "description": "環境の回答によってクワイエットモードが有効になったときに表示される確認文。",
+    "message": "クワイエットモードオン。小さな声も拾い、控えめな音量で返答します。目立たずに話せます。"
+  },
+  "onboarding_envTitle": {
+    "description": "ユーザーの利用環境について尋ねるオンボーディング質問の見出し。",
+    "message": "普段どこで話しますか"
+  },
+  "onboarding_footer": {
+    "description": "初回オンボーディングページのフッターテキスト。",
+    "message": "これはいつでも Say, Pi の設定から見直せます。プライバシーは大切です。音声は通話中のみ取得されます。"
+  },
+  "onboarding_heading": {
+    "description": "初回オンボーディング ページのメイン見出し。",
+    "message": "🗣️ Say, Pi へようこそ"
+  },
+  "onboarding_intro": {
+    "description": "初回オンボーディング ページの導入段落。",
+    "message": "AI と最初の音声会話まであと 2 ステップです。話すのは入力の約 3 倍速いので、設定を始めましょう。"
+  },
+  "onboarding_micTestButton": {
+    "description": "リスクなしのオンボーディング用マイクテストを開始するボタン。",
+    "message": "🎤 マイクをテスト"
+  },
+  "onboarding_micTestDone": {
+    "description": "オンボーディングのマイクテストが正常に完了した後に表示されるステータス。",
+    "message": "いい感じです。マイクは動作しています 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "オンボーディングのマイクテストが入力レベルを測定している間に表示されるステータス。",
+    "message": "聞いています。何か話してみてください 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "オンボーディングのマイクテストで許可待ちの間に表示されるステータス。",
+    "message": "マイクをリクエスト中…"
+  },
+  "onboarding_micTestStop": {
+    "description": "実行中のオンボーディング用マイクテストを停止するボタンのラベル。",
+    "message": "テストを停止"
+  },
+  "onboarding_step1Body": {
+    "description": "拡張機能を固定する方法を説明する、オンボーディング最初のステップの本文。",
+    "message": "ブラウザ右上のパズルピース 🧩 アイコンをクリックし、Say, Pi の横にあるピン 📌 を押します。これで通話ボタンがワンクリックで使えます。"
+  },
+  "onboarding_step1Title": {
+    "description": "オンボーディングの最初のステップのタイトル（拡張機能を固定）。",
+    "message": "Say, Pi をツールバーに固定"
+  },
+  "onboarding_step2Body": {
+    "description": "音声会話を始める方法を説明する、オンボーディング 2 つ目のステップの本文。",
+    "message": "下の対応アシスタントのいずれかを開き、Say, Pi の通話ボタンを押して「こんにちは」と話してみてください。初回はマイクへのアクセスを求めますが、想定どおりです。通話中のときだけ音声を聞き取ります。"
+  },
+  "onboarding_step2Title": {
+    "description": "オンボーディングの 2 つ目のステップのタイトル（会話を開始）。",
+    "message": "AI チャットを開いて話し始める"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "マイクの許可"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "マイクの権限がブロックされている場合の復旧案内。",
+    "message": "ブラウザがマイクをブロックしています。アドレスバーのカメラまたは鍵アイコンをクリックし、マイクを「許可」に設定してから、もう一度お試しください。macOS では「システム設定 → プライバシーとセキュリティ → マイク」も確認してください。"
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "マイクの権限が拒否/ブロックされたときに表示される復旧パネルのタイトル。",
+    "message": "マイクへのアクセスがブロックされています"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "マイクが他で使用中の場合の復旧案内。",
+    "message": "別のアプリやタブがマイクを使っている可能性があります。録音していそうなもの（ビデオ通話、ボイスメモなど）を閉じてから、もう一度お試しください。"
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "別のアプリがマイクを使用している場合に表示される復旧パネルのタイトル。",
+    "message": "マイクが使用中です"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "利用できるマイクデバイスがない場合の復旧案内。",
+    "message": "マイクが見つかりませんでした。接続する（またはヘッドセットを接続する）うえで、入力デバイスとして選ばれていることを確認し、もう一度お試しください。"
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "利用できるマイクデバイスがない場合に表示される復旧パネルのタイトル。",
+    "message": "マイクが見つかりません"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "不明なマイクエラーの場合の復旧案内。",
+    "message": "マイクへのアクセスで問題が起きました。接続されていることと、ブラウザ設定で許可されていることを確認してから、もう一度お試しください。"
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "不明なマイクエラーの復旧パネルのタイトル。",
+    "message": "マイクにアクセスできませんでした"
+  },
+  "permissions_retryButton": {
+    "description": "マイク権限を再リクエストするボタンのラベル。",
+    "message": "もう一度試す"
+  },
+  "permissions_revokedHeading": {
+    "description": "マイクへのアクセスが以前は許可されていたが、その後取り消された場合に表示される見出し。",
+    "message": "マイクを再接続しましょう"
+  },
+  "permissions_revokedInfo": {
+    "description": "許可されていたマイクへのアクセスが後から取り消された場合に表示される案内文。",
+    "message": "マイクへのアクセスがオフになっています。これはブラウザやシステムのアップデート後によく起こります。下で再度許可すると、通話中は $productName$ がまた聞き取りを開始します。",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "プロフィール"
+  },
+  "quietModeLabel": {
+    "description": "静音／ささやきモードを有効にする切り替えのラベル。",
+    "message": "静音モード"
+  },
+  "quietModeTooltip": {
+    "description": "静音／ささやきモードの内容を説明するツールチップ。",
+    "message": "小さめの声でも認識し、アシスタントの返信音量を下げます。周りに人がいる場所でも音声を使えます。"
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "認証の進行中にサインイン ボタンに表示するテキスト。",
+    "message": "サインイン中…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "効果音"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "音声フィードバックの問題を防ぐために、Firefox ではサウンド効果が無効になっています。"
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "最初の音声でのやり取り後に一度だけ表示される、速度メリット通知の見出し。",
+    "message": "いいですね。話すほうが入力より約 3 倍速いです。"
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "節約できた時間（分）を整数で示す、速度メリット通知の任意の 2 行目。",
+    "message": "入力していた場合より約 $minutes$ 分ぶん速く話せています。",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "ボタンを押したときのみ送信します"
   },
+  "surveyQuestion": {
+    "description": "勝利後に一度だけ表示するマイクロアンケートの単一質問。",
+    "message": "これまで音声の使い心地はいかがですか？"
+  },
+  "surveyRatingLabel": {
+    "description": "アンケートの評価ボタン用のアクセシブルなラベル。",
+    "message": "5 段階中 $rating$ を評価",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "ユーザーが勝利後アンケートに回答した後に表示する謝辞。",
+    "message": "ありがとう。Say, Pi をより良くするのに役立ちます。"
+  },
   "tabAIChat": {
     "description": "AIチャット設定セクションのタブラベル。",
     "message": "AIチャット"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "一般設定セクションのタブラベル。",
     "message": "一般"
+  },
+  "tabVoices": {
+    "description": "音声設定セクション（サイト別の音声カタログ）のタブラベル。",
+    "message": "音声"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "クレジット"
   },
+  "ttsCreditsRemaining": {
+    "description": "音声ごとのクレジットプールとして残りの TTS 上限を表示するテキスト（saypi-api #181 Stage 2）。文字数の残量ではない。",
+    "message": "残り $credits$ クレジット",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "現在、Safari では多言語音声はサポートされていません。"
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "音声生成"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "お知らせ！$browserName$で$chatbotName$を使用した音声再生はまだ利用できません。良いニュース？音声入力は素晴らしく機能します！TTSの場合は、デスクトップでChromeまたはEdgeをお試しください。",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "$browserName$ + $chatbotName$でTTSは利用できません。音声入力は機能します！TTSの場合はChromeデスクトップをお試しください。",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS音声"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "音声らしい音が検出されたが、音量が小さすぎる／信頼度が低すぎて文字起こしできなかった場合の VAD 詳細（クライアント側の admission-gate によるドロップ）。",
+    "message": "音声が小さすぎて文字起こしできません"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "新しいタブがマイクを使用したため通話が終了したことを説明する VAD 詳細。",
+    "message": "音声入力が別のタブに移動しました"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "音声は利用できません。\nデスクトップでChromeまたはFirefoxをお試しください。"
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "お知らせ！$browserName$で$chatbotName$を使用した音声再生はまだ利用できません。良いニュース？音声入力は素晴らしく機能します！TTSの場合は、デスクトップでChromeまたはEdgeをお試しください。",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "$browserName$ + $chatbotName$でTTSは利用できません。音声入力は機能します！TTSの場合はChromeデスクトップをお試しください。",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "了解",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "別のタブに音声入力が引き継がれたタブに表示される VAD ステータス。",
+    "message": "一時停止中"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "詳細を表示します"
   },
+  "voiceIntroductionGeneric": {
+    "description": "選択された SayPi の声に専用の導入スクリプトがない場合（かつ読み上げる最近のメッセージがない場合）に再生される汎用の音声導入。",
+    "message": "こんにちは、$voice$です。こんな声です。気に入ってもらえるとうれしいです。",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "やあ！ \nПривет! \n你好！\n私は Pi です。多言語 AI アシスタントです。 \n32 の言語を自由に操ることができ、世界中のアイデアや文化を探求できます。\nこの声についてどう思いますか？"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "音声設定"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "設定のボイス カタログで、ボイスに説明がない場合に表示されるボイス行の代替サブタイトル。$count$ はボイスが対応する言語数。",
+    "message": "$count$ 言語に対応",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "「Addison」ボイス用に作成された性格タグライン（設定の Voices スタジオ、クライアント側のボイス識別マップ）。",
+    "message": "朗らかで話し方が明瞭"
+  },
+  "voiceTagline_alloy": {
+    "description": "「Alloy」音声のために作成された性格のタグライン（設定の音声スタジオ、クライアント側の音声アイデンティティマップ）。",
+    "message": "バランスがよく万能"
+  },
+  "voiceTagline_ash": {
+    "description": "「Ash」音声のために作成された性格のタグライン（設定の音声スタジオ、クライアント側の音声アイデンティティマップ）。",
+    "message": "低めで思慮深く落ち着いている"
+  },
+  "voiceTagline_ballad": {
+    "description": "「Ballad」音声のために作成された性格のタグライン（設定の音声スタジオ、クライアント側の音声アイデンティティマップ）。",
+    "message": "なめらかでメロディック"
+  },
+  "voiceTagline_cassidy": {
+    "description": "「Cassidy」ボイス用に作成された性格タグライン（設定の Voices スタジオ、クライアント側のボイス識別マップ）。",
+    "message": "親しみやすく率直"
+  },
+  "voiceTagline_cedar": {
+    "description": "「Cedar」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "落ち着いて安心感がある"
+  },
+  "voiceTagline_coral": {
+    "description": "「Coral」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "明るく前向きなエネルギー"
+  },
+  "voiceTagline_echo": {
+    "description": "「Echo」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "すっきりして中立的"
+  },
+  "voiceTagline_fable": {
+    "description": "「Fable」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "物語を語るような抑揚"
+  },
+  "voiceTagline_finn": {
+    "description": "「Finn」ボイス用に作成された性格タグライン（設定の Voices スタジオ、クライアント側のボイス識別マップ）。",
+    "message": "新鮮でエネルギッシュ"
+  },
+  "voiceTagline_jamahal": {
+    "description": "「Jamahal」ボイス用に作成された性格タグライン（設定の Voices スタジオ、クライアント側のボイス識別マップ）。",
+    "message": "深みがあり惹きつける"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "「Jarnathan」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "深夜向きのベルベット調バリトン"
+  },
+  "voiceTagline_jeff": {
+    "description": "「Jeff」ボイス用に作成された性格タグライン（設定の Voices スタジオ、クライアント側のボイス識別マップ）。",
+    "message": "飾らず落ち着いている"
+  },
+  "voiceTagline_jessica": {
+    "description": "「Jessica」ボイス用に作成された性格タグライン（設定の Voices スタジオ、クライアント側のボイス識別マップ）。",
+    "message": "温かく洗練されている"
+  },
+  "voiceTagline_joey": {
+    "description": "「Joey」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "気楽で会話調のアメリカ英語"
+  },
+  "voiceTagline_juniper": {
+    "description": "「Juniper」ボイス用に作成された性格タグライン（設定の Voices スタジオ、クライアント側のボイス識別マップ）。",
+    "message": "キレがあり明るく生き生き"
+  },
+  "voiceTagline_lucy": {
+    "description": "「Lucy」ボイス用に作成された性格タグライン（設定の Voices スタジオ、クライアント側のボイス識別マップ）。",
+    "message": "穏やかで透明感がある"
+  },
+  "voiceTagline_marin": {
+    "description": "「Marin」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "温かい朝ラジオの落ち着き"
+  },
+  "voiceTagline_mark": {
+    "description": "「Mark」ボイス用に作成された性格タグライン（設定の Voices スタジオ、クライアント側のボイス識別マップ）。",
+    "message": "明瞭で自信ある語り口"
+  },
+  "voiceTagline_nova": {
+    "description": "「Nova」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "素早くて好奇心旺盛"
+  },
+  "voiceTagline_onyx": {
+    "description": "「Onyx」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "深く響く重厚感"
+  },
+  "voiceTagline_paola": {
+    "description": "「Paola」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "表情豊かなイタリアの温かさ"
+  },
+  "voiceTagline_sage": {
+    "description": "「Sage」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "穏やかな声の明瞭さ"
+  },
+  "voiceTagline_shimmer": {
+    "description": "「Shimmer」音声のための作成済みの人格タグライン（設定のVoices studio、クライアント側の音声アイデンティティマップ）。",
+    "message": "軽やかで空気のよう"
+  },
+  "voicesAddToMenuShort": {
+    "description": "設定の音声スタジオで、音声カードのピン切り替え（オフ状態）に表示する短いラベル。押すとホストのチャット内メニューに音声を追加する。",
+    "message": "+ メニュー"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "音声カードのピン切り替え（オフ状態）のアクセシブルなラベル。$name$ は音声名、$host$ はアシスタント。",
+    "message": "$name$を$host$のメニューに追加",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "音声コントロールバーのトグルのラベル。矢印キーでリストを移動したとき、フォーカスが到達するたびに各音声を再生するかどうかを示す。",
+    "message": "移動しながら再生"
+  },
+  "voicesArrowsLive": {
+    "description": "設定の「音声」一覧で最初の「Playing <voice>」アナウンスに続けて付くスクリーンリーダー確認文。矢印キー操作が音として聞こえるようになったことを伝える。「Play as you move」切り替えの文言に合わせている。",
+    "message": "移動すると矢印キーで再生します。Esc で停止します。"
+  },
+  "voicesBuiltinsNote": {
+    "description": "ネイティブ音声を同梱するホスト（例: Pi の内蔵8音声）向けの、メニュー枠の下の注記。これらはスタジオでは管理しない。$host$ はアシスタント名。",
+    "message": "$host$の内蔵音声も、メニューに常に表示されます。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "チャット内音声メニューがないホスト向けの voicesBuiltinsNote の別文言（Pi は 2026 年にメニューを廃止）。元の「メニューに表示される」という約束が不正確になるため。$host$ はアシスタント名。",
+    "message": "$host$には内蔵音声もありますが、ここには表示されません。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "設定の「音声」コントロールバーの進捗表示。一覧の音声のうち、ユーザーがすでに聴いた数を示す。数値のみなので、Chrome i18n に複数形がなくても1で正しく読める。",
+    "message": "$total$ 件中 $heard$ 件聴取済み",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "設定の「音声」一覧の音声行のアクセシブル名の一部。このプロファイルで既に聴いた音声であることを示す。見た目では音紋のインク濃度で表され、スクリーンリーダーでは見えない。",
+    "message": "聴取済み"
+  },
+  "voicesInHostMenu": {
+    "description": "設定の音声スタジオで、メニュースロット行の上に表示されるセクション見出し。$host$ はアシスタント。",
+    "message": "$host$のメニュー",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "設定の音声スタジオで、音声カードのピン切り替え（オン状態）に表示する短いラベル。",
+    "message": "✓ メニュー内"
+  },
+  "voicesInUse": {
+    "description": "設定の音声一覧で、ホストが現在選択している音声に常時表示されるバッジ。大文字表示される。意図的に「再生中」ではない。このページでは各行がサンプルを再生するため、選択されていても無音の音声が、別の行が再生中なのに「再生中」と表示してはいけない。",
+    "message": "使用中"
+  },
+  "voicesKeyboardHint": {
+    "description": "設定の「音声」コントロールバーにある1行のキーボードヒント。記号はキー（Space、上下矢印、Shift+Space）を表す。",
+    "message": "Space で再生、↑↓ で音声を移動、⇧Space で戻す"
+  },
+  "voicesLoadError": {
+    "description": "特定ホストのスタジオ内で、そのホストの音声カタログの読み込みに失敗したときのエラー状態。$host$ はアシスタント名。",
+    "message": "$host$の音声を読み込めませんでした。後でもう一度お試しください。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "ホストのチャット内メニューが最大数の音声で埋まっているとき、無効化された「+ メニュー」切り替えに表示されるツールチップ／ヒント。",
+    "message": "メニューがいっぱいです。別の音声を削除してください"
+  },
+  "voicesMenuHint": {
+    "description": "「$host$のメニュー」見出しの横に表示する1行ヒント。スロット行がチャット内の音声メニューを反映していることを説明する。",
+    "message": "チャットで表示される内容"
+  },
+  "voicesMenuOverflow": {
+    "description": "ユーザーがピン留めした音声がチャット内メニューで表示できる数を超えている場合（旧状態）に、メニュー枠の下に出す注記。$count$ は収まらない数、$cap$ はメニューのサイズ。",
+    "message": "ピン留めした音声があと$count$個、メニューの$cap$枠の外で待機しています。",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "voicesMenuOverflow の単数形。チャット内メニューに収まらないピン留め音声がちょうど1つのときに使用。$cap$ はメニューのサイズ。",
+    "message": "ピン留めした音声があと1つ、メニューの$cap$枠の外で待機しています。",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "設定の「音声」一覧の下に出る要約行。チャット内のホストの音声メニューがどれだけ埋まっているかを示す。$host$ はアシスタント、$used$ は使用中の席数、$cap$ は席数の上限。Chrome i18n に複数形がないため、1でも複数でも自然に読める表現にする。",
+    "message": "$host$ のメニュー: $cap$ 席中 $used$ 席",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "設定の「音声」一覧の末尾にある、再生できるサンプルクリップがない音声のグループ見出し。$count$ は数。Chrome i18n に複数形がないため、1でも複数でも自然に読める表現にする。",
+    "message": "まだサンプルなし ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "ログイン済みユーザーで、設定のボイス カタログのリストが空のときに表示（例: ネットワーク問題）。",
+    "message": "現在ボイスを読み込めません。後でもう一度お試しください。"
+  },
+  "voicesNowPlaying": {
+    "description": "設定の「音声」一覧で音声のサンプルクリップが再生開始したときのスクリーンリーダー向けアナウンス。$name$ は音声名。",
+    "message": "$name$ を再生中",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "設定の「音声」コントロールバーのボタン。現在一覧にある音声をすべて順番に再生する。$count$ は数。Chrome i18n に複数形がないため、1でも複数でも自然に読める表現にする。",
+    "message": "すべて再生 ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "再訪時に表示される設定の「音声」コントロールバーのボタン。まだ聴いていない一覧の音声だけを再生する。$count$ は数。Chrome i18n に複数形がないため、1でも複数でも自然に読める表現にする。",
+    "message": "新しいものを再生 ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "ページでまだユーザー操作がないため、ブラウザがサンプル再生を拒否したときに設定の音声コントロールバーに表示される行。",
+    "message": "音声を有効にするには、いずれかの音声をクリックしてください。"
+  },
+  "voicesPreview": {
+    "description": "ボイス行でボイスの無料サンプルクリップを試聴する再生（▶）ボタンのアクセシブル ラベル。$name$ はボイス名。",
+    "message": "$name$ のサンプルを再生",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "設定の音声リストのアクセシブル名（全音声を1行ずつ表示するリストボックス）。",
+    "message": "音声（低音から高音の順）"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "音声カードのピン切り替え（オン状態）およびメニュースロットの削除ボタンのアクセシブルなラベル。$name$ は音声名、$host$ はアシスタント。",
+    "message": "$name$を$host$のメニューから削除",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "特定の音声のサンプルクリップの読み込みまたは再生に失敗したときに、設定の音声コントロールバーに表示される行。$name$ はその音声名。モーダルではなく、サンプルの連続再生はそのまま続行される。",
+    "message": "$name$ のサンプルを再生できませんでした。",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "設定の AI Chat タブにある音声カタログ セクションのサブ見出し。",
+    "message": "各サイトで返信を読み上げる音声を選びます。"
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "音声設定の見出しの下にある小見出し。ピッチ順の音声レール向け。",
+    "message": "低音から高音まで。聴いてから選べます。"
+  },
+  "voicesSectionTitle": {
+    "description": "設定の AI Chat タブにある音声カタログ セクションの見出し。",
+    "message": "音声"
+  },
+  "voicesShelfEveryday": {
+    "description": "設定の音声カタログでのバリュー層音声のグループ見出し。CSS により大文字表示される。",
+    "message": "日常音声"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "設定の Voices スタジオで、Everyday グループ見出しの横に表示する 1 行メモ。この層が HD よりどれだけ長く使えるかをスタジオ内で示す唯一の箇所。",
+    "message": "自然でクリア。HD より約 20 倍長く聴けます。"
+  },
+  "voicesShelfHd": {
+    "description": "設定の音声カタログでのプレミアム（HD）音声のグループ見出し。CSS により大文字表示される。",
+    "message": "HD 音声"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "設定の Voices スタジオで、HD グループ見出しの横に表示する 1 行メモ。",
+    "message": "最も豊かで表現力のある音。"
+  },
+  "voicesShowAll": {
+    "description": "設定の音声「表示」フィルターの選択肢。絞り込みなしで、すべての音声を一覧表示する。",
+    "message": "すべての音声"
+  },
+  "voicesShowEveryday": {
+    "description": "設定の音声「表示」フィルターの選択肢。標準（非 HD）音声のみを一覧表示する。",
+    "message": "標準のみ"
+  },
+  "voicesShowHd": {
+    "description": "設定の音声「表示」フィルターの選択肢。プレミアム（HD）音声のみを一覧表示する。",
+    "message": "HD のみ"
+  },
+  "voicesShowLabel": {
+    "description": "設定の音声コントロールバーにあるフィルターのラベル。リストに表示する音声を絞り込む。",
+    "message": "表示"
+  },
+  "voicesShowUnheard": {
+    "description": "設定の音声「表示」フィルターの選択肢。ユーザーがまだ聴いていない音声のみを一覧表示する。",
+    "message": "未試聴"
+  },
+  "voicesSpeakingNow": {
+    "description": "設定の音声スタジオで、ホストが現在選択している音声に付く状態ラベル（メニュースロットと音声カード）。",
+    "message": "再生中"
+  },
+  "voicesSpeaksWith": {
+    "description": "設定の音声スタジオ画面で、現在の音声名の上に表示される見出し行。$host$ はアシスタント（例: Pi）。CSS で大文字表示される。",
+    "message": "$host$の話し声",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "ホストが独自の音声を提供する場合（例: Pi）のステージ注記。Say, Pi の音声を選ぶとホストの音声を置き換える。",
+    "message": "下から選ぶまで、$host$は自分の声を使います。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "ホスト自体に音声がない場合（例: Claude）のステージ注記。Say, Pi の音声を選ぶまで読み上げが行われない。",
+    "message": "下から選ぶまで、$host$は返信を読み上げません。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "設定の音声スタジオのステージ見出し。ホストに Say, Pi の音声が未選択のときに表示。$host$ はアシスタント（例: Pi, Claude）。名前サイズで描画される。",
+    "message": "$host$の声を選ぶ",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "設定の音声スタジオのステージ上のボタン。現在の音声の無料サンプルクリップを再生する。",
+    "message": "サンプルを聴く"
+  },
+  "voicesStopPlayback": {
+    "description": "設定の「音声」コントロールバーのボタン。「すべて再生」で開始した連続再生を停止する。",
+    "message": "停止"
+  },
+  "voicesSweepPosition": {
+    "description": "設定の音声コントロールバーで「すべて再生」がリストを順に再生している間に表示される現在位置。$index$ は再生中の音声、$total$ はキューに入っている数。",
+    "message": "$total$ 件中 $index$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "設定の「音声」コントロールバーにある比較コントロールのアクセシブル ラベル。直近で聴いた2つのうち、もう一方の音声を再生する。$name$ はその音声名。",
+    "message": "$name$ に戻す",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "長すぎるリストで「すべて再生」が押されたときに、設定の音声コントロールバーに表示される行。$count$ は音声数、$minutes$ はおおよその分数。「min」は 1 のときも正しく読めるように省略表記（Chrome i18n には複数形がない）。",
+    "message": "$count$ 件の音声です。約 $minutes$ min。先にリストを絞り込んでください。",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "設定の音声カタログで、ホストごとの「この音声を使う」ボタンのアクセシブルなラベル。$name$ は音声名、$host$ はアシスタント（例: Pi、Claude）。",
+    "message": "$host$で$name$を使う",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "統合設定の音声カタログで、ホストごとの「この音声を使う」ボタンに表示する短いラベル（ホスト名が隣に表示される）。",
+    "message": "使う"
+  },
+  "voicesYourVoice": {
+    "description": "設定の「音声」一覧のコントロールバーのボタン。現在このホストが使っている音声の行へフォーカスを移動する。$name$ はその音声名。",
+    "message": "あなたの音声: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "音声検出モデルに必要な WebAssembly メモリを十分に割り当てられない場合に投げられるエラー。",
+    "message": "音声検出を開始できません: 音声モデルに必要な WebAssembly メモリが不足しています。$detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "音声検出モデルの実行に必要な初期 WebAssembly メモリがブラウザで公開されていない場合に投げられるエラー。",
+    "message": "音声検出を開始できません: このブラウザでは WebAssembly メモリを利用できません。"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "인증 모달에 표시되는 혜택 - 사용 한도 증가.",
+    "message": "무료 계정으로 더 높은 사용 한도"
+  },
+  "authBenefitPremium": {
+    "description": "인증 모달에 표시되는 혜택 - 챗봇 전반의 프리미엄 기능.",
+    "message": "프리미엄 기능 및 챗봇 지원"
+  },
+  "authBenefitSupport": {
+    "description": "인증 모달에 표시되는 혜택 - 우선 지원.",
+    "message": "문제에 대한 우선 지원"
+  },
+  "authBenefitSync": {
+    "description": "인증 모달에 표시되는 혜택 - 설정 동기화.",
+    "message": "어디서나 음성 설정 동기화"
+  },
+  "authBenefitTTS": {
+    "description": "인증 모달에 표시되는 혜택 - TTS 기능.",
+    "message": "텍스트 음성 변환 음성(유료 요금제)"
+  },
+  "authBenefitUsage": {
+    "description": "인증 모달에 표시되는 혜택 - 사용량 추적.",
+    "message": "기기 전반의 음성 사용량 추적"
+  },
+  "authPromptModalFull": {
+    "description": "가치 제안을 포함한 전체 모달 인증 프롬프트의 설명.",
+    "message": "Say, Pi를 유용하게 사용하고 계시네요. 더 높은 한도, 텍스트 음성 변환 음성, 그리고 지원되는 모든 챗봇에서의 프리미엄 기능을 위해 로그인하세요."
+  },
+  "authPromptModalSoft": {
+    "description": "부드러운 모달 인증 프롬프트의 설명.",
+    "message": "더 높은 사용 한도와 프리미엄 음성 기능 이용을 위해 무료 Say, Pi 계정을 만드세요."
+  },
+  "authPromptTitle": {
+    "description": "인증 프롬프트 모달의 제목.",
+    "message": "더 많은 음성 기능 잠금 해제"
+  },
+  "authPromptToast": {
+    "description": "사용자에게 로그인을 권장하는 토스트 알림.",
+    "message": "더 높은 한도와 프리미엄 기능을 위해 Say, Pi에 로그인하세요"
+  },
   "autoReadAloudChatGPT": {
     "description": "음성 통화 중 ChatGPT 응답을 자동으로 읽어주는 기능을 켜거나 끄는 확인란 레이블입니다.",
     "message": "자동 읽기 (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "텍스트 음성 연설을 비활성화합니다"
   },
+  "dismiss": {
+    "message": "알겠습니다",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "해고하다"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "집중"
   },
+  "errorVadInitFailed": {
+    "description": "음성 활동 감지가 초기화에 실패했을 때 표시되는 오류 토스트.",
+    "message": "음성 감지를 초기화하지 못했어요"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "음성 녹음 설정 중 예기치 않은 오류가 발생했을 때 표시되는 오류 토스트.",
+    "message": "음성 녹음 설정에 실패했어요"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "음성 감지 클라이언트가 녹음 시작에 실패했을 때 표시되는 오류 토스트.",
+    "message": "음성 녹음을 시작하지 못했어요"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "음성 감지(VAD) 클라이언트를 사용할 수 없어 녹음을 시작할 수 없을 때 표시되는 오류 토스트.",
+    "message": "음성 녹음을 사용할 수 없어요"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "집중 모드 종료"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "프리미엄(HD) 음성과 밸류 음성이 모두 제공될 때 음성 메뉴에 표시되는 한 줄 안내",
+    "message": "HD 음성은 월간 사용 한도를 약 20배 더 빨리 소모합니다."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "이것을 멀리 잡고 ..."
   },
+  "maybeLater": {
+    "description": "인증 프롬프트를 닫는 버튼 텍스트.",
+    "message": "나중에"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "마이크 설정이 필수 사양을 충족하지 않습니다. \n다른 마이크를 사용하거나 오디오 설정을 조정해 보세요."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "마이크에 액세스할 수 없습니다. \n기기 설정을 확인하고 다시 시도해 주세요."
   },
+  "microphonePermissionDeniedError": {
+    "description": "권한 요청 흐름 이후 마이크 권한이 거부되었을 때 표시되는 오류 토스트.",
+    "message": "마이크 권한이 허용되지 않았어요. 권한 요청 창과 확장 프로그램 설정에서 접근을 허용했는지 확인해 주세요."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "정확도"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "응답은 가장 빠르지만 정확도는 떨어집니다. \n방해하는 경향이 있습니다."
   },
+  "moreVoices": {
+    "description": "페이지 내 음성 메뉴에서 확장 프로그램 설정의 전체 음성 카탈로그로 이동하는 메뉴 항목.",
+    "message": "더 많은 음성…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "도우미 별명"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "로그인하지 않았습니다"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "ChatGPT를 여는 버튼 라벨입니다.",
+    "message": "ChatGPT 열기"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Claude.ai를 여는 버튼 라벨.",
+    "message": "Claude 열기"
+  },
+  "onboarding_ctaPi": {
+    "description": "Pi.ai를 여는 버튼 라벨.",
+    "message": "Pi 열기"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "환경 옵션: 다른 사람들 주변입니다.",
+    "message": "다른 사람들과 함께"
+  },
+  "onboarding_envMixed": {
+    "description": "환경 옵션: 개인 공간과 공유 공간이 섞여 있습니다.",
+    "message": "여러 장소가 섞여 있어요"
+  },
+  "onboarding_envPrivate": {
+    "description": "환경 옵션: 개인적인 공간입니다.",
+    "message": "개인적인 공간"
+  },
+  "onboarding_envQuietOff": {
+    "description": "환경 질문에서 조용한 모드를 끈 상태로 둘 때 표시되는 확인 문구입니다.",
+    "message": "알겠어요. 표준 듣기 및 재생 설정을 유지할게요."
+  },
+  "onboarding_envQuietOn": {
+    "description": "환경 답변으로 조용한 모드가 활성화될 때 표시되는 확인 문구입니다.",
+    "message": "조용한 모드 켬 — 작은 목소리도 더 잘 듣고 조용히 답해 드려서, 눈치 보지 않고 말할 수 있어요."
+  },
+  "onboarding_envTitle": {
+    "description": "사용자의 환경을 묻는 온보딩 질문의 제목입니다.",
+    "message": "보통 어디에서 대화하나요?"
+  },
+  "onboarding_footer": {
+    "description": "첫 실행 온보딩 페이지의 하단 문구입니다.",
+    "message": "이는 언제든 Say, Pi 설정에서 다시 볼 수 있어요. 개인 정보는 중요해요. 오디오는 통화가 진행 중일 때만 캡처돼요."
+  },
+  "onboarding_heading": {
+    "description": "최초 실행 온보딩 페이지의 메인 제목.",
+    "message": "🗣️ Say, Pi에 오신 것을 환영합니다"
+  },
+  "onboarding_intro": {
+    "description": "최초 실행 온보딩 페이지의 소개 문단.",
+    "message": "AI와 첫 음성 대화까지 두 단계만 남았습니다. 말하는 건 타이핑보다 약 3배 빨라요. 설정을 도와드릴게요."
+  },
+  "onboarding_micTestButton": {
+    "description": "부담 없이 진행하는 온보딩 마이크 테스트를 시작하는 버튼입니다.",
+    "message": "🎤 마이크 테스트"
+  },
+  "onboarding_micTestDone": {
+    "description": "온보딩 마이크 테스트가 성공적으로 완료된 후 표시되는 상태입니다.",
+    "message": "좋아요. 마이크가 잘 작동해요 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "온보딩 마이크 테스트가 입력 레벨을 측정하는 동안 표시되는 상태입니다.",
+    "message": "듣는 중 — 말해 보세요 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "온보딩 마이크 테스트가 권한을 기다리는 동안 표시되는 상태입니다.",
+    "message": "마이크 권한 요청 중…"
+  },
+  "onboarding_micTestStop": {
+    "description": "온보딩 마이크 테스트가 실행 중일 때 중지하는 버튼 라벨입니다.",
+    "message": "테스트 중지"
+  },
+  "onboarding_step1Body": {
+    "description": "확장 프로그램을 고정하는 방법을 설명하는 첫 번째 온보딩 단계 본문.",
+    "message": "브라우저 오른쪽 위의 퍼즐 조각 🧩 아이콘을 누른 다음 Say, Pi 옆의 고정 📌을 누르세요. 통화 버튼을 한 번에 열 수 있어요."
+  },
+  "onboarding_step1Title": {
+    "description": "첫 번째 온보딩 단계 제목(확장 프로그램 고정).",
+    "message": "Say, Pi를 툴바에 고정하세요"
+  },
+  "onboarding_step2Body": {
+    "description": "음성 대화를 시작하는 방법을 설명하는 두 번째 온보딩 단계 본문.",
+    "message": "아래의 지원되는 도우미 중 하나로 이동한 다음 Say, Pi 통화 버튼을 눌러 인사해 보세요. 처음에는 마이크 접근 권한을 요청하는데, 정상이에요. 그리고 통화 중일 때만 듣습니다."
+  },
+  "onboarding_step2Title": {
+    "description": "두 번째 온보딩 단계 제목(대화 시작).",
+    "message": "AI 채팅을 열고 말하기를 시작하세요"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "마이크 허가"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "마이크 권한이 차단되었을 때의 복구 안내입니다.",
+    "message": "브라우저가 마이크를 차단하고 있어요. 주소창의 카메라 또는 자물쇠 아이콘을 클릭하고 마이크를 \"허용\"으로 설정한 다음 다시 시도하세요. macOS에서는 시스템 설정 → 개인정보 보호 및 보안 → 마이크도 확인하세요."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "마이크 권한이 거부/차단되었을 때 복구 패널의 제목입니다.",
+    "message": "마이크 액세스가 차단됨"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "마이크가 다른 곳에서 사용 중일 때의 복구 안내입니다.",
+    "message": "다른 앱이나 탭이 마이크를 사용 중일 수 있어요. 녹음 중일 수 있는 다른 항목(화상 통화, 음성 메모)을 모두 닫은 다음 다시 시도하세요."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "다른 앱이 마이크를 사용 중일 때 복구 패널의 제목입니다.",
+    "message": "마이크가 사용 중임"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "사용 가능한 마이크 장치가 없을 때의 복구 안내입니다.",
+    "message": "마이크를 찾지 못했어요. 마이크를 연결하거나(또는 헤드셋을 연결하고), 입력 장치로 선택되어 있는지 확인한 다음 다시 시도하세요."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "사용 가능한 마이크 장치가 없을 때 복구 패널의 제목입니다.",
+    "message": "마이크를 찾을 수 없음"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "알 수 없는 마이크 오류에 대한 복구 안내입니다.",
+    "message": "마이크에 연결하는 중 문제가 생겼어요. 연결되어 있는지 확인하고 브라우저 설정에서 허용되어 있는지 확인한 다음 다시 시도하세요."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "알 수 없는 마이크 오류에 대한 복구 패널의 제목입니다.",
+    "message": "마이크에 접근할 수 없어요"
+  },
+  "permissions_retryButton": {
+    "description": "마이크 권한을 다시 요청하는 버튼의 라벨입니다.",
+    "message": "다시 시도"
+  },
+  "permissions_revokedHeading": {
+    "description": "마이크 액세스가 이전에 허용되었지만 이후에 취소된 경우 표시되는 제목입니다.",
+    "message": "마이크를 다시 연결해요"
+  },
+  "permissions_revokedInfo": {
+    "description": "허용된 이후 마이크 액세스가 취소되었을 때 표시되는 안내 문구입니다.",
+    "message": "마이크 액세스가 꺼졌어요. 브라우저 또는 시스템 업데이트 후에 자주 발생해요. 아래에서 다시 허용하면 통화 중에 $productName$가 다시 듣기 시작해요.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "윤곽"
+  },
+  "quietModeLabel": {
+    "description": "조용/속삭임 모드를 켜는 토글의 라벨.",
+    "message": "조용 모드"
+  },
+  "quietModeTooltip": {
+    "description": "조용/속삭임 모드가 무엇을 하는지 설명하는 툴팁.",
+    "message": "작게 말해도 잘 인식하고, 어시스턴트 답변 볼륨을 낮춰 주변에 사람이 있어도 음성 사용이 쉬워져요."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "인증이 진행 중일 때 로그인 버튼에 표시되는 텍스트.",
+    "message": "로그인 중..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "사운드 이펙트"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "오디오 피드백 문제를 방지하기 위해 Firefox에서는 사운드 효과가 비활성화되어 있습니다."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "첫 음성 대화 이후 한 번만 표시되는 속도 이점 안내의 제목.",
+    "message": "좋아요, 말하기는 타이핑보다 약 3배 빨라요."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "절약된 시간을 분 단위(정수)로 보여 주는 속도 이점 안내의 선택적 두 번째 줄.",
+    "message": "이미 타이핑했을 때보다 대략 $minutes$분을 아꼈어요.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "버튼을 누를 때만 제출하세요."
   },
+  "surveyQuestion": {
+    "description": "한 번만 표시되는 승리 후 마이크로 설문의 단일 질문.",
+    "message": "지금까지 음성 기능은 어떠셨나요?"
+  },
+  "surveyRatingLabel": {
+    "description": "설문 평가 버튼의 접근성 라벨.",
+    "message": "5점 만점에 $rating$점 평가",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "사용자가 승리 후 설문에 답한 뒤 표시되는 감사 문구.",
+    "message": "감사합니다. Say, Pi를 더 좋게 만드는 데 도움이 돼요."
+  },
   "tabAIChat": {
     "description": "AI 채팅 설정 섹션의 탭 레이블입니다.",
     "message": "AI 채팅"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "일반 설정 섹션의 탭 레이블입니다.",
     "message": "일반"
+  },
+  "tabVoices": {
+    "description": "음성 설정 섹션(사이트별 음성 카탈로그)의 탭 라벨.",
+    "message": "음성"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "크레딧"
   },
+  "ttsCreditsRemaining": {
+    "description": "남은 TTS 할당량을 문자 수가 아니라 음성별 크레딧 풀로 표시하는 텍스트(saypi-api #181 Stage 2).",
+    "message": "남은 크레딧 $credits$",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "현재 Safari에서는 다국어 음성이 지원되지 않습니다."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "음성 생성"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "주목하세요! $browserName$에서 $chatbotName$과 함께 음성 재생은 아직 사용할 수 없습니다. 좋은 소식? 음성 입력은 훌륭하게 작동합니다! TTS의 경우 데스크탑에서 Chrome 또는 Edge를 사용해보세요.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "$browserName$ + $chatbotName$에서 TTS를 사용할 수 없습니다. 음성 입력은 작동합니다! TTS의 경우 Chrome 데스크탑을 사용해보세요.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS 음성"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "말소리 같은 오디오가 감지됐지만 너무 작거나 신뢰도가 낮아 받아쓰지 못했을 때의 VAD 상세(클라이언트 측 admission-gate drop).",
+    "message": "음성이 너무 작아 받아쓰기할 수 없습니다"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "새 탭이 마이크를 점유해 통화가 종료됐음을 설명하는 VAD 상세.",
+    "message": "음성 입력이 다른 탭으로 이동했습니다"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "음성을 사용할 수 없습니다. \n데스크탑에서 Chrome 또는 Firefox를 사용해보십시오."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "주목하세요! $browserName$에서 $chatbotName$과 함께 음성 재생은 아직 사용할 수 없습니다. 좋은 소식? 음성 입력은 훌륭하게 작동합니다! TTS의 경우 데스크탑에서 Chrome 또는 Edge를 사용해보세요.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "$browserName$ + $chatbotName$에서 TTS를 사용할 수 없습니다. 음성 입력은 작동합니다! TTS의 경우 Chrome 데스크탑을 사용해보세요.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "알겠습니다",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "다른 탭이 음성 입력을 가져가 이 탭이 중단됐을 때 표시되는 VAD 상태.",
+    "message": "일시정지됨"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "자세한 내용을보십시오"
   },
+  "voiceIntroductionGeneric": {
+    "description": "선택한 SayPi 음성에 음성별 소개 스크립트가 없을 때(그리고 읽어 줄 최근 메시지도 없을 때) 재생되는 일반 음성 소개.",
+    "message": "안녕하세요, 저는 $voice$예요. 제 목소리는 이렇게 들려요. 이 목소리가 마음에 들면 좋겠어요.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "안녕하세요! \n감사합니다! \n정말! \n저는 여러분의 다국어 AI 비서 Pi입니다. \n32개 언어를 사용하여 전 세계의 아이디어와 문화를 탐색할 수 있습니다. \n이 목소리에 대해 어떻게 생각하시나요?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "음성 설정"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "설정 음성 카탈로그의 음성 행에서 음성 설명이 없을 때 표시되는 대체 부제; $count$는 해당 음성이 지원하는 언어 수.",
+    "message": "$count$개 언어 지원",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "'Addison' 음성의 작성된 성격 태그라인(설정 > Voices 스튜디오; 클라이언트 측 음성 아이덴티티 맵).",
+    "message": "밝고 또박또박한"
+  },
+  "voiceTagline_alloy": {
+    "description": "‘Alloy’ 음성의 작성된 성격 태그라인(설정의 음성 스튜디오, 클라이언트 측 음성 아이덴티티 맵)입니다.",
+    "message": "균형 잡힌 다용도"
+  },
+  "voiceTagline_ash": {
+    "description": "‘Ash’ 음성의 작성된 성격 태그라인(설정의 음성 스튜디오, 클라이언트 측 음성 아이덴티티 맵)입니다.",
+    "message": "낮고 사려 깊고 차분함"
+  },
+  "voiceTagline_ballad": {
+    "description": "‘Ballad’ 음성의 작성된 성격 태그라인(설정의 음성 스튜디오, 클라이언트 측 음성 아이덴티티 맵)입니다.",
+    "message": "부드럽고 선율적"
+  },
+  "voiceTagline_cassidy": {
+    "description": "'Cassidy' 음성의 작성된 성격 태그라인(설정 > Voices 스튜디오; 클라이언트 측 음성 아이덴티티 맵).",
+    "message": "친근하고 담백한"
+  },
+  "voiceTagline_cedar": {
+    "description": "'Cedar' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "차분하고 든든한 느낌"
+  },
+  "voiceTagline_coral": {
+    "description": "'Coral' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "밝고 경쾌한 에너지"
+  },
+  "voiceTagline_echo": {
+    "description": "'Echo' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "깔끔하고 중립적인 톤"
+  },
+  "voiceTagline_fable": {
+    "description": "'Fable' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "이야기꾼 같은 운율"
+  },
+  "voiceTagline_finn": {
+    "description": "'Finn' 음성의 작성된 성격 태그라인(설정 > Voices 스튜디오; 클라이언트 측 음성 아이덴티티 맵).",
+    "message": "신선하고 에너지 넘치는"
+  },
+  "voiceTagline_jamahal": {
+    "description": "'Jamahal' 음성의 작성된 성격 태그라인(설정 > Voices 스튜디오; 클라이언트 측 음성 아이덴티티 맵).",
+    "message": "풍부하고 끌림 있는"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "'Jarnathan' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "벨벳 같은 심야 바리톤"
+  },
+  "voiceTagline_jeff": {
+    "description": "'Jeff' 음성의 작성된 성격 태그라인(설정 > Voices 스튜디오; 클라이언트 측 음성 아이덴티티 맵).",
+    "message": "꾸밈없고 흔들림 없는"
+  },
+  "voiceTagline_jessica": {
+    "description": "'Jessica' 음성의 작성된 성격 태그라인(설정 > Voices 스튜디오; 클라이언트 측 음성 아이덴티티 맵).",
+    "message": "따뜻하고 세련된 품격"
+  },
+  "voiceTagline_joey": {
+    "description": "'Joey' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "편안한 미국식 대화 톤"
+  },
+  "voiceTagline_juniper": {
+    "description": "'Juniper' 음성의 작성된 성격 태그라인(설정 > Voices 스튜디오; 클라이언트 측 음성 아이덴티티 맵).",
+    "message": "또렷하고 밝고 생기 있는"
+  },
+  "voiceTagline_lucy": {
+    "description": "'Lucy' 음성의 작성된 성격 태그라인(설정 > Voices 스튜디오; 클라이언트 측 음성 아이덴티티 맵).",
+    "message": "부드럽고 빛나는"
+  },
+  "voiceTagline_marin": {
+    "description": "'Marin' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "따뜻한 아침 라디오 같은 차분함"
+  },
+  "voiceTagline_mark": {
+    "description": "'Mark' 음성의 작성된 성격 태그라인(설정 > Voices 스튜디오; 클라이언트 측 음성 아이덴티티 맵).",
+    "message": "명확하고 자신감 있는 내레이터"
+  },
+  "voiceTagline_nova": {
+    "description": "'Nova' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "빠르고 호기심 많은 느낌"
+  },
+  "voiceTagline_onyx": {
+    "description": "'Onyx' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "깊고 울림 있는 중후함"
+  },
+  "voiceTagline_paola": {
+    "description": "'Paola' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "표현력 있는 이탈리아식 따뜻함"
+  },
+  "voiceTagline_sage": {
+    "description": "'Sage' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "부드럽게 말하는 또렷함"
+  },
+  "voiceTagline_shimmer": {
+    "description": "'Shimmer' 음성의 작성된 성격 태그라인(설정 음성 스튜디오, 클라이언트 측 음성 정체성 맵).",
+    "message": "가볍고 산뜻한 느낌"
+  },
+  "voicesAddToMenuShort": {
+    "description": "설정 음성 스튜디오에서 음성 카드의 고정 토글(꺼짐 상태)에 표시되는 짧은 라벨. 누르면 해당 음성이 호스트의 채팅 내 메뉴에 추가됨.",
+    "message": "+ 메뉴"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "음성 카드의 고정 토글(꺼짐 상태)에 대한 접근성 라벨. $name$은 음성, $host$는 어시스턴트.",
+    "message": "$host$ 메뉴에 $name$ 추가",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "화살표 키로 목록을 이동할 때 포커스가 도달하는 각 음성을 재생할지 여부를 나타내는 Voices 제어 막대의 토글 라벨.",
+    "message": "이동할 때 재생"
+  },
+  "voicesArrowsLive": {
+    "description": "설정의 음성 목록에서 첫 번째 'Playing <voice>' 알림 뒤에 덧붙는 화면 읽기 프로그램 확인 문구로, 화살표 키가 방금부터 소리가 나기 시작했음을 알립니다. 'Play as you move' 토글의 문구를 그대로 반영합니다.",
+    "message": "이제 이동할 때 화살표로 재생됩니다. Esc로 중지합니다."
+  },
+  "voicesBuiltinsNote": {
+    "description": "기본 음성을 제공하는 호스트(예: Pi의 8개 내장 음성)의 경우 메뉴 슬롯 아래에 표시되는 안내. 스튜디오는 이를 관리하지 않음; $host$는 어시스턴트.",
+    "message": "$host$의 기본 내장 음성도 항상 메뉴에 함께 표시돼요.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "채팅 내 음성 메뉴가 없는 호스트를 위한 voicesBuiltinsNote 변형(Pi는 2026년에 메뉴를 종료), 원문의 '메뉴에 표시된다'는 약속이 사실이 아니게 되는 경우; $host$는 어시스턴트.",
+    "message": "$host$에는 여기에 나열되지 않은 기본 내장 음성도 있어요.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "설정의 음성 제어 막대에 표시되는 진행 상황으로, 사용자가 목록의 음성 중 얼마나 많이 이미 들어봤는지 보여줍니다. 숫자만 사용하므로 1일 때도 올바르게 읽힙니다. Chrome i18n에는 복수형이 없습니다.",
+    "message": "$total$개 중 $heard$개 들음",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "설정의 음성 목록에서 음성 행의 접근성 이름 일부로, 이 프로필이 이미 들어본 음성을 표시합니다. 화면에서는 음성의 사운드프린트에 잉크 농도로 그려지지만 화면 읽기 프로그램은 이를 볼 수 없습니다.",
+    "message": "들음"
+  },
+  "voicesInHostMenu": {
+    "description": "설정 음성 스튜디오에서 메뉴 슬롯 행 위에 표시되는 섹션 제목. $host$는 어시스턴트.",
+    "message": "$host$ 메뉴에",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "설정 음성 스튜디오에서 음성 카드의 고정 토글(켜짐 상태)에 표시되는 짧은 라벨.",
+    "message": "✓ 메뉴에 있음"
+  },
+  "voicesInUse": {
+    "description": "설정의 음성 목록에서 호스트가 현재 선택한 음성에 지속적으로 표시되는 배지로, 대문자로 렌더링됨. 의도적으로 ‘지금 말하는 중’이 아님: 이 페이지에서는 각 행이 샘플 클립을 재생하므로, 선택되어 있지만 조용한 음성이 다른 행이 재생 중일 때 스스로 말하고 있다고 표시하면 안 됨.",
+    "message": "사용 중"
+  },
+  "voicesKeyboardHint": {
+    "description": "설정의 음성(Voices) 제어 막대에 표시되는 한 줄 키보드 힌트입니다. 기호는 키를 뜻합니다: Space, 위/아래 화살표, Shift+Space.",
+    "message": "Space로 듣기, ↑↓로 음성 이동, ⇧Space로 다시 전환"
+  },
+  "voicesLoadError": {
+    "description": "특정 호스트의 스튜디오 안에서 해당 호스트의 음성 카탈로그 로드가 실패했을 때의 오류 상태; $host$는 어시스턴트.",
+    "message": "$host$의 음성을 불러오지 못했어요. 나중에 다시 시도해 주세요.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "호스트의 채팅 내 메뉴가 최대 음성 수에 도달했을 때 비활성화된 ‘+ 메뉴’ 토글에 표시되는 툴팁/힌트.",
+    "message": "메뉴가 가득 찼어요. 다른 음성을 제거하고 추가하세요"
+  },
+  "voicesMenuHint": {
+    "description": "‘In {host}'s menu’ 제목 옆의 한 줄 힌트로, 슬롯 행이 채팅 내 음성 메뉴를 그대로 반영한다는 것을 설명함.",
+    "message": "채팅에서 보이는 항목"
+  },
+  "voicesMenuOverflow": {
+    "description": "사용자가 채팅 내 메뉴에 표시할 수 있는 것보다 더 많은 음성을 고정해 둔 경우(레거시 상태) 메뉴 슬롯 아래에 표시되는 안내; $count$는 들어가지 못하는 개수, $cap$은 메뉴 크기.",
+    "message": "메뉴의 $cap$개 슬롯 너머에 고정된 음성이 $count$개 더 있어요.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "voicesMenuOverflow의 단수형. 채팅 내 메뉴에 들어가지 못하는 고정 음성이 정확히 하나일 때 사용; $cap$은 메뉴 크기.",
+    "message": "메뉴의 $cap$개 슬롯 너머에 고정된 음성이 1개 더 있어요.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "설정의 음성 목록 아래에 표시되는 요약 문장으로, 호스트의 채팅 내 음성 메뉴가 얼마나 채워졌는지 알려줍니다. $host$는 어시스턴트, $used$는 사용 중인 좌석 수, $cap$은 총 좌석 수입니다. 1일 때도 자연스럽게 읽히도록 작성되어야 합니다. Chrome i18n에는 복수형이 없습니다.",
+    "message": "$host$의 메뉴: $cap$석 중 $used$석 사용",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "설정의 음성 목록 끝에 있는, 재생할 샘플 클립이 없는 음성들을 담은 그룹의 제목입니다. $count$는 개수입니다. 1일 때도 자연스럽게 읽히도록 작성되어야 합니다. Chrome i18n에는 복수형이 없습니다.",
+    "message": "아직 샘플 없음 ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "로그인한 사용자의 설정 음성 카탈로그에서 음성 목록이 비어 있을 때 표시됨(예: 네트워크 문제).",
+    "message": "지금은 음성을 불러올 수 없습니다. 나중에 다시 시도해 주세요."
+  },
+  "voicesNowPlaying": {
+    "description": "설정의 음성 목록에서 음성의 샘플 클립 재생이 시작될 때 화면 읽기 프로그램이 알리는 문구입니다. $name$은 해당 음성입니다.",
+    "message": "$name$ 재생 중",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "설정의 음성 제어 막대에 있는 버튼으로, 현재 목록에 있는 모든 음성을 하나씩 연속으로 재생합니다. $count$는 개수입니다. 1일 때도 자연스럽게 읽히도록 작성되어야 합니다. Chrome i18n에는 복수형이 없습니다.",
+    "message": "모두 재생 ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "재방문 시 설정의 음성 제어 막대에 있는 버튼으로, 아직 들어보지 않은 목록의 음성만 재생합니다. $count$는 개수입니다. 1일 때도 자연스럽게 읽히도록 작성되어야 합니다. Chrome i18n에는 복수형이 없습니다.",
+    "message": "새 항목 재생 ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "페이지에서 아직 사용자 상호작용이 없어 브라우저가 샘플 재생을 거부했을 때 설정의 음성 제어 막대에 표시되는 문장입니다.",
+    "message": "소리를 켜려면 아무 음성이나 클릭하세요."
+  },
+  "voicesPreview": {
+    "description": "음성 행에서 무료 샘플 클립을 들어보는 재생(▶) 버튼의 접근성 라벨; $name$은(는) 음성 이름.",
+    "message": "$name$ 샘플 재생",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "설정의 Voices 목록(모든 음성을 한 줄씩 보여주는 리스트박스)의 접근성 이름.",
+    "message": "음성 목록, 가장 낮은 톤부터 가장 밝은 톤 순"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "음성 카드의 고정 토글(켜짐 상태) 및 메뉴 슬롯의 제거 버튼에 대한 접근성 라벨. $name$은 음성, $host$는 어시스턴트.",
+    "message": "$host$ 메뉴에서 $name$ 제거",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "특정 음성의 샘플 클립이 로드 또는 재생에 실패했을 때 설정의 음성 제어 막대에 표시되는 문장입니다. $name$은 해당 음성 이름입니다. 모달이 아니며 샘플 재생은 이를 건너뛰고 계속됩니다.",
+    "message": "$name$ 샘플을 재생할 수 없었습니다.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "설정의 AI Chat 탭에서 음성 카탈로그 섹션 부제목.",
+    "message": "각 사이트에서 답변을 읽어줄 음성을 선택하세요."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "피치 순으로 정렬된 음성 레일을 위한 Voices 설정 제목 아래의 부제목.",
+    "message": "가장 낮은 톤부터 가장 밝은 톤까지. 들어보고 고르세요."
+  },
+  "voicesSectionTitle": {
+    "description": "설정의 AI Chat 탭에서 음성 카탈로그 섹션 제목.",
+    "message": "음성"
+  },
+  "voicesShelfEveryday": {
+    "description": "설정 음성 카탈로그에서 가성비 등급 음성 그룹 제목. CSS로 대문자로 렌더링됨.",
+    "message": "일상 음성"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "설정의 Voices 스튜디오에서 Everyday 그룹 제목 옆에 표시되는 한 줄 설명으로, 이 등급이 HD보다 얼마나 더 오래 가는지 스튜디오에서 유일하게 밝히는 문구.",
+    "message": "자연스럽고 또렷해요. HD보다 약 20배 더 오래 들을 수 있어요."
+  },
+  "voicesShelfHd": {
+    "description": "설정 음성 카탈로그에서 프리미엄(HD) 음성 그룹 제목. CSS로 대문자로 렌더링됨.",
+    "message": "HD 음성"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "설정의 Voices 스튜디오에서 HD 그룹 제목 옆에 표시되는 한 줄 설명.",
+    "message": "가장 풍부하고 표현력 있는 음성."
+  },
+  "voicesShowAll": {
+    "description": "설정의 음성 ‘표시’ 필터 옵션: 필터링 없이 모든 음성을 나열합니다.",
+    "message": "모든 음성"
+  },
+  "voicesShowEveryday": {
+    "description": "설정의 음성 ‘표시’ 필터 옵션: 표준(비 HD) 음성만 나열합니다.",
+    "message": "일반만"
+  },
+  "voicesShowHd": {
+    "description": "설정의 음성 ‘표시’ 필터 옵션: 프리미엄(HD) 음성만 나열합니다.",
+    "message": "HD만"
+  },
+  "voicesShowLabel": {
+    "description": "설정의 음성 제어 막대에서 목록에 표시할 음성을 좁히는 필터의 라벨입니다.",
+    "message": "표시"
+  },
+  "voicesShowUnheard": {
+    "description": "설정의 음성 ‘표시’ 필터 옵션: 사용자가 아직 들어 보지 않은 음성만 나열합니다.",
+    "message": "아직 듣지 않음"
+  },
+  "voicesSpeakingNow": {
+    "description": "설정 음성 스튜디오에서 호스트가 현재 선택한 음성에 표시되는 상태 라벨(메뉴 슬롯과 음성 카드).",
+    "message": "지금 말하는 중"
+  },
+  "voicesSpeaksWith": {
+    "description": "설정의 음성 스튜디오 화면에서 현재 음성 이름 위에 표시되는 눈썹 라인. $host$는 어시스턴트(예: Pi). CSS로 대문자 표시됨.",
+    "message": "$host$ 목소리",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "호스트가 자체 오디오를 제공하는 경우(예: Pi) 스테이지에 표시되는 안내로, Say, Pi 음성을 선택하면 호스트의 음성을 대체함.",
+    "message": "아래에서 하나를 고르기 전까지는 $host$의 자체 음성이 사용돼요.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "호스트에 자체 음성이 없는 경우(예: Claude) 스테이지에 표시되는 안내로, Say, Pi 음성을 선택하기 전까지는 아무것도 소리 내어 읽지 않음.",
+    "message": "아래에서 하나를 고르기 전까지 $host$는 답변을 소리 내어 읽지 않아요.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "호스트에 선택된 SayPi 음성이 없을 때 설정의 Voices 스튜디오 스테이지에 표시되는 제목; $host$는 어시스턴트(예: Pi, Claude). 이름 크기로 렌더링됨.",
+    "message": "$host$의 목소리를 선택하세요",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "설정의 Voices 스튜디오 스테이지에서 현재 음성의 무료 샘플 클립을 재생하는 버튼.",
+    "message": "샘플 듣기"
+  },
+  "voicesStopPlayback": {
+    "description": "설정의 음성 제어 막대에 있는 버튼으로, 'Play all'로 시작한 샘플 연속 재생을 중지합니다.",
+    "message": "중지"
+  },
+  "voicesSweepPosition": {
+    "description": "설정의 음성 제어 막대에서 ‘모두 재생’이 목록을 훑는 동안 표시되는 실시간 위치 표기입니다. $index$는 현재 재생 중인 음성이고 $total$은 대기 중인 음성 수입니다.",
+    "message": "$total$개 중 $index$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "설정의 음성 제어 막대에 있는 비교 컨트롤의 접근성 라벨입니다. 최근에 들은 두 음성 중 다른 쪽 음성을 다시 재생합니다. $name$은 그 음성입니다.",
+    "message": "$name$로 다시 전환",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "목록이 너무 길 때 ‘모두 재생’을 누르면 설정의 음성 제어 막대에 표시되는 문장입니다. $count$는 음성 수이고 $minutes$는 대략 소요 시간(분)입니다. Chrome i18n에는 복수형이 없어서 1에서도 자연스럽게 읽히도록 ‘min’으로 축약했습니다.",
+    "message": "$count$개 음성입니다. 약 $minutes$ min. 먼저 목록을 좁히세요.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "설정 음성 카탈로그에서 호스트별 ‘이 음성 사용’ 버튼의 접근성 라벨. $name$은 음성, $host$는 어시스턴트(예: Pi, Claude).",
+    "message": "$host$에서 $name$ 사용",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "통합 설정 음성 카탈로그에서 호스트별 ‘이 음성 사용’ 버튼에 표시되는 짧은 라벨(호스트가 옆에 함께 표시됨).",
+    "message": "사용"
+  },
+  "voicesYourVoice": {
+    "description": "설정의 음성 목록 제어 막대 버튼입니다. 현재 이 호스트가 사용하는 음성의 행으로 포커스를 이동합니다. $name$은 그 음성입니다.",
+    "message": "내 음성: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "브라우저가 음성 감지 모델에 충분한 WebAssembly 메모리를 할당할 수 없을 때 발생하는 오류.",
+    "message": "음성 감지를 시작할 수 없어요: 음성 모델에 필요한 WebAssembly 메모리가 부족해요. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "브라우저가 음성 감지 모델을 실행하는 데 필요한 초기 WebAssembly 메모리를 제공하지 않을 때 발생하는 오류.",
+    "message": "음성 감지를 시작할 수 없어요: 이 브라우저에서는 WebAssembly 메모리를 사용할 수 없어요."
   }
 }

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Manfaat yang disenaraikan dalam modal pengesahan - had penggunaan ditingkatkan.",
+    "message": "Had penggunaan lebih tinggi dengan akaun percuma"
+  },
+  "authBenefitPremium": {
+    "description": "Manfaat yang disenaraikan dalam modal pengesahan - ciri premium merentas chatbot.",
+    "message": "Ciri premium dan sokongan chatbot"
+  },
+  "authBenefitSupport": {
+    "description": "Manfaat yang disenaraikan dalam modal pengesahan - sokongan keutamaan.",
+    "message": "Sokongan keutamaan untuk isu"
+  },
+  "authBenefitSync": {
+    "description": "Manfaat yang disenaraikan dalam modal pengesahan - penyegerakan tetapan.",
+    "message": "Segerakkan tetapan suara di mana-mana"
+  },
+  "authBenefitTTS": {
+    "description": "Manfaat yang disenaraikan dalam modal pengesahan - ciri TTS.",
+    "message": "Suara teks-ke-pertuturan (pelan berbayar)"
+  },
+  "authBenefitUsage": {
+    "description": "Manfaat yang disenaraikan dalam modal pengesahan - penjejakan penggunaan.",
+    "message": "Jejaki penggunaan suara anda merentas peranti"
+  },
+  "authPromptModalFull": {
+    "description": "Penerangan untuk gesaan pengesahan modal penuh dengan cadangan nilai.",
+    "message": "Anda banyak menggunakan Say, Pi. Log masuk untuk had lebih tinggi, suara teks-ke-pertuturan dan ciri premium di semua chatbot yang disokong."
+  },
+  "authPromptModalSoft": {
+    "description": "Penerangan untuk gesaan pengesahan modal lembut.",
+    "message": "Cipta akaun percuma Say, Pi untuk had penggunaan lebih tinggi dan akses kepada ciri suara premium."
+  },
+  "authPromptTitle": {
+    "description": "Tajuk untuk modal gesaan pengesahan.",
+    "message": "Buka lebih banyak ciri suara"
+  },
+  "authPromptToast": {
+    "description": "Pemberitahuan toast yang menggalakkan pengguna untuk log masuk.",
+    "message": "Log masuk ke Say, Pi untuk had lebih tinggi dan ciri premium"
+  },
   "autoReadAloudChatGPT": {
     "description": "Label untuk kotak semak bagi mengaktifkan atau menyahaktifkan bacaan automatik tindak balas ChatGPT semasa panggilan suara.",
     "message": "Bacaan Automatik (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Lumpuhkan teks-ke-ucapan"
   },
+  "dismiss": {
+    "message": "Faham",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Buang"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Tumpukan"
   },
+  "errorVadInitFailed": {
+    "description": "Toast ralat yang dipaparkan apabila pengesanan aktiviti suara gagal dimulakan.",
+    "message": "Gagal memulakan pengesanan suara"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Toast ralat yang dipaparkan apabila ralat yang tidak dijangka berlaku semasa menyediakan rakaman suara.",
+    "message": "Gagal menyediakan rakaman suara"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Toast ralat yang dipaparkan apabila klien pengesanan suara gagal memulakan rakaman.",
+    "message": "Gagal memulakan rakaman suara"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Toast ralat yang dipaparkan apabila klien pengesanan suara (VAD) tidak tersedia, jadi rakaman tidak boleh dimulakan.",
+    "message": "Rakaman suara tidak tersedia"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Keluar Mod Fokus"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Nota satu baris yang dipaparkan dalam menu suara apabila suara premium (HD) dan suara nilai kedua-duanya tersedia",
+    "message": "Suara HD menggunakan kuota bulanan anda kira-kira 20× lebih cepat."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Tucking ini ..."
   },
+  "maybeLater": {
+    "description": "Teks butang untuk menutup gesaan pengesahan.",
+    "message": "Mungkin nanti"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Tetapan mikrofon anda tidak memenuhi spesifikasi yang diperlukan. \nCuba gunakan mikrofon lain atau laraskan tetapan audio anda."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Tidak dapat mengakses mikrofon. \nSila semak tetapan peranti anda dan cuba lagi."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Toast ralat yang dipaparkan apabila keizinan mikrofon ditolak selepas aliran gesaan keizinan.",
+    "message": "Keizinan mikrofon tidak diberikan. Sila pastikan anda telah membenarkan akses dalam gesaan dan dalam tetapan sambungan."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "ketepatan"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Respons terpantas, tetapi kurang tepat. \nTerdedah kepada gangguan."
   },
+  "moreVoices": {
+    "description": "Baris menu yang memaut dari menu suara dalam halaman ke katalog suara penuh dalam tetapan sambungan",
+    "message": "Lagi suara…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Nama samaran pembantu"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Tidak masuk"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Label butang yang membuka ChatGPT.",
+    "message": "Buka ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Label butang yang membuka Claude.ai.",
+    "message": "Buka Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Label butang yang membuka Pi.ai.",
+    "message": "Buka Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Pilihan persekitaran: di sekitar orang lain.",
+    "message": "Di sekitar orang lain"
+  },
+  "onboarding_envMixed": {
+    "description": "Pilihan persekitaran: campuran ruang peribadi dan ruang berkongsi.",
+    "message": "Campuran tempat"
+  },
+  "onboarding_envPrivate": {
+    "description": "Pilihan persekitaran: ruang peribadi.",
+    "message": "Di tempat yang peribadi"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Pengesahan yang ditunjukkan apabila jawapan persekitaran membiarkan mod senyap dimatikan.",
+    "message": "Baik — kami akan kekalkan tetapan mendengar dan main balik standard."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Pengesahan yang dipaparkan apabila jawapan persekitaran mengaktifkan mod senyap.",
+    "message": "Mod senyap dihidupkan — kami akan menangkap pertuturan yang lebih perlahan dan membalas dengan perlahan, supaya anda boleh bercakap secara discreet."
+  },
+  "onboarding_envTitle": {
+    "description": "Tajuk untuk soalan onboarding tentang persekitaran pengguna.",
+    "message": "Di mana anda biasanya akan bercakap?"
+  },
+  "onboarding_footer": {
+    "description": "Teks kaki pada halaman onboarding kali pertama dijalankan.",
+    "message": "Anda boleh kembali ke sini pada bila-bila masa melalui tetapan Say, Pi. Privasi anda penting — audio hanya dirakam semasa panggilan aktif."
+  },
+  "onboarding_heading": {
+    "description": "Tajuk utama pada halaman onboarding kali pertama dijalankan.",
+    "message": "🗣️ Selamat datang ke Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Perenggan pengenalan pada halaman onboarding kali pertama dijalankan.",
+    "message": "Anda hanya dua langkah lagi daripada perbualan pertama anda yang dituturkan dengan AI. Bercakap kira-kira 3× lebih pantas daripada menaip — mari sediakan semuanya."
+  },
+  "onboarding_micTestButton": {
+    "description": "Butang yang memulakan ujian mikrofon onboarding tanpa risiko.",
+    "message": "🎤 Uji mikrofon anda"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status yang dipaparkan selepas ujian mikrofon onboarding berjaya diselesaikan.",
+    "message": "Bagus — mikrofon anda berfungsi. 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status yang dipaparkan semasa ujian mikrofon onboarding mengukur input.",
+    "message": "Mendengar — sebut sesuatu. 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status yang dipaparkan semasa ujian mikrofon onboarding menunggu kebenaran.",
+    "message": "Meminta akses mikrofon…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Label butang untuk menghentikan ujian mikrofon onboarding semasa ia sedang berjalan.",
+    "message": "Hentikan ujian"
+  },
+  "onboarding_step1Body": {
+    "description": "Isi langkah onboarding pertama yang menerangkan cara untuk pin sambungan.",
+    "message": "Klik ikon kepingan puzzle 🧩 di bahagian kanan atas pelayar anda, kemudian pin 📌 di sebelah Say, Pi. Ini memastikan butang panggilan hanya satu klik sahaja."
+  },
+  "onboarding_step1Title": {
+    "description": "Tajuk untuk langkah onboarding pertama (pin sambungan).",
+    "message": "Pin Say, Pi pada bar alat anda"
+  },
+  "onboarding_step2Body": {
+    "description": "Isi langkah onboarding kedua yang menerangkan cara untuk memulakan perbualan suara.",
+    "message": "Pergi ke salah satu pembantu yang disokong di bawah, kemudian ketik butang panggilan Say, Pi dan ucapkan hai. Kami akan meminta akses mikrofon kali pertama — itu memang dijangka, dan kami hanya mendengar apabila anda sedang aktif dalam panggilan."
+  },
+  "onboarding_step2Title": {
+    "description": "Tajuk untuk langkah onboarding kedua (mulakan perbualan).",
+    "message": "Buka chat AI dan mula bercakap"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Kebenaran mikrofon"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Panduan pemulihan apabila kebenaran mikrofon disekat.",
+    "message": "Pelayar anda menyekat mikrofon. Klik ikon kamera atau kunci pada bar alamat, tetapkan Mikrofon kepada \"Benarkan\", kemudian cuba lagi. Pada macOS, semak juga Tetapan Sistem → Privasi & Keselamatan → Mikrofon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Tajuk panel pemulihan apabila kebenaran mikrofon ditolak/disekat.",
+    "message": "Akses mikrofon disekat"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Panduan pemulihan apabila mikrofon sedang digunakan di tempat lain.",
+    "message": "Aplikasi atau tab lain mungkin sedang menggunakan mikrofon anda. Tutup apa-apa yang mungkin sedang merakam (panggilan video, memo suara), kemudian cuba lagi."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Tajuk panel pemulihan apabila mikrofon sedang digunakan oleh aplikasi lain.",
+    "message": "Mikrofon anda sedang digunakan"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Panduan pemulihan apabila tiada peranti mikrofon tersedia.",
+    "message": "Kami tidak dapat mencari mikrofon. Sambungkan satu (atau sambungkan set kepala anda), pastikan ia dipilih sebagai peranti input anda, kemudian cuba lagi."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Tajuk panel pemulihan apabila tiada peranti mikrofon tersedia.",
+    "message": "Tiada mikrofon ditemui"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Panduan pemulihan untuk ralat mikrofon yang tidak diketahui.",
+    "message": "Ada sesuatu yang tidak kena semasa mengakses mikrofon anda. Pastikan ia disambungkan dan dibenarkan dalam tetapan pelayar anda, kemudian cuba lagi."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Tajuk panel pemulihan untuk ralat mikrofon yang tidak diketahui.",
+    "message": "Kami tidak dapat mengakses mikrofon anda"
+  },
+  "permissions_retryButton": {
+    "description": "Label untuk butang yang meminta semula kebenaran mikrofon.",
+    "message": "Cuba lagi"
+  },
+  "permissions_revokedHeading": {
+    "description": "Tajuk yang ditunjukkan apabila akses mikrofon sebelum ini telah diberikan tetapi kemudiannya telah ditarik balik.",
+    "message": "Mari sambungkan semula mikrofon anda"
+  },
+  "permissions_revokedInfo": {
+    "description": "Teks maklumat yang ditunjukkan apabila akses mikrofon telah ditarik balik selepas diberikan.",
+    "message": "Akses mikrofon anda telah dimatikan — ini sering berlaku selepas kemas kini pelayar atau sistem. Benarkan semula di bawah dan $productName$ akan kembali mendengar apabila anda sedang dalam panggilan.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Label untuk togol yang mengaktifkan mod senyap/bisikan.",
+    "message": "Mod senyap"
+  },
+  "quietModeTooltip": {
+    "description": "Tooltip yang menerangkan fungsi mod senyap/bisikan.",
+    "message": "Bercakap perlahan — mengesan pertuturan yang lebih senyap dan merendahkan kelantangan balasan pembantu, supaya anda boleh guna suara di sekitar orang lain."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Teks untuk butang log masuk semasa pengesahan sedang berjalan.",
+    "message": "Sedang log masuk..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Kesan bunyi"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Kesan bunyi dilumpuhkan dalam Firefox untuk mengelakkan isu maklum balas audio."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Tajuk notis faedah kelajuan sekali sahaja selepas pertukaran bersuara pertama.",
+    "message": "Bagus — bercakap kira-kira 3× lebih pantas daripada menaip."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Baris kedua pilihan bagi notis faedah kelajuan yang menunjukkan jumlah minit penuh yang dijimatkan.",
+    "message": "Anda sudah bercakap lebih kurang $minutes$ min lebih pantas daripada menaipnya.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Hanya serahkan apabila anda menekan butang"
   },
+  "surveyQuestion": {
+    "description": "Soalan tunggal untuk mikro-tinjauan sekali sahaja selepas kejayaan.",
+    "message": "Macam mana suara setakat ini?"
+  },
+  "surveyRatingLabel": {
+    "description": "Label kebolehcapaian untuk butang penilaian tinjauan.",
+    "message": "Beri penilaian $rating$ daripada 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Penghargaan yang dipaparkan selepas pengguna menjawab tinjauan selepas kejayaan.",
+    "message": "Terima kasih — ini membantu kami menambah baik Say, Pi. 🙏"
+  },
   "tabAIChat": {
     "description": "Label tab untuk seksyen tetapan chat AI.",
     "message": "Chat AI"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Label tab untuk seksyen tetapan umum.",
     "message": "Umum"
+  },
+  "tabVoices": {
+    "description": "Label tab untuk bahagian tetapan suara (katalog suara mengikut laman).",
+    "message": "Suara"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "Kredit"
   },
+  "ttsCreditsRemaining": {
+    "description": "Teks yang menunjukkan kuota TTS yang tinggal sebagai kumpulan kredit mengikut suara (saypi-api #181 Peringkat 2), bukan aksara mentah.",
+    "message": "Baki $credits$ kredit",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Suara berbilang bahasa pada masa ini tidak disokong dalam Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Penjanaan suara"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Perhatian! Mainbalik pertuturan belum tersedia di $browserName$ dengan $chatbotName$ lagi. Berita baik? Input suara berfungsi dengan baik! Untuk TTS, cuba Chrome atau Edge di desktop.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS tidak tersedia di $browserName$ + $chatbotName$. Input suara berfungsi! Cuba Chrome desktop untuk TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Suara TTS"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Butiran VAD apabila audio seperti pertuturan dikesan tetapi terlalu perlahan / keyakinan terlalu rendah untuk ditranskripsikan (digugurkan oleh pintu kemasukan di sisi klien).",
+    "message": "Audio terlalu perlahan untuk ditranskripsikan"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Butiran VAD yang menerangkan panggilan tamat kerana mikrofon dituntut oleh tab yang lebih baharu.",
+    "message": "Input suara dipindahkan ke tab lain"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Suara tidak tersedia. \nCuba Chrome atau Firefox di desktop."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Perhatian! Mainbalik pertuturan belum tersedia di $browserName$ dengan $chatbotName$ lagi. Berita baik? Input suara berfungsi dengan baik! Untuk TTS, cuba Chrome atau Edge di desktop.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS tidak tersedia di $browserName$ + $chatbotName$. Input suara berfungsi! Cuba Chrome desktop untuk TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Faham",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Status VAD yang dipaparkan pada tab yang input suaranya diambil alih oleh tab lain.",
+    "message": "Dijeda"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Lihat butiran"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Pengenalan suara generik yang dimainkan apabila suara SayPi yang dipilih tiada skrip pengenalan khusus suara (dan tiada mesej terbaru untuk dibacakan semula).",
+    "message": "Hai, saya $voice$. Inilah bunyi suara saya. Saya harap anda suka suara ini.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hola! \nПривет! \n你好! \nSaya Pi, pembantu AI poliglot anda. \nDengan 32 bahasa di bawah arahan saya, kami boleh meneroka idea dan budaya dari seluruh dunia. \nApa pendapat anda tentang suara ini?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Tetapan suara"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Sarikata sandaran untuk baris suara dalam katalog suara tetapan apabila suara tiada perihalan; $count$ ialah bilangan bahasa yang disokong oleh suara tersebut.",
+    "message": "Bertutur $count$ bahasa",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Addison' (tetapan studio Suara; peta identiti suara di sisi klien).",
+    "message": "Ceria dan petah"
+  },
+  "voiceTagline_alloy": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Alloy' (studio Suara di tetapan; peta identiti suara sisi klien).",
+    "message": "Seimbang dan serba guna"
+  },
+  "voiceTagline_ash": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Ash' (studio Suara di tetapan; peta identiti suara sisi klien).",
+    "message": "Rendah, berfikir, tenang"
+  },
+  "voiceTagline_ballad": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Ballad' (studio Suara di tetapan; peta identiti suara sisi klien).",
+    "message": "Lembut dan melodik"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Cassidy' (tetapan studio Suara; peta identiti suara di sisi klien).",
+    "message": "Mesra dan terus terang"
+  },
+  "voiceTagline_cedar": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Cedar' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Tenang dan meyakinkan"
+  },
+  "voiceTagline_coral": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Coral' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Cerah, bertenaga dan ceria"
+  },
+  "voiceTagline_echo": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Echo' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Bersih dan neutral"
+  },
+  "voiceTagline_fable": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Fable' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Lenggok pencerita"
+  },
+  "voiceTagline_finn": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Finn' (tetapan studio Suara; peta identiti suara di sisi klien).",
+    "message": "Segar dan bertenaga"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Jamahal' (tetapan studio Suara; peta identiti suara di sisi klien).",
+    "message": "Mewah dan memukau"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Jarnathan' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Bariton baldu lewat malam"
+  },
+  "voiceTagline_jeff": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Jeff' (tetapan studio Suara; peta identiti suara di sisi klien).",
+    "message": "Terus terang dan stabil"
+  },
+  "voiceTagline_jessica": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Jessica' (tetapan studio Suara; peta identiti suara di sisi klien).",
+    "message": "Hangat dan anggun"
+  },
+  "voiceTagline_joey": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Joey' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Amerika yang santai dan berbual"
+  },
+  "voiceTagline_juniper": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Juniper' (tetapan studio Suara; peta identiti suara di sisi klien).",
+    "message": "Tegas, cerah, bertenaga"
+  },
+  "voiceTagline_lucy": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Lucy' (tetapan studio Suara; peta identiti suara di sisi klien).",
+    "message": "Lembut dan bersinar"
+  },
+  "voiceTagline_marin": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Marin' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Hangat, tenang ala radio pagi"
+  },
+  "voiceTagline_mark": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Mark' (tetapan studio Suara; peta identiti suara di sisi klien).",
+    "message": "Pencerita yang jelas dan yakin"
+  },
+  "voiceTagline_nova": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Nova' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Pantas dan ingin tahu"
+  },
+  "voiceTagline_onyx": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Onyx' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Dalam, berwibawa dan bergema"
+  },
+  "voiceTagline_paola": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Paola' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Kehangatan Itali yang ekspresif"
+  },
+  "voiceTagline_sage": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Sage' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Jelas dengan tutur yang lembut"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Tagline personaliti yang ditulis untuk suara 'Shimmer' (tetapan studio Suara; peta identiti suara sisi klien).",
+    "message": "Ringan dan lapang"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Label ringkas pada togol pin kad suara (keadaan mati) dalam studio Suara tetapan; menekan akan menambah suara ke menu dalam chat hos.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Label kebolehcapaian untuk togol pin kad suara (keadaan mati); $name$ ialah suara, $host$ ialah pembantu.",
+    "message": "Tambah $name$ ke menu $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Label pada togol di bar kawalan Suara yang menyatakan sama ada menelusuri senarai dengan kekunci anak panah memainkan setiap suara apabila fokus sampai kepadanya.",
+    "message": "Main semasa anda bergerak"
+  },
+  "voicesArrowsLive": {
+    "description": "Pengesahan pembaca skrin, ditambah pada pengumuman pertama 'Memainkan <suara>' dalam senarai Suara di tetapan, menyatakan bahawa kekunci anak panah baru sahaja menjadi boleh didengar. Menggemakan perkataan bagi togol 'Main semasa anda bergerak'.",
+    "message": "Anak panah kini dimainkan semasa anda bergerak. Esc berhenti."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Nota di bawah slot menu untuk hos yang disertakan dengan suara natif (cth. 8 suara terbina dalam Pi), yang tidak diurus oleh studio; $host$ ialah pembantu.",
+    "message": "Suara terbina dalam $host$ sendiri sentiasa turut muncul dalam menunya.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Varian bagi voicesBuiltinsNote untuk hos tanpa menu suara dalam chat (Pi menamatkan menunya pada 2026), di mana janji asal bahawa suara terbina dalam 'muncul dalam menunya' akan tidak benar; $host$ ialah pembantu.",
+    "message": "$host$ juga mempunyai suara terbina dalam sendiri, yang tidak disenaraikan di sini.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Paparan kemajuan dalam bar kawalan Suara di tetapan: berapa banyak suara yang disenaraikan sudah didengar oleh pengguna. Nombor semata-mata, jadi ia dibaca betul pada 1 — Chrome i18n tiada bentuk jamak.",
+    "message": "$heard$ daripada $total$ didengar",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Sebahagian daripada nama boleh capai bagi baris suara dalam senarai Suara di tetapan, menandakan suara yang profil ini sudah dengar. Secara visual ini dilukis sebagai kepekatan dakwat pada cap bunyi suara, yang pembaca skrin tidak dapat lihat.",
+    "message": "Didengar"
+  },
+  "voicesInHostMenu": {
+    "description": "Tajuk seksyen di atas baris slot menu dalam studio Suara tetapan; $host$ ialah pembantu.",
+    "message": "Dalam menu $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Label ringkas pada togol pin kad suara (keadaan hidup) dalam studio Suara tetapan.",
+    "message": "✓ Dalam menu"
+  },
+  "voicesInUse": {
+    "description": "Lencana kekal pada suara yang sedang dipilih untuk hos dalam senarai Suara tetapan, dirender huruf besar. Dengan sengaja BUKAN 'Sedang bercakap': pada halaman ini baris memainkan klip contoh mereka, jadi suara yang dipilih tetapi senyap tidak boleh mendakwa sedang bercakap ketika baris lain sedang dimainkan.",
+    "message": "Sedang digunakan"
+  },
+  "voicesKeyboardHint": {
+    "description": "Petunjuk papan kekunci sebaris dalam bar kawalan Suara di tetapan. Glif ialah kekunci: Space, anak panah atas/bawah, dan Shift+Space.",
+    "message": "Tekan Space untuk dengar, ↑↓ untuk bergerak antara suara, ⇧Space untuk tukar semula."
+  },
+  "voicesLoadError": {
+    "description": "Keadaan ralat dalam studio satu hos apabila katalog suara hos itu gagal dimuatkan; $host$ ialah pembantu.",
+    "message": "Tidak dapat memuatkan suara $host$. Sila cuba lagi nanti.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tip/petunjuk pada togol '+ Menu' yang dilumpuhkan apabila menu dalam chat hos sudah mencapai bilangan maksimum suara.",
+    "message": "Menu penuh, alih keluar satu suara untuk tambah yang lain"
+  },
+  "voicesMenuHint": {
+    "description": "Petunjuk satu baris di sebelah tajuk 'Dalam menu {host}', menerangkan bahawa baris slot mencerminkan menu suara dalam chat.",
+    "message": "Apa yang anda akan lihat dalam chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Nota di bawah slot menu apabila pengguna mempunyai lebih banyak suara dipin daripada yang boleh dipaparkan oleh menu dalam chat (keadaan lama); $count$ ialah bilangan yang tidak muat, $cap$ ialah saiz menu.",
+    "message": "$count$ lagi suara dipin sedang menunggu di luar $cap$ slot menu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Bentuk tunggal bagi voicesMenuOverflow, digunakan apabila tepat satu suara dipin tidak muat dalam menu dalam chat; $cap$ ialah saiz menu.",
+    "message": "1 lagi suara dipin sedang menunggu di luar $cap$ slot menu.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Baris ringkasan di bawah senarai Suara di tetapan yang menyatakan berapa penuh menu suara dalam sembang hos; $host$ ialah pembantu, $used$ berapa tempat diisi, $cap$ berapa jumlahnya. Dirangka supaya dibaca betul pada 1 — Chrome i18n tiada bentuk jamak.",
+    "message": "Menu $host$: $used$ daripada $cap$ tempat",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Tajuk untuk kumpulan di hujung senarai Suara di tetapan yang mengandungi suara tanpa klip sampel untuk dimainkan; $count$ ialah bilangannya. Dirangka supaya dibaca betul pada 1 — Chrome i18n tiada bentuk jamak.",
+    "message": "Belum ada sampel ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Dipaparkan dalam katalog suara tetapan apabila senarai suara kosong untuk pengguna yang telah log masuk (contohnya masalah rangkaian).",
+    "message": "Suara tidak dapat dimuatkan buat masa ini. Sila cuba lagi nanti."
+  },
+  "voicesNowPlaying": {
+    "description": "Pengumuman pembaca skrin apabila klip sampel sesuatu suara mula dimainkan dalam senarai Suara di tetapan; $name$ ialah suara itu.",
+    "message": "Memainkan $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Butang dalam bar kawalan Suara di tetapan yang memainkan setiap suara yang sedang disenaraikan, satu demi satu; $count$ ialah bilangannya. Dirangka supaya dibaca betul pada 1 — Chrome i18n tiada bentuk jamak.",
+    "message": "Mainkan semua ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Butang dalam bar kawalan Suara di tetapan semasa lawatan semula: memainkan hanya suara yang disenaraikan yang anda belum dengar lagi; $count$ ialah bilangannya. Dirangka supaya dibaca betul pada 1 — Chrome i18n tiada bentuk jamak.",
+    "message": "Mainkan yang baharu ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Baris dalam bar kawalan Suara di tetapan apabila pelayar enggan memainkan sampel kerana halaman belum mempunyai interaksi pengguna.",
+    "message": "Klik mana-mana suara untuk mengaktifkan bunyi."
+  },
+  "voicesPreview": {
+    "description": "Label kebolehcapaian untuk butang main (▶) yang menguji klip sampel percuma sesuatu suara pada baris suara; $name$ ialah nama suara tersebut.",
+    "message": "Mainkan sampel $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Nama boleh capai bagi senarai Suara dalam tetapan (sebuah listbox bagi setiap suara, satu baris setiap satu).",
+    "message": "Suara, diurutkan dari paling rendah ke paling cerah"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Label kebolehcapaian untuk togol pin kad suara (keadaan hidup) dan butang buang pada slot menu; $name$ ialah suara, $host$ ialah pembantu.",
+    "message": "Alih keluar $name$ daripada menu $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Baris dalam bar kawalan Suara di tetapan apabila klip sampel satu suara gagal dimuatkan atau dimainkan; $name$ ialah suara tersebut. Bukan modal — siri sampel diteruskan selepasnya.",
+    "message": "Sampel $name$ tidak dapat dimainkan.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Subtajuk untuk bahagian katalog suara dalam tab AI Chat di tetapan",
+    "message": "Pilih suara yang membacakan balasan dengan kuat di setiap laman."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Subtajuk di bawah tajuk tetapan Suara, untuk rel suara yang diurutkan mengikut pic.",
+    "message": "Setiap suara, dari paling rendah ke paling cerah. Dengar, kemudian pilih."
+  },
+  "voicesSectionTitle": {
+    "description": "Tajuk untuk bahagian katalog suara dalam tab AI Chat di tetapan",
+    "message": "Suara"
+  },
+  "voicesShelfEveryday": {
+    "description": "Tajuk kumpulan untuk suara peringkat nilai dalam katalog suara tetapan. Dirender dalam huruf besar oleh CSS.",
+    "message": "Suara harian"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Nota satu baris di sebelah tajuk kumpulan Harian dalam studio Suara tetapan; satu-satunya tempat studio menyatakan sejauh mana peringkat ini lebih lama daripada HD.",
+    "message": "Semula jadi dan jelas — anda boleh mendengar kira-kira 20× lebih lama berbanding HD."
+  },
+  "voicesShelfHd": {
+    "description": "Tajuk kumpulan untuk suara premium (HD) dalam katalog suara tetapan. Dirender dalam huruf besar oleh CSS.",
+    "message": "Suara HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Nota satu baris di sebelah tajuk kumpulan HD dalam studio Suara tetapan.",
+    "message": "Bunyi kami yang paling kaya dan paling ekspresif."
+  },
+  "voicesShowAll": {
+    "description": "Pilihan dalam penapis 'Tunjukkan' Suara di tetapan: tiada penapisan, semua suara disenaraikan.",
+    "message": "Semua suara"
+  },
+  "voicesShowEveryday": {
+    "description": "Pilihan dalam penapis 'Tunjukkan' Suara di tetapan: senaraikan hanya suara standard (bukan HD).",
+    "message": "Biasa sahaja"
+  },
+  "voicesShowHd": {
+    "description": "Pilihan dalam penapis 'Tunjukkan' Suara di tetapan: senaraikan hanya suara premium (HD).",
+    "message": "HD sahaja"
+  },
+  "voicesShowLabel": {
+    "description": "Label pada penapis dalam bar kawalan Suara di tetapan yang mengecilkan suara yang dipaparkan dalam senarai.",
+    "message": "Tunjukkan"
+  },
+  "voicesShowUnheard": {
+    "description": "Pilihan dalam penapis 'Tunjukkan' Suara di tetapan: senaraikan hanya suara yang belum didengari pengguna.",
+    "message": "Belum didengar"
+  },
+  "voicesSpeakingNow": {
+    "description": "Label status pada suara yang sedang dipilih untuk hos dalam studio Suara tetapan (slot menu dan kad suara).",
+    "message": "Sedang bercakap"
+  },
+  "voicesSpeaksWith": {
+    "description": "Baris kening di atas nama suara semasa pada pentas studio Suara dalam tetapan; $host$ ialah pembantu (cth. Pi). Dirender huruf besar oleh CSS.",
+    "message": "$host$ bercakap dengan",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Nota pentas apabila hos menyediakan audio sendiri (cth. Pi), jadi memilih suara Say, Pi akan menggantikan suara hos.",
+    "message": "$host$ akan menggunakan suaranya sendiri sehingga anda memilih satu di bawah.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Nota pentas apabila hos tidak mempunyai suara sendiri (cth. Claude), jadi tiada apa yang dibacakan dengan kuat sehingga suara Say, Pi dipilih.",
+    "message": "$host$ tidak akan membacakan balasan dengan kuat sehingga anda memilih satu di bawah.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Tajuk pada pentas studio Suara dalam tetapan apabila hos belum memilih suara SayPi; $host$ ialah pembantu (cth. Pi, Claude). Dipaparkan pada saiz nama.",
+    "message": "Pilih bunyi $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Butang pada pentas studio Suara dalam tetapan yang memainkan klip sampel percuma bagi suara semasa.",
+    "message": "Dengar sampel"
+  },
+  "voicesStopPlayback": {
+    "description": "Butang dalam bar kawalan Suara di tetapan yang menghentikan siri sampel yang dimulakan oleh 'Mainkan semua'.",
+    "message": "Henti"
+  },
+  "voicesSweepPosition": {
+    "description": "Paparan kedudukan langsung dalam bar kawalan Suara di tetapan semasa 'Main semua' menyusuri senarai; $index$ ialah suara yang sedang dimainkan dan $total$ ialah bilangan yang beratur.",
+    "message": "$index$ daripada $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Label kebolehcapaian untuk kawalan perbandingan dalam bar kawalan Suara di tetapan, yang memainkan semula suara satu lagi daripada dua yang terakhir didengar; $name$ ialah suara itu.",
+    "message": "Tukar semula ke $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Baris dalam bar kawalan Suara di tetapan apabila 'Main semua' ditekan pada senarai yang terlalu panjang untuk didengar; $count$ ialah bilangan suara dan $minutes$ kira-kira berapa minit yang akan diambil. Dipendekkan kepada 'min' supaya dibaca betul pada 1 — Chrome i18n tiada bentuk jamak.",
+    "message": "Itu $count$ suara — kira-kira $minutes$ min. Kecilkan senarai dahulu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Label kebolehcapaian untuk butang per hos 'guna suara ini' dalam katalog suara tetapan; $name$ ialah suara, $host$ ialah pembantu (cth. Pi, Claude).",
+    "message": "Guna $name$ pada $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Label ringkas pada butang per hos 'guna suara ini' dalam katalog suara tetapan bersatu (hos dipaparkan di sebelahnya).",
+    "message": "Guna"
+  },
+  "voicesYourVoice": {
+    "description": "Butang bar kawalan dalam senarai Suara di tetapan yang mengalihkan fokus ke baris suara yang sedang digunakan oleh hos ini; $name$ ialah suara itu.",
+    "message": "Suara anda: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Ralat yang dibuang apabila pelayar tidak dapat memperuntukkan memori WebAssembly yang mencukupi untuk model pengesanan suara.",
+    "message": "Pengesanan suara tidak boleh bermula: memori WebAssembly tidak mencukupi untuk model suara. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Ralat yang dibuang apabila pelayar tidak mendedahkan memori WebAssembly awal yang diperlukan untuk menjalankan model pengesanan suara.",
+    "message": "Pengesanan suara tidak boleh bermula: memori WebAssembly tidak tersedia dalam pelayar ini."
   }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Voordeel in de aanmeldingsprompt: hogere gebruikslimieten.",
+    "message": "Hogere gebruikslimieten met een gratis account"
+  },
+  "authBenefitPremium": {
+    "description": "Voordeel in de aanmeldingsprompt: premium functies voor chatbots.",
+    "message": "Premium functies en ondersteuning voor chatbots"
+  },
+  "authBenefitSupport": {
+    "description": "Voordeel in de aanmeldingsprompt: prioriteitsondersteuning.",
+    "message": "Prioriteitsondersteuning bij problemen"
+  },
+  "authBenefitSync": {
+    "description": "Voordeel in de aanmeldingsprompt: instellingen synchroniseren.",
+    "message": "Synchroniseer steminstellingen overal"
+  },
+  "authBenefitTTS": {
+    "description": "Voordeel in de aanmeldingsprompt: TTS-functie.",
+    "message": "Tekst-naar-spraak-stemmen (betaalde abonnementen)"
+  },
+  "authBenefitUsage": {
+    "description": "Voordeel in de aanmeldingsprompt: gebruik bijhouden.",
+    "message": "Volg je stemgebruik op al je apparaten"
+  },
+  "authPromptModalFull": {
+    "description": "Beschrijving voor de volledige aanmeldingsprompt met waardepropositie.",
+    "message": "Je haalt veel uit Say, Pi. Meld je aan voor hogere limieten, tekst-naar-spraak-stemmen en premium functies voor alle ondersteunde chatbots."
+  },
+  "authPromptModalSoft": {
+    "description": "Beschrijving voor de zachte aanmeldingsprompt.",
+    "message": "Maak een gratis Say, Pi-account aan voor hogere gebruikslimieten en toegang tot premium stemfuncties."
+  },
+  "authPromptTitle": {
+    "description": "Titel voor het aanmeldingsvenster.",
+    "message": "Ontgrendel meer stemfuncties"
+  },
+  "authPromptToast": {
+    "description": "Toastmelding die de gebruiker aanmoedigt om zich aan te melden.",
+    "message": "Meld je aan bij Say, Pi voor hogere limieten en premium functies"
+  },
   "autoReadAloudChatGPT": {
     "description": "Label voor het selectievakje om het automatisch voorlezen van ChatGPT-antwoorden tijdens spraakoproepen in of uit te schakelen.",
     "message": "Automatisch voorlezen (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Schakel tekst-naar-spraak uit"
   },
+  "dismiss": {
+    "message": "Begrepen",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Afwijzen"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Focus"
   },
+  "errorVadInitFailed": {
+    "description": "Foutmelding die wordt getoond wanneer voice-activity detection niet kan worden geïnitialiseerd.",
+    "message": "Initialiseren van spraakdetectie mislukt"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Foutmelding die wordt getoond wanneer er een onverwachte fout optreedt tijdens het instellen van spraakopname.",
+    "message": "Instellen van spraakopname mislukt"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Foutmelding die wordt getoond wanneer de voice-detection client er niet in slaagt de opname te starten.",
+    "message": "Starten van spraakopname mislukt"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Foutmelding die wordt getoond wanneer de voice-detection (VAD)-client niet beschikbaar is, waardoor opnemen niet kan starten.",
+    "message": "Spraakopname niet beschikbaar"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Focusmodus uitschakelen"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Regel met uitleg die in stemmenu’s wordt getoond wanneer zowel premium- (HD) als value-stemmen beschikbaar zijn",
+    "message": "HD-stemmen verbruiken je maandelijkse limiet ongeveer 20× sneller."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Dit wegstappen ..."
   },
+  "maybeLater": {
+    "description": "Knoptekst om de aanmeldingsprompt te sluiten.",
+    "message": "Misschien later"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Je microfooninstellingen voldoen niet aan de vereiste specificaties. \nProbeer een andere microfoon te gebruiken of pas uw audio-instellingen aan."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Kan geen toegang krijgen tot de microfoon. \nControleer uw apparaatinstellingen en probeer het opnieuw."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Foutmelding die wordt getoond wanneer microfoontoestemming is geweigerd na de toestemmingsprompt.",
+    "message": "Microfoontoestemming is niet verleend. Zorg dat je toegang hebt toegestaan in de melding en in de extensie-instellingen."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "nauwkeurigheid"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Snelste reactie, maar minder nauwkeurig. \nGevoelig voor onderbrekingen."
   },
+  "moreVoices": {
+    "description": "Menuregel die vanuit het stemmenu op de pagina linkt naar de volledige stemcatalogus in de extensie-instellingen.",
+    "message": "Meer stemmen…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Assistent bijnaam"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Niet aangemeld"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Knoplabel dat ChatGPT opent.",
+    "message": "ChatGPT openen"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Knoplabel dat Claude.ai opent.",
+    "message": "Open Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Knoplabel dat Pi.ai opent.",
+    "message": "Open Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Omgevingsoptie: in de buurt van andere mensen.",
+    "message": "Tussen andere mensen"
+  },
+  "onboarding_envMixed": {
+    "description": "Omgevingsoptie: een mix van privé- en gedeelde ruimtes.",
+    "message": "Een mix van plekken"
+  },
+  "onboarding_envPrivate": {
+    "description": "Omgevingsoptie: een privéplek.",
+    "message": "Ergens privé"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Bevestiging die wordt getoond wanneer het omgevingsantwoord de stille modus uit laat.",
+    "message": "Begrepen, we houden de standaard luister- en afspeelinstellingen aan."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Bevestiging die wordt getoond wanneer het omgevingsantwoord de stille modus inschakelt.",
+    "message": "Stille modus aan — we pikken zachtere spraak op en antwoorden rustig, zodat je discreet kunt praten."
+  },
+  "onboarding_envTitle": {
+    "description": "Kop voor de onboarding-vraag over de omgeving van de gebruiker.",
+    "message": "Waar praat je meestal?"
+  },
+  "onboarding_footer": {
+    "description": "Voettekst op de onboardingpagina die bij het eerste gebruik wordt getoond.",
+    "message": "Je kunt dit altijd opnieuw bekijken via de instellingen van Say, Pi. Je privacy is belangrijk — audio wordt alleen vastgelegd tijdens een actieve oproep."
+  },
+  "onboarding_heading": {
+    "description": "Hoofdkop op de onboardingpagina die bij de eerste keer openen wordt getoond.",
+    "message": "🗣️ Welkom bij Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Intro-alinea op de onboardingpagina die bij de eerste keer openen wordt getoond.",
+    "message": "Je bent nog twee stappen verwijderd van je eerste gesproken gesprek met een AI. Praten is ongeveer 3× sneller dan typen — laten we je instellen."
+  },
+  "onboarding_micTestButton": {
+    "description": "Knop die de onboarding-microfoontest zonder gevolgen start.",
+    "message": "🎤 Je microfoon testen"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status die wordt getoond nadat de onboarding-microfoontest succesvol is afgerond.",
+    "message": "Mooi — je microfoon werkt! 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status die wordt getoond terwijl de onboarding-microfoontest het invoerniveau meet.",
+    "message": "Luisteren — zeg iets! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status die wordt getoond terwijl de onboarding-microfoontest wacht op toestemming.",
+    "message": "Microfoontoegang aanvragen…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Knoplabel om de onboarding-microfoontest te stoppen terwijl die actief is.",
+    "message": "Test stoppen"
+  },
+  "onboarding_step1Body": {
+    "description": "Tekst van de eerste onboardingstap die uitlegt hoe je de extensie vastzet.",
+    "message": "Klik op het puzzelstukje 🧩-pictogram rechtsboven in je browser, en daarna op de punaise 📌 naast Say, Pi. Zo staat de belknop altijd op één klik afstand."
+  },
+  "onboarding_step1Title": {
+    "description": "Titel van de eerste onboardingstap (de extensie vastzetten).",
+    "message": "Zet Say, Pi vast op je werkbalk"
+  },
+  "onboarding_step2Body": {
+    "description": "Tekst van de tweede onboardingstap die uitlegt hoe je een spraakgesprek start.",
+    "message": "Ga naar een van de ondersteunde assistants hieronder, tik op de Say, Pi-belknop en zeg hallo. De eerste keer vragen we om microfoontoegang — dat is normaal, en we luisteren alleen terwijl je actief in een gesprek zit."
+  },
+  "onboarding_step2Title": {
+    "description": "Titel van de tweede onboardingstap (een gesprek starten).",
+    "message": "Open een AI-chat en begin te praten"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Microfoonvergunning"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Herstelinstructies wanneer microfoonrechten zijn geblokkeerd.",
+    "message": "Je browser blokkeert de microfoon. Klik op het camera- of slotpictogram in de adresbalk, zet Microfoon op \"Toestaan\" en probeer het opnieuw. Controleer op macOS ook Systeeminstellingen → Privacy en beveiliging → Microfoon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Titel van het herstelpaneel wanneer microfoonrechten zijn geweigerd/geblokkeerd.",
+    "message": "Microfoontoegang is geblokkeerd"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Herstelinstructies wanneer de microfoon elders in gebruik is.",
+    "message": "Een andere app of tabblad gebruikt mogelijk je microfoon. Sluit alles wat mogelijk opneemt (videogesprekken, spraakmemo's) en probeer het opnieuw."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Titel van het herstelpaneel wanneer de microfoon door een andere app wordt gebruikt.",
+    "message": "Je microfoon is in gebruik"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Herstelinstructies wanneer er geen microfoonapparaat beschikbaar is.",
+    "message": "We konden geen microfoon vinden. Sluit er een aan (of verbind je headset), zorg dat die is geselecteerd als je invoerapparaat en probeer het opnieuw."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Titel van het herstelpaneel wanneer er geen microfoonapparaat beschikbaar is.",
+    "message": "Geen microfoon gevonden"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Herstelinstructies voor een onbekende microfoonfout.",
+    "message": "Er ging iets mis bij het benaderen van je microfoon. Controleer of die is aangesloten en is toegestaan in de instellingen van je browser en probeer het opnieuw."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Titel van het herstelpaneel voor een onbekende microfoonfout.",
+    "message": "We konden je microfoon niet bereiken"
+  },
+  "permissions_retryButton": {
+    "description": "Label voor de knop die microfoontoestemming opnieuw aanvraagt.",
+    "message": "Opnieuw proberen"
+  },
+  "permissions_revokedHeading": {
+    "description": "Kop die wordt getoond wanneer microfoontoegang eerder was toegestaan maar inmiddels is ingetrokken.",
+    "message": "Laten we je microfoon opnieuw verbinden"
+  },
+  "permissions_revokedInfo": {
+    "description": "Informatieve tekst die wordt getoond wanneer microfoontoegang is ingetrokken nadat deze was toegestaan.",
+    "message": "Je microfoontoegang is uitgezet, dit gebeurt vaak na een browser- of systeemupdate. Sta het hieronder opnieuw toe en $productName$ luistert weer wanneer je in een gesprek zit.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profiel"
+  },
+  "quietModeLabel": {
+    "description": "Label voor de schakelaar die de stille/fluistermodus inschakelt.",
+    "message": "Stille modus"
+  },
+  "quietModeTooltip": {
+    "description": "Tooltip die uitlegt wat de stille/fluistermodus doet.",
+    "message": "Spreek zachtjes — pikt stillere spraak op en verlaagt het volume van het antwoord van de assistent, zodat je spraak kunt gebruiken in de buurt van anderen."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Tekst voor de aanmeldknop terwijl de authenticatie bezig is.",
+    "message": "Aanmelden..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Geluidseffecten"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Geluidseffecten zijn uitgeschakeld in Firefox om problemen met audiofeedback te voorkomen."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Kop van de eenmalige speed-payoff-melding die na de eerste gesproken uitwisseling wordt getoond.",
+    "message": "Mooi — praten is ongeveer 3× sneller dan typen."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Optionele tweede regel van de speed-payoff-melding met het aantal bespaarde hele minuten.",
+    "message": "Je hebt al ongeveer $minutes$ min sneller gesproken dan wanneer je het had getypt.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Alleen verzenden als u op de knop drukt"
   },
+  "surveyQuestion": {
+    "description": "De enige vraag van de eenmalige micro-enquête na de win.",
+    "message": "Hoe bevalt de stem tot nu toe?"
+  },
+  "surveyRatingLabel": {
+    "description": "Toegankelijk label voor een beoordelingsknop in de enquête.",
+    "message": "Beoordeel $rating$ van 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Bevestiging die wordt getoond nadat de gebruiker de enquête na de win heeft ingevuld.",
+    "message": "Bedankt, dit helpt ons Say, Pi beter te maken. 🙏"
+  },
   "tabAIChat": {
     "description": "Tablabel voor de AI-chatinstellingen.",
     "message": "AI Chat"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Tablabel voor de algemene instellingen.",
     "message": "Algemeen"
+  },
+  "tabVoices": {
+    "description": "Tablabel voor het gedeelte met steminstellingen (stemmencatalogus per site).",
+    "message": "Stemmen"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "credits"
   },
+  "ttsCreditsRemaining": {
+    "description": "Tekst die het resterende TTS-quotum toont als een tegoedpool per stem (saypi-api #181 Stage 2), niet als ruwe tekens.",
+    "message": "Nog $credits$ tegoed",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Meertalige stemmen worden momenteel niet ondersteund in Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Spraakgeneratie"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Let op! Spraakweergave is nog niet beschikbaar op $browserName$ met $chatbotName$. Het goede nieuws? Spraakinvoer werkt geweldig! Probeer Chrome of Edge op desktop voor TTS.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS niet beschikbaar op $browserName$ + $chatbotName$. Spraakinvoer werkt! Probeer Chrome desktop voor TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS -stem"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "VAD-detail wanneer spraakachtig geluid is gedetecteerd maar te zacht / met te lage zekerheid was om te transcriberen (client-side admission-gate drop).",
+    "message": "Audio te zacht om te transcriberen"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "VAD-detail dat uitlegt dat de oproep is beëindigd omdat de microfoon door een nieuwer tabblad is geclaimd.",
+    "message": "Spraakinvoer verplaatst naar een ander tabblad"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Stem niet beschikbaar. \nProbeer Chrome of Firefox op desktop."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Let op! Spraakweergave is nog niet beschikbaar op $browserName$ met $chatbotName$. Het goede nieuws? Spraakinvoer werkt geweldig! Probeer Chrome of Edge op desktop voor TTS.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS niet beschikbaar op $browserName$ + $chatbotName$. Spraakinvoer werkt! Probeer Chrome desktop voor TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Begrepen",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "VAD-status die wordt getoond op een tabblad waarvan de spraakinvoer is overgenomen door een ander tabblad.",
+    "message": "Gepauzeerd"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Bekijk details"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Algemene gesproken introductie die wordt afgespeeld wanneer een geselecteerde SayPi-stem geen stem-specifiek introductiescript heeft (en er geen recent bericht is om voor te lezen).",
+    "message": "Hoi, ik ben $voice$. Zo klink ik. Ik hoop dat je deze stem fijn vindt.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hallo! \nGoed! \nJa! \nIk ben Pi, je meertalige AI-assistent. \nMet 32 ​​talen tot mijn beschikking kunnen we ideeën en culturen van over de hele wereld verkennen. \nWat vind jij van deze stem?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Spraakinstellingen"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Reserve-ondertitel voor een stemrij in de stemmencatalogus in de instellingen wanneer de stem geen beschrijving heeft; $count$ is het aantal talen dat de stem ondersteunt.",
+    "message": "Spreekt $count$ talen",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Addison' (instellingen Voices studio; client-side voice identity map).",
+    "message": "Zonnig en welbespraakt"
+  },
+  "voiceTagline_alloy": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Alloy' (instellingen Stemmen-studio; client-side stem-identiteitsmap).",
+    "message": "Evenwichtig en veelzijdig"
+  },
+  "voiceTagline_ash": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Ash' (instellingen Stemmen-studio; client-side stem-identiteitsmap).",
+    "message": "Laag, bedachtzaam, kalm"
+  },
+  "voiceTagline_ballad": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Ballad' (instellingen Stemmen-studio; client-side stem-identiteitsmap).",
+    "message": "Soepel en melodieus"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Cassidy' (instellingen Voices studio; client-side voice identity map).",
+    "message": "Vriendelijk en nuchter"
+  },
+  "voiceTagline_cedar": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Cedar' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Rustig en geruststellend"
+  },
+  "voiceTagline_coral": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Coral' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Helder, opgewekte energie"
+  },
+  "voiceTagline_echo": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Echo' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Helder en neutraal"
+  },
+  "voiceTagline_fable": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Fable' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Met een verhalende cadans"
+  },
+  "voiceTagline_finn": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Finn' (instellingen Voices studio; client-side voice identity map).",
+    "message": "Fris en energiek"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Jamahal' (instellingen Voices studio; client-side voice identity map).",
+    "message": "Rijk en magnetisch"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Jarnathan' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Fluwelen bariton voor laat op de avond"
+  },
+  "voiceTagline_jeff": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Jeff' (instellingen Voices studio; client-side voice identity map).",
+    "message": "Nuchter en standvastig"
+  },
+  "voiceTagline_jessica": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Jessica' (instellingen Voices studio; client-side voice identity map).",
+    "message": "Warm en stijlvol"
+  },
+  "voiceTagline_joey": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Joey' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Ontspannen, converserend Amerikaans"
+  },
+  "voiceTagline_juniper": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Juniper' (instellingen Voices studio; client-side voice identity map).",
+    "message": "Helder, sprankelend, levendig"
+  },
+  "voiceTagline_lucy": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Lucy' (instellingen Voices studio; client-side voice identity map).",
+    "message": "Zacht en stralend"
+  },
+  "voiceTagline_marin": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Marin' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Warm, kalm als ochtendradio"
+  },
+  "voiceTagline_mark": {
+    "description": "Geschreven persoonlijkheidstagline voor de stem 'Mark' (instellingen Voices studio; client-side voice identity map).",
+    "message": "Heldere, zelfverzekerde verteller"
+  },
+  "voiceTagline_nova": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Nova' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Snel en nieuwsgierig"
+  },
+  "voiceTagline_onyx": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Onyx' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Diep, resonerend gezag"
+  },
+  "voiceTagline_paola": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Paola' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Expressieve Italiaanse warmte"
+  },
+  "voiceTagline_sage": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Sage' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Zachte, heldere stem"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Geschreven persoonlijkheidsslogan voor de stem 'Shimmer' (instellingen Stemmen-studio; client-side stemidentiteitskaart).",
+    "message": "Licht en luchtig"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Korte label op de vastzetknop van een stemkaart (uit-stand) in de stemmenstudio van de instellingen; indrukken voegt de stem toe aan het in-chatmenu van de host.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Toegankelijkheidslabel voor de vastzetknop van een stemkaart (uit-stand); $name$ is de stem, $host$ de assistent.",
+    "message": "Voeg $name$ toe aan het menu van $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Label bij de schakelaar in de bedieningsbalk van Stemmen die aangeeft of het doorlopen van de lijst met de pijltoetsen elke stem afspeelt zodra de focus erop komt.",
+    "message": "Afspelen tijdens bladeren"
+  },
+  "voicesArrowsLive": {
+    "description": "Bevestiging voor de schermlezer, toegevoegd aan de eerste aankondiging 'Speelt <stem> af' in de lijst Stemmen in de instellingen, die zegt dat de pijltjestoetsen zojuist hoorbaar zijn geworden. Sluit aan bij de bewoording van de schakelaar 'Afspelen tijdens bewegen'.",
+    "message": "Pijltjestoetsen spelen nu af terwijl je beweegt. Esc stopt."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Opmerking onder de menuplekken voor hosts die standaard eigen stemmen hebben (bijv. Pi's 8 ingebouwde stemmen), die de studio niet beheert; $host$ is de assistent.",
+    "message": "De ingebouwde stemmen van $host$ staan ook altijd in het menu.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variant van voicesBuiltinsNote voor een host zonder in-chat stemmenmenu (Pi heeft zijn menu in 2026 uitgefaseerd), waarbij de belofte uit het origineel dat de ingebouwde stemmen 'in het menu verschijnen' onjuist zou zijn; $host$ is de assistent.",
+    "message": "$host$ heeft ook eigen ingebouwde stemmen, maar die staan hier niet.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Voortgangsweergave in de bedieningsbalk Stemmen in de instellingen: hoeveel van de vermelde stemmen de gebruiker al heeft beluisterd. Kale getallen, zodat het ook bij 1 klopt — Chrome i18n heeft geen meervoudsvormen.",
+    "message": "$heard$ van $total$ gehoord",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Onderdeel van de toegankelijke naam van een stemrij in de lijst Stemmen in de instellingen, markeert een stem waar dit profiel al naar heeft geluisterd. Visueel wordt dit getoond als inktdichtheid op de geluidsafdruk van de stem, wat een schermlezer niet kan zien.",
+    "message": "Gehoord"
+  },
+  "voicesInHostMenu": {
+    "description": "Sectiekop boven de rij met menuslots in de stemmenstudio van de instellingen; $host$ is de assistent.",
+    "message": "In het menu van $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Korte label op de vastzetknop van een stemkaart (aan-stand) in de stemmenstudio van de instellingen.",
+    "message": "✓ In menu"
+  },
+  "voicesInUse": {
+    "description": "Persistente badge op de momenteel geselecteerde stem van de host in de stemmenlijst van de instellingen, weergegeven in hoofdletters. Bewust NIET 'Spreekt nu': op deze pagina spelen rijen hun voorbeeldclips af, dus een geselecteerde maar stille stem mag niet beweren te spreken terwijl een andere rij dat is.",
+    "message": "In gebruik"
+  },
+  "voicesKeyboardHint": {
+    "description": "Hint van één regel voor het toetsenbord in de bedieningsbalk Stemmen in de instellingen. De symbolen zijn toetsen: Spatie, de pijlen omhoog/omlaag en Shift+Spatie.",
+    "message": "Druk op Spatie om te luisteren, ↑↓ om tussen stemmen te gaan, ⇧Spatie om terug te schakelen."
+  },
+  "voicesLoadError": {
+    "description": "Foutstatus binnen de studio van één host wanneer de stemmencatalogus van die host niet kon worden geladen; $host$ is de assistent.",
+    "message": "Kon de stemmen van $host$ niet laden. Probeer het later opnieuw.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/hint op een uitgeschakelde '+ Menu'-schakelaar wanneer het in-chatmenu van de host al het maximale aantal stemmen heeft.",
+    "message": "Menu vol, verwijder een stem om er nog een toe te voegen"
+  },
+  "voicesMenuHint": {
+    "description": "Hint van één regel naast de kop 'In het menu van {host}', die uitlegt dat de rij met slots het stemmenmenu in de chat weerspiegelt.",
+    "message": "Wat je in de chat ziet"
+  },
+  "voicesMenuOverflow": {
+    "description": "Opmerking onder de menuplekken wanneer de gebruiker meer vastgezette stemmen heeft dan het in-chatmenu kan tonen (legacy-status); $count$ is hoeveel er niet passen, $cap$ is de menugrootte.",
+    "message": "Er wachten nog $count$ vastgezette stemmen buiten de $cap$ menuplekken.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Enkelvoud van voicesMenuOverflow, gebruikt wanneer precies één vastgezette stem niet in het in-chatmenu past; $cap$ is de menugrootte.",
+    "message": "Er wacht nog 1 vastgezette stem buiten de $cap$ menuplekken.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Samenvattingsregel onder de lijst Stemmen in de instellingen die aangeeft hoeveel van het in-chat stemmenmenu van de host is gevuld; $host$ is de assistent, $used$ hoeveel plaatsen bezet zijn, $cap$ hoeveel er zijn. Geformuleerd zodat het ook bij 1 klopt — Chrome i18n heeft geen meervoudsvormen.",
+    "message": "$host$'s menu: $used$ van $cap$ plaatsen",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Kop voor de groep aan het eind van de lijst Stemmen in de instellingen met stemmen zonder voorbeeldfragment om af te spelen; $count$ is hoeveel. Geformuleerd zodat het ook bij 1 klopt — Chrome i18n heeft geen meervoudsvormen.",
+    "message": "Nog geen voorbeeld ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Wordt getoond in de stemmencatalogus in de instellingen wanneer de stemmenlijst leeg is voor een ingelogde gebruiker (bijv. een netwerkprobleem).",
+    "message": "Stemmen konden nu niet worden geladen. Probeer het later opnieuw."
+  },
+  "voicesNowPlaying": {
+    "description": "Schermlezer-aankondiging wanneer het voorbeeldfragment van een stem begint met afspelen in de lijst Stemmen in de instellingen; $name$ is de stem.",
+    "message": "Speelt $name$ af",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Knop in de bedieningsbalk Stemmen in de instellingen die elke momenteel vermelde stem één voor één afspeelt; $count$ is hoeveel. Geformuleerd zodat het ook bij 1 klopt — Chrome i18n heeft geen meervoudsvormen.",
+    "message": "Alles afspelen ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Knop in de bedieningsbalk Stemmen in de instellingen bij een terugkeerbezoek: speelt alleen de vermelde stemmen af waar je nog niet naar hebt geluisterd; $count$ is hoeveel. Geformuleerd zodat het ook bij 1 klopt — Chrome i18n heeft geen meervoudsvormen.",
+    "message": "Nieuwe afspelen ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Regel in de instellingenbalk voor Stemmen wanneer de browser weigerde een voorbeeld af te spelen omdat de pagina nog geen gebruikersinteractie heeft gehad.",
+    "message": "Klik op een stem om geluid in te schakelen."
+  },
+  "voicesPreview": {
+    "description": "Toegankelijk label voor de afspeelknop (▶) waarmee je het gratis voorbeeldfragment van een stem op een stemrij beluistert; $name$ is de naam van de stem.",
+    "message": "Speel een voorbeeld van $name$ af",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Toegankelijke naam van de instellingenlijst Stemmen (een listbox met elke stem, één rij per stem).",
+    "message": "Stemmen, geordend van diep tot helder"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Toegankelijkheidslabel voor de vastzetknop van een stemkaart (aan-stand) en de verwijderknop van een menuslot; $name$ is de stem, $host$ de assistent.",
+    "message": "Verwijder $name$ uit het menu van $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Regel in de instellingenbalk voor Stemmen wanneer het voorbeeldfragment van één stem niet kon laden of afspelen; $name$ is die stem. Niet-modale melding — een reeks voorbeelden gaat erna gewoon door.",
+    "message": "Kon het voorbeeld van $name$ niet afspelen.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Subkop voor de sectie stemcatalogus in het tabblad AI Chat van de instellingen.",
+    "message": "Kies de stem die antwoorden op elke site voorleest."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Subkop onder de instellingstitel Stemmen, voor de op toonhoogte geordende rail met stemmen.",
+    "message": "Elke stem, van diep tot helder. Luister, en kies dan."
+  },
+  "voicesSectionTitle": {
+    "description": "Kop voor de sectie stemcatalogus in het tabblad AI Chat van de instellingen.",
+    "message": "Stemmen"
+  },
+  "voicesShelfEveryday": {
+    "description": "Groepskop voor stemmen uit de voordeligere categorie in de stemcatalogus van de instellingen. Wordt door CSS in hoofdletters weergegeven.",
+    "message": "Dagelijkse stemmen"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Opmerking van één regel naast de groepskop Dagelijks in de stemmenstudio van de instellingen; de enige plek waar de studio aangeeft hoeveel langer deze categorie meegaat dan HD.",
+    "message": "Natuurlijk en helder — je kunt ongeveer 20× langer luisteren dan met HD."
+  },
+  "voicesShelfHd": {
+    "description": "Groepskop voor premium (HD)-stemmen in de stemcatalogus van de instellingen. Wordt door CSS in hoofdletters weergegeven.",
+    "message": "HD-stemmen"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Opmerking van één regel naast de HD-groepskop in de stemmenstudio van de instellingen.",
+    "message": "Ons rijkste, meest expressieve geluid."
+  },
+  "voicesShowAll": {
+    "description": "Optie in het filter 'Tonen' bij instellingen > Stemmen: geen filtering, alle stemmen worden getoond.",
+    "message": "Alle stemmen"
+  },
+  "voicesShowEveryday": {
+    "description": "Optie in het filter 'Tonen' bij instellingen > Stemmen: toon alleen de standaard (niet-HD)-stemmen.",
+    "message": "Alleen standaard"
+  },
+  "voicesShowHd": {
+    "description": "Optie in het filter 'Tonen' bij instellingen > Stemmen: toon alleen de premium (HD)-stemmen.",
+    "message": "Alleen HD"
+  },
+  "voicesShowLabel": {
+    "description": "Label op het filter in de instellingenbalk voor Stemmen waarmee wordt beperkt welke stemmen de lijst toont.",
+    "message": "Tonen"
+  },
+  "voicesShowUnheard": {
+    "description": "Optie in het filter 'Tonen' bij instellingen > Stemmen: toon alleen de stemmen waar de gebruiker nog niet naar geluisterd heeft.",
+    "message": "Nog niet beluisterd"
+  },
+  "voicesSpeakingNow": {
+    "description": "Statuslabel op de momenteel geselecteerde stem van de host in de stemmenstudio van de instellingen (menuslot en stemkaart).",
+    "message": "Spreekt nu"
+  },
+  "voicesSpeaksWith": {
+    "description": "Wenkbrauwregel boven de naam van de huidige stem op het instellingenpodium van de stemmenstudio; $host$ is de assistent (bijv. Pi). Wordt door CSS in hoofdletters weergegeven.",
+    "message": "$host$ spreekt met",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Podiumopmerking wanneer de host zijn eigen audio levert (bijv. Pi), dus het kiezen van een Say, Pi-stem die van de host vervangt.",
+    "message": "$host$ gebruikt zijn eigen stem tot je hieronder een stem kiest.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Podiumopmerking wanneer de host geen eigen stem heeft (bijv. Claude), dus er wordt niets hardop voorgelezen totdat een Say, Pi-stem is gekozen.",
+    "message": "$host$ leest antwoorden niet hardop voor tot je hieronder een stem kiest.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Kop op het podium van de instellingen van de Stemmen-studio wanneer er geen SayPi-stem is geselecteerd voor de host; $host$ is de assistent (bijv. Pi, Claude). Wordt weergegeven op naamgrootte.",
+    "message": "Kies hoe $host$ klinkt",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Knop op het podium van de Stemmen-studio in de instellingen die het gratis voorbeeldfragment van de huidige stem afspeelt.",
+    "message": "Voorbeeld beluisteren"
+  },
+  "voicesStopPlayback": {
+    "description": "Knop in de bedieningsbalk Stemmen in de instellingen die de reeks voorbeelden stopt die is gestart door 'Alles afspelen'.",
+    "message": "Stoppen"
+  },
+  "voicesSweepPosition": {
+    "description": "Live positie-indicator in de instellingenbalk voor Stemmen terwijl 'Alles afspelen' door de lijst loopt; $index$ is de stem die nu speelt en $total$ hoeveel er in de wachtrij staan.",
+    "message": "$index$ van $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Toegankelijk label voor de vergelijken-bediening in de bedieningsbalk Stemmen in de instellingen, die de andere stem van de laatste twee gehoorde opnieuw afspeelt; $name$ is die stem.",
+    "message": "Schakel terug naar $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Regel in de instellingenbalk voor Stemmen wanneer op 'Alles afspelen' wordt gedrukt bij een lijst die te lang is om te beluisteren; $count$ is hoeveel stemmen en $minutes$ ongeveer hoeveel minuten ze zouden duren. Afgekort 'min' zodat het bij 1 ook klopt — Chrome i18n heeft geen meervoudsvormen.",
+    "message": "Dat zijn $count$ stemmen — ongeveer $minutes$ min. Maak de lijst eerst kleiner.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Toegankelijkheidslabel voor de per-hostknop 'gebruik deze stem' in de instellingen-stemcatalogus; $name$ is de stem, $host$ is de assistent (bijv. Pi, Claude).",
+    "message": "Gebruik $name$ op $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Korte label op de per-hostknop 'gebruik deze stem' in de gecombineerde instellingen-stemcatalogus (de host wordt ernaast getoond).",
+    "message": "Gebruik"
+  },
+  "voicesYourVoice": {
+    "description": "Knop in de bedieningsbalk in de lijst Stemmen in de instellingen die de focus naar de rij verplaatst van de stem die deze host momenteel gebruikt; $name$ is die stem.",
+    "message": "Jouw stem: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Fout die wordt opgegooid wanneer de browser niet genoeg WebAssembly-geheugen kan toewijzen voor het spraakdetectiemodel.",
+    "message": "Spraakdetectie kan niet starten: niet genoeg WebAssembly-geheugen voor het spraakmodel. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Fout die wordt opgegooid wanneer de browser het initiële WebAssembly-geheugen dat nodig is om het spraakdetectiemodel te draaien niet aanbiedt.",
+    "message": "Spraakdetectie kan niet starten: WebAssembly-geheugen is niet beschikbaar in deze browser."
   }
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Korzyść wymieniona w modalu logowania — zwiększone limity użycia.",
+    "message": "Wyższe limity użycia z bezpłatnym kontem"
+  },
+  "authBenefitPremium": {
+    "description": "Korzyść wymieniona w modalu logowania — funkcje premium w różnych chatbotach.",
+    "message": "Funkcje premium i obsługa chatbotów"
+  },
+  "authBenefitSupport": {
+    "description": "Korzyść wymieniona w modalu logowania — priorytetowe wsparcie.",
+    "message": "Priorytetowe wsparcie w razie problemów"
+  },
+  "authBenefitSync": {
+    "description": "Korzyść wymieniona w modalu logowania — synchronizacja ustawień.",
+    "message": "Synchronizuj ustawienia głosu wszędzie"
+  },
+  "authBenefitTTS": {
+    "description": "Korzyść wymieniona w modalu logowania — funkcja TTS.",
+    "message": "Głosy zamiany tekstu na mowę (plany płatne)"
+  },
+  "authBenefitUsage": {
+    "description": "Korzyść wymieniona w modalu logowania — śledzenie użycia.",
+    "message": "Śledź użycie głosu na różnych urządzeniach"
+  },
+  "authPromptModalFull": {
+    "description": "Opis dla pełnego modalu zachęcającego do uwierzytelnienia z propozycją wartości.",
+    "message": "Świetnie korzystasz z Say, Pi. Zaloguj się, aby uzyskać wyższe limity, głosy zamiany tekstu na mowę i funkcje premium we wszystkich obsługiwanych chatbotach."
+  },
+  "authPromptModalSoft": {
+    "description": "Opis dla łagodnego modalu zachęcającego do uwierzytelnienia.",
+    "message": "Utwórz bezpłatne konto Say, Pi, aby mieć wyższe limity użycia i dostęp do funkcji głosowych premium."
+  },
+  "authPromptTitle": {
+    "description": "Tytuł okna modalnego zachęcającego do zalogowania.",
+    "message": "Odblokuj więcej funkcji głosowych"
+  },
+  "authPromptToast": {
+    "description": "Powiadomienie typu toast zachęcające użytkownika do zalogowania się.",
+    "message": "Zaloguj się do Say, Pi, aby uzyskać wyższe limity i funkcje premium"
+  },
   "autoReadAloudChatGPT": {
     "description": "Etykieta pola wyboru do włączania/wyłączania automatycznego czytania odpowiedzi ChatGPT podczas rozmów głosowych.",
     "message": "Automatyczne czytanie na głos (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Wyłącz tekst na mowę"
   },
+  "dismiss": {
+    "message": "Rozumiem",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Odrzucać"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Skupienie"
   },
+  "errorVadInitFailed": {
+    "description": "Komunikat błędu (toast) wyświetlany, gdy nie udaje się zainicjować wykrywania aktywności głosu.",
+    "message": "Nie udało się zainicjować wykrywania głosu"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Komunikat błędu (toast) wyświetlany, gdy podczas konfiguracji nagrywania głosu wystąpi nieoczekiwany błąd.",
+    "message": "Nie udało się skonfigurować nagrywania głosu"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Komunikat błędu (toast) wyświetlany, gdy klient wykrywania głosu nie może rozpocząć nagrywania.",
+    "message": "Nie udało się rozpocząć nagrywania głosu"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Komunikat błędu (toast) wyświetlany, gdy klient wykrywania głosu (VAD) jest niedostępny, więc nie można rozpocząć nagrywania.",
+    "message": "Nagrywanie głosu jest niedostępne"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Wyjdź z trybu skupienia"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Jednolinijkowa notatka pokazywana w menu głosów, gdy dostępne są zarówno głosy premium (HD), jak i głosy ekonomiczne",
+    "message": "Głosy HD zużywają Twój miesięczny limit około 20× szybciej."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Wykrzykując to ..."
   },
+  "maybeLater": {
+    "description": "Tekst przycisku do zamknięcia zachęty do logowania.",
+    "message": "Może później"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Ustawienia mikrofonu nie spełniają wymaganych specyfikacji. \nSpróbuj użyć innego mikrofonu lub dostosować ustawienia dźwięku."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Nie można uzyskać dostępu do mikrofonu. \nSprawdź ustawienia urządzenia i spróbuj ponownie."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Komunikat błędu (toast) wyświetlany, gdy po przejściu przez prośbę o uprawnienia odmówiono dostępu do mikrofonu.",
+    "message": "Nie przyznano uprawnień do mikrofonu. Upewnij się, że zezwoliłeś(-aś) na dostęp w oknie prośby i w ustawieniach rozszerzenia."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "dokładność"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Najszybsza reakcja, ale mniej dokładna. \nSkłonny do przerywania."
   },
+  "moreVoices": {
+    "description": "Wiersz menu prowadzący z menu głosu na stronie do pełnego katalogu głosów w ustawieniach rozszerzenia.",
+    "message": "Więcej głosów…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Pseudonim asystenta"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Nie zalogowane"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Etykieta przycisku, który otwiera ChatGPT.",
+    "message": "Otwórz ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Etykieta przycisku otwierającego Claude.ai.",
+    "message": "Otwórz Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Etykieta przycisku otwierającego Pi.ai.",
+    "message": "Otwórz Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Opcja otoczenia: wśród innych osób.",
+    "message": "Wśród innych osób"
+  },
+  "onboarding_envMixed": {
+    "description": "Opcja otoczenia: mieszanka miejsc prywatnych i współdzielonych.",
+    "message": "W różnych miejscach"
+  },
+  "onboarding_envPrivate": {
+    "description": "Opcja otoczenia: prywatna przestrzeń.",
+    "message": "W prywatnym miejscu"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Potwierdzenie wyświetlane, gdy odpowiedź dotycząca środowiska pozostawia tryb cichy wyłączony.",
+    "message": "Rozumiemy — zostawimy standardowe ustawienia nasłuchiwania i odtwarzania."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Potwierdzenie wyświetlane, gdy odpowiedź dotycząca otoczenia włącza tryb cichy.",
+    "message": "Tryb cichy włączony — wykryjemy cichszą mowę i odpowiemy ciszej, żeby można było rozmawiać dyskretnie."
+  },
+  "onboarding_envTitle": {
+    "description": "Nagłówek pytania podczas wdrożenia o otoczenie użytkownika.",
+    "message": "Gdzie najczęściej będziesz rozmawiać?"
+  },
+  "onboarding_footer": {
+    "description": "Tekst stopki na stronie wdrożenia przy pierwszym uruchomieniu.",
+    "message": "W każdej chwili możesz wrócić do tego w ustawieniach Say, Pi. Twoja prywatność jest ważna — dźwięk jest przechwytywany tylko podczas aktywnej rozmowy."
+  },
+  "onboarding_heading": {
+    "description": "Główny nagłówek na stronie pierwszego uruchomienia (onboarding).",
+    "message": "🗣️ Witamy w Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Akapit wprowadzający na stronie pierwszego uruchomienia (onboarding).",
+    "message": "Do Twojej pierwszej rozmowy głosowej z AI dzielą Cię dwa kroki. Mówienie jest około 3× szybsze niż pisanie — skonfigurujmy to."
+  },
+  "onboarding_micTestButton": {
+    "description": "Przycisk uruchamiający bezstresowy test mikrofonu podczas wdrożenia.",
+    "message": "🎤 Przetestuj mikrofon"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status wyświetlany po pomyślnym zakończeniu testu mikrofonu podczas wdrożenia.",
+    "message": "Super, mikrofon działa 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status wyświetlany, gdy test mikrofonu podczas wdrożenia mierzy sygnał wejściowy.",
+    "message": "Słucham — powiedz coś 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status wyświetlany, gdy test mikrofonu podczas wdrożenia czeka na uprawnienie.",
+    "message": "Prośba o dostęp do mikrofonu…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Etykieta przycisku zatrzymania testu mikrofonu podczas wdrożenia, gdy jest uruchomiony.",
+    "message": "Zatrzymaj test"
+  },
+  "onboarding_step1Body": {
+    "description": "Treść pierwszego kroku onboardingu wyjaśniająca, jak przypiąć rozszerzenie.",
+    "message": "Kliknij ikonę puzzla 🧩 w prawym górnym rogu przeglądarki, a potem pinezkę 📌 obok Say, Pi. Dzięki temu przycisk rozmowy będzie o jedno kliknięcie."
+  },
+  "onboarding_step1Title": {
+    "description": "Tytuł pierwszego kroku onboardingu (przypięcie rozszerzenia).",
+    "message": "Przypnij Say, Pi do paska narzędzi"
+  },
+  "onboarding_step2Body": {
+    "description": "Treść drugiego kroku onboardingu wyjaśniająca, jak rozpocząć rozmowę głosową.",
+    "message": "Wejdź do jednego z obsługiwanych asystentów poniżej, a potem kliknij przycisk połączenia Say, Pi i przywitaj się. Przy pierwszym razie poprosimy o dostęp do mikrofonu — to normalne, a słuchamy tylko wtedy, gdy jesteś aktywnie w połączeniu."
+  },
+  "onboarding_step2Title": {
+    "description": "Tytuł drugiego kroku onboardingu (rozpoczęcie rozmowy).",
+    "message": "Otwórz czat AI i zacznij mówić"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Zezwolenie na mikrofon"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Wskazówki naprawcze, gdy uprawnienie do mikrofonu jest zablokowane.",
+    "message": "Przeglądarka blokuje mikrofon. Kliknij ikonę kamery lub kłódki na pasku adresu, ustaw Mikrofon na „Zezwól”, a potem spróbuj ponownie. Na macOS sprawdź też Ustawienia systemowe → Prywatność i ochrona → Mikrofon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Tytuł panelu odzyskiwania, gdy uprawnienie do mikrofonu zostało odrzucone/zablokowane.",
+    "message": "Dostęp do mikrofonu jest zablokowany"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Wskazówki naprawcze, gdy mikrofon jest używany gdzie indziej.",
+    "message": "Inna aplikacja lub karta może używać mikrofonu. Zamknij wszystko, co może nagrywać (wideorozmowy, notatki głosowe), a potem spróbuj ponownie."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Tytuł panelu odzyskiwania, gdy mikrofon jest używany przez inną aplikację.",
+    "message": "Mikrofon jest zajęty"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Wskazówki naprawcze, gdy nie jest dostępne żadne urządzenie mikrofonu.",
+    "message": "Nie udało się znaleźć mikrofonu. Podłącz go (lub podłącz zestaw słuchawkowy), upewnij się, że jest wybrany jako urządzenie wejściowe, a potem spróbuj ponownie."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Tytuł panelu odzyskiwania, gdy nie jest dostępne żadne urządzenie mikrofonu.",
+    "message": "Nie znaleziono mikrofonu"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Wskazówki naprawcze dla nieznanego błędu mikrofonu.",
+    "message": "Coś poszło nie tak podczas łączenia z mikrofonem. Sprawdź, czy jest podłączony i dozwolony w ustawieniach przeglądarki, a potem spróbuj ponownie."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Tytuł panelu odzyskiwania w przypadku nieznanego błędu mikrofonu.",
+    "message": "Nie udało się uzyskać dostępu do mikrofonu"
+  },
+  "permissions_retryButton": {
+    "description": "Etykieta przycisku, który ponownie prosi o uprawnienie do mikrofonu.",
+    "message": "Spróbuj ponownie"
+  },
+  "permissions_revokedHeading": {
+    "description": "Nagłówek wyświetlany, gdy dostęp do mikrofonu był wcześniej przyznany, ale później został cofnięty.",
+    "message": "🎙️ Połączmy ponownie mikrofon"
+  },
+  "permissions_revokedInfo": {
+    "description": "Tekst informacyjny wyświetlany, gdy dostęp do mikrofonu został cofnięty po wcześniejszym przyznaniu.",
+    "message": "Dostęp do mikrofonu został wyłączony — często dzieje się to po aktualizacji przeglądarki lub systemu. Zezwól ponownie poniżej, a $productName$ znów będzie nasłuchiwać, gdy jesteś w rozmowie.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Etykieta przełącznika włączającego tryb cichy/szeptu.",
+    "message": "Tryb cichy"
+  },
+  "quietModeTooltip": {
+    "description": "Podpowiedź wyjaśniająca, co robi tryb cichy/szeptu.",
+    "message": "Mów ciszej — wychwytuje cichszą mowę i obniża głośność odpowiedzi asystenta, więc możesz używać głosu wśród innych."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Tekst na przycisku logowania podczas trwającego uwierzytelniania.",
+    "message": "Logowanie..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Efekty dźwiękowe"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Efekty dźwiękowe są wyłączone w przeglądarce Firefox, aby zapobiec problemom ze sprzężeniem zwrotnym dźwięku."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Nagłówek jednorazowego powiadomienia o korzyści z szybkości, pokazywanego po pierwszej wymianie głosowej.",
+    "message": "Dobrze — mówienie jest około 3× szybsze niż pisanie."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Opcjonalna druga linia powiadomienia o korzyści z szybkości, pokazująca zaoszczędzone pełne minuty.",
+    "message": "Masz już około $minutes$ min przewagi nad pisaniem.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Prześlij dopiero po naciśnięciu przycisku"
   },
+  "surveyQuestion": {
+    "description": "Pojedyncze pytanie w jednorazowej mikroankiecie po „wygranej”.",
+    "message": "Jak Ci się do tej pory sprawdza głos?"
+  },
+  "surveyRatingLabel": {
+    "description": "Etykieta ułatwień dostępu dla przycisku oceny w ankiecie.",
+    "message": "Oceń: $rating$ na 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Podziękowanie wyświetlane po udzieleniu odpowiedzi w ankiecie po „wygranej”.",
+    "message": "Dziękujemy — to pomaga nam ulepszać Say, Pi. 🙏"
+  },
   "tabAIChat": {
     "description": "Etykieta zakładki dla sekcji ustawień czatu AI.",
     "message": "Czat AI"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Etykieta zakładki dla sekcji ustawień ogólnych.",
     "message": "Ogólne"
+  },
+  "tabVoices": {
+    "description": "Etykieta karty dla sekcji ustawień głosów (katalog głosów dla poszczególnych witryn).",
+    "message": "Głosy"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "kredyty"
   },
+  "ttsCreditsRemaining": {
+    "description": "Tekst pokazujący pozostały limit TTS jako pulę kredytów na głos (saypi-api #181 Stage 2), a nie jako surowe znaki.",
+    "message": "Pozostało $credits$ kredytów",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Głosy wielojęzyczne nie są obecnie obsługiwane w przeglądarce Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Generowanie głosu"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Uwaga! Odtwarzanie mowy nie jest jeszcze dostępne na $browserName$ z $chatbotName$. Dobra wiadomość? Wprowadzanie głosowe działa świetnie! W przypadku TTS wypróbuj Chrome lub Edge na komputerze.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS niedostępny na $browserName$ + $chatbotName$. Wprowadzanie głosowe działa! Wypróbuj Chrome na komputerze dla TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Głos TTS"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Szczegół VAD, gdy wykryto dźwięk podobny do mowy, ale był zbyt cichy / zbyt niska pewność, by go transkrybować (odrzucenie na bramce dopuszczenia po stronie klienta).",
+    "message": "Dźwięk zbyt cichy, by go transkrybować"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1123,7 +1423,7 @@
   },
   "vadDetailSpeechEndedDuration": {
     "description": "VAD detail indicating speech ended and its duration.",
-    "message": "Przemowa zakończyła się (czas trwania: $ czas trwania ms)",
+    "message": "Mowa zakończona (czas trwania: $duration$ ms)",
     "placeholders": {
       "duration": {
         "content": "$1",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Szczegół VAD wyjaśniający, że połączenie zakończyło się, ponieważ mikrofon został przejęty przez nowszą kartę.",
+    "message": "Wejście głosowe przeniesiono do innej karty"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Głos niedostępny. \nWypróbuj Chrome lub Firefox na komputerze."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Uwaga! Odtwarzanie mowy nie jest jeszcze dostępne na $browserName$ z $chatbotName$. Dobra wiadomość? Wprowadzanie głosowe działa świetnie! W przypadku TTS wypróbuj Chrome lub Edge na komputerze.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS niedostępny na $browserName$ + $chatbotName$. Wprowadzanie głosowe działa! Wypróbuj Chrome na komputerze dla TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Rozumiem",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Status VAD wyświetlany na karcie, której wejście głosowe zostało przejęte przez inną kartę.",
+    "message": "Wstrzymane"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Zobacz szczegóły"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Ogólne wprowadzenie odtwarzane, gdy wybrany głos SayPi nie ma własnego skryptu wprowadzenia (i nie ma ostatniej wiadomości do odczytania).",
+    "message": "Cześć, jestem $voice$. Tak brzmi mój głos. Mam nadzieję, że ci się spodoba.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hola! \nPokaż! \n你好! \nJestem Pi, twój poliglota AI asystent. \nDysponując 32 językami, możemy poznawać idee i kultury z całego świata. \nCo sądzisz o tym głosie?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Ustawienia głosu"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Zastępczy podtytuł dla wiersza głosu w katalogu głosów w ustawieniach, gdy głos nie ma opisu; $count$ to liczba języków obsługiwanych przez głos.",
+    "message": "Obsługuje $count$ języków",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Autorski slogan osobowości dla głosu „Addison” (ustawienia: studio Głosy; mapowanie tożsamości głosu po stronie klienta).",
+    "message": "Pogodny i elokwentny"
+  },
+  "voiceTagline_alloy": {
+    "description": "Autorski tagline osobowości dla głosu „Alloy” (studio Głosy w ustawieniach; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Zrównoważony i uniwersalny"
+  },
+  "voiceTagline_ash": {
+    "description": "Autorski tagline osobowości dla głosu „Ash” (studio Głosy w ustawieniach; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Niski, uważny, spokojny"
+  },
+  "voiceTagline_ballad": {
+    "description": "Autorski tagline osobowości dla głosu „Ballad” (studio Głosy w ustawieniach; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Gładki i melodyjny"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Autorski slogan osobowości dla głosu „Cassidy” (ustawienia: studio Głosy; mapowanie tożsamości głosu po stronie klienta).",
+    "message": "Przyjazna i rzeczowa"
+  },
+  "voiceTagline_cedar": {
+    "description": "Autorski slogan osobowości dla głosu „Cedar” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Spokojny i kojący"
+  },
+  "voiceTagline_coral": {
+    "description": "Autorski slogan osobowości dla głosu „Coral” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Jasna, pełna energii"
+  },
+  "voiceTagline_echo": {
+    "description": "Autorski slogan osobowości dla głosu „Echo” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Czysty i neutralny"
+  },
+  "voiceTagline_fable": {
+    "description": "Autorski slogan osobowości dla głosu „Fable” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Narracyjna nuta"
+  },
+  "voiceTagline_finn": {
+    "description": "Autorski slogan osobowości dla głosu „Finn” (ustawienia: studio Głosy; mapowanie tożsamości głosu po stronie klienta).",
+    "message": "Świeży i pełen energii"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Autorski slogan osobowości dla głosu „Jamahal” (ustawienia: studio Głosy; mapowanie tożsamości głosu po stronie klienta).",
+    "message": "Głęboki i magnetyczny"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Autorski slogan osobowości dla głosu „Jarnathan” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Aksamitny nocny baryton"
+  },
+  "voiceTagline_jeff": {
+    "description": "Autorski slogan osobowości dla głosu „Jeff” (ustawienia: studio Głosy; mapowanie tożsamości głosu po stronie klienta).",
+    "message": "Konkretny i opanowany"
+  },
+  "voiceTagline_jessica": {
+    "description": "Autorski slogan osobowości dla głosu „Jessica” (ustawienia: studio Głosy; mapowanie tożsamości głosu po stronie klienta).",
+    "message": "Ciepły, dopracowany spokój"
+  },
+  "voiceTagline_joey": {
+    "description": "Autorski slogan osobowości dla głosu „Joey” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Swobodny, amerykański styl rozmowy"
+  },
+  "voiceTagline_juniper": {
+    "description": "Autorski slogan osobowości dla głosu „Juniper” (ustawienia: studio Głosy; mapowanie tożsamości głosu po stronie klienta).",
+    "message": "Wyrazisty, jasny, żywy"
+  },
+  "voiceTagline_lucy": {
+    "description": "Autorski slogan osobowości dla głosu „Lucy” (ustawienia: studio Głosy; mapowanie tożsamości głosu po stronie klienta).",
+    "message": "Delikatna i świetlista"
+  },
+  "voiceTagline_marin": {
+    "description": "Autorski slogan osobowości dla głosu „Marin” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Ciepły, radiowy spokój"
+  },
+  "voiceTagline_mark": {
+    "description": "Autorski slogan osobowości dla głosu „Mark” (ustawienia: studio Głosy; mapowanie tożsamości głosu po stronie klienta).",
+    "message": "Wyraźny, pewny narrator"
+  },
+  "voiceTagline_nova": {
+    "description": "Autorski slogan osobowości dla głosu „Nova” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Szybki i ciekawski"
+  },
+  "voiceTagline_onyx": {
+    "description": "Autorski slogan osobowości dla głosu „Onyx” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Głęboka, rezonująca powaga"
+  },
+  "voiceTagline_paola": {
+    "description": "Autorski slogan osobowości dla głosu „Paola” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Wyraziste włoskie ciepło"
+  },
+  "voiceTagline_sage": {
+    "description": "Autorski slogan osobowości dla głosu „Sage” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Spokojna klarowność"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Autorski slogan osobowości dla głosu „Shimmer” (ustawienia: studio Głosy; mapowanie tożsamości głosów po stronie klienta).",
+    "message": "Lekki i zwiewny"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Krótka etykieta na przełączniku przypinania na karcie głosu (stan wyłączony) w studiu Głosy w ustawieniach; naciśnięcie dodaje głos do menu hosta na czacie.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Etykieta dostępności dla przełącznika przypinania na karcie głosu (stan wyłączony); $name$ to głos, $host$ to asystent.",
+    "message": "Dodaj $name$ do menu $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Etykieta przełącznika na pasku sterowania Głosów, który określa, czy poruszanie się po liście klawiszami strzałek odtwarza każdy głos w momencie, gdy fokus na niego przechodzi.",
+    "message": "Odtwarzaj podczas przewijania"
+  },
+  "voicesArrowsLive": {
+    "description": "Potwierdzenie dla czytnika ekranu, dopisywane do pierwszego komunikatu „Odtwarzanie <głos>” na liście Głosy w ustawieniach, informujące, że klawisze strzałek właśnie stały się słyszalne. Nawiązuje do brzmienia przełącznika „Odtwarzaj podczas przemieszczania”.",
+    "message": "Strzałki odtwarzają podczas przemieszczania. Esc zatrzymuje."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Notatka pod miejscami w menu dla hostów z natywnymi głosami (np. 8 wbudowanych w Pi), których studio nie zarządza; $host$ to asystent.",
+    "message": "Wbudowane głosy $host$ zawsze też są widoczne w jego menu.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Wariant voicesBuiltinsNote dla hosta bez menu głosów na czacie (Pi wycofał menu w 2026), gdzie obietnica z oryginału, że wbudowane głosy „pojawiają się w jego menu”, byłaby nieprawdziwa; $host$ to asystent.",
+    "message": "$host$ ma też własne wbudowane głosy, których nie ma na tej liście.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Wskaźnik postępu na pasku sterowania Głosy w ustawieniach: ile z wymienionych głosów użytkownik już odsłuchał. Same liczby, więc brzmi poprawnie przy 1 — Chrome i18n nie ma form liczby mnogiej.",
+    "message": "Odsłuchano: $heard$ z $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Część dostępnej nazwy wiersza głosu na liście Głosy w ustawieniach, oznaczająca głos, którego ten profil już słuchał. Wizualnie jest to rysowane jako gęstość atramentu na odcisku dźwięku głosu, czego czytnik ekranu nie widzi.",
+    "message": "Odsłuchano"
+  },
+  "voicesInHostMenu": {
+    "description": "Nagłówek sekcji nad wierszem slotów menu w studiu Głosy w ustawieniach; $host$ to asystent.",
+    "message": "W menu $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Krótka etykieta na przełączniku przypinania na karcie głosu (stan włączony) w studiu Głosy w ustawieniach.",
+    "message": "✓ W menu"
+  },
+  "voicesInUse": {
+    "description": "Stała plakietka na aktualnie wybranym głosie hosta na liście Głosy w ustawieniach, renderowana jako wersaliki. Celowo NIE „Teraz mówi”: na tej stronie wiersze odtwarzają próbki, więc wybrany, ale milczący głos nie może twierdzić, że mówi, gdy odtwarzany jest inny wiersz.",
+    "message": "W użyciu"
+  },
+  "voicesKeyboardHint": {
+    "description": "Jednowierszowa podpowiedź klawiaturowa na pasku sterowania Głosy w ustawieniach. Glify oznaczają klawisze: Spacja, strzałki w górę/w dół oraz Shift+Spacja.",
+    "message": "Naciśnij Spację, aby odsłuchać, ↑↓ aby przechodzić między głosami, ⇧Spacja aby przełączyć z powrotem."
+  },
+  "voicesLoadError": {
+    "description": "Stan błędu w studiu jednego hosta, gdy nie udało się wczytać katalogu głosów tego hosta; $host$ to asystent.",
+    "message": "Nie udało się wczytać głosów dla $host$. Spróbuj ponownie później.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Podpowiedź/tooltip na wyłączonym przełączniku „+ Menu”, gdy menu hosta na czacie ma już maksymalną liczbę głosów.",
+    "message": "Menu pełne — usuń głos, aby dodać kolejny"
+  },
+  "voicesMenuHint": {
+    "description": "Jednolinijkowa wskazówka obok nagłówka „W menu {host}”, wyjaśniająca, że wiersz slotów odzwierciedla menu głosów na czacie.",
+    "message": "To zobaczysz na czacie"
+  },
+  "voicesMenuOverflow": {
+    "description": "Notatka pod miejscami w menu, gdy użytkownik ma więcej przypiętych głosów, niż może pokazać menu na czacie (stan starszy); $count$ to liczba głosów, które się nie mieszczą, $cap$ to rozmiar menu.",
+    "message": "Jeszcze $count$ przypiętych głosów czeka poza $cap$ miejscami w menu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Liczba pojedyncza dla voicesMenuOverflow, używana, gdy dokładnie jeden przypięty głos nie mieści się w menu na czacie; $cap$ to rozmiar menu.",
+    "message": "Jeszcze 1 przypięty głos czeka poza $cap$ miejscami w menu.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Wiersz podsumowania pod listą Głosy w ustawieniach, mówiący, jak bardzo zapełnione jest menu głosów hosta w czacie; $host$ to asystent, $used$ to ile miejsc jest zajętych, $cap$ to ile ich jest. Sformułowane tak, by brzmiało poprawnie przy 1 — Chrome i18n nie ma form liczby mnogiej.",
+    "message": "Menu $host$: $used$ z $cap$ miejsc",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Nagłówek grupy na końcu listy Głosy w ustawieniach, zawierającej głosy bez klipu próbki do odtworzenia; $count$ to ile ich jest. Sformułowane tak, by brzmiało poprawnie przy 1 — Chrome i18n nie ma form liczby mnogiej.",
+    "message": "Brak próbki ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Wyświetlane w katalogu głosów w ustawieniach, gdy lista głosów jest pusta dla zalogowanego użytkownika (np. problem z siecią).",
+    "message": "Nie można teraz wczytać głosów. Spróbuj ponownie później."
+  },
+  "voicesNowPlaying": {
+    "description": "Komunikat czytnika ekranu, gdy zaczyna się odtwarzanie klipu próbki głosu na liście Głosy w ustawieniach; $name$ to głos.",
+    "message": "Odtwarzanie: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Przycisk na pasku sterowania Głosy w ustawieniach, który odtwarza każdy aktualnie wyświetlony głos, jeden po drugim; $count$ to ile ich jest. Sformułowane tak, by brzmiało poprawnie przy 1 — Chrome i18n nie ma form liczby mnogiej.",
+    "message": "Odtwórz wszystkie ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Przycisk na pasku sterowania Głosy w ustawieniach przy ponownej wizycie: odtwarza tylko te głosy z listy, których jeszcze nie odsłuchano; $count$ to ile ich jest. Sformułowane tak, by brzmiało poprawnie przy 1 — Chrome i18n nie ma form liczby mnogiej.",
+    "message": "Odtwórz nowe ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Linia na pasku sterowania Głosami w ustawieniach, gdy przeglądarka odmówiła odtworzenia próbki, ponieważ strona nie miała jeszcze interakcji użytkownika.",
+    "message": "Kliknij dowolny głos, aby włączyć dźwięk."
+  },
+  "voicesPreview": {
+    "description": "Etykieta dostępności dla przycisku odtwarzania (▶), który uruchamia darmową próbkę głosu w wierszu głosu; $name$ to nazwa głosu.",
+    "message": "Odtwórz próbkę głosu $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Nazwa dostępności listy Głosy w ustawieniach (listbox wszystkich głosów, po jednym wierszu na głos).",
+    "message": "Głosy, od najniższego do najjaśniejszego"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Etykieta dostępności dla przełącznika przypinania na karcie głosu (stan włączony) oraz przycisku usuwania w slocie menu; $name$ to głos, $host$ to asystent.",
+    "message": "Usuń $name$ z menu $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Linia na pasku sterowania Głosami w ustawieniach, gdy próbka jednego głosu nie wczytała się lub nie dała się odtworzyć; $name$ to ten głos. Nieniemodalne — seria próbek odtwarza się dalej mimo tego.",
+    "message": "Nie udało się odtworzyć próbki głosu $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Podtytuł sekcji katalogu głosów w karcie ustawień AI Chat.",
+    "message": "Wybierz głos, który będzie czytał odpowiedzi na głos na każdej stronie."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Podtytuł pod nagłówkiem ustawień Głosy, dla listy głosów ułożonych według wysokości.",
+    "message": "Każdy głos, od najniższego do najjaśniejszego. Posłuchaj, potem wybierz."
+  },
+  "voicesSectionTitle": {
+    "description": "Nagłówek sekcji katalogu głosów w karcie ustawień AI Chat.",
+    "message": "Głosy"
+  },
+  "voicesShelfEveryday": {
+    "description": "Nagłówek grupy dla głosów z segmentu ekonomicznego w katalogu głosów w ustawieniach. Renderowane wielkimi literami przez CSS.",
+    "message": "Głosy codzienne"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Jednolinijkowa notatka obok nagłówka grupy Codzienne w studiu Głosy w ustawieniach; jedyne miejsce, w którym studio podaje, o ile dalej sięga ten poziom niż HD.",
+    "message": "Naturalne i wyraźne — możesz słuchać ok. 20× dłużej niż w HD."
+  },
+  "voicesShelfHd": {
+    "description": "Nagłówek grupy dla premium (HD) głosów w katalogu głosów w ustawieniach. Renderowane wielkimi literami przez CSS.",
+    "message": "Głosy HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Jednolinijkowa notatka obok nagłówka grupy HD w studiu Głosy w ustawieniach.",
+    "message": "Nasze najbogatsze, najbardziej ekspresyjne brzmienie."
+  },
+  "voicesShowAll": {
+    "description": "Opcja w filtrze „Pokaż” w ustawieniach Głosów: bez filtrowania, na liście są wszystkie głosy.",
+    "message": "Wszystkie głosy"
+  },
+  "voicesShowEveryday": {
+    "description": "Opcja w filtrze „Pokaż” w ustawieniach Głosów: pokazuj tylko standardowe głosy (nie-HD).",
+    "message": "Tylko standardowe"
+  },
+  "voicesShowHd": {
+    "description": "Opcja w filtrze „Pokaż” w ustawieniach Głosów: pokazuj tylko głosy premium (HD).",
+    "message": "Tylko HD"
+  },
+  "voicesShowLabel": {
+    "description": "Etykieta filtra na pasku sterowania Głosami w ustawieniach, która zawęża, które głosy są pokazywane na liście.",
+    "message": "Pokaż"
+  },
+  "voicesShowUnheard": {
+    "description": "Opcja w filtrze „Pokaż” w ustawieniach Głosów: pokazuj tylko głosy, których użytkownik jeszcze nie odsłuchał.",
+    "message": "Jeszcze nieodsłuchane"
+  },
+  "voicesSpeakingNow": {
+    "description": "Etykieta stanu na aktualnie wybranym głosie hosta w studiu Głosy w ustawieniach (pozycja menu i karta głosu).",
+    "message": "Teraz mówi"
+  },
+  "voicesSpeaksWith": {
+    "description": "Linia nad nazwą bieżącego głosu na scenie studia Głosy w ustawieniach; $host$ to asystent (np. Pi). Renderowane jako wersaliki przez CSS.",
+    "message": "$host$ mówi głosem",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Notatka na scenie, gdy host udostępnia własne audio (np. Pi), więc wybranie głosu Say, Pi zastępuje głos hosta.",
+    "message": "$host$ używa własnego głosu, dopóki nie wybierzesz poniżej innego.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Notatka na scenie, gdy host nie ma własnego głosu (np. Claude), więc nic nie jest czytane na głos, dopóki nie zostanie wybrany głos Say, Pi.",
+    "message": "$host$ nie będzie czytać odpowiedzi na głos, dopóki nie wybierzesz poniżej głosu.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Nagłówek na scenie studia Głosy w ustawieniach, gdy host nie ma wybranego głosu Say, Pi; $host$ to asystent (np. Pi, Claude). Renderowane w rozmiarze nazwy.",
+    "message": "Wybierz, jak brzmi $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Przycisk na scenie studia Głosy w ustawieniach, który odtwarza bezpłatną próbkę aktualnego głosu.",
+    "message": "Posłuchaj próbki"
+  },
+  "voicesStopPlayback": {
+    "description": "Przycisk na pasku sterowania Głosy w ustawieniach, który zatrzymuje serię próbek uruchomioną przez „Odtwórz wszystkie”.",
+    "message": "Zatrzymaj"
+  },
+  "voicesSweepPosition": {
+    "description": "Bieżący odczyt pozycji na pasku sterowania Głosami w ustawieniach podczas przechodzenia po liście przez „Odtwórz wszystkie”; $index$ to aktualnie odtwarzany głos, a $total$ to liczba głosów w kolejce.",
+    "message": "$index$ z $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Etykieta dostępności dla kontrolki porównania na pasku sterowania Głosy w ustawieniach, która odtwarza ponownie drugi z dwóch ostatnio odsłuchanych głosów; $name$ to ten głos.",
+    "message": "Przełącz z powrotem na $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Linia na pasku sterowania Głosami w ustawieniach, gdy „Odtwórz wszystkie” zostanie użyte dla zbyt długiej listy; $count$ to liczba głosów, a $minutes$ to przybliżona liczba minut. Skrót „min”, aby brzmiało poprawnie przy 1 — Chrome i18n nie ma liczby mnogiej.",
+    "message": "To $count$ głosów — około $minutes$ min. Najpierw zawęź listę.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Etykieta dostępności dla przycisku „użyj tego głosu” dla danego hosta w katalogu głosów w ustawieniach; $name$ to głos, $host$ to asystent (np. Pi, Claude).",
+    "message": "Użyj $name$ w $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Krótka etykieta na przycisku „użyj tego głosu” dla danego hosta w ujednoliconym katalogu głosów w ustawieniach (host jest pokazany obok).",
+    "message": "Użyj"
+  },
+  "voicesYourVoice": {
+    "description": "Przycisk na pasku sterowania na liście Głosy w ustawieniach, który przenosi fokus do wiersza głosu, którego obecnie używa ten host; $name$ to ten głos.",
+    "message": "Twój głos: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Błąd zgłaszany, gdy przeglądarka nie może przydzielić wystarczającej ilości pamięci WebAssembly dla modelu wykrywania głosu.",
+    "message": "Nie można uruchomić wykrywania głosu: za mało pamięci WebAssembly dla modelu głosu. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Błąd zgłaszany, gdy przeglądarka nie udostępnia początkowej pamięci WebAssembly potrzebnej do uruchomienia modelu wykrywania głosu.",
+    "message": "Nie można uruchomić wykrywania głosu: pamięć WebAssembly jest niedostępna w tej przeglądarce."
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Benefício listado no modal de autenticação: aumento dos limites de uso.",
+    "message": "Limites de uso maiores com conta gratuita"
+  },
+  "authBenefitPremium": {
+    "description": "Benefício listado no modal de autenticação: recursos premium em chatbots.",
+    "message": "Recursos premium e suporte a chatbots"
+  },
+  "authBenefitSupport": {
+    "description": "Benefício listado no modal de autenticação: suporte prioritário.",
+    "message": "Suporte prioritário para problemas"
+  },
+  "authBenefitSync": {
+    "description": "Benefício listado no modal de autenticação: sincronização de configurações.",
+    "message": "Sincronize as configurações de voz em todo lugar"
+  },
+  "authBenefitTTS": {
+    "description": "Benefício listado no modal de autenticação: recurso de TTS.",
+    "message": "Vozes de texto para fala (planos pagos)"
+  },
+  "authBenefitUsage": {
+    "description": "Benefício listado no modal de autenticação: acompanhamento de uso.",
+    "message": "Acompanhe seu uso de voz em todos os dispositivos"
+  },
+  "authPromptModalFull": {
+    "description": "Descrição do modal completo de solicitação de autenticação com proposta de valor.",
+    "message": "Você está usando bastante o Say, Pi. Faça login para ter limites maiores, vozes de texto para fala e recursos premium em todos os chatbots compatíveis."
+  },
+  "authPromptModalSoft": {
+    "description": "Descrição do modal leve de solicitação de autenticação.",
+    "message": "Crie uma conta gratuita do Say, Pi para ter limites de uso maiores e acesso a recursos premium de voz."
+  },
+  "authPromptTitle": {
+    "description": "Título do modal de solicitação de autenticação.",
+    "message": "Desbloqueie mais recursos de voz"
+  },
+  "authPromptToast": {
+    "description": "Notificação toast incentivando o usuário a fazer login.",
+    "message": "Faça login no Say, Pi para ter limites maiores e recursos premium"
+  },
   "autoReadAloudChatGPT": {
     "description": "Etiqueta para a caixa de seleção que ativa ou desativa a leitura automática das respostas do ChatGPT durante chamadas de voz.",
     "message": "Leitura Automática (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Desative o texto em fala"
   },
+  "dismiss": {
+    "message": "Entendi",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Demitir"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Focar"
   },
+  "errorVadInitFailed": {
+    "description": "Toast de erro mostrado quando a detecção de atividade de voz falha ao inicializar.",
+    "message": "Falha ao inicializar a detecção de voz"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Toast de erro mostrado quando ocorre um erro inesperado durante a configuração da gravação de voz.",
+    "message": "Falha ao configurar a gravação de voz"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Toast de erro mostrado quando o cliente de detecção de voz falha ao iniciar a gravação.",
+    "message": "Falha ao iniciar a gravação de voz"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Toast de erro mostrado quando o cliente de detecção de voz (VAD) não está disponível, então a gravação não pode começar.",
+    "message": "Gravação de voz indisponível"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Sair do Modo Foco"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Nota de uma linha mostrada nos menus de voz quando vozes premium (HD) e vozes econômicas estão disponíveis",
+    "message": "As vozes HD usam sua cota mensal cerca de 20× mais rápido."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Afastando isso ..."
   },
+  "maybeLater": {
+    "description": "Texto do botão para dispensar a solicitação de autenticação.",
+    "message": "Talvez mais tarde"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "As configurações do seu microfone não atendem às especificações exigidas. \nTente usar um microfone diferente ou ajustar as configurações de áudio."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Não é possível acessar o microfone. \nVerifique as configurações do seu dispositivo e tente novamente."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Toast de erro mostrado quando a permissão do microfone foi negada após o fluxo do aviso de permissão.",
+    "message": "A permissão do microfone não foi concedida. Verifique se você permitiu o acesso no aviso e nas configurações da extensão."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "precisão"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Resposta mais rápida, mas menos precisa. \nPropenso a interromper."
   },
+  "moreVoices": {
+    "description": "Linha do menu que leva do menu de vozes na página para o catálogo completo de vozes nas configurações da extensão.",
+    "message": "Mais vozes…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Apelido do assistente"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Não assinou"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Rótulo do botão que abre o ChatGPT.",
+    "message": "Abrir o ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Rótulo do botão que abre o Claude.ai.",
+    "message": "Abrir Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Rótulo do botão que abre o Pi.ai.",
+    "message": "Abrir Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Opção de ambiente: perto de outras pessoas.",
+    "message": "Perto de outras pessoas"
+  },
+  "onboarding_envMixed": {
+    "description": "Opção de ambiente: uma mistura de espaços privados e compartilhados.",
+    "message": "Em lugares variados"
+  },
+  "onboarding_envPrivate": {
+    "description": "Opção de ambiente: um espaço privado.",
+    "message": "Em um lugar privado"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Confirmação mostrada quando a resposta sobre o ambiente deixa o modo silencioso desativado.",
+    "message": "Certo — vamos manter as configurações padrão de escuta e reprodução."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Confirmação mostrada quando a resposta sobre o ambiente ativa o modo silencioso.",
+    "message": "Modo silencioso ativado — vamos captar falas mais baixas e responder em voz baixa, para você falar com discrição."
+  },
+  "onboarding_envTitle": {
+    "description": "Título da pergunta do onboarding sobre o ambiente do usuário.",
+    "message": "Onde você costuma falar?"
+  },
+  "onboarding_footer": {
+    "description": "Texto do rodapé na página de onboarding da primeira execução.",
+    "message": "Você pode ver isso de novo a qualquer momento nas configurações do Say, Pi. Sua privacidade importa — o áudio só é capturado durante uma chamada ativa."
+  },
+  "onboarding_heading": {
+    "description": "Título principal na página de onboarding da primeira execução.",
+    "message": "🗣️ Boas-vindas ao Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Parágrafo de introdução na página de onboarding da primeira execução.",
+    "message": "Faltam dois passos para sua primeira conversa falada com uma IA. Falar é cerca de 3× mais rápido do que digitar — vamos configurar tudo."
+  },
+  "onboarding_micTestButton": {
+    "description": "Botão que inicia o teste de microfone do onboarding, sem consequências.",
+    "message": "🎤 Testar seu microfone"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status mostrado após o teste de microfone do onboarding ser concluído com sucesso.",
+    "message": "Boa — seu microfone está funcionando 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status mostrado enquanto o teste de microfone do onboarding está medindo a entrada.",
+    "message": "Ouvindo — diga algo 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status mostrado enquanto o teste de microfone do onboarding aguarda permissão.",
+    "message": "Solicitando acesso ao microfone…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Rótulo do botão para interromper o teste de microfone do onboarding enquanto ele está em execução.",
+    "message": "Parar teste"
+  },
+  "onboarding_step1Body": {
+    "description": "Texto do primeiro passo do onboarding explicando como fixar a extensão.",
+    "message": "Clique no ícone de peça de quebra-cabeça 🧩 no canto superior direito do navegador e depois no alfinete 📌 ao lado de Say, Pi. Assim, o botão de chamada fica a um clique."
+  },
+  "onboarding_step1Title": {
+    "description": "Título do primeiro passo do onboarding (fixar a extensão).",
+    "message": "Fixe o Say, Pi na barra de ferramentas"
+  },
+  "onboarding_step2Body": {
+    "description": "Texto do segundo passo do onboarding explicando como iniciar uma conversa por voz.",
+    "message": "Acesse um dos assistentes compatíveis abaixo, toque no botão de chamada do Say, Pi e diga oi. Na primeira vez, vamos pedir acesso ao microfone — isso é esperado, e só ouvimos enquanto você estiver em uma chamada."
+  },
+  "onboarding_step2Title": {
+    "description": "Título do segundo passo do onboarding (iniciar uma conversa).",
+    "message": "Abra um chat de IA e comece a falar"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Permissão de microfone"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Orientação de recuperação quando a permissão do microfone está bloqueada.",
+    "message": "Seu navegador está bloqueando o microfone. Clique no ícone de câmera ou cadeado na barra de endereços, defina Microfone como \"Permitir\" e tente novamente. No macOS, verifique também Ajustes do Sistema → Privacidade e Segurança → Microfone."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Título do painel de recuperação quando a permissão do microfone foi negada/bloqueada.",
+    "message": "O acesso ao microfone está bloqueado"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Orientação de recuperação quando o microfone está em uso em outro lugar.",
+    "message": "Outro app ou aba pode estar usando seu microfone. Feche qualquer coisa que possa estar gravando (chamadas de vídeo, gravador de voz) e tente novamente."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Título do painel de recuperação quando o microfone está sendo usado por outro app.",
+    "message": "Seu microfone está em uso"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Orientação de recuperação quando nenhum dispositivo de microfone está disponível.",
+    "message": "Não encontramos um microfone. Conecte um (ou conecte seu headset), verifique se ele está selecionado como dispositivo de entrada e tente novamente."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Título do painel de recuperação quando nenhum dispositivo de microfone está disponível.",
+    "message": "Nenhum microfone encontrado"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Orientação de recuperação para um erro desconhecido do microfone.",
+    "message": "Algo deu errado ao acessar seu microfone. Verifique se ele está conectado e permitido nas configurações do navegador e tente novamente."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Título do painel de recuperação para um erro desconhecido do microfone.",
+    "message": "Não foi possível acessar seu microfone"
+  },
+  "permissions_retryButton": {
+    "description": "Rótulo do botão que solicita novamente a permissão do microfone.",
+    "message": "Tentar novamente"
+  },
+  "permissions_revokedHeading": {
+    "description": "Título mostrado quando o acesso ao microfone já foi concedido anteriormente, mas depois foi revogado.",
+    "message": "🎙️ Vamos reconectar seu microfone"
+  },
+  "permissions_revokedInfo": {
+    "description": "Texto informativo mostrado quando o acesso ao microfone foi revogado após ter sido concedido.",
+    "message": "O acesso ao microfone foi desativado — isso costuma acontecer após uma atualização do navegador ou do sistema. Permita novamente abaixo e o $productName$ voltará a escutar quando você estiver em uma chamada.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Perfil"
+  },
+  "quietModeLabel": {
+    "description": "Rótulo para o botão de alternância que ativa o modo silencioso/sussurro.",
+    "message": "Modo silencioso"
+  },
+  "quietModeTooltip": {
+    "description": "Tooltip explicando o que o modo silencioso/sussurro faz.",
+    "message": "Fale mais baixo — capta fala mais baixa e reduz o volume da resposta do assistente, para você usar voz perto de outras pessoas."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Texto do botão de login enquanto a autenticação está em andamento.",
+    "message": "Fazendo login..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Efeitos sonoros"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Os efeitos sonoros estão desativados no Firefox para evitar problemas de feedback de áudio."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Título do aviso único de ganho de velocidade mostrado após a primeira troca falada.",
+    "message": "Legal — falar é cerca de 3× mais rápido do que digitar."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Segunda linha opcional do aviso de ganho de velocidade mostrando os minutos inteiros economizados.",
+    "message": "Você já falou aproximadamente $minutes$ min mais rápido do que se tivesse digitado.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Envie apenas quando você pressionar o botão"
   },
+  "surveyQuestion": {
+    "description": "A única pergunta da micro-pesquisa única após a vitória.",
+    "message": "Como a voz está funcionando para você até agora?"
+  },
+  "surveyRatingLabel": {
+    "description": "Rótulo acessível para um botão de avaliação da pesquisa.",
+    "message": "Avalie $rating$ de 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Agradecimento mostrado após o usuário responder à pesquisa pós-vitória.",
+    "message": "Obrigado — isso nos ajuda a melhorar o Say, Pi. 🙏"
+  },
   "tabAIChat": {
     "description": "Rótulo da aba para a seção de configurações de chat com IA.",
     "message": "Chat com IA"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Rótulo da aba para a seção de configurações gerais.",
     "message": "Geral"
+  },
+  "tabVoices": {
+    "description": "Rótulo da aba para a seção de configurações de vozes (catálogo de vozes por site).",
+    "message": "Vozes"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "Créditos"
   },
+  "ttsCreditsRemaining": {
+    "description": "Texto que mostra a cota de TTS restante como um conjunto de créditos por voz (saypi-api #181 Stage 2), não caracteres brutos.",
+    "message": "$credits$ créditos restantes",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Atualmente, vozes multilíngues não são suportadas no Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Geração de voz"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Atenção! A reprodução de fala ainda não está disponível no $browserName$ com $chatbotName$. A boa notícia? A entrada de voz funciona muito bem! Para TTS, experimente o Chrome ou Edge na área de trabalho.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS indisponível no $browserName$ + $chatbotName$. A entrada de voz funciona! Experimente o Chrome na área de trabalho para TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Voz tts"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Detalhe do VAD quando foi detectado áudio parecido com fala, mas estava muito baixo / com baixa confiança para transcrever (descartado no cliente pelo gate de admissão).",
+    "message": "Áudio muito baixo para transcrever"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Detalhe do VAD explicando que a chamada terminou porque o microfone foi assumido por uma aba mais recente.",
+    "message": "A entrada de voz foi movida para outra aba"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Voz não disponível. \nExperimente o Chrome ou o Firefox na área de trabalho."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Atenção! A reprodução de fala ainda não está disponível no $browserName$ com $chatbotName$. A boa notícia? A entrada de voz funciona muito bem! Para TTS, experimente o Chrome ou Edge na área de trabalho.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS indisponível no $browserName$ + $chatbotName$. A entrada de voz funciona! Experimente o Chrome na área de trabalho para TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Entendi",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Status do VAD mostrado em uma aba cuja entrada de voz foi assumida por outra aba.",
+    "message": "Em pausa"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Ver detalhes"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Introdução genérica falada, tocada quando uma voz do SayPi selecionada não tem um roteiro de introdução específico da voz (e não há uma mensagem recente para ler em voz alta).",
+    "message": "Oi, eu sou $voice$. É assim que eu soio. Espero que você goste desta voz.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Olá! \nPrivado! \nVocê! \nSou Pi, seu assistente poliglota de IA. \nCom 32 idiomas sob meu comando, podemos explorar ideias e culturas de todo o mundo. \nO que você acha dessa voz?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Configurações de voz"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Subtítulo alternativo para uma linha de voz no catálogo de vozes das configurações quando a voz não tem descrição; $count$ é o número de idiomas compatíveis com a voz.",
+    "message": "Fala $count$ idioma(s)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Slogan de personalidade criado para a voz \"Addison\" (configurações > estúdio de Vozes; mapa de identidade de voz no cliente).",
+    "message": "Radiante e articulado"
+  },
+  "voiceTagline_alloy": {
+    "description": "Slogan de personalidade escrito para a voz \"Alloy\" (estúdio de Vozes nas configurações; mapa de identidade de voz no cliente).",
+    "message": "Equilibrada e versátil"
+  },
+  "voiceTagline_ash": {
+    "description": "Slogan de personalidade escrito para a voz \"Ash\" (estúdio de Vozes nas configurações; mapa de identidade de voz no cliente).",
+    "message": "Grave, reflexiva, calma"
+  },
+  "voiceTagline_ballad": {
+    "description": "Slogan de personalidade escrito para a voz \"Ballad\" (estúdio de Vozes nas configurações; mapa de identidade de voz no cliente).",
+    "message": "Suave e melódica"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Slogan de personalidade criado para a voz \"Cassidy\" (configurações > estúdio de Vozes; mapa de identidade de voz no cliente).",
+    "message": "Amigável e objetivo"
+  },
+  "voiceTagline_cedar": {
+    "description": "Slogan de personalidade criado para a voz 'Cedar' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Estável e reconfortante"
+  },
+  "voiceTagline_coral": {
+    "description": "Slogan de personalidade criado para a voz 'Coral' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Energia leve e animada"
+  },
+  "voiceTagline_echo": {
+    "description": "Slogan de personalidade criado para a voz 'Echo' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Limpa e neutra"
+  },
+  "voiceTagline_fable": {
+    "description": "Slogan de personalidade criado para a voz 'Fable' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Cadência de contador de histórias"
+  },
+  "voiceTagline_finn": {
+    "description": "Slogan de personalidade criado para a voz \"Finn\" (configurações > estúdio de Vozes; mapa de identidade de voz no cliente).",
+    "message": "Leve e cheio de energia"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Slogan de personalidade criado para a voz \"Jamahal\" (configurações > estúdio de Vozes; mapa de identidade de voz no cliente).",
+    "message": "Marcante e magnético"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Slogan de personalidade criado para a voz 'Jarnathan' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Barítono aveludado da madrugada"
+  },
+  "voiceTagline_jeff": {
+    "description": "Slogan de personalidade criado para a voz \"Jeff\" (configurações > estúdio de Vozes; mapa de identidade de voz no cliente).",
+    "message": "Direto e constante"
+  },
+  "voiceTagline_jessica": {
+    "description": "Slogan de personalidade criado para a voz \"Jessica\" (configurações > estúdio de Vozes; mapa de identidade de voz no cliente).",
+    "message": "Calorosa e refinada"
+  },
+  "voiceTagline_joey": {
+    "description": "Slogan de personalidade criado para a voz 'Joey' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Americano fácil, de conversa"
+  },
+  "voiceTagline_juniper": {
+    "description": "Slogan de personalidade criado para a voz \"Juniper\" (configurações > estúdio de Vozes; mapa de identidade de voz no cliente).",
+    "message": "Nítido, vibrante, expressivo"
+  },
+  "voiceTagline_lucy": {
+    "description": "Slogan de personalidade criado para a voz \"Lucy\" (configurações > estúdio de Vozes; mapa de identidade de voz no cliente).",
+    "message": "Suave e luminosa"
+  },
+  "voiceTagline_marin": {
+    "description": "Slogan de personalidade criado para a voz 'Marin' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Calma acolhedora de rádio matinal"
+  },
+  "voiceTagline_mark": {
+    "description": "Slogan de personalidade criado para a voz \"Mark\" (configurações > estúdio de Vozes; mapa de identidade de voz no cliente).",
+    "message": "Narrador claro e confiante"
+  },
+  "voiceTagline_nova": {
+    "description": "Slogan de personalidade criado para a voz 'Nova' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Rápida e curiosa"
+  },
+  "voiceTagline_onyx": {
+    "description": "Slogan de personalidade criado para a voz 'Onyx' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Gravidade profunda e ressonante"
+  },
+  "voiceTagline_paola": {
+    "description": "Slogan de personalidade criado para a voz 'Paola' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Calor italiano expressivo"
+  },
+  "voiceTagline_sage": {
+    "description": "Slogan de personalidade criado para a voz 'Sage' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Clareza em voz baixa"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Slogan de personalidade criado para a voz 'Shimmer' (configurações do estúdio de Vozes; mapa de identidade de voz no lado do cliente).",
+    "message": "Leve e arejada"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Rótulo curto no alternador de fixar de um cartão de voz (estado desligado) no estúdio de Vozes nas configurações; ao pressionar, adiciona a voz ao menu no chat do host.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Rótulo acessível para o alternador de fixar de um cartão de voz (estado desligado); $name$ é a voz, $host$ é o assistente.",
+    "message": "Adicionar $name$ ao menu do $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Rótulo no alternador na barra de controle de Vozes que indica se navegar pela lista com as setas toca cada voz quando o foco chega nela.",
+    "message": "Reproduzir ao mover"
+  },
+  "voicesArrowsLive": {
+    "description": "Confirmação do leitor de tela, acrescentada ao primeiro anúncio \"Reproduzindo <voz>\" na lista de Vozes nas configurações, dizendo que as teclas de seta acabaram de se tornar audíveis. Ecoa a redação do próprio alternador \"Tocar ao navegar\".",
+    "message": "As setas agora tocam enquanto você navega. Esc para parar."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Nota sob os espaços do menu para hosts que vêm com vozes nativas (ex.: as 8 vozes do Pi), que o estúdio não gerencia; $host$ é o assistente.",
+    "message": "As vozes nativas do $host$ sempre aparecem no menu dele também.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variante de voicesBuiltinsNote para um host sem menu de voz no chat (Pi removeu o menu em 2026), em que a promessa original de que as vozes nativas 'aparecem no menu' seria falsa; $host$ é o assistente.",
+    "message": "$host$ também tem vozes nativas, que não são listadas aqui.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Indicador de progresso na barra de controle de Vozes nas configurações: quantas das vozes listadas o usuário já ouviu. Apenas números, para soar correto com 1 — o Chrome i18n não tem formas de plural.",
+    "message": "$heard$ de $total$ ouvidas",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Parte do nome acessível de uma linha de voz na lista de Vozes nas configurações, marcando uma voz que este perfil já ouviu. Visualmente isso é desenhado como densidade de tinta na impressão sonora da voz, o que um leitor de tela não consegue ver.",
+    "message": "Ouvida"
+  },
+  "voicesInHostMenu": {
+    "description": "Título de seção acima da linha de slots do menu no estúdio de Vozes nas configurações; $host$ é o assistente.",
+    "message": "No menu do $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Rótulo curto no alternador de fixar de um cartão de voz (estado ligado) no estúdio de Vozes nas configurações.",
+    "message": "✓ No menu"
+  },
+  "voicesInUse": {
+    "description": "Selo persistente na voz selecionada atualmente para o host na lista de Vozes nas configurações, renderizado em maiúsculas. Deliberadamente NÃO \"Falando agora\": nesta página as linhas reproduzem seus clipes de amostra, então uma voz selecionada porém silenciosa não deve afirmar que está falando enquanto uma linha diferente está.",
+    "message": "Em uso"
+  },
+  "voicesKeyboardHint": {
+    "description": "Dica de teclado em uma linha na barra de controle de Vozes nas configurações. Os símbolos são teclas: Espaço, as setas para cima/baixo e Shift+Espaço.",
+    "message": "Pressione Espaço para ouvir, ↑↓ para alternar entre vozes, ⇧Espaço para voltar."
+  },
+  "voicesLoadError": {
+    "description": "Estado de erro dentro do estúdio de um host quando o catálogo de vozes desse host falhou ao carregar; $host$ é o assistente.",
+    "message": "Não foi possível carregar as vozes de $host$. Tente novamente mais tarde.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/dica em um alternador \"+ Menu\" desativado quando o menu no chat do host já tem o número máximo de vozes.",
+    "message": "Menu cheio — remova uma voz para adicionar outra"
+  },
+  "voicesMenuHint": {
+    "description": "Dica de uma linha ao lado do título \"No menu do {host}\", explicando que a linha de slots espelha o menu de voz no chat.",
+    "message": "O que você verá no chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Nota sob os espaços do menu quando o usuário tem mais vozes fixadas do que o menu no chat consegue mostrar (estado legado); $count$ é quantas não cabem, $cap$ é o tamanho do menu.",
+    "message": "Mais $count$ vozes fixadas estão além dos $cap$ espaços do menu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Singular de voicesMenuOverflow, usado quando exatamente uma voz fixada não cabe no menu no chat; $cap$ é o tamanho do menu.",
+    "message": "Mais 1 voz fixada está além dos $cap$ espaços do menu.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Linha de resumo sob a lista de Vozes nas configurações dizendo quanto do menu de vozes no chat do host está preenchido; $host$ é o assistente, $used$ quantas vagas estão ocupadas, $cap$ quantas existem. Formulado para soar correto com 1 — o Chrome i18n não tem formas de plural.",
+    "message": "Menu de $host$: $used$ de $cap$ vagas",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Cabeçalho do grupo no fim da lista de Vozes nas configurações com vozes sem clipe de amostra para reproduzir; $count$ é quantas. Formulado para soar correto com 1 — o Chrome i18n não tem formas de plural.",
+    "message": "Ainda sem amostra ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Mostrado no catálogo de vozes das configurações quando a lista de vozes está vazia para um usuário conectado (por exemplo, um problema de rede).",
+    "message": "Não foi possível carregar as vozes agora. Tente novamente mais tarde."
+  },
+  "voicesNowPlaying": {
+    "description": "Anúncio do leitor de tela quando o clipe de amostra de uma voz começa a tocar na lista de Vozes nas configurações; $name$ é a voz.",
+    "message": "Reproduzindo $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Botão na barra de controle de Vozes nas configurações que toca todas as vozes listadas no momento, uma após a outra; $count$ é quantas. Formulado para soar correto com 1 — o Chrome i18n não tem formas de plural.",
+    "message": "Tocar tudo ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Botão na barra de controle de Vozes nas configurações em uma visita de retorno: toca apenas as vozes listadas que você ainda não ouviu; $count$ é quantas. Formulado para soar correto com 1 — o Chrome i18n não tem formas de plural.",
+    "message": "Tocar novas ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Linha na barra de controle de Vozes nas configurações quando o navegador se recusou a tocar uma amostra porque a página ainda não teve interação do usuário.",
+    "message": "Clique em uma voz para ativar o som."
+  },
+  "voicesPreview": {
+    "description": "Rótulo acessível para o botão de reproduzir (▶) que testa o clipe de amostra grátis de uma voz em uma linha de voz; $name$ é o nome da voz.",
+    "message": "Reproduzir uma amostra de $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Nome acessível da lista de Vozes nas configurações (uma listbox de todas as vozes, uma linha por voz).",
+    "message": "Vozes, ordenadas das mais graves às mais agudas"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Rótulo acessível para o alternador de fixar de um cartão de voz (estado ligado) e para o botão de remover de um slot do menu; $name$ é a voz, $host$ é o assistente.",
+    "message": "Remover $name$ do menu do $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Linha na barra de controle de Vozes nas configurações quando a amostra de uma voz falhou ao carregar ou tocar; $name$ é essa voz. Não modal — uma sequência de amostras continua apesar disso.",
+    "message": "Não foi possível reproduzir a amostra de $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Subtítulo da seção do catálogo de vozes na aba de configurações de chat com IA.",
+    "message": "Escolha a voz que lê as respostas em voz alta em cada site."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Subtítulo sob o título de configurações de Vozes, para a trilha de vozes ordenada por altura.",
+    "message": "Todas as vozes, das mais graves às mais agudas. Ouça, depois escolha."
+  },
+  "voicesSectionTitle": {
+    "description": "Título da seção do catálogo de vozes na aba de configurações de chat com IA.",
+    "message": "Vozes"
+  },
+  "voicesShelfEveryday": {
+    "description": "Título do grupo de vozes da faixa econômica no catálogo de vozes nas configurações. Renderizado em maiúsculas pelo CSS.",
+    "message": "Vozes do dia a dia"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Nota de uma linha ao lado do título do grupo do dia a dia no estúdio de Vozes nas configurações; o único lugar em que o estúdio informa quanto mais esse nível vai em relação ao HD.",
+    "message": "Natural e clara — dá para ouvir cerca de 20× mais do que com HD."
+  },
+  "voicesShelfHd": {
+    "description": "Título do grupo de vozes premium (HD) no catálogo de vozes nas configurações. Renderizado em maiúsculas pelo CSS.",
+    "message": "Vozes HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Nota de uma linha ao lado do título do grupo HD no estúdio de Vozes nas configurações.",
+    "message": "Nosso som mais rico e expressivo."
+  },
+  "voicesShowAll": {
+    "description": "Opção no filtro \"Mostrar\" de Vozes nas configurações: sem filtragem, todas as vozes são listadas.",
+    "message": "Todas as vozes"
+  },
+  "voicesShowEveryday": {
+    "description": "Opção no filtro \"Mostrar\" de Vozes nas configurações: lista apenas as vozes padrão (não HD).",
+    "message": "Somente comuns"
+  },
+  "voicesShowHd": {
+    "description": "Opção no filtro \"Mostrar\" de Vozes nas configurações: lista apenas as vozes premium (HD).",
+    "message": "Somente HD"
+  },
+  "voicesShowLabel": {
+    "description": "Rótulo no filtro na barra de controle de Vozes nas configurações que limita quais vozes a lista mostra.",
+    "message": "Mostrar"
+  },
+  "voicesShowUnheard": {
+    "description": "Opção no filtro \"Mostrar\" de Vozes nas configurações: lista apenas as vozes que o usuário ainda não ouviu.",
+    "message": "Ainda não ouvidas"
+  },
+  "voicesSpeakingNow": {
+    "description": "Rótulo de estado na voz selecionada atualmente para o host no estúdio de Vozes nas configurações (slot do menu e cartão de voz).",
+    "message": "Falando agora"
+  },
+  "voicesSpeaksWith": {
+    "description": "Linha de destaque acima do nome da voz atual no palco do estúdio de Vozes nas configurações; $host$ é o assistente (ex.: Pi). Renderizado em maiúsculas via CSS.",
+    "message": "$host$ fala com",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Nota da área quando o host fornece o próprio áudio (ex.: Pi), então escolher uma voz do Say, Pi substitui a do host.",
+    "message": "$host$ usa a própria voz até você escolher uma abaixo.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Nota da área quando o host não tem voz própria (ex.: Claude), então nada é lido em voz alta até que uma voz do Say, Pi seja escolhida.",
+    "message": "$host$ não vai ler as respostas em voz alta até você escolher uma abaixo.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Título na área do estúdio de Vozes nas configurações quando o host não tem nenhuma voz do Say, Pi selecionada; $host$ é o assistente (ex.: Pi, Claude). Renderizado no tamanho de nome.",
+    "message": "Escolha como $host$ soa",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Botão na área do estúdio de Vozes nas configurações que reproduz o clipe de amostra grátis da voz atual.",
+    "message": "Ouvir uma amostra"
+  },
+  "voicesStopPlayback": {
+    "description": "Botão na barra de controle de Vozes nas configurações que interrompe a sequência de amostras iniciada por \"Tocar tudo\".",
+    "message": "Parar"
+  },
+  "voicesSweepPosition": {
+    "description": "Leitura de posição ao vivo na barra de controle de Vozes nas configurações enquanto \"Reproduzir tudo\" percorre a lista; $index$ é a voz que está tocando agora e $total$ quantas estão na fila.",
+    "message": "$index$ de $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Rótulo acessível para o controle de comparação na barra de controle de Vozes nas configurações, que reproduz a outra voz das duas últimas ouvidas; $name$ é essa voz.",
+    "message": "Voltar para $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Linha na barra de controle de Vozes nas configurações quando \"Reproduzir tudo\" é pressionado em uma lista longa demais para ouvir até o fim; $count$ é quantas vozes e $minutes$ aproximadamente quantos minutos elas levariam. \"min\" abreviado para ler corretamente com 1 — o Chrome i18n não tem formas de plural.",
+    "message": "São $count$ vozes — cerca de $minutes$ min. Filtre a lista primeiro.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Rótulo acessível para o botão por host \"usar esta voz\" no catálogo de vozes nas configurações; $name$ é a voz, $host$ é o assistente (ex.: Pi, Claude).",
+    "message": "Usar $name$ no $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Rótulo curto no botão por host \"usar esta voz\" no catálogo unificado de vozes nas configurações (o host é mostrado ao lado).",
+    "message": "Usar"
+  },
+  "voicesYourVoice": {
+    "description": "Botão da barra de controle na lista de Vozes nas configurações que leva o foco para a linha da voz que este host usa atualmente; $name$ é essa voz.",
+    "message": "Sua voz: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Erro lançado quando o navegador não consegue alocar memória do WebAssembly suficiente para o modelo de detecção de voz.",
+    "message": "A detecção de voz não pode iniciar: não há memória do WebAssembly suficiente para o modelo de voz. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Erro lançado quando o navegador não expõe a memória inicial do WebAssembly necessária para executar o modelo de detecção de voz.",
+    "message": "A detecção de voz não pode iniciar: a memória do WebAssembly não está disponível neste navegador."
   }
 }

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Beneficiu listat în modalul de autentificare - limite de utilizare crescute.",
+    "message": "Limite de utilizare mai mari cu un cont gratuit"
+  },
+  "authBenefitPremium": {
+    "description": "Beneficiu listat în modalul de autentificare - funcții premium în chatboturi.",
+    "message": "Funcții premium și suport pentru chatboturi"
+  },
+  "authBenefitSupport": {
+    "description": "Beneficiu listat în modalul de autentificare - asistență prioritară.",
+    "message": "Asistență prioritară pentru probleme"
+  },
+  "authBenefitSync": {
+    "description": "Beneficiu listat în modalul de autentificare - sincronizarea setărilor.",
+    "message": "Sincronizează setările vocii peste tot"
+  },
+  "authBenefitTTS": {
+    "description": "Beneficiu listat în modalul de autentificare - funcția TTS.",
+    "message": "Voci text-în-vorbire (planuri plătite)"
+  },
+  "authBenefitUsage": {
+    "description": "Beneficiu listat în modalul de autentificare - urmărirea utilizării.",
+    "message": "Urmărește-ți utilizarea vocii pe toate dispozitivele"
+  },
+  "authPromptModalFull": {
+    "description": "Descriere pentru promptul de autentificare din fereastra modală completă, cu propunerea de valoare.",
+    "message": "Folosești Say, Pi foarte mult. Conectează-te pentru limite mai mari, voci de tip text-în-vorbire și funcții premium în toate chatboturile acceptate."
+  },
+  "authPromptModalSoft": {
+    "description": "Descriere pentru promptul de autentificare din fereastra modală soft.",
+    "message": "Creează un cont Say, Pi gratuit pentru limite de utilizare mai mari și acces la funcții vocale premium."
+  },
+  "authPromptTitle": {
+    "description": "Titlu pentru fereastra modală de autentificare.",
+    "message": "Deblochează mai multe funcții vocale"
+  },
+  "authPromptToast": {
+    "description": "Notificare toast care încurajează utilizatorul să se conecteze.",
+    "message": "Conectează-te la Say, Pi pentru limite mai mari și funcții premium"
+  },
   "autoReadAloudChatGPT": {
     "description": "Etichetă pentru caseta de selectare care activează sau dezactivează citirea automată a răspunsurilor ChatGPT în timpul apelurilor vocale.",
     "message": "Citire automată cu voce tare (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Dezactivați text-la-speech"
   },
+  "dismiss": {
+    "message": "Am înțeles",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Renunță"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Concentrează-te"
   },
+  "errorVadInitFailed": {
+    "description": "Toast de eroare afișat când detectarea activității vocale nu reușește să se inițializeze.",
+    "message": "Inițializarea detectării vocale a eșuat"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Toast de eroare afișat când apare o eroare neașteptată în timpul configurării înregistrării vocale.",
+    "message": "Configurarea înregistrării vocale a eșuat"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Toast de eroare afișat când clientul de detectare vocală nu reușește să pornească înregistrarea.",
+    "message": "Pornirea înregistrării vocale a eșuat"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Toast de eroare afișat când clientul de detectare vocală (VAD) nu este disponibil, astfel încât înregistrarea nu poate începe.",
+    "message": "Înregistrarea vocală nu este disponibilă"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Ieși din modul concentrație"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Notă pe un singur rând afișată în meniurile de voci când sunt disponibile atât voci premium (HD), cât și voci value",
+    "message": "Vocile HD îți consumă alocația lunară de aproximativ 20× mai repede."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Îndepărtând asta ..."
   },
+  "maybeLater": {
+    "description": "Textul butonului pentru a închide promptul de autentificare.",
+    "message": "Poate mai târziu"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Setările microfonului nu îndeplinesc specificațiile necesare. \nÎncercați să utilizați un alt microfon sau să ajustați setările audio."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Nu se poate accesa microfonul. \nVerificați setările dispozitivului și încercați din nou."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Toast de eroare afișat când permisiunea pentru microfon a fost refuzată după fluxul ferestrei de solicitare a permisiunii.",
+    "message": "Permisiunea pentru microfon nu a fost acordată. Asigură-te că ai permis accesul în fereastra de solicitare și în setările extensiei."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "acuratețe"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Cel mai rapid răspuns, dar mai puțin precis. \nPredispus la întrerupere."
   },
+  "moreVoices": {
+    "description": "Rând de meniu care leagă din meniul de voci din pagină către catalogul complet de voci din setările extensiei.",
+    "message": "Mai multe voci…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Porecla asistentului"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Nu a fost conectat"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Etichetă de buton care deschide ChatGPT.",
+    "message": "Deschide ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Etichetă de buton care deschide Claude.ai.",
+    "message": "Deschide Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Etichetă de buton care deschide Pi.ai.",
+    "message": "Deschide Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Opțiune de mediu: în preajma altor oameni.",
+    "message": "În preajma altor oameni"
+  },
+  "onboarding_envMixed": {
+    "description": "Opțiune de mediu: un amestec de spații private și partajate.",
+    "message": "Un mix de locuri"
+  },
+  "onboarding_envPrivate": {
+    "description": "Opțiune de mediu: un spațiu privat.",
+    "message": "Undeva privat"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Confirmare afișată când răspunsul despre mediu lasă modul silențios dezactivat.",
+    "message": "Am înțeles — vom păstra setările standard de ascultare și redare."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Confirmare afișată când răspunsul despre mediu activează modul silențios.",
+    "message": "Mod silențios activ — îți vom prelua vocea mai încet și vom răspunde încet, ca să poți vorbi discret."
+  },
+  "onboarding_envTitle": {
+    "description": "Titlu pentru întrebarea din onboarding despre mediul utilizatorului.",
+    "message": "Unde vorbești de obicei?"
+  },
+  "onboarding_footer": {
+    "description": "Text de subsol pe pagina de onboarding la prima rulare.",
+    "message": "Poți reveni la asta oricând din setările Say, Pi. Confidențialitatea ta contează — audio este captat doar în timpul unui apel activ."
+  },
+  "onboarding_heading": {
+    "description": "Titlul principal pe pagina de onboarding la prima rulare.",
+    "message": "🗣️ Bun venit la Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Paragraful de introducere pe pagina de onboarding la prima rulare.",
+    "message": "Ești la doi pași de prima ta conversație vorbită cu un AI. Vorbitul e de aproximativ 3× mai rapid decât tastatul — hai să te configurăm."
+  },
+  "onboarding_micTestButton": {
+    "description": "Buton care pornește testul de microfon din onboarding, fără miză.",
+    "message": "🎤 Testează-ți microfonul"
+  },
+  "onboarding_micTestDone": {
+    "description": "Stare afișată după ce testul de microfon din onboarding se încheie cu succes.",
+    "message": "Super — microfonul tău funcționează! 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Stare afișată în timp ce testul de microfon din onboarding măsoară semnalul de intrare.",
+    "message": "Ascult — spune ceva! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Stare afișată în timp ce testul de microfon din onboarding așteaptă permisiunea.",
+    "message": "Se solicită acces la microfon…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Etichetă de buton pentru a opri testul de microfon din onboarding în timp ce rulează.",
+    "message": "Oprește testul"
+  },
+  "onboarding_step1Body": {
+    "description": "Conținutul primului pas de onboarding care explică cum să fixezi extensia.",
+    "message": "Dă clic pe pictograma piesă de puzzle 🧩 din dreapta sus a browserului, apoi pe acul 📌 de lângă Say, Pi. Așa butonul de apel rămâne la un clic distanță."
+  },
+  "onboarding_step1Title": {
+    "description": "Titlul primului pas de onboarding (fixarea extensiei).",
+    "message": "Fixează Say, Pi în bara de instrumente"
+  },
+  "onboarding_step2Body": {
+    "description": "Conținutul celui de-al doilea pas de onboarding care explică cum să pornești o conversație vocală.",
+    "message": "Mergi la unul dintre asistenții acceptați de mai jos, apoi apasă butonul de apel Say, Pi și spune salut. Îți vom cere acces la microfon prima dată — e normal, iar noi ascultăm doar cât timp ești într-un apel."
+  },
+  "onboarding_step2Title": {
+    "description": "Titlul celui de-al doilea pas de onboarding (începerea unei conversații).",
+    "message": "Deschide un chat AI și începe să vorbești"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Permisiunea microfonului"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Instrucțiuni de recuperare când permisiunea pentru microfon este blocată.",
+    "message": "Browserul îți blochează microfonul. Apasă pictograma camerei sau a lacătului din bara de adrese, setează Microfon la „Permite”, apoi încearcă din nou. Pe macOS, verifică și Setări sistem → Confidențialitate și securitate → Microfon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Titlul panoului de recuperare când permisiunea pentru microfon a fost refuzată/blocată.",
+    "message": "Accesul la microfon este blocat"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Instrucțiuni de recuperare când microfonul este folosit în altă parte.",
+    "message": "O altă aplicație sau filă poate folosi microfonul. Închide orice altceva care ar putea înregistra (apeluri video, note vocale), apoi încearcă din nou."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Titlul panoului de recuperare când microfonul este folosit de o altă aplicație.",
+    "message": "Microfonul este ocupat"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Instrucțiuni de recuperare când nu este disponibil niciun dispoziv microfon.",
+    "message": "Nu am putut găsi un microfon. Conectează unul (sau căștile cu microfon), asigură-te că este selectat ca dispozitiv de intrare, apoi încearcă din nou."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Titlul panoului de recuperare când nu este disponibil niciun dispozitiv microfon.",
+    "message": "Nu a fost găsit niciun microfon"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Instrucțiuni de recuperare pentru o eroare necunoscută a microfonului.",
+    "message": "Ceva nu a mers bine la accesarea microfonului. Verifică dacă este conectat și permis în setările browserului, apoi încearcă din nou."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Titlul panoului de recuperare pentru o eroare necunoscută a microfonului.",
+    "message": "Nu am putut accesa microfonul"
+  },
+  "permissions_retryButton": {
+    "description": "Etichetă pentru butonul care solicită din nou permisiunea pentru microfon.",
+    "message": "Încearcă din nou"
+  },
+  "permissions_revokedHeading": {
+    "description": "Titlu afișat când accesul la microfon a fost acordat anterior, dar între timp a fost revocat.",
+    "message": "🎙️ Să reconectăm microfonul"
+  },
+  "permissions_revokedInfo": {
+    "description": "Text informativ afișat când accesul la microfon a fost revocat după ce fusese acordat.",
+    "message": "Accesul la microfon a fost dezactivat — asta se întâmplă des după o actualizare a browserului sau a sistemului. Permite-l din nou mai jos și $productName$ va asculta din nou când ești într-un apel.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Etichetă pentru comutatorul care activează modul silențios/șoaptă.",
+    "message": "Mod silențios"
+  },
+  "quietModeTooltip": {
+    "description": "Tooltip care explică ce face modul silențios/șoaptă.",
+    "message": "Vorbește încet — detectează vorbirea mai discretă și reduce volumul răspunsului asistentului, ca să poți folosi vocea în preajma altora."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Text pentru butonul de conectare în timp ce autentificarea este în curs.",
+    "message": "Se conectează..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Efecte sonore"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Efectele sonore sunt dezactivate în Firefox pentru a preveni problemele de feedback audio."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Titlul notificării unice despre câștigul de viteză, afișată după primul schimb vorbit.",
+    "message": "Bine — vorbitul este de aproximativ 3× mai rapid decât tastatul."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "A doua linie opțională a notificării despre câștigul de viteză, care arată minutele întregi economisite.",
+    "message": "Ai vorbit deja cu aproximativ $minutes$ min mai repede decât ai fi tastat.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Trimiteți doar când apăsați butonul"
   },
+  "surveyQuestion": {
+    "description": "Întrebarea unică din micro-sondajul unic, afișat după un câștig.",
+    "message": "Cum ți se pare vocea până acum?"
+  },
+  "surveyRatingLabel": {
+    "description": "Etichetă accesibilă pentru un buton de evaluare din sondaj.",
+    "message": "Evaluează $rating$ din 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Mesaj de mulțumire afișat după ce utilizatorul răspunde la sondajul post-câștig.",
+    "message": "Mulțumim — asta ne ajută să facem Say, Pi mai bun. 🙏"
+  },
   "tabAIChat": {
     "description": "Eticheta tab-ului pentru secțiunea setărilor de chat AI.",
     "message": "Chat AI"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Eticheta tab-ului pentru secțiunea setărilor generale.",
     "message": "General"
+  },
+  "tabVoices": {
+    "description": "Etichetă de filă pentru secțiunea de setări a vocilor (catalog de voci per site).",
+    "message": "Voci"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "credite"
   },
+  "ttsCreditsRemaining": {
+    "description": "Text care arată cota TTS rămasă ca un fond de credite per voce (saypi-api #181 Etapa 2), nu ca număr brut de caractere.",
+    "message": "$credits$ credite rămase",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Vocile multilingve nu sunt acceptate momentan în Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Generarea vocală"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Atenție! Redarea vorbirii nu este încă disponibilă pe $browserName$ cu $chatbotName$. Vestea bună? Intrarea vocală funcționează grozav! Pentru TTS, încercați Chrome sau Edge pe desktop.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS indisponibil pe $browserName$ + $chatbotName$. Intrarea vocală funcționează! Încercați Chrome desktop pentru TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Voce tts"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Detaliu VAD când a fost detectat sunet asemănător vorbirii, dar era prea slab / cu încredere prea mică pentru a fi transcris (renunțare la poarta de admitere pe client).",
+    "message": "Sunet prea slab pentru transcriere"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Detaliu VAD care explică faptul că apelul s-a încheiat deoarece microfonul a fost revendicat de un tab mai nou.",
+    "message": "Intrarea vocală a fost mutată în alt tab"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Vocea nu este disponibilă. \nÎncercați Chrome sau Firefox pe desktop."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Atenție! Redarea vorbirii nu este încă disponibilă pe $browserName$ cu $chatbotName$. Vestea bună? Intrarea vocală funcționează grozav! Pentru TTS, încercați Chrome sau Edge pe desktop.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS indisponibil pe $browserName$ + $chatbotName$. Intrarea vocală funcționează! Încercați Chrome desktop pentru TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Am înțeles",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Stare VAD afișată pe un tab a cărui intrare vocală a fost preluată de un alt tab.",
+    "message": "În pauză"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Vizualizați detalii"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Introducere vocală generică redată când o voce SayPi selectată nu are un script de introducere specific vocii (și nu există un mesaj recent de citit).",
+    "message": "Salut, sunt $voice$. Așa sun. Sper să îți placă această voce.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hola! \nПривет! \n你好! \nEu sunt Pi, asistentul tău poliglot AI. \nCu 32 de limbi la comandă, putem explora idei și culturi din întreaga lume. \nCe părere ai de această voce?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Setări vocale"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Subtitlu de rezervă pentru un rând de voce în catalogul de voci din setări când vocea nu are descriere; $count$ este numărul de limbi pe care vocea le acceptă.",
+    "message": "Vorbește $count$ limbi",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Slogan de personalitate redactat pentru vocea „Addison” (setări, studio Voci; mapare de identitate a vocii pe client).",
+    "message": "Însorită și articulată"
+  },
+  "voiceTagline_alloy": {
+    "description": "Slogan de personalitate redactat pentru vocea „Alloy” (studioul Voci din setări; hartă de identitate a vocii pe client).",
+    "message": "Echilibrată și bună la orice"
+  },
+  "voiceTagline_ash": {
+    "description": "Slogan de personalitate redactat pentru vocea „Ash” (studioul Voci din setări; hartă de identitate a vocii pe client).",
+    "message": "Gravă, reflexivă, calmă"
+  },
+  "voiceTagline_ballad": {
+    "description": "Slogan de personalitate redactat pentru vocea „Ballad” (studioul Voci din setări; hartă de identitate a vocii pe client).",
+    "message": "Lină și melodioasă"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Slogan de personalitate redactat pentru vocea „Cassidy” (setări, studio Voci; mapare de identitate a vocii pe client).",
+    "message": "Prietenos și concret"
+  },
+  "voiceTagline_cedar": {
+    "description": "Slogan de personalitate redactat pentru vocea „Cedar” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Stabil și liniștitor"
+  },
+  "voiceTagline_coral": {
+    "description": "Slogan de personalitate redactat pentru vocea „Coral” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Energie luminoasă și optimistă"
+  },
+  "voiceTagline_echo": {
+    "description": "Slogan de personalitate redactat pentru vocea „Echo” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Clar și neutru"
+  },
+  "voiceTagline_fable": {
+    "description": "Slogan de personalitate redactat pentru vocea „Fable” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Cadență de povestitor"
+  },
+  "voiceTagline_finn": {
+    "description": "Slogan de personalitate redactat pentru vocea „Finn” (setări, studio Voci; mapare de identitate a vocii pe client).",
+    "message": "Proaspătă și energică"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Slogan de personalitate redactat pentru vocea „Jamahal” (setări, studio Voci; mapare de identitate a vocii pe client).",
+    "message": "Bogată și magnetică"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Slogan de personalitate redactat pentru vocea „Jarnathan” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Bariton catifelat de noapte târzie"
+  },
+  "voiceTagline_jeff": {
+    "description": "Slogan de personalitate redactat pentru vocea „Jeff” (setări, studio Voci; mapare de identitate a vocii pe client).",
+    "message": "Direct și echilibrat"
+  },
+  "voiceTagline_jessica": {
+    "description": "Slogan de personalitate redactat pentru vocea „Jessica” (setări, studio Voci; mapare de identitate a vocii pe client).",
+    "message": "Căldură și eleganță"
+  },
+  "voiceTagline_joey": {
+    "description": "Slogan de personalitate redactat pentru vocea „Joey” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "American relaxat, conversațional"
+  },
+  "voiceTagline_juniper": {
+    "description": "Slogan de personalitate redactat pentru vocea „Juniper” (setări, studio Voci; mapare de identitate a vocii pe client).",
+    "message": "Clar, luminos, animat"
+  },
+  "voiceTagline_lucy": {
+    "description": "Slogan de personalitate redactat pentru vocea „Lucy” (setări, studio Voci; mapare de identitate a vocii pe client).",
+    "message": "Blândă și luminoasă"
+  },
+  "voiceTagline_marin": {
+    "description": "Slogan de personalitate redactat pentru vocea „Marin” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Calm cald, ca la radio dimineața"
+  },
+  "voiceTagline_mark": {
+    "description": "Slogan de personalitate redactat pentru vocea „Mark” (setări, studio Voci; mapare de identitate a vocii pe client).",
+    "message": "Narator clar, încrezător"
+  },
+  "voiceTagline_nova": {
+    "description": "Slogan de personalitate redactat pentru vocea „Nova” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Rapid și curios"
+  },
+  "voiceTagline_onyx": {
+    "description": "Slogan de personalitate redactat pentru vocea „Onyx” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Gravitate profundă, rezonantă"
+  },
+  "voiceTagline_paola": {
+    "description": "Slogan de personalitate redactat pentru vocea „Paola” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Căldură italiană expresivă"
+  },
+  "voiceTagline_sage": {
+    "description": "Slogan de personalitate redactat pentru vocea „Sage” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Claritate, cu voce blândă"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Slogan de personalitate redactat pentru vocea „Shimmer” (setări > studioul Voci; hartă de identitate a vocilor pe partea de client).",
+    "message": "Lejer și aerat"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Etichetă scurtă pe comutatorul de fixare al unui card de voce (stare oprită) în studio-ul Voices din setări; apăsarea adaugă vocea în meniul din chat al gazdei.",
+    "message": "+ Meniu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Etichetă accesibilă pentru comutatorul de fixare al unui card de voce (stare oprită); $name$ este vocea, $host$ asistentul.",
+    "message": "Adaugă $name$ în meniul lui $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Etichetă pe comutatorul din bara de control Voci care indică dacă parcurgerea listei cu tastele săgeți redă fiecare voce când focalizarea ajunge la ea.",
+    "message": "Redă pe măsură ce te deplasezi"
+  },
+  "voicesArrowsLive": {
+    "description": "Confirmare pentru cititorul de ecran, adăugată la primul anunț „Se redă <voce>” în lista Voci din setări, care spune că tastele săgeți au devenit tocmai audibile. Reia formularea comutatorului „Redă în timp ce te muți”.",
+    "message": "Săgețile redau acum în timp ce te muți. Esc oprește."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Notă sub locurile meniului pentru hosturi care au voci native (de ex. cele 8 voci încorporate ale lui Pi), pe care studioul nu le gestionează; $host$ este asistentul.",
+    "message": "Vocile încorporate ale lui $host$ apar întotdeauna și în meniul lui.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variantă a voicesBuiltinsNote pentru un host fără meniu de voci în chat (Pi și-a retras meniul în 2026), unde promisiunea din original că vocile încorporate „apar în meniul lui” ar fi falsă; $host$ este asistentul.",
+    "message": "$host$ are și voci încorporate, care nu sunt listate aici.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Indicator de progres în bara de control Voci din setări: câte dintre vocile listate a ascultat deja utilizatorul. Doar numere, ca să se citească corect la 1 — Chrome i18n nu are forme de plural.",
+    "message": "$heard$ din $total$ ascultate",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Parte din numele accesibil al unui rând de voce în lista Voci din setări, marcând o voce pe care acest profil a ascultat-o deja. Vizual, acest lucru este reprezentat ca densitate a cernelii pe amprenta sonoră a vocii, pe care un cititor de ecran nu o poate vedea.",
+    "message": "Ascultat"
+  },
+  "voicesInHostMenu": {
+    "description": "Titlu de secțiune deasupra rândului cu sloturi de meniu în studio-ul Voices din setări; $host$ este asistentul.",
+    "message": "În meniul lui $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Etichetă scurtă pe comutatorul de fixare al unui card de voce (stare pornită) în studio-ul Voices din setări.",
+    "message": "✓ În meniu"
+  },
+  "voicesInUse": {
+    "description": "Insignă persistentă pe vocea selectată în prezent pentru gazdă în lista Voices din setări, redată cu majuscule. Deliberat NU „Vorbește acum”: pe această pagină rândurile redau mostre, așa că o voce selectată, dar tăcută, nu trebuie să pretindă că vorbește în timp ce un alt rând o face.",
+    "message": "În uz"
+  },
+  "voicesKeyboardHint": {
+    "description": "Indiciu de tastatură pe un rând în bara de control Voci din setări. Simbolurile sunt taste: Space, săgețile sus/jos și Shift+Space.",
+    "message": "Apasă Space ca să asculți, ↑↓ ca să te muți între voci, ⇧Space ca să revii."
+  },
+  "voicesLoadError": {
+    "description": "Stare de eroare în studioul unui host când catalogul de voci al acelui host nu s-a putut încărca; $host$ este asistentul.",
+    "message": "Nu s-au putut încărca vocile lui $host$. Încearcă din nou mai târziu.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/indiciu pe un comutator „+ Meniu” dezactivat atunci când meniul din chat al gazdei are deja numărul maxim de voci.",
+    "message": "Meniul este plin — elimină o voce ca să adaugi alta"
+  },
+  "voicesMenuHint": {
+    "description": "Indiciu de o linie lângă titlul „În meniul lui {host}”, explicând că rândul cu sloturi reflectă meniul de voci din chat.",
+    "message": "Ce vei vedea în chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Notă sub locurile meniului când utilizatorul are mai multe voci fixate decât poate afișa meniul din chat (stare veche); $count$ este câte nu încap, $cap$ este dimensiunea meniului.",
+    "message": "Încă $count$ voci fixate așteaptă dincolo de cele $cap$ locuri ale meniului.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Singularul pentru voicesMenuOverflow, folosit când exact o voce fixată nu încape în meniul din chat; $cap$ este dimensiunea meniului.",
+    "message": "Încă 1 voce fixată așteaptă dincolo de cele $cap$ locuri ale meniului.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Linie rezumat sub lista Voci din setări care spune cât din meniul de voci din chat al hostului este ocupat; $host$ este asistentul, $used$ câte locuri sunt ocupate, $cap$ câte sunt în total. Formulat să se citească corect și la 1 — Chrome i18n nu are forme de plural.",
+    "message": "Meniul lui $host$: $used$ din $cap$ locuri",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Titlu pentru grupul de la finalul listei Voci din setări care conține voci fără un clip mostră de redat; $count$ este câte sunt. Formulat să se citească corect și la 1 — Chrome i18n nu are forme de plural.",
+    "message": "Încă fără mostră ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Afișat în catalogul de voci din setări când lista de voci este goală pentru un utilizator autentificat (de ex., o problemă de rețea).",
+    "message": "Vocile nu au putut fi încărcate acum. Te rugăm să încerci din nou mai târziu."
+  },
+  "voicesNowPlaying": {
+    "description": "Anunț pentru cititorul de ecran când începe redarea clipului mostră al unei voci în lista Voci din setări; $name$ este vocea.",
+    "message": "Se redă $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Buton în bara de control Voci din setări care redă pe rând fiecare voce listată în prezent; $count$ este câte sunt. Formulat să se citească corect și la 1 — Chrome i18n nu are forme de plural.",
+    "message": "Redă toate ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Buton în bara de control Voci din setări la o revenire: redă doar vocile listate pe care nu le-ai ascultat încă; $count$ este câte sunt. Formulat să se citească corect și la 1 — Chrome i18n nu are forme de plural.",
+    "message": "Redă noi ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Linie în bara de control Voci din setări când browserul a refuzat să redea un eșantion deoarece pagina nu a avut încă nicio interacțiune din partea utilizatorului.",
+    "message": "Dă clic pe orice voce ca să activezi sunetul."
+  },
+  "voicesPreview": {
+    "description": "Etichetă accesibilă pentru butonul de redare (▶) care ascultă clipul de exemplu gratuit al unei voci dintr-un rând de voce; $name$ este numele vocii.",
+    "message": "Redă un exemplu pentru $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Nume accesibil al listei Voci din setări (un listbox cu fiecare voce, câte un rând pentru fiecare).",
+    "message": "Voci, ordonate de la cele mai grave la cele mai luminoase"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Etichetă accesibilă pentru comutatorul de fixare al unui card de voce (stare pornită) și butonul de eliminare al unui slot de meniu; $name$ este vocea, $host$ asistentul.",
+    "message": "Elimină $name$ din meniul lui $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Linie în bara de control Voci din setări când eșantionul unei voci nu a reușit să se încarce sau să se redea; $name$ este acea voce. Nemodal — o serie de eșantioane continuă și după ea.",
+    "message": "Nu s-a putut reda eșantionul pentru $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Subtitlu pentru secțiunea catalogului de voci din fila AI Chat a setărilor.",
+    "message": "Alege vocea care citește cu voce tare răspunsurile pe fiecare site."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Subtitlu sub titlul setării Voci, pentru șina de voci ordonată după înălțime.",
+    "message": "Fiecare voce, de la cea mai gravă la cea mai luminoasă. Ascultă, apoi alege."
+  },
+  "voicesSectionTitle": {
+    "description": "Titlu pentru secțiunea catalogului de voci din fila AI Chat a setărilor.",
+    "message": "Voci"
+  },
+  "voicesShelfEveryday": {
+    "description": "Titlu de grup pentru vocile din nivelul economic din catalogul de voci din setări. Redat cu majuscule de CSS.",
+    "message": "Voci de zi cu zi"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Notă de o linie lângă titlul grupului Everyday în studioul de voci din setări; singurul loc în care studioul precizează cât de mult depășește acest nivel HD.",
+    "message": "Natural și clar — poți asculta de aproximativ 20× mai mult decât cu HD."
+  },
+  "voicesShelfHd": {
+    "description": "Titlu de grup pentru vocile premium (HD) din catalogul de voci din setări. Redat cu majuscule de CSS.",
+    "message": "Voci HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Notă de o linie lângă titlul grupului HD în studioul de voci din setări.",
+    "message": "Cel mai bogat și expresiv sunet al nostru."
+  },
+  "voicesShowAll": {
+    "description": "Opțiune în filtrul „Afișează” din Voci (setări): fără filtrare, este listată fiecare voce.",
+    "message": "Toate vocile"
+  },
+  "voicesShowEveryday": {
+    "description": "Opțiune în filtrul „Afișează” din Voci (setări): listează doar vocile standard (non-HD).",
+    "message": "Doar standard"
+  },
+  "voicesShowHd": {
+    "description": "Opțiune în filtrul „Afișează” din Voci (setări): listează doar vocile premium (HD).",
+    "message": "Doar HD"
+  },
+  "voicesShowLabel": {
+    "description": "Etichetă pe filtrul din bara de control Voci din setări care restrânge ce voci arată lista.",
+    "message": "Afișează"
+  },
+  "voicesShowUnheard": {
+    "description": "Opțiune în filtrul „Afișează” din Voci (setări): listează doar vocile pe care utilizatorul nu le-a ascultat încă.",
+    "message": "Neascultate încă"
+  },
+  "voicesSpeakingNow": {
+    "description": "Etichetă de stare pe vocea selectată în prezent pentru gazdă în studio-ul Voices din setări (slot de meniu și card de voce).",
+    "message": "Vorbește acum"
+  },
+  "voicesSpeaksWith": {
+    "description": "Linie tip sprânceană deasupra numelui vocii curente pe scena studio Voices din setări; $host$ este asistentul (de ex. Pi). Redată cu majuscule de CSS.",
+    "message": "$host$ vorbește cu",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Notă în scenă când hostul își oferă propriul audio (de ex. Pi), astfel încât alegerea unei voci Say, Pi o înlocuiește pe cea a hostului.",
+    "message": "$host$ folosește propria voce până alegi una mai jos.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Notă în scenă când hostul nu are o voce proprie (de ex. Claude), astfel încât nu se citește nimic cu voce tare până este aleasă o voce Say, Pi.",
+    "message": "$host$ nu va citi răspunsurile cu voce tare până alegi una mai jos.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Titlu în scena studioului de voci din setări când hostul nu are selectată nicio voce SayPi; $host$ este asistentul (de ex. Pi, Claude). Randat la dimensiunea numelui.",
+    "message": "Alege cum sună $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Buton pe scena studioului de voci din setări care redă clipul demonstrativ gratuit al vocii curente.",
+    "message": "Ascultă un exemplu"
+  },
+  "voicesStopPlayback": {
+    "description": "Buton în bara de control Voci din setări care oprește rularea mostrelor pornită de „Redă toate”.",
+    "message": "Oprește"
+  },
+  "voicesSweepPosition": {
+    "description": "Afișare în direct a poziției în bara de control Voci din setări, în timp ce „Redă tot” parcurge lista; $index$ este vocea care rulează acum, iar $total$ câte sunt în coadă.",
+    "message": "$index$ din $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Etichetă accesibilă pentru controlul de comparare din bara de control Voci din setări, care redă cealaltă voce dintre ultimele două ascultate; $name$ este acea voce.",
+    "message": "Revino la $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Linie în bara de control Voci din setări când se apasă „Redă tot” pe o listă prea lungă ca să o parcurgi; $count$ este câte voci sunt, iar $minutes$ aproximativ câte minute ar dura. Abreviat „min” ca să se citească corect la 1 — Chrome i18n nu are forme de plural.",
+    "message": "Sunt $count$ voci — cam $minutes$ min. Îngustează lista mai întâi.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Etichetă accesibilă pentru butonul per-gazdă „folosește această voce” din catalogul de voci din setări; $name$ este vocea, $host$ este asistentul (de ex. Pi, Claude).",
+    "message": "Folosește $name$ pe $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Etichetă scurtă pe butonul per-gazdă „folosește această voce” din catalogul unificat de voci din setări (gazda este afișată alături).",
+    "message": "Folosește"
+  },
+  "voicesYourVoice": {
+    "description": "Buton din bara de control în lista Voci din setări care mută focalizarea la rândul vocii folosite în prezent de acest host; $name$ este acea voce.",
+    "message": "Vocea ta: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Eroare aruncată când browserul nu poate aloca suficientă memorie WebAssembly pentru modelul de detectare vocală.",
+    "message": "Detectarea vocală nu poate porni: nu există suficientă memorie WebAssembly pentru modelul vocal. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Eroare aruncată când browserul nu expune memoria WebAssembly inițială necesară pentru a rula modelul de detectare vocală.",
+    "message": "Detectarea vocală nu poate porni: memoria WebAssembly nu este disponibilă în acest browser."
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Преимущество в модальном окне авторизации — увеличение лимитов использования.",
+    "message": "Повышенные лимиты с бесплатным аккаунтом"
+  },
+  "authBenefitPremium": {
+    "description": "Преимущество в модальном окне авторизации — премиум-функции для разных чат-ботов.",
+    "message": "Премиум-функции и поддержка чат-ботов"
+  },
+  "authBenefitSupport": {
+    "description": "Преимущество в модальном окне авторизации — приоритетная поддержка.",
+    "message": "Приоритетная поддержка по проблемам"
+  },
+  "authBenefitSync": {
+    "description": "Преимущество в модальном окне авторизации — синхронизация настроек.",
+    "message": "Синхронизируйте голосовые настройки везде"
+  },
+  "authBenefitTTS": {
+    "description": "Преимущество в модальном окне авторизации — функция TTS.",
+    "message": "Голоса для озвучивания текста (платные планы)"
+  },
+  "authBenefitUsage": {
+    "description": "Преимущество в модальном окне авторизации — отслеживание использования.",
+    "message": "Отслеживайте использование голоса на разных устройствах"
+  },
+  "authPromptModalFull": {
+    "description": "Описание для полного модального окна с предложением авторизации и описанием ценности.",
+    "message": "Вы активно используете SayPi. Войдите, чтобы повысить лимиты, получить голоса для озвучивания текста и премиум-функции во всех поддерживаемых чат-ботах."
+  },
+  "authPromptModalSoft": {
+    "description": "Описание для мягкого модального окна с предложением авторизации.",
+    "message": "Создайте бесплатный аккаунт SayPi, чтобы повысить лимиты использования и получить доступ к премиум-голосовым функциям."
+  },
+  "authPromptTitle": {
+    "description": "Заголовок модального окна с предложением авторизации.",
+    "message": "Откройте больше голосовых функций"
+  },
+  "authPromptToast": {
+    "description": "Всплывающее уведомление, побуждающее пользователя войти в аккаунт.",
+    "message": "Войдите в SayPi, чтобы повысить лимиты и получить премиум-функции"
+  },
   "autoReadAloudChatGPT": {
     "description": "Метка для флажка, позволяющего включать или отключать автоматическое озвучивание ответов ChatGPT во время голосовых вызовов.",
     "message": "Автоматическое озвучивание (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Отключить текст в речь"
   },
+  "dismiss": {
+    "message": "Понятно",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Уволить"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Сосредоточиться"
   },
+  "errorVadInitFailed": {
+    "description": "Сообщение об ошибке, показываемое, когда не удаётся инициализировать распознавание голосовой активности.",
+    "message": "Не удалось инициализировать распознавание голоса"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Сообщение об ошибке, показываемое, когда при настройке записи голоса происходит непредвиденная ошибка.",
+    "message": "Не удалось настроить запись голоса"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Сообщение об ошибке, показываемое, когда клиент распознавания голоса не может начать запись.",
+    "message": "Не удалось начать запись голоса"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Сообщение об ошибке, показываемое, когда клиент распознавания голоса (VAD) недоступен, поэтому запись не может начаться.",
+    "message": "Запись голоса недоступна"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Выйти из режима концентрации"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Однострочная заметка, показываемая в меню голосов, когда доступны и премиальные (HD), и выгодные голоса",
+    "message": "HD-голоса расходуют ваш месячный лимит примерно в 20× быстрее."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Уравновешивая это ..."
   },
+  "maybeLater": {
+    "description": "Текст кнопки для закрытия предложения авторизации.",
+    "message": "Возможно позже"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Настройки вашего микрофона не соответствуют требуемым характеристикам. \nПопробуйте использовать другой микрофон или изменить настройки звука."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Невозможно получить доступ к микрофону. \nПожалуйста, проверьте настройки вашего устройства и повторите попытку."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Сообщение об ошибке, показываемое, когда доступ к микрофону был отклонён после запроса разрешения.",
+    "message": "Доступ к микрофону не был предоставлен. Убедитесь, что вы разрешили доступ в запросе и в настройках расширения."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "точность"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Самый быстрый ответ, но менее точный. \nСклонен перебивать."
   },
+  "moreVoices": {
+    "description": "Строка меню, ведущая из меню голосов на странице к полному каталогу голосов в настройках расширения.",
+    "message": "Больше голосов…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Псевдоним помощника"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Не подписан"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Текст кнопки, которая открывает ChatGPT.",
+    "message": "Открыть ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Подпись кнопки, открывающей Claude.ai.",
+    "message": "Открыть Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Подпись кнопки, открывающей Pi.ai.",
+    "message": "Открыть Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Вариант среды: рядом с другими людьми.",
+    "message": "Рядом с другими людьми"
+  },
+  "onboarding_envMixed": {
+    "description": "Вариант среды: сочетание уединённых и общих пространств.",
+    "message": "В разных местах"
+  },
+  "onboarding_envPrivate": {
+    "description": "Вариант среды: уединённое место.",
+    "message": "Где-нибудь в уединении"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Подтверждение, показываемое, когда ответ про окружение оставляет тихий режим выключенным.",
+    "message": "Поняли, оставим стандартные настройки прослушивания и воспроизведения."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Подтверждение, показываемое, когда ответ о среде включает тихий режим.",
+    "message": "Тихий режим включён — мы будем лучше улавливать тихую речь и отвечать негромко, чтобы вы могли говорить незаметно."
+  },
+  "onboarding_envTitle": {
+    "description": "Заголовок вопроса онбординга о среде, в которой находится пользователь.",
+    "message": "Где вы обычно будете говорить?"
+  },
+  "onboarding_footer": {
+    "description": "Текст внизу страницы онбординга при первом запуске.",
+    "message": "Вы можете вернуться к этому в любое время в настройках Say, Pi. Ваша конфиденциальность важна — звук записывается только во время активного звонка."
+  },
+  "onboarding_heading": {
+    "description": "Основной заголовок на странице первого запуска (onboarding).",
+    "message": "🗣️ Добро пожаловать в Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Вступительный абзац на странице первого запуска (onboarding).",
+    "message": "Вас отделяют два шага от первого разговора с ИИ голосом. Говорить примерно в 3× быстрее, чем печатать — давайте всё настроим."
+  },
+  "onboarding_micTestButton": {
+    "description": "Кнопка, которая запускает безопасную проверку микрофона в онбординге.",
+    "message": "🎤 Проверить микрофон"
+  },
+  "onboarding_micTestDone": {
+    "description": "Статус, показываемый после успешного завершения проверки микрофона в онбординге.",
+    "message": "Отлично — микрофон работает 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Статус, показываемый, пока проверка микрофона в онбординге измеряет входной сигнал.",
+    "message": "Слушаем — скажите что-нибудь 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Статус, показываемый, пока проверка микрофона в онбординге ожидает разрешения.",
+    "message": "Запрашиваем доступ к микрофону…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Текст кнопки для остановки проверки микрофона в онбординге во время её выполнения.",
+    "message": "Остановить проверку"
+  },
+  "onboarding_step1Body": {
+    "description": "Текст первого шага онбординга, объясняющий, как закрепить расширение.",
+    "message": "Нажмите значок пазла 🧩 в правом верхнем углу браузера, затем значок закрепления 📌 рядом с Say, Pi. Так кнопка звонка будет в одном клике."
+  },
+  "onboarding_step1Title": {
+    "description": "Заголовок первого шага онбординга (закрепить расширение).",
+    "message": "Закрепите Say, Pi на панели инструментов"
+  },
+  "onboarding_step2Body": {
+    "description": "Текст второго шага онбординга, объясняющий, как начать голосовой разговор.",
+    "message": "Перейдите к одному из поддерживаемых ассистентов ниже, затем нажмите кнопку звонка Say, Pi и поздоровайтесь. В первый раз мы запросим доступ к микрофону — это нормально, и мы слушаем только пока вы активно в звонке."
+  },
+  "onboarding_step2Title": {
+    "description": "Заголовок второго шага онбординга (начать разговор).",
+    "message": "Откройте чат с ИИ и начните говорить"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Разрешение микрофона"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Инструкции по восстановлению, когда разрешение на микрофон заблокировано.",
+    "message": "Браузер блокирует микрофон. Нажмите на значок камеры или замка в адресной строке, установите для «Микрофон» значение «Разрешить», затем попробуйте снова. В macOS также проверьте: Системные настройки → Конфиденциальность и безопасность → Микрофон."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Заголовок панели восстановления, когда разрешение на микрофон было отклонено/заблокировано.",
+    "message": "Доступ к микрофону заблокирован"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Инструкции по восстановлению, когда микрофон используется где-то ещё.",
+    "message": "Возможно, микрофон использует другое приложение или вкладка. Закройте всё, что может вести запись (видеозвонки, диктофон), затем попробуйте снова."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Заголовок панели восстановления, когда микрофон используется другим приложением.",
+    "message": "Микрофон занят"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Инструкции по восстановлению, когда устройство микрофона недоступно.",
+    "message": "Мы не нашли микрофон. Подключите его (или гарнитуру), убедитесь, что он выбран как устройство ввода, затем попробуйте снова."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Заголовок панели восстановления, когда устройство микрофона недоступно.",
+    "message": "Микрофон не найден"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Инструкции по восстановлению для неизвестной ошибки микрофона.",
+    "message": "Не удалось подключиться к микрофону. Проверьте, что он подключён и разрешён в настройках браузера, затем попробуйте снова."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Заголовок панели восстановления для неизвестной ошибки микрофона.",
+    "message": "Не удалось получить доступ к микрофону"
+  },
+  "permissions_retryButton": {
+    "description": "Надпись на кнопке, которая повторно запрашивает разрешение на использование микрофона.",
+    "message": "Попробовать снова"
+  },
+  "permissions_revokedHeading": {
+    "description": "Заголовок, показываемый, когда доступ к микрофону ранее был предоставлен, но затем был отозван.",
+    "message": "🎙️ Подключим микрофон заново"
+  },
+  "permissions_revokedInfo": {
+    "description": "Информационный текст, показываемый, когда доступ к микрофону был отозван после того, как был предоставлен.",
+    "message": "Доступ к микрофону отключён — так часто бывает после обновления браузера или системы. Разрешите его ниже, и $productName$ снова будет слушать, когда вы в звонке.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Профиль"
+  },
+  "quietModeLabel": {
+    "description": "Подпись для переключателя, который включает тихий/шепчущий режим.",
+    "message": "Тихий режим"
+  },
+  "quietModeTooltip": {
+    "description": "Подсказка, объясняющая, что делает тихий/шепчущий режим.",
+    "message": "Говорите тише — распознаёт более тихую речь и снижает громкость ответа помощника, чтобы вы могли пользоваться голосом рядом с другими."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Текст для кнопки входа, пока выполняется аутентификация.",
+    "message": "Вход…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Звуковые эффекты"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Звуковые эффекты отключены в Firefox, чтобы предотвратить проблемы со звуком."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Заголовок одноразового уведомления о выигрыше во времени, показываемого после первого голосового обмена.",
+    "message": "Хорошо — говорить примерно в 3 раза быстрее, чем печатать."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Необязательная вторая строка уведомления о выигрыше во времени, показывающая целые минуты, которые удалось сэкономить.",
+    "message": "Вы уже сэкономили примерно $minutes$ мин по сравнению с набором текста.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Отправлять только при нажатии кнопки"
   },
+  "surveyQuestion": {
+    "description": "Единственный вопрос одноразового микроопроса после выигрыша.",
+    "message": "Как вам голосовая озвучка на данный момент?"
+  },
+  "surveyRatingLabel": {
+    "description": "Доступная метка для кнопки оценки в опросе.",
+    "message": "Оценить: $rating$ из 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Благодарность, показываемая после ответа пользователя в опросе после выигрыша.",
+    "message": "Спасибо, это помогает нам сделать Say, Pi лучше."
+  },
   "tabAIChat": {
     "description": "Название вкладки для секции настроек AI-чата.",
     "message": "AI Чат"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Название вкладки для секции общих настроек.",
     "message": "Общие"
+  },
+  "tabVoices": {
+    "description": "Название вкладки для раздела настроек голосов (каталог голосов для каждого сайта).",
+    "message": "Голоса"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "Кредиты"
   },
+  "ttsCreditsRemaining": {
+    "description": "Текст, показывающий оставшуюся квоту TTS как пул кредитов на голос (saypi-api #181 Stage 2), а не как количество символов.",
+    "message": "Осталось кредитов: $credits$",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Многоязычная речь в настоящее время не поддерживается в Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Генерация голоса"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Внимание! Воспроизведение речи пока недоступно в $browserName$ с $chatbotName$. Хорошая новость? Голосовой ввод работает отлично! Для TTS попробуйте Chrome или Edge на рабочем столе.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS недоступен в $browserName$ + $chatbotName$. Голосовой ввод работает! Попробуйте Chrome на рабочем столе для TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS голос"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Деталь VAD, когда обнаружили похожее на речь аудио, но оно было слишком тихим / с низкой уверенностью для расшифровки (отбрасывание на клиенте на этапе допуска).",
+    "message": "Аудио слишком тихое для расшифровки"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Деталь VAD, объясняющая, что звонок завершился, потому что микрофон был занят более новой вкладкой.",
+    "message": "Голосовой ввод перенесён на другую вкладку"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Голос недоступен. \nПопробуйте Chrome или Firefox на рабочем столе."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Внимание! Воспроизведение речи пока недоступно в $browserName$ с $chatbotName$. Хорошая новость? Голосовой ввод работает отлично! Для TTS попробуйте Chrome или Edge на рабочем столе.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS недоступен в $browserName$ + $chatbotName$. Голосовой ввод работает! Попробуйте Chrome на рабочем столе для TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Понятно",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Статус VAD, показываемый на вкладке, у которой голосовой ввод был перехвачен другой вкладкой.",
+    "message": "На паузе"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Просмотреть детали"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Общее голосовое представление, проигрываемое, когда у выбранного голоса SayPi нет собственного вступительного текста (и нет недавнего сообщения для озвучивания).",
+    "message": "Привет, я $voice$. Вот как я звучу. Надеюсь, вам понравится этот голос.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Привет! \nПривет! \n你好! \nЯ Пи, ваш ИИ-помощник-полиглот. \nИмея в своем распоряжении 32 языка, мы можем изучать идеи и культуры со всего мира. \nЧто вы думаете об этом голосе?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Настройки голоса"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Запасной подзаголовок для строки голоса в каталоге голосов в настройках, когда у голоса нет описания; $count$ — число языков, которые поддерживает голос.",
+    "message": "Говорит на $count$ языках",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Авторский слоган личности для голоса «Addison» (настройки: студия голосов; клиентская карта идентичности голоса).",
+    "message": "Солнечный и выразительный"
+  },
+  "voiceTagline_alloy": {
+    "description": "Авторский слоган характера для голоса «Alloy» (студия голосов в настройках; клиентская карта идентичностей голосов).",
+    "message": "Сбалансированный, на все случаи"
+  },
+  "voiceTagline_ash": {
+    "description": "Авторский слоган характера для голоса «Ash» (студия голосов в настройках; клиентская карта идентичностей голосов).",
+    "message": "Низкий, вдумчивый, спокойный"
+  },
+  "voiceTagline_ballad": {
+    "description": "Авторский слоган характера для голоса «Ballad» (студия голосов в настройках; клиентская карта идентичностей голосов).",
+    "message": "Мягкий и мелодичный"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Авторский слоган личности для голоса «Cassidy» (настройки: студия голосов; клиентская карта идентичности голоса).",
+    "message": "Дружелюбный и по делу"
+  },
+  "voiceTagline_cedar": {
+    "description": "Авторский слоган характера для голоса «Cedar» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Спокойный и внушающий уверенность"
+  },
+  "voiceTagline_coral": {
+    "description": "Авторский слоган характера для голоса «Coral» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Яркая, бодрая энергия"
+  },
+  "voiceTagline_echo": {
+    "description": "Авторский слоган характера для голоса «Echo» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Чистый и нейтральный"
+  },
+  "voiceTagline_fable": {
+    "description": "Авторский слоган характера для голоса «Fable» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Сказительная интонация"
+  },
+  "voiceTagline_finn": {
+    "description": "Авторский слоган личности для голоса «Finn» (настройки: студия голосов; клиентская карта идентичности голоса).",
+    "message": "Свежий и энергичный"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Авторский слоган личности для голоса «Jamahal» (настройки: студия голосов; клиентская карта идентичности голоса).",
+    "message": "Насыщенный и притягательный"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Авторский слоган характера для голоса «Jarnathan» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Бархатный ночной баритон"
+  },
+  "voiceTagline_jeff": {
+    "description": "Авторский слоган личности для голоса «Jeff» (настройки: студия голосов; клиентская карта идентичности голоса).",
+    "message": "Простой и уверенный"
+  },
+  "voiceTagline_jessica": {
+    "description": "Авторский слоган личности для голоса «Jessica» (настройки: студия голосов; клиентская карта идентичности голоса).",
+    "message": "Тёплая, отточенная уверенность"
+  },
+  "voiceTagline_joey": {
+    "description": "Авторский слоган характера для голоса «Joey» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Непринуждённая американская беседа"
+  },
+  "voiceTagline_juniper": {
+    "description": "Авторский слоган личности для голоса «Juniper» (настройки: студия голосов; клиентская карта идентичности голоса).",
+    "message": "Чёткий, яркий, живой"
+  },
+  "voiceTagline_lucy": {
+    "description": "Авторский слоган личности для голоса «Lucy» (настройки: студия голосов; клиентская карта идентичности голоса).",
+    "message": "Нежный и светлый"
+  },
+  "voiceTagline_marin": {
+    "description": "Авторский слоган характера для голоса «Marin» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Тёплое спокойствие утреннего радио"
+  },
+  "voiceTagline_mark": {
+    "description": "Авторский слоган личности для голоса «Mark» (настройки: студия голосов; клиентская карта идентичности голоса).",
+    "message": "Ясный, уверенный рассказчик"
+  },
+  "voiceTagline_nova": {
+    "description": "Авторский слоган характера для голоса «Nova» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Быстрый и любознательный"
+  },
+  "voiceTagline_onyx": {
+    "description": "Авторский слоган характера для голоса «Onyx» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Глубокая, резонансная солидность"
+  },
+  "voiceTagline_paola": {
+    "description": "Авторский слоган характера для голоса «Paola» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Выразительное итальянское тепло"
+  },
+  "voiceTagline_sage": {
+    "description": "Авторский слоган характера для голоса «Sage» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Мягкая, спокойная ясность"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Авторский слоган характера для голоса «Shimmer» (настройки: студия Voices; карта идентичности голоса на стороне клиента).",
+    "message": "Лёгкий и воздушный"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Короткая подпись на переключателе закрепления на карточке голоса (состояние выкл.) в Voices studio в настройках; нажатие добавляет голос в меню $host$ в чате.",
+    "message": "+ В меню"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Доступная подпись для переключателя закрепления на карточке голоса (состояние выкл.); $name$ — голос, $host$ — ассистент.",
+    "message": "Добавить $name$ в меню $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Подпись у переключателя на панели управления голосами, которая показывает, проигрывается ли каждый голос при перемещении по списку клавишами со стрелками, когда фокус до него доходит.",
+    "message": "Проигрывать при перемещении"
+  },
+  "voicesArrowsLive": {
+    "description": "Подтверждение для скринридера, добавляемое к первому объявлению «Воспроизводится <голос>» в списке «Голоса» в настройках: сообщает, что клавиши-стрелки только что стали озвучиваться. Повторяет формулировку переключателя «Озвучивать при перемещении».",
+    "message": "Стрелки теперь озвучивают при перемещении. Esc останавливает."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Примечание под слотами меню для хостов со встроенными нативными голосами (например, 8 встроенных голосов Pi), которыми студия не управляет; $host$ — ассистент.",
+    "message": "Встроенные голоса $host$ всегда тоже показываются в его меню.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Вариант voicesBuiltinsNote для хоста без меню голоса в чате (Pi убрал своё меню в 2026), где обещание из оригинала, что встроенные голоса «появляются в его меню», было бы неверным; $host$ — ассистент.",
+    "message": "У $host$ также есть встроенные голоса, но здесь они не перечислены.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Индикатор прогресса в панели управления «Голоса» в настройках: сколько голосов из списка пользователь уже прослушал. Только числа, чтобы корректно читалось и при 1 — в Chrome i18n нет форм множественного числа.",
+    "message": "Прослушано: $heard$ из $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Часть доступного имени строки голоса в списке «Голоса» в настройках, отмечающая голос, который этот профиль уже слушал. Визуально это показано плотностью чернил на звуковом отпечатке голоса, чего скринридер не видит.",
+    "message": "Прослушано"
+  },
+  "voicesInHostMenu": {
+    "description": "Заголовок раздела над строкой слотов меню в Voices studio в настройках; $host$ — ассистент.",
+    "message": "В меню $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Короткая подпись на переключателе закрепления на карточке голоса (состояние вкл.) в Voices studio в настройках.",
+    "message": "✓ В меню"
+  },
+  "voicesInUse": {
+    "description": "Постоянный бейдж на текущем выбранном голосе хоста в списке Voices в настройках, отображается в верхнем регистре. Намеренно НЕ «Сейчас говорит»: на этой странице строки проигрывают свои примеры, поэтому выбранный, но молчащий голос не должен утверждать, что говорит, пока говорит другая строка.",
+    "message": "Используется"
+  },
+  "voicesKeyboardHint": {
+    "description": "Однострочная подсказка по клавишам в панели управления «Голоса» в настройках. Символы — это клавиши: Space, стрелки вверх/вниз и Shift+Space.",
+    "message": "Нажмите Space, чтобы слушать, ↑↓ для перехода между голосами, ⇧Space чтобы вернуться."
+  },
+  "voicesLoadError": {
+    "description": "Состояние ошибки внутри студии одного хоста, когда не удалось загрузить каталог голосов этого хоста; $host$ — ассистент.",
+    "message": "Не удалось загрузить голоса $host$. Попробуйте позже.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Подсказка/хинт для отключённого переключателя «+ В меню», когда в меню $host$ в чате уже максимальное число голосов.",
+    "message": "Меню заполнено — удалите голос, чтобы добавить другой"
+  },
+  "voicesMenuHint": {
+    "description": "Однострочная подсказка рядом с заголовком «В меню {host}», объясняющая, что строка слотов отражает меню голосов в чате.",
+    "message": "Что вы увидите в чате"
+  },
+  "voicesMenuOverflow": {
+    "description": "Примечание под слотами меню, когда у пользователя закреплено больше голосов, чем может показать меню в чате (устаревшее состояние); $count$ — сколько не помещается, $cap$ — размер меню.",
+    "message": "Ещё $count$ закреплённых голосов ждут за пределами $cap$ мест в меню.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Единственное число для voicesMenuOverflow, используется, когда ровно один закреплённый голос не помещается в меню в чате; $cap$ — размер меню.",
+    "message": "Ещё 1 закреплённый голос ждёт за пределами $cap$ мест в меню.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Строка-сводка под списком «Голоса» в настройках, показывающая, насколько заполнено голосовое меню хоста в чате; $host$ — ассистент, $used$ — сколько мест занято, $cap$ — сколько всего. Сформулировано так, чтобы корректно читалось и при 1 — в Chrome i18n нет форм множественного числа.",
+    "message": "меню $host$: $used$ из $cap$ мест",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Заголовок группы в конце списка «Голоса» в настройках, где находятся голоса без демонстрационного фрагмента; $count$ — сколько их. Сформулировано так, чтобы корректно читалось и при 1 — в Chrome i18n нет форм множественного числа.",
+    "message": "Пока без примера ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Показывается в каталоге голосов в настройках, когда список голосов пуст для вошедшего пользователя (например, из-за проблем с сетью).",
+    "message": "Сейчас не удалось загрузить голоса. Попробуйте позже."
+  },
+  "voicesNowPlaying": {
+    "description": "Объявление для скринридера, когда начинает воспроизводиться демонстрационный фрагмент голоса в списке «Голоса» в настройках; $name$ — голос.",
+    "message": "Воспроизводится $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Кнопка в панели управления «Голоса» в настройках, которая воспроизводит каждый голос из текущего списка один за другим; $count$ — сколько их. Сформулировано так, чтобы корректно читалось и при 1 — в Chrome i18n нет форм множественного числа.",
+    "message": "Воспроизвести все ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Кнопка в панели управления «Голоса» в настройках при повторном посещении: воспроизводит только голоса из списка, которые вы ещё не слушали; $count$ — сколько их. Сформулировано так, чтобы корректно читалось и при 1 — в Chrome i18n нет форм множественного числа.",
+    "message": "Воспроизвести новые ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Строка в панели управления «Голоса» в настройках, когда браузер отказался воспроизвести пример, потому что на странице еще не было взаимодействия пользователя.",
+    "message": "Нажмите на любой голос, чтобы включить звук."
+  },
+  "voicesPreview": {
+    "description": "Доступная метка для кнопки воспроизведения (▶), которая проигрывает бесплатный пример клипа голоса в строке голоса; $name$ — имя голоса.",
+    "message": "Воспроизвести пример $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Доступное имя списка голосов в настройках (listbox всех голосов, по одной строке на каждый).",
+    "message": "Голоса, упорядоченные от самых низких до самых ярких"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Доступная подпись для переключателя закрепления на карточке голоса (состояние вкл.) и кнопки удаления слота меню; $name$ — голос, $host$ — ассистент.",
+    "message": "Убрать $name$ из меню $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Строка в панели управления «Голоса» в настройках, когда клип-пример одного голоса не удалось загрузить или воспроизвести; $name$ — этот голос. Немодально — серия примеров продолжается дальше.",
+    "message": "Не удалось воспроизвести пример $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Подзаголовок раздела каталога голосов на вкладке AI Chat в настройках.",
+    "message": "Выберите голос, который будет читать ответы вслух на каждом сайте."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Подзаголовок под заголовком настроек голосов, для ряда голосов, упорядоченных по высоте.",
+    "message": "Все голоса, от самых низких до самых ярких. Слушайте, затем выбирайте."
+  },
+  "voicesSectionTitle": {
+    "description": "Заголовок раздела каталога голосов на вкладке AI Chat в настройках.",
+    "message": "Голоса"
+  },
+  "voicesShelfEveryday": {
+    "description": "Заголовок группы голосов уровня value в каталоге голосов в настройках. Отображается в верхнем регистре с помощью CSS.",
+    "message": "Повседневные голоса"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Короткая заметка рядом с заголовком группы Everyday в студии голосов в настройках Voices; единственное место, где студия указывает, насколько дальше хватает этого уровня по сравнению с HD.",
+    "message": "Естественно и ясно — можно слушать примерно в 20× дольше, чем с HD."
+  },
+  "voicesShelfHd": {
+    "description": "Заголовок группы премиальных (HD) голосов в каталоге голосов в настройках. Отображается в верхнем регистре с помощью CSS.",
+    "message": "Голоса HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Короткая заметка рядом с заголовком группы HD в студии голосов в настройках Voices.",
+    "message": "Самое богатое и выразительное звучание."
+  },
+  "voicesShowAll": {
+    "description": "Вариант в фильтре «Показывать» раздела «Голоса» в настройках: без фильтрации, перечислены все голоса.",
+    "message": "Все голоса"
+  },
+  "voicesShowEveryday": {
+    "description": "Вариант в фильтре «Показывать» раздела «Голоса» в настройках: показывать только стандартные (не HD) голоса.",
+    "message": "Только обычные"
+  },
+  "voicesShowHd": {
+    "description": "Вариант в фильтре «Показывать» раздела «Голоса» в настройках: показывать только премиальные (HD) голоса.",
+    "message": "Только HD"
+  },
+  "voicesShowLabel": {
+    "description": "Подпись у фильтра в панели управления «Голоса» в настройках, который сужает список отображаемых голосов.",
+    "message": "Показывать"
+  },
+  "voicesShowUnheard": {
+    "description": "Вариант в фильтре «Показывать» раздела «Голоса» в настройках: показывать только голоса, которые пользователь еще не слушал.",
+    "message": "Еще не прослушанные"
+  },
+  "voicesSpeakingNow": {
+    "description": "Метка состояния на текущем выбранном голосе хоста в Voices studio в настройках (слот меню и карточка голоса).",
+    "message": "Сейчас говорит"
+  },
+  "voicesSpeaksWith": {
+    "description": "Строка-«надбровка» над названием текущего голоса на сцене Voices studio в настройках; $host$ — ассистент (например, Pi). Отображается в верхнем регистре через CSS.",
+    "message": "$host$ говорит голосом",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Примечание на сцене, когда хост воспроизводит свой собственный звук (например, Pi), поэтому выбор голоса Say, Pi заменяет голос хоста.",
+    "message": "$host$ использует свой голос, пока вы не выберете один ниже.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Примечание на сцене, когда у хоста нет собственного голоса (например, Claude), поэтому ничего не читается вслух, пока не выбран голос Say, Pi.",
+    "message": "$host$ не будет читать ответы вслух, пока вы не выберете один ниже.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Заголовок на сцене студии голосов в настройках, когда для хоста не выбран голос SayPi; $host$ — ассистент (например, Pi, Claude). Отрисовывается размером имени.",
+    "message": "Выберите, как звучит $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Кнопка на сцене студии голосов в настройках, которая проигрывает бесплатный пример текущего голоса.",
+    "message": "Прослушать пример"
+  },
+  "voicesStopPlayback": {
+    "description": "Кнопка в панели управления «Голоса» в настройках, которая останавливает последовательное воспроизведение примеров, запущенное «Воспроизвести все».",
+    "message": "Остановить"
+  },
+  "voicesSweepPosition": {
+    "description": "Индикатор текущей позиции в панели управления «Голоса» в настройках, пока «Воспроизвести все» проходит по списку; $index$ — голос, который сейчас звучит, а $total$ — сколько всего в очереди.",
+    "message": "$index$ из $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Доступная метка для элемента сравнения в панели управления «Голоса» в настройках, который воспроизводит другой голос из последних двух прослушанных; $name$ — это тот голос.",
+    "message": "Вернуться к $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Строка в панели управления «Голоса» в настройках, когда «Воспроизвести все» нажато для слишком длинного списка; $count$ — сколько голосов, а $minutes$ — примерно сколько минут это займет. Сокращение «мин», чтобы корректно читалось при 1 — у Chrome i18n нет форм множественного числа.",
+    "message": "Это $count$ голосов — примерно $minutes$ мин. Сначала сузьте список.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Доступная подпись для кнопки «использовать этот голос» для конкретного хоста в каталоге голосов в настройках; $name$ — голос, $host$ — ассистент (например, Pi, Claude).",
+    "message": "Использовать $name$ в $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Короткая подпись на кнопке «использовать этот голос» для конкретного хоста в общем каталоге голосов в настройках (хост показывается рядом).",
+    "message": "Использовать"
+  },
+  "voicesYourVoice": {
+    "description": "Кнопка в панели управления в списке «Голоса» в настройках, которая переводит фокус на строку голоса, который сейчас использует этот хост; $name$ — это тот голос.",
+    "message": "Ваш голос: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Ошибка, возникающая, когда браузер не может выделить достаточно памяти WebAssembly для модели распознавания голоса.",
+    "message": "Распознавание голоса не может запуститься: недостаточно памяти WebAssembly для голосовой модели. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Ошибка, возникающая, когда браузер не предоставляет начальную память WebAssembly, необходимую для запуска модели распознавания голоса.",
+    "message": "Распознавание голоса не может запуститься: в этом браузере недоступна память WebAssembly."
   }
 }

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Výhoda uvedená v auth modale – zvýšené limity používania.",
+    "message": "Vyššie limity používania s bezplatným účtom"
+  },
+  "authBenefitPremium": {
+    "description": "Výhoda uvedená v auth modale – prémiové funkcie naprieč chatbotmi.",
+    "message": "Prémiové funkcie a podpora chatbotov"
+  },
+  "authBenefitSupport": {
+    "description": "Výhoda uvedená v auth modale – prioritná podpora.",
+    "message": "Prioritná podpora pri problémoch"
+  },
+  "authBenefitSync": {
+    "description": "Výhoda uvedená v auth modale – synchronizácia nastavení.",
+    "message": "Synchronizujte nastavenia hlasu všade"
+  },
+  "authBenefitTTS": {
+    "description": "Výhoda uvedená v auth modale – funkcia TTS.",
+    "message": "Hlasy prevodu textu na reč (platené plány)"
+  },
+  "authBenefitUsage": {
+    "description": "Výhoda uvedená v auth modale – sledovanie používania.",
+    "message": "Sledujte používanie hlasu na všetkých zariadeniach"
+  },
+  "authPromptModalFull": {
+    "description": "Popis pre plnú modálnu výzvu na prihlásenie s hodnotovou ponukou.",
+    "message": "Say, Pi už používate naplno. Prihláste sa pre vyššie limity, hlasy prevodu textu na reč a prémiové funkcie vo všetkých podporovaných chatbotov."
+  },
+  "authPromptModalSoft": {
+    "description": "Popis pre jemnú modálnu výzvu na prihlásenie.",
+    "message": "Vytvorte si bezplatný účet Say, Pi pre vyššie limity používania a prístup k prémiovým hlasovým funkciám."
+  },
+  "authPromptTitle": {
+    "description": "Nadpis modálneho okna s výzvou na prihlásenie.",
+    "message": "Odomknite viac hlasových funkcií"
+  },
+  "authPromptToast": {
+    "description": "Toast notifikácia, ktorá povzbudzuje používateľa, aby sa prihlásil.",
+    "message": "Prihláste sa do Say, Pi pre vyššie limity a prémiové funkcie"
+  },
   "autoReadAloudChatGPT": {
     "description": "Popis za zaškrtávacie políčko na povolenie alebo zakázanie automatického čítania odpovedí ChatGPT počas hlasových hovorov.",
     "message": "Automatické čítanie nahlas (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Zakázať text-reč"
   },
+  "dismiss": {
+    "message": "Rozumiem",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Zamietnuť"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Zamerať sa"
   },
+  "errorVadInitFailed": {
+    "description": "Chybový toast zobrazený, keď sa nepodarí inicializovať detekciu hlasovej aktivity.",
+    "message": "Nepodarilo sa inicializovať detekciu hlasu"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Chybový toast zobrazený, keď dôjde k neočakávanej chybe počas nastavovania hlasového nahrávania.",
+    "message": "Nepodarilo sa nastaviť hlasové nahrávanie"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Chybový toast zobrazený, keď sa klientovi detekcie hlasu nepodarí spustiť nahrávanie.",
+    "message": "Nepodarilo sa spustiť hlasové nahrávanie"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Chybový toast zobrazený, keď nie je dostupný klient detekcie hlasu (VAD), takže nahrávanie sa nemôže spustiť.",
+    "message": "Hlasové nahrávanie nie je dostupné"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Opustiť režim sústredenia"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Jednoriadková poznámka zobrazená v ponukách hlasu, keď sú dostupné prémiové (HD) aj výhodné hlasy",
+    "message": "Hlasy v HD míňajú váš mesačný limit asi 20× rýchlejšie."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "To zastrčenie ..."
   },
+  "maybeLater": {
+    "description": "Text tlačidla na zrušenie výzvy na prihlásenie.",
+    "message": "Možno neskôr"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Nastavenia mikrofónu nespĺňajú požadované špecifikácie. \nSkúste použiť iný mikrofón alebo upravte nastavenia zvuku."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Nedá sa získať prístup k mikrofónu. \nSkontrolujte nastavenia zariadenia a skúste to znova."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Chybový toast zobrazený, keď bolo povolenie mikrofónu zamietnuté po procese výzvy na povolenie.",
+    "message": "Povolenie mikrofónu nebolo udelené. Uistite sa, že ste povolili prístup vo výzve aj v nastaveniach rozšírenia."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "presnosť"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Najrýchlejšia odozva, ale menej presná. \nSklon k prerušovaniu."
   },
+  "moreVoices": {
+    "description": "Riadok menu, ktorý odkazuje z hlasového menu na stránke na celý katalóg hlasov v nastaveniach rozšírenia",
+    "message": "Ďalšie hlasy…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Prezývka asistenta"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Nie podpísané"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Názov tlačidla, ktoré otvorí ChatGPT.",
+    "message": "Otvoriť ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Popis tlačidla, ktoré otvorí Claude.ai.",
+    "message": "Otvoriť Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Popis tlačidla, ktoré otvorí Pi.ai.",
+    "message": "Otvoriť Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Možnosť prostredia: okolo iných ľudí.",
+    "message": "V prítomnosti iných ľudí"
+  },
+  "onboarding_envMixed": {
+    "description": "Možnosť prostredia: mix súkromných a zdieľaných priestorov.",
+    "message": "Striedanie miest"
+  },
+  "onboarding_envPrivate": {
+    "description": "Možnosť prostredia: súkromný priestor.",
+    "message": "Niekde v súkromí"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Potvrdenie zobrazené, keď odpoveď o prostredí nechá tichý režim vypnutý.",
+    "message": "Dobre, ponecháme štandardné nastavenia počúvania a prehrávania."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Potvrdenie zobrazené vtedy, keď odpoveď o prostredí zapne tichý režim.",
+    "message": "Tichý režim je zapnutý — zachytíme aj tichšiu reč a odpovieme potichu, aby si sa mohol rozprávať diskrétne."
+  },
+  "onboarding_envTitle": {
+    "description": "Nadpis otázky v úvodnom sprievodcovi o prostredí používateľa.",
+    "message": "Kde sa budeš zvyčajne rozprávať?"
+  },
+  "onboarding_footer": {
+    "description": "Text v pätičke na stránke úvodného sprievodcu pri prvom spustení.",
+    "message": "K tomuto sa môžeš kedykoľvek vrátiť v nastaveniach Say, Pi. Na tvojom súkromí záleží — zvuk sa zachytáva iba počas aktívneho hovoru."
+  },
+  "onboarding_heading": {
+    "description": "Hlavný nadpis na úvodnej stránke pri prvom spustení.",
+    "message": "🗣️ Vitajte v Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Úvodný odsek na úvodnej stránke pri prvom spustení.",
+    "message": "Od prvého hovoreného rozhovoru s AI vás delia dva kroky. Hovorenie je asi 3× rýchlejšie než písanie — poďme to nastaviť."
+  },
+  "onboarding_micTestButton": {
+    "description": "Tlačidlo, ktoré spustí nezáväzný test mikrofónu v úvodnom sprievodcovi.",
+    "message": "🎤 Otestovať mikrofón"
+  },
+  "onboarding_micTestDone": {
+    "description": "Stav zobrazený po úspešnom dokončení testu mikrofónu v úvodnom sprievodcovi.",
+    "message": "Super — mikrofón funguje! 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Stav zobrazený počas toho, ako test mikrofónu v úvodnom sprievodcovi meria vstup.",
+    "message": "Počúvam — povedz niečo! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Stav zobrazený počas toho, ako test mikrofónu v úvodnom sprievodcovi čaká na povolenie.",
+    "message": "Žiada sa o prístup k mikrofónu…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Názov tlačidla na zastavenie testu mikrofónu v úvodnom sprievodcovi, kým beží.",
+    "message": "Zastaviť test"
+  },
+  "onboarding_step1Body": {
+    "description": "Text prvého kroku úvodného nastavenia, ktorý vysvetľuje, ako pripnúť rozšírenie.",
+    "message": "Kliknite na ikonu dielika skladačky 🧩 vpravo hore v prehliadači a potom na pripináčik 📌 vedľa Say, Pi. Vďaka tomu bude tlačidlo hovoru na jeden klik."
+  },
+  "onboarding_step1Title": {
+    "description": "Názov prvého kroku úvodného nastavenia (pripnutie rozšírenia).",
+    "message": "Pripnite si Say, Pi na panel nástrojov"
+  },
+  "onboarding_step2Body": {
+    "description": "Text druhého kroku úvodného nastavenia, ktorý vysvetľuje, ako začať hlasový rozhovor.",
+    "message": "Prejdite na jedného z podporovaných asistentov nižšie, potom ťuknite na tlačidlo hovoru Say, Pi a pozdravte. Prvýkrát si vyžiadame prístup k mikrofónu — je to v poriadku a počúvame len vtedy, keď ste aktívne v hovore."
+  },
+  "onboarding_step2Title": {
+    "description": "Názov druhého kroku úvodného nastavenia (začatie konverzácie).",
+    "message": "Otvorte chat s AI a začnite rozprávať"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Mikrofón"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Pokyny na obnovu, keď je povolenie mikrofónu zablokované.",
+    "message": "Váš prehliadač blokuje mikrofón. Kliknite na ikonu kamery alebo zámku v paneli s adresou, nastavte Mikrofón na „Povoliť“ a potom to skúste znova. V macOS skontrolujte aj Systémové nastavenia → Súkromie a zabezpečenie → Mikrofón."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Názov panela obnovy, keď bolo povolenie mikrofónu zamietnuté/zablokované.",
+    "message": "Prístup k mikrofónu je zablokovaný"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Pokyny na obnovu, keď sa mikrofón používa inde.",
+    "message": "Váš mikrofón môže používať iná aplikácia alebo karta. Zatvorte všetko, čo by mohlo nahrávať (videohovory, hlasové poznámky), a potom to skúste znova."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Názov panela obnovy, keď mikrofón používa iná aplikácia.",
+    "message": "Váš mikrofón sa používa"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Pokyny na obnovu, keď nie je k dispozícii žiadne zariadenie mikrofónu.",
+    "message": "Nenašli sme mikrofón. Pripojte ho (alebo pripojte slúchadlá s mikrofónom), uistite sa, že je vybraný ako vstupné zariadenie, a potom to skúste znova."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Názov panela obnovy, keď nie je k dispozícii žiadne zariadenie mikrofónu.",
+    "message": "Nenašiel sa žiadny mikrofón"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Pokyny na obnovu pri neznámej chybe mikrofónu.",
+    "message": "Pri prístupe k mikrofónu sa niečo pokazilo. Skontrolujte, či je pripojený a povolený v nastaveniach prehliadača, a potom to skúste znova."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Názov panela obnovy pri neznámej chybe mikrofónu.",
+    "message": "Nepodarilo sa nám získať prístup k vášmu mikrofónu"
+  },
+  "permissions_retryButton": {
+    "description": "Popis tlačidla, ktoré znovu požiada o povolenie mikrofónu.",
+    "message": "Skúsiť znova"
+  },
+  "permissions_revokedHeading": {
+    "description": "Nadpis zobrazený, keď bol prístup k mikrofónu predtým udelený, ale neskôr bol odobratý.",
+    "message": "🎙️ Znova pripojme váš mikrofón"
+  },
+  "permissions_revokedInfo": {
+    "description": "Informačný text zobrazený, keď bol prístup k mikrofónu odobratý po tom, čo bol udelený.",
+    "message": "Prístup k mikrofónu bol vypnutý — často sa to stáva po aktualizácii prehliadača alebo systému. Znova ho povoľte nižšie a $productName$ bude pri hovore opäť počúvať.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Označenie prepínača, ktorý zapína tichý/šepkací režim.",
+    "message": "Tichý režim"
+  },
+  "quietModeTooltip": {
+    "description": "Pomocný popis vysvetľujúci, čo robí tichý/šepkací režim.",
+    "message": "Hovorí jemnejšie — zachytí tichšiu reč a zníži hlasitosť odpovede asistenta, aby ste mohli používať hlas medzi ľuďmi."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Text na tlačidle prihlásenia počas prebiehajúceho overovania.",
+    "message": "Prihlasujem..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Zvukové efekty"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Zvukové efekty sú vo Firefoxe zakázané, aby sa predišlo problémom so spätnou väzbou."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Nadpis jednorazového oznámenia o časovej úspore zobrazeného po prvej hovorenej výmene.",
+    "message": "Fajn — rozprávanie je asi 3× rýchlejšie než písanie."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Voliteľný druhý riadok oznámenia o časovej úspore zobrazujúci počet ušetrených celých minút.",
+    "message": "Už ste ušetrili približne $minutes$ min oproti písaniu.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Odošlite iba vtedy, keď stlačíte tlačidlo"
   },
+  "surveyQuestion": {
+    "description": "Jediná otázka jednorazového mikroprieskumu po úspešnom použití.",
+    "message": "Ako vám zatiaľ funguje hlas?"
+  },
+  "surveyRatingLabel": {
+    "description": "Prístupný štítok pre tlačidlo hodnotenia v prieskume.",
+    "message": "Ohodnoťte $rating$ z 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Poďakovanie zobrazené po tom, ako používateľ odpovie na prieskum po úspešnom použití.",
+    "message": "Ďakujeme — pomáha nám to zlepšovať Say, Pi."
+  },
   "tabAIChat": {
     "description": "Označenie záložky pre sekciu nastavení AI chatu.",
     "message": "AI Chat"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Označenie záložky pre sekciu všeobecných nastavení.",
     "message": "Všeobecné"
+  },
+  "tabVoices": {
+    "description": "Popisok karty pre sekciu nastavení hlasov (katalóg hlasov podľa webu).",
+    "message": "Hlasy"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "kredity"
   },
+  "ttsCreditsRemaining": {
+    "description": "Text zobrazujúci zostávajúcu kvótu TTS ako fond kreditov na hlas (saypi-api #181 Stage 2), nie ako počet znakov.",
+    "message": "Zostáva $credits$ kreditov",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "V Safari momentálne nie sú podporované viacjazyčné hlasy."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Generácia hlasu"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Pozor! Prehrávanie reči ešte nie je k dispozícii na $browserName$ s $chatbotName$. Dobrá správa? Hlasový vstup funguje skvelé! Pre TTS vyskúšajte Chrome alebo Edge na pracovnej ploche.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS nie je k dispozícii na $browserName$ + $chatbotName$. Hlasový vstup funguje! Vyskúšajte Chrome na pracovnej ploche pre TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS hlas"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Detail VAD, keď bol zistený zvuk podobný reči, ale bol príliš tichý / s nízkou mierou istoty na prepis (zahodené na strane klienta pri vstupnej kontrole).",
+    "message": "Zvuk je príliš tichý na prepis"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Detail VAD vysvetľujúci, že hovor sa skončil, pretože mikrofón si prevzala novšia karta.",
+    "message": "Hlasový vstup bol presunutý do inej karty"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Hlas nie je k dispozícii. \nVyskúšajte Chrome alebo Firefox na pracovnej ploche."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Pozor! Prehrávanie reči ešte nie je k dispozícii na $browserName$ s $chatbotName$. Dobrá správa? Hlasový vstup funguje skvelé! Pre TTS vyskúšajte Chrome alebo Edge na pracovnej ploche.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS nie je k dispozícii na $browserName$ + $chatbotName$. Hlasový vstup funguje! Vyskúšajte Chrome na pracovnej ploche pre TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Rozumiem",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Stav VAD zobrazený na karte, ktorej hlasový vstup prevzala iná karta.",
+    "message": "Pozastavené"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Zobraziť podrobnosti"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Všeobecné hovorené predstavenie prehrané vtedy, keď vybraný hlas SayPi nemá vlastný úvodný skript (a nie je ani žiadna nedávna správa na prečítanie).",
+    "message": "Ahoj, som $voice$. Takto zniem. Dúfam, že sa ti tento hlas bude páčiť.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Ahoj! \nПривет! \n你好! \nSom Pi, váš polyglot AI asistent. \nS 32 jazykmi, ktoré ovládam, môžeme skúmať myšlienky a kultúry z celého sveta. \nČo si myslíte o tomto hlase?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Nastavenia hlasu"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Núdzový podtitulok pre riadok hlasu v katalógu hlasov v nastaveniach, keď hlas nemá popis; $count$ je počet jazykov, ktoré hlas podporuje.",
+    "message": "Hovorí $count$ jazykmi",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Autorský slogan osobnosti pre hlas „Addison“ (nastavenia: štúdio Hlasy; mapovanie identity hlasu na strane klienta).",
+    "message": "Slnečná a výrečná"
+  },
+  "voiceTagline_alloy": {
+    "description": "Autorské sloganové vyjadrenie osobnosti pre hlas „Alloy“ (štúdio Hlasov v nastaveniach; mapovanie identity hlasu na strane klienta).",
+    "message": "Vyvážený a univerzálny"
+  },
+  "voiceTagline_ash": {
+    "description": "Autorské sloganové vyjadrenie osobnosti pre hlas „Ash“ (štúdio Hlasov v nastaveniach; mapovanie identity hlasu na strane klienta).",
+    "message": "Nízky, premýšľavý, pokojný"
+  },
+  "voiceTagline_ballad": {
+    "description": "Autorské sloganové vyjadrenie osobnosti pre hlas „Ballad“ (štúdio Hlasov v nastaveniach; mapovanie identity hlasu na strane klienta).",
+    "message": "Jemný a melodický"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Autorský slogan osobnosti pre hlas „Cassidy“ (nastavenia: štúdio Hlasy; mapovanie identity hlasu na strane klienta).",
+    "message": "Priateľská a vecná"
+  },
+  "voiceTagline_cedar": {
+    "description": "Autorský slogan osobnosti pre hlas „Cedar“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Pokojný a upokojujúci"
+  },
+  "voiceTagline_coral": {
+    "description": "Autorský slogan osobnosti pre hlas „Coral“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Jasná, povzbudivá energia"
+  },
+  "voiceTagline_echo": {
+    "description": "Autorský slogan osobnosti pre hlas „Echo“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Čistý a neutrálny"
+  },
+  "voiceTagline_fable": {
+    "description": "Autorský slogan osobnosti pre hlas „Fable“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Rozprávačský šarm"
+  },
+  "voiceTagline_finn": {
+    "description": "Autorský slogan osobnosti pre hlas „Finn“ (nastavenia: štúdio Hlasy; mapovanie identity hlasu na strane klienta).",
+    "message": "Svieži a energický"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Autorský slogan osobnosti pre hlas „Jamahal“ (nastavenia: štúdio Hlasy; mapovanie identity hlasu na strane klienta).",
+    "message": "Bohatý a príťažlivý"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Autorský slogan osobnosti pre hlas „Jarnathan“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Zamatový nočný barytón"
+  },
+  "voiceTagline_jeff": {
+    "description": "Autorský slogan osobnosti pre hlas „Jeff“ (nastavenia: štúdio Hlasy; mapovanie identity hlasu na strane klienta).",
+    "message": "Priamočiary a vyrovnaný"
+  },
+  "voiceTagline_jessica": {
+    "description": "Autorský slogan osobnosti pre hlas „Jessica“ (nastavenia: štúdio Hlasy; mapovanie identity hlasu na strane klienta).",
+    "message": "Vrelá, uhladená elegancia"
+  },
+  "voiceTagline_joey": {
+    "description": "Autorský slogan osobnosti pre hlas „Joey“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Nenútená americká konverzácia"
+  },
+  "voiceTagline_juniper": {
+    "description": "Autorský slogan osobnosti pre hlas „Juniper“ (nastavenia: štúdio Hlasy; mapovanie identity hlasu na strane klienta).",
+    "message": "Čistý, jasný, živý"
+  },
+  "voiceTagline_lucy": {
+    "description": "Autorský slogan osobnosti pre hlas „Lucy“ (nastavenia: štúdio Hlasy; mapovanie identity hlasu na strane klienta).",
+    "message": "Jemná a žiarivá"
+  },
+  "voiceTagline_marin": {
+    "description": "Autorský slogan osobnosti pre hlas „Marin“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Teplý pokoj ranného rádia"
+  },
+  "voiceTagline_mark": {
+    "description": "Autorský slogan osobnosti pre hlas „Mark“ (nastavenia: štúdio Hlasy; mapovanie identity hlasu na strane klienta).",
+    "message": "Jasný, sebavedomý rozprávač"
+  },
+  "voiceTagline_nova": {
+    "description": "Autorský slogan osobnosti pre hlas „Nova“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Rýchly a zvedavý"
+  },
+  "voiceTagline_onyx": {
+    "description": "Autorský slogan osobnosti pre hlas „Onyx“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Hlboká, rezonujúca vážnosť"
+  },
+  "voiceTagline_paola": {
+    "description": "Autorský slogan osobnosti pre hlas „Paola“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Výrazná talianska srdečnosť"
+  },
+  "voiceTagline_sage": {
+    "description": "Autorský slogan osobnosti pre hlas „Sage“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Jemná, zrozumiteľná jasnosť"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Autorský slogan osobnosti pre hlas „Shimmer“ (nastavenia Voices studio; klientská mapa identity hlasu).",
+    "message": "Ľahký a vzdušný"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Krátky štítok na prepínači pripnutia na karte hlasu (vypnutý stav) v štúdiu Hlasov v nastaveniach; stlačením sa hlas pridá do ponuky v chate pre daného asistenta.",
+    "message": "+ Ponuka"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Prístupný štítok pre prepínač pripnutia na karte hlasu (vypnutý stav); $name$ je hlas, $host$ je asistent.",
+    "message": "Pridať $name$ do ponuky asistenta $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Popis pri prepínači v ovládacej lište Hlasov, ktorý hovorí, či prechádzanie zoznamom šípkami prehrá každý hlas, keď sa naň presunie fokus.",
+    "message": "Prehrávať pri prechádzaní"
+  },
+  "voicesArrowsLive": {
+    "description": "Potvrdenie pre čítačku obrazovky, pripojené k prvému oznámeniu „Prehráva sa <hlas>“ v zozname Hlasov v nastaveniach, že šípkové klávesy sa práve stali počuteľnými. Nadväzuje na znenie prepínača „Prehrávať počas presunu“.",
+    "message": "Šípky teraz prehrávajú počas presunu. Esc zastaví."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Poznámka pod miestami v ponuke pre hostiteľov, ktorí majú natívne hlasy (napr. 8 vstavaných hlasov Pi), ktoré štúdio nespravuje; $host$ je asistent.",
+    "message": "V ponuke sa vždy zobrazujú aj vstavané hlasy od $host$.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variant voicesBuiltinsNote pre hostiteľa bez hlasovej ponuky v chate (Pi v roku 2026 zrušil ponuku), kde by pôvodný sľub, že vstavané hlasy „sa zobrazujú v jeho ponuke“, neplatil; $host$ je asistent.",
+    "message": "$host$ má aj vlastné vstavané hlasy, ktoré tu nie sú uvedené.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Zobrazenie postupu v ovládacom paneli Hlasov v nastaveniach: koľko z uvedených hlasov si používateľ už vypočul. Holé čísla, aby to znelo správne aj pri 1 — Chrome i18n nemá tvary množného čísla.",
+    "message": "Vypočuté: $heard$ z $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Súčasť prístupného názvu riadku hlasu v zozname Hlasov v nastaveniach, označuje hlas, ktorý si tento profil už vypočul. Vizuálne je to zobrazené ako hustota atramentu na zvukovej stope hlasu, čo čítačka obrazovky nevie vidieť.",
+    "message": "Vypočuté"
+  },
+  "voicesInHostMenu": {
+    "description": "Nadpis sekcie nad riadkom slotov ponuky v štúdiu Hlasov v nastaveniach; $host$ je asistent.",
+    "message": "V ponuke asistenta $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Krátky štítok na prepínači pripnutia na karte hlasu (zapnutý stav) v štúdiu Hlasov v nastaveniach.",
+    "message": "✓ V ponuke"
+  },
+  "voicesInUse": {
+    "description": "Trvalý odznak na aktuálne vybranom hlase hostiteľa v zozname Hlasov v nastaveniach, zobrazený veľkými písmenami. Zámerne NIE „Práve hovorí“: na tejto stránke riadky prehrávajú ukážky, takže vybraný, ale tichý hlas nesmie tvrdiť, že hovorí, kým iný riadok hrá.",
+    "message": "Používa sa"
+  },
+  "voicesKeyboardHint": {
+    "description": "Jednoriadková klávesová nápoveda v ovládacom paneli Hlasov v nastaveniach. Symboly sú klávesy: medzerník, šípky hore/dole a Shift+medzerník.",
+    "message": "Stlačte medzerník na počúvanie, ↑↓ na prechod medzi hlasmi, ⇧Medzerník na prepnutie späť."
+  },
+  "voicesLoadError": {
+    "description": "Chybový stav v štúdiu jedného hostiteľa, keď sa nepodarilo načítať katalóg hlasov tohto hostiteľa; $host$ je asistent.",
+    "message": "Nepodarilo sa načítať hlasy pre $host$. Skúste to neskôr.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Pomocný text/nápoveda pri deaktivovanom prepínači „+ Ponuka“, keď má ponuka hlasov v chate pre daného asistenta už maximálny počet hlasov.",
+    "message": "Ponuka je plná, odstráňte hlas a pridajte iný"
+  },
+  "voicesMenuHint": {
+    "description": "Jednoriadková nápoveda vedľa nadpisu „V ponuke asistenta {host}“, ktorá vysvetľuje, že riadok slotov zodpovedá hlasovej ponuke v chate.",
+    "message": "Čo uvidíte v chate"
+  },
+  "voicesMenuOverflow": {
+    "description": "Poznámka pod miestami v ponuke, keď má používateľ viac pripnutých hlasov, než dokáže zobraziť ponuka v chate (legacy stav); $count$ je počet tých, ktoré sa nezmestia, $cap$ je veľkosť ponuky.",
+    "message": "Ďalších pripnutých hlasov $count$ čaká mimo $cap$ miest v ponuke.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Jednotné číslo pre voicesMenuOverflow, používa sa, keď sa do ponuky v chate nezmestí presne jeden pripnutý hlas; $cap$ je veľkosť ponuky.",
+    "message": "1 ďalší pripnutý hlas čaká mimo $cap$ miest v ponuke.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Súhrnný riadok pod zoznamom Hlasov v nastaveniach, ktorý hovorí, koľko miesta je obsadeného v hlasovom menu hostiteľa v chate; $host$ je asistent, $used$ je počet obsadených miest, $cap$ je celkový počet. Formulované tak, aby to znelo správne aj pri 1 — Chrome i18n nemá tvary množného čísla.",
+    "message": "Menu pre $host$: $used$ z $cap$ miest",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Nadpis skupiny na konci zoznamu Hlasov v nastaveniach, ktorá obsahuje hlasy bez ukážkového klipu na prehranie; $count$ je počet. Formulované tak, aby to znelo správne aj pri 1 — Chrome i18n nemá tvary množného čísla.",
+    "message": "Zatiaľ bez ukážky ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Zobrazuje sa v katalógu hlasov v nastaveniach, keď je zoznam hlasov prázdny pre prihláseného používateľa (napr. problém so sieťou).",
+    "message": "Hlasy sa teraz nepodarilo načítať. Skúste to znova neskôr."
+  },
+  "voicesNowPlaying": {
+    "description": "Oznámenie čítačky obrazovky, keď sa v zozname Hlasov v nastaveniach začne prehrávať ukážkový klip hlasu; $name$ je hlas.",
+    "message": "Prehráva sa $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Tlačidlo v ovládacom paneli Hlasov v nastaveniach, ktoré prehrá všetky práve uvedené hlasy, jeden po druhom; $count$ je počet. Formulované tak, aby to znelo správne aj pri 1 — Chrome i18n nemá tvary množného čísla.",
+    "message": "Prehrať všetko ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Tlačidlo v ovládacom paneli Hlasov v nastaveniach pri návrate: prehrá iba uvedené hlasy, ktoré ste si ešte nevypočuli; $count$ je počet. Formulované tak, aby to znelo správne aj pri 1 — Chrome i18n nemá tvary množného čísla.",
+    "message": "Prehrať nové ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Riadok v ovládacom paneli Hlasov v nastaveniach, keď prehliadač odmietol prehrať ukážku, pretože stránka ešte nemala žiadnu interakciu od používateľa.",
+    "message": "Kliknite na ľubovoľný hlas, aby sa zapol zvuk."
+  },
+  "voicesPreview": {
+    "description": "Prístupný popis pre tlačidlo prehratia (▶), ktoré prehrá bezplatnú ukážku hlasu v riadku hlasu; $name$ je názov hlasu.",
+    "message": "Prehrať ukážku hlasu $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Prístupný názov zoznamu Hlasov v nastaveniach (listbox všetkých hlasov, jeden riadok na hlas).",
+    "message": "Hlasy zoradené od najhlbších po najjasnejšie"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Prístupný štítok pre prepínač pripnutia na karte hlasu (zapnutý stav) a pre tlačidlo odstránenia slotu v ponuke; $name$ je hlas, $host$ je asistent.",
+    "message": "Odstrániť $name$ z ponuky asistenta $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Riadok v ovládacom paneli Hlasov v nastaveniach, keď sa nepodarilo načítať alebo prehrať ukážku jedného hlasu; $name$ je daný hlas. Nemodálne — prehrávanie série ukážok pokračuje ďalej.",
+    "message": "Nepodarilo sa prehrať ukážku hlasu $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Podnadpis sekcie katalógu hlasov v nastaveniach na karte AI Chat",
+    "message": "Vyberte hlas, ktorý na každej stránke číta odpovede nahlas."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Podnadpis pod nadpisom nastavení Hlasov, pre lištu hlasov zoradenú podľa výšky.",
+    "message": "Všetky hlasy, od najhlbších po najjasnejšie. Vypočujte si a vyberte."
+  },
+  "voicesSectionTitle": {
+    "description": "Nadpis sekcie katalógu hlasov v nastaveniach na karte AI Chat",
+    "message": "Hlasy"
+  },
+  "voicesShelfEveryday": {
+    "description": "Nadpis skupiny hlasov výhodnejšej úrovne v katalógu hlasov v nastaveniach. CSS ho vykresľuje veľkými písmenami.",
+    "message": "Každodenné hlasy"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Jednoriadková poznámka vedľa nadpisu skupiny Každodenné hlasy v štúdiu Hlasy v nastaveniach; jediné miesto, kde štúdio uvádza, o koľko ďalej siaha táto úroveň oproti HD.",
+    "message": "Prirodzené a jasné — môžete počúvať asi 20× dlhšie než s HD."
+  },
+  "voicesShelfHd": {
+    "description": "Nadpis skupiny prémiových (HD) hlasov v katalógu hlasov v nastaveniach. CSS ho vykresľuje veľkými písmenami.",
+    "message": "HD hlasy"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Jednoriadková poznámka vedľa nadpisu skupiny HD v štúdiu Hlasy v nastaveniach.",
+    "message": "Náš najbohatší a najvýraznejší zvuk."
+  },
+  "voicesShowAll": {
+    "description": "Možnosť vo filtri „Zobraziť“ v nastaveniach Hlasov: bez filtrovania, zobrazia sa všetky hlasy.",
+    "message": "Všetky hlasy"
+  },
+  "voicesShowEveryday": {
+    "description": "Možnosť vo filtri „Zobraziť“ v nastaveniach Hlasov: zobrazí len štandardné (nie HD) hlasy.",
+    "message": "Len bežné"
+  },
+  "voicesShowHd": {
+    "description": "Možnosť vo filtri „Zobraziť“ v nastaveniach Hlasov: zobrazí len prémiové (HD) hlasy.",
+    "message": "Len HD"
+  },
+  "voicesShowLabel": {
+    "description": "Štítok pri filtri v ovládacom paneli Hlasov v nastaveniach, ktorý zužuje, ktoré hlasy sa zobrazia v zozname.",
+    "message": "Zobraziť"
+  },
+  "voicesShowUnheard": {
+    "description": "Možnosť vo filtri „Zobraziť“ v nastaveniach Hlasov: zobrazí len hlasy, ktoré si používateľ ešte nevypočul.",
+    "message": "Ešte nevypočuté"
+  },
+  "voicesSpeakingNow": {
+    "description": "Štítok stavu na aktuálne vybranom hlase hostiteľa v štúdiu Hlasov v nastaveniach (v položke menu aj na karte hlasu).",
+    "message": "Práve hovorí"
+  },
+  "voicesSpeaksWith": {
+    "description": "Riadok nad názvom aktuálneho hlasu na scéne štúdia Hlasov v nastaveniach; $host$ je asistent (napr. Pi). CSS to zobrazuje veľkými písmenami.",
+    "message": "$host$ hovorí hlasom",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Poznámka na scéne, keď hostiteľ poskytuje vlastný zvuk (napr. Pi), takže výber hlasu Say, Pi nahradí hlas hostiteľa.",
+    "message": "$host$ používa vlastný hlas, kým si nevyberiete jeden nižšie.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Poznámka na scéne, keď hostiteľ nemá vlastný hlas (napr. Claude), takže sa nič nečíta nahlas, kým sa nezvolí hlas Say, Pi.",
+    "message": "$host$ nebude čítať odpovede nahlas, kým si nevyberiete jeden nižšie.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Nadpis na scéne štúdia hlasov v nastaveniach, keď hostiteľ nemá vybraný hlas Say, Pi; $host$ je asistent (napr. Pi, Claude). Zobrazuje sa veľkosťou písma ako meno.",
+    "message": "Vyberte, ako znie $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Tlačidlo na scéne štúdia hlasov v nastaveniach, ktoré prehrá bezplatnú ukážku aktuálneho hlasu.",
+    "message": "Vypočuť ukážku"
+  },
+  "voicesStopPlayback": {
+    "description": "Tlačidlo v ovládacom paneli Hlasov v nastaveniach, ktoré zastaví sériu ukážok spustenú cez „Prehrať všetko“.",
+    "message": "Zastaviť"
+  },
+  "voicesSweepPosition": {
+    "description": "Živé zobrazenie pozície v ovládacom paneli Hlasov v nastaveniach počas prehrávania „Prehrať všetko“; $index$ je hlas, ktorý práve hrá, a $total$ je počet hlasov vo fronte.",
+    "message": "$index$ z $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Prístupný popis pre ovládací prvok porovnania v ovládacom paneli Hlasov v nastaveniach, ktorý znovu prehrá druhý hlas z posledných dvoch vypočutých; $name$ je tento hlas.",
+    "message": "Prepnúť späť na $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Riadok v ovládacom paneli Hlasov v nastaveniach, keď sa stlačí „Prehrať všetko“ pri príliš dlhom zozname; $count$ je počet hlasov a $minutes$ približne počet minút, ktoré by to trvalo. Skratka „min“, aby to znelo správne pri 1 — Chrome i18n nemá tvary množného čísla.",
+    "message": "To je $count$ hlasov — asi $minutes$ min. Najprv zúžte zoznam.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Prístupný štítok pre tlačidlo „použiť tento hlas“ pre konkrétneho hostiteľa v katalógu hlasov v nastaveniach; $name$ je hlas, $host$ je asistent (napr. Pi, Claude).",
+    "message": "Použiť $name$ v $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Krátky štítok na tlačidle „použiť tento hlas“ pre konkrétneho hostiteľa v zjednotenom katalógu hlasov v nastaveniach (hostiteľ je zobrazený vedľa).",
+    "message": "Použiť"
+  },
+  "voicesYourVoice": {
+    "description": "Tlačidlo v ovládacom paneli v zozname Hlasov v nastaveniach, ktoré presunie fokus na riadok hlasu, ktorý tento hostiteľ momentálne používa; $name$ je tento hlas.",
+    "message": "Váš hlas: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Chyba vyhodená, keď prehliadač nedokáže prideliť dostatok pamäte WebAssembly pre model detekcie hlasu.",
+    "message": "Detekciu hlasu sa nepodarilo spustiť: pre hlasový model nie je dosť pamäte WebAssembly. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Chyba vyhodená, keď prehliadač neposkytuje počiatočnú pamäť WebAssembly potrebnú na spustenie modelu detekcie hlasu.",
+    "message": "Detekciu hlasu sa nepodarilo spustiť: pamäť WebAssembly nie je v tomto prehliadači dostupná."
   }
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Förmån listad i autentiseringsmodalen – ökade användningsgränser.",
+    "message": "Högre användningsgränser med gratis konto"
+  },
+  "authBenefitPremium": {
+    "description": "Förmån listad i autentiseringsmodalen – premiumfunktioner i olika chatbots.",
+    "message": "Premiumfunktioner och chatbot-stöd"
+  },
+  "authBenefitSupport": {
+    "description": "Förmån listad i autentiseringsmodalen – prioriterad support.",
+    "message": "Prioriterad support vid problem"
+  },
+  "authBenefitSync": {
+    "description": "Förmån listad i autentiseringsmodalen – synk av inställningar.",
+    "message": "Synka röstinställningar överallt"
+  },
+  "authBenefitTTS": {
+    "description": "Förmån listad i autentiseringsmodalen – TTS-funktion.",
+    "message": "Text-till-tal-röster (betalda planer)"
+  },
+  "authBenefitUsage": {
+    "description": "Förmån listad i autentiseringsmodalen – användningsspårning.",
+    "message": "Följ din röst-användning på olika enheter"
+  },
+  "authPromptModalFull": {
+    "description": "Beskrivning för den fullständiga modala autentiseringsprompten med värdeerbjudande.",
+    "message": "Du använder SayPi flitigt. Logga in för högre gränser, text-till-tal-röster och premiumfunktioner i alla chatbots som stöds."
+  },
+  "authPromptModalSoft": {
+    "description": "Beskrivning för den mjuka modala autentiseringsprompten.",
+    "message": "Skapa ett gratis SayPi-konto för högre användningsgränser och tillgång till premiumröstfunktioner."
+  },
+  "authPromptTitle": {
+    "description": "Titel för autentiseringspromptens modal.",
+    "message": "Lås upp fler röstfunktioner"
+  },
+  "authPromptToast": {
+    "description": "Toast-notis som uppmuntrar användaren att logga in.",
+    "message": "Logga in på SayPi för högre gränser och premiumfunktioner"
+  },
   "autoReadAloudChatGPT": {
     "description": "Etikett för kryssrutan som aktiverar eller inaktiverar automatisk uppläsning av ChatGPT:s svar under röstsamtal.",
     "message": "Automatisk uppläsning (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Inaktivera text-till-tal"
   },
+  "dismiss": {
+    "message": "Jag förstår",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Avfärda"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Fokus"
   },
+  "errorVadInitFailed": {
+    "description": "Fel-toast som visas när röstaktivitetsdetektering inte kan initieras.",
+    "message": "Kunde inte initiera röstigenkänning"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Fel-toast som visas när ett oväntat fel inträffar vid konfigurering av röstinspelning.",
+    "message": "Kunde inte konfigurera röstinspelning"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Fel-toast som visas när klienten för röstigenkänning inte kan starta inspelning.",
+    "message": "Kunde inte starta röstinspelning"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Fel-toast som visas när klienten för röstigenkänning (VAD) inte är tillgänglig, så inspelning inte kan starta.",
+    "message": "Röstinspelning är inte tillgänglig"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Avsluta fokusläge"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Enradig notis som visas i röstmenyer när både premiumröster (HD) och värderöster finns tillgängliga",
+    "message": "HD-röster använder din månadsgräns ungefär 20× snabbare."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Tucking detta bort ..."
   },
+  "maybeLater": {
+    "description": "Knapptext för att stänga autentiseringsprompten.",
+    "message": "Kanske senare"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Dina mikrofoninställningar uppfyller inte de obligatoriska specifikationerna. \nProva att använda en annan mikrofon eller justera dina ljudinställningar."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Det går inte att komma åt mikrofonen. \nKontrollera dina enhetsinställningar och försök igen."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Fel-toast som visas när mikrofontillstånd nekades efter flödet för tillståndsfrågan.",
+    "message": "Mikrofontillstånd beviljades inte. Kontrollera att du har tillåtit åtkomst i dialogrutan och i tilläggets inställningar."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "noggrannhet"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Snabbast svar, men mindre exakt. \nBenägna att avbryta."
   },
+  "moreVoices": {
+    "description": "Menyval som länkar från röstmenyn på sidan till den fullständiga röstkatalogen i tilläggets inställningar",
+    "message": "Fler röster…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Assistents smeknamn"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Inte inloggad"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Knappetikett som öppnar ChatGPT.",
+    "message": "Öppna ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Knappetikett som öppnar Claude.ai.",
+    "message": "Öppna Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Knappetikett som öppnar Pi.ai.",
+    "message": "Öppna Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Miljöalternativ: bland andra människor.",
+    "message": "Bland andra människor"
+  },
+  "onboarding_envMixed": {
+    "description": "Miljöalternativ: en blandning av privata och delade platser.",
+    "message": "En blandning av platser"
+  },
+  "onboarding_envPrivate": {
+    "description": "Miljöalternativ: en privat plats.",
+    "message": "Någonstans privat"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Bekräftelse som visas när svaret om miljön lämnar tyst läge avstängt.",
+    "message": "Okej, vi behåller standardinställningarna för lyssning och uppspelning."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Bekräftelse som visas när miljösvaret aktiverar tyst läge.",
+    "message": "Tyst läge är på — vi plockar upp tystare tal och svarar tyst, så att du kan prata diskret."
+  },
+  "onboarding_envTitle": {
+    "description": "Rubrik för introduktionsfrågan om användarens miljö.",
+    "message": "Var pratar du oftast?"
+  },
+  "onboarding_footer": {
+    "description": "Sidfotstext på introduktionssidan som visas första gången.",
+    "message": "Du kan gå tillbaka hit när som helst i inställningarna för Say, Pi. Din integritet är viktig — ljud fångas bara upp under ett aktivt samtal."
+  },
+  "onboarding_heading": {
+    "description": "Huvudrubrik på introduktionssidan vid första körningen.",
+    "message": "🗣️ Välkommen till Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Ingress på introduktionssidan vid första körningen.",
+    "message": "Du är två steg från din första talade konversation med en AI. Att prata är ungefär 3× snabbare än att skriva, så nu fixar vi inställningarna."
+  },
+  "onboarding_micTestButton": {
+    "description": "Knapp som startar det riskfria mikrofontestet i introduktionen.",
+    "message": "🎤 Testa din mikrofon"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status som visas efter att mikrofontestet i introduktionen har slutförts.",
+    "message": "Bra — din mikrofon fungerar. 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status som visas medan mikrofontestet i introduktionen mäter ljudnivån.",
+    "message": "Lyssnar — säg något. 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status som visas medan mikrofontestet i introduktionen väntar på behörighet.",
+    "message": "Begär åtkomst till mikrofonen…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Knappetikett för att stoppa mikrofontestet i introduktionen medan det körs.",
+    "message": "Stoppa testet"
+  },
+  "onboarding_step1Body": {
+    "description": "Brödtext för det första introduktionssteget som förklarar hur man fäster tillägget.",
+    "message": "Klicka på pusselbiten 🧩 uppe till höger i webbläsaren och sedan på nålen 📌 bredvid Say, Pi. Då är samtalsknappen bara ett klick bort."
+  },
+  "onboarding_step1Title": {
+    "description": "Rubrik för det första introduktionssteget (fäst tillägget).",
+    "message": "Fäst Say, Pi i verktygsfältet"
+  },
+  "onboarding_step2Body": {
+    "description": "Brödtext för det andra introduktionssteget som förklarar hur man startar en röstkonversation.",
+    "message": "Gå till någon av assistenterna som stöds nedan, tryck på Say, Pi-samtalsknappen och säg hej. Vi ber om åtkomst till mikrofonen första gången, det är som det ska, och vi lyssnar bara när du är aktivt med i ett samtal."
+  },
+  "onboarding_step2Title": {
+    "description": "Rubrik för det andra introduktionssteget (starta en konversation).",
+    "message": "Öppna en AI-chatt och börja prata"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Mikrofonbehörighet"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Återställningsvägledning när mikrofonbehörigheten är blockerad.",
+    "message": "Din webbläsare blockerar mikrofonen. Klicka på kamera- eller låsikonen i adressfältet, ställ in Mikrofon på \"Tillåt\" och försök sedan igen. På macOS kan du också kontrollera Systeminställningar → Integritet och säkerhet → Mikrofon."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Titel för återställningspanelen när mikrofonbehörighet nekades/blockerades.",
+    "message": "Mikrofonåtkomst är blockerad"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Återställningsvägledning när mikrofonen används någon annanstans.",
+    "message": "En annan app eller flik kan använda din mikrofon. Stäng allt annat som kan spela in (videosamtal, röstanteckningar) och försök sedan igen."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Titel för återställningspanelen när mikrofonen används av en annan app.",
+    "message": "Din mikrofon används"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Återställningsvägledning när ingen mikrofonenhet är tillgänglig.",
+    "message": "Vi kunde inte hitta någon mikrofon. Anslut en (eller anslut ditt headset), se till att den är vald som inmatningsenhet och försök sedan igen."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Titel för återställningspanelen när ingen mikrofonenhet är tillgänglig.",
+    "message": "Ingen mikrofon hittades"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Återställningsvägledning vid ett okänt mikrofonfel.",
+    "message": "Något gick fel när vi försökte nå din mikrofon. Kontrollera att den är ansluten och tillåten i webbläsarens inställningar och försök sedan igen."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Titel för återställningspanelen vid ett okänt mikrofonfel.",
+    "message": "Vi kunde inte komma åt din mikrofon"
+  },
+  "permissions_retryButton": {
+    "description": "Etikett för knappen som begär mikrofonbehörighet igen.",
+    "message": "Försök igen"
+  },
+  "permissions_revokedHeading": {
+    "description": "Rubrik som visas när mikrofonåtkomst tidigare beviljats men sedan har återkallats.",
+    "message": "Låt oss ansluta din mikrofon igen"
+  },
+  "permissions_revokedInfo": {
+    "description": "Informationstext som visas när mikrofonåtkomst återkallades efter att ha beviljats.",
+    "message": "Din mikrofonåtkomst har stängts av. Det händer ofta efter en uppdatering av webbläsaren eller systemet. Tillåt den igen nedan så lyssnar $productName$ när du är i ett samtal.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Etikett för reglaget som aktiverar tyst-/viskningsläge.",
+    "message": "Tyst läge"
+  },
+  "quietModeTooltip": {
+    "description": "Beskrivning som förklarar vad tyst-/viskningsläge gör.",
+    "message": "Tala mjukt – tar upp tystare tal och sänker assistentens svarsvolym, så att du kan använda röst bland andra."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Text för inloggningsknappen medan autentisering pågår.",
+    "message": "Loggar in…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Ljudeffekter"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Ljudeffekter är inaktiverade i Firefox för att förhindra problem med ljudåterkoppling."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Rubrik för den engångsavisering om tidsvinsten som visas efter den första talade växlingen.",
+    "message": "Bra – att prata är ungefär 3× snabbare än att skriva."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Valfri andra rad i aviseringen om tidsvinsten som visar hela minuter som sparats.",
+    "message": "Du har redan pratat ungefär $minutes$ min snabbare än att skriva det.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Skicka bara när du trycker på knappen"
   },
+  "surveyQuestion": {
+    "description": "Den enda frågan i den engångs mikroenkäten efter en vinst.",
+    "message": "Hur fungerar rösten för dig hittills?"
+  },
+  "surveyRatingLabel": {
+    "description": "Tillgänglighetsetikett för en betygsknapp i en enkät.",
+    "message": "Betygsätt $rating$ av 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Bekräftelse som visas efter att användaren har svarat på enkäten efter vinsten.",
+    "message": "Tack — det hjälper oss att göra Say, Pi bättre."
+  },
   "tabAIChat": {
     "description": "Fliketikett för AI-chattinställningar.",
     "message": "AI Chatt"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Fliketikett för allmänna inställningar.",
     "message": "Allmänt"
+  },
+  "tabVoices": {
+    "description": "Fliketikett för inställningsavsnittet för röster (röstkatalog per webbplats).",
+    "message": "Röster"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "krediter"
   },
+  "ttsCreditsRemaining": {
+    "description": "Text som visar återstående TTS-kvot som en kreditpool per röst (saypi-api #181 Stage 2), inte råa tecken.",
+    "message": "$credits$ krediter kvar",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Flerspråkiga röster stöds för närvarande inte i Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Röstproduktion"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Observera! Taluppspelning är inte tillgänglig på $browserName$ med $chatbotName$ ännu. De goda nyheterna? Röstinmatning fungerar utmärkt! För TTS, prova Chrome eller Edge på skrivbordet.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS inte tillgänglig på $browserName$ + $chatbotName$. Röstinmatning fungerar! Prova Chrome skrivbord för TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS -röst"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "VAD-detalj när tal-liknande ljud upptäcktes men var för svagt / med för låg säkerhet för att transkribera (klientsidig admission-gate drop).",
+    "message": "Ljudet är för svagt för att transkribera"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "VAD-detalj som förklarar att samtalet avslutades eftersom mikrofonen togs över av en nyare flik.",
+    "message": "Röstinmatningen flyttades till en annan flik"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Röst inte tillgänglig. \nProva Chrome eller Firefox på skrivbordet."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Observera! Taluppspelning är inte tillgänglig på $browserName$ med $chatbotName$ ännu. De goda nyheterna? Röstinmatning fungerar utmärkt! För TTS, prova Chrome eller Edge på skrivbordet.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS inte tillgänglig på $browserName$ + $chatbotName$. Röstinmatning fungerar! Prova Chrome skrivbord för TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Jag förstår",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "VAD-status som visas på en flik vars röstinmatning togs över av en annan flik.",
+    "message": "Pausad"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Visa detaljer"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Generisk talad introduktion som spelas när en vald Say, Pi-röst inte har ett röstspecifikt introduktionsmanus (och det inte finns något nyligt meddelande att läsa upp).",
+    "message": "Hej, jag är $voice$. Så här låter jag. Hoppas att du gillar den här rösten.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hej! \nПривет! \n你好! \nJag är Pi, din polyglot AI-assistent. \nMed 32 språk på mitt kommando kan vi utforska idéer och kulturer från hela världen. \nVad tycker du om den här rösten?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Röstinställningar"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Reservundertext för en röstrad i röstkatalogen i inställningarna när rösten saknar beskrivning; $count$ är antalet språk som rösten stöder.",
+    "message": "Talar $count$ språk",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Författad personlighetstagline för rösten \"Addison\" (inställningar: Röststudio; klientbaserad karta för röstidentitet).",
+    "message": "Solig och vältalig"
+  },
+  "voiceTagline_alloy": {
+    "description": "Författad tagline för personligheten hos rösten \"Alloy\" (inställningar: Röster-studio; klientbaserad karta för röstidentitet).",
+    "message": "Balanserad och mångsidig"
+  },
+  "voiceTagline_ash": {
+    "description": "Författad tagline för personligheten hos rösten \"Ash\" (inställningar: Röster-studio; klientbaserad karta för röstidentitet).",
+    "message": "Mörk, eftertänksam, lugn"
+  },
+  "voiceTagline_ballad": {
+    "description": "Författad tagline för personligheten hos rösten \"Ballad\" (inställningar: Röster-studio; klientbaserad karta för röstidentitet).",
+    "message": "Mjuk och melodisk"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Författad personlighetstagline för rösten \"Cassidy\" (inställningar: Röststudio; klientbaserad karta för röstidentitet).",
+    "message": "Vänlig och saklig"
+  },
+  "voiceTagline_cedar": {
+    "description": "Författad personlighetstext för rösten ”Cedar” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Stadig och trygg"
+  },
+  "voiceTagline_coral": {
+    "description": "Författad personlighetstext för rösten ”Coral” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Ljus, positiv energi"
+  },
+  "voiceTagline_echo": {
+    "description": "Författad personlighetstext för rösten ”Echo” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Ren och neutral"
+  },
+  "voiceTagline_fable": {
+    "description": "Författad personlighetstext för rösten ”Fable” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "En berättares tonfall"
+  },
+  "voiceTagline_finn": {
+    "description": "Författad personlighetstagline för rösten \"Finn\" (inställningar: Röststudio; klientbaserad karta för röstidentitet).",
+    "message": "Fräsch och energisk"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Författad personlighetstagline för rösten \"Jamahal\" (inställningar: Röststudio; klientbaserad karta för röstidentitet).",
+    "message": "Fyllig och magnetisk"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Författad personlighetstext för rösten ”Jarnathan” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Sammetslen senkvällsbariton"
+  },
+  "voiceTagline_jeff": {
+    "description": "Författad personlighetstagline för rösten \"Jeff\" (inställningar: Röststudio; klientbaserad karta för röstidentitet).",
+    "message": "Rakt på sak och stabil"
+  },
+  "voiceTagline_jessica": {
+    "description": "Författad personlighetstagline för rösten \"Jessica\" (inställningar: Röststudio; klientbaserad karta för röstidentitet).",
+    "message": "Varmt och välpolerat lugn"
+  },
+  "voiceTagline_joey": {
+    "description": "Författad personlighetstext för rösten ”Joey” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Avslappnad, samtalston från USA"
+  },
+  "voiceTagline_juniper": {
+    "description": "Författad personlighetstagline för rösten \"Juniper\" (inställningar: Röststudio; klientbaserad karta för röstidentitet).",
+    "message": "Klar, ljus, livlig"
+  },
+  "voiceTagline_lucy": {
+    "description": "Författad personlighetstagline för rösten \"Lucy\" (inställningar: Röststudio; klientbaserad karta för röstidentitet).",
+    "message": "Mjuk och strålande"
+  },
+  "voiceTagline_marin": {
+    "description": "Författad personlighetstext för rösten ”Marin” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Varmt, morgonradio-lugnt"
+  },
+  "voiceTagline_mark": {
+    "description": "Författad personlighetstagline för rösten \"Mark\" (inställningar: Röststudio; klientbaserad karta för röstidentitet).",
+    "message": "Tydlig, självsäker berättare"
+  },
+  "voiceTagline_nova": {
+    "description": "Författad personlighetstext för rösten ”Nova” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Snabb och nyfiken"
+  },
+  "voiceTagline_onyx": {
+    "description": "Författad personlighetstext för rösten ”Onyx” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Djup, resonant tyngd"
+  },
+  "voiceTagline_paola": {
+    "description": "Författad personlighetstext för rösten ”Paola” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Uttrycksfull italiensk värme"
+  },
+  "voiceTagline_sage": {
+    "description": "Författad personlighetstext för rösten ”Sage” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Mjuk och tydlig"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Författad personlighetstext för rösten ”Shimmer” (inställningar > Voice studio; klientbaserad röstidentitetskarta).",
+    "message": "Lätt och luftig"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Kort etikett på ett röstkorts fästreglage (av-läge) i inställningarnas röststudio; vid tryck läggs rösten till i värdens röstmeny i chatten.",
+    "message": "+ Meny"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Tillgänglighetsetikett för ett röstkorts fästreglage (av-läge); $name$ är rösten, $host$ assistenten.",
+    "message": "Lägg till $name$ i $host$s meny",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Etikett på reglaget i rösternas kontrollfält som anger om det spelas upp en röst när fokus når den när man går i listan med piltangenterna.",
+    "message": "Spela upp när du bläddrar"
+  },
+  "voicesArrowsLive": {
+    "description": "Bekräftelse för skärmläsare, som läggs till efter det första \"Spelar upp <röst>\"-utropet i inställningarnas lista för Röster, som säger att piltangenterna just har blivit hörbara. Återger samma formulering som reglaget \"Spela när du flyttar\".",
+    "message": "Pilarna spelar nu när du flyttar. Esc stoppar."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Notis under menyplatserna för värdar som har inbyggda röster (t.ex. Pis 8 inbyggda), som studion inte hanterar; $host$ är assistenten.",
+    "message": "$host$ egna inbyggda röster visas alltid också i dess meny.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Variant av voicesBuiltinsNote för en värd utan röstmeny i chatten (Pi tog bort sin meny 2026), där originalets löfte att de inbyggda rösterna \"visas i dess meny\" skulle vara fel; $host$ är assistenten.",
+    "message": "$host$ har också egna inbyggda röster, som inte listas här.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Förloppsvisning i inställningarnas kontrollrad för Röster: hur många av de listade rösterna användaren redan har lyssnat på. Bara siffror, så att det läses korrekt även vid 1 — Chrome i18n har inga pluralformer.",
+    "message": "$heard$ av $total$ hörda",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Del av en rads tillgängliga namn i inställningarnas lista för Röster som markerar en röst som den här profilen redan har lyssnat på. Visuellt ritas detta som bläcktäthet i röstens ljudavtryck, vilket en skärmläsare inte kan se.",
+    "message": "Hörd"
+  },
+  "voicesInHostMenu": {
+    "description": "Avsnittsrubrik ovanför raden med menyplatser i inställningarnas röststudio; $host$ är assistenten.",
+    "message": "I $host$s meny",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Kort etikett på ett röstkorts fästreglage (på-läge) i inställningarnas röststudio.",
+    "message": "✓ I menyn"
+  },
+  "voicesInUse": {
+    "description": "Bestående märkning på värdens aktuella valda röst i listan Röster i inställningarna, renderas i versaler. Avsiktligt INTE ”Talar nu”: på den här sidan spelar raderna upp sina exempelklipp, så en vald men tyst röst får inte påstå att den talar när en annan rad gör det.",
+    "message": "Används"
+  },
+  "voicesKeyboardHint": {
+    "description": "Kort tangentbordstips på en rad i inställningarnas kontrollrad för Röster. Symbolerna är tangenter: mellanslag, upp-/nedpilarna och Skift+mellanslag.",
+    "message": "Tryck på mellanslag för att lyssna, ↑↓ för att flytta mellan röster, ⇧mellanslag för att växla tillbaka."
+  },
+  "voicesLoadError": {
+    "description": "Felläge i en värds studio när värdens röstkatalog inte gick att läsa in; $host$ är assistenten.",
+    "message": "Kunde inte läsa in $host$-röster. Försök igen senare.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/hint på ett inaktiverat ”+ Meny”-reglage när värdens röstmeny i chatten redan har sitt maxantal röster.",
+    "message": "Menyn är full, ta bort en röst för att lägga till en annan"
+  },
+  "voicesMenuHint": {
+    "description": "Enradig hint bredvid rubriken ”I {host}s meny” som förklarar att raden med platser speglar röstmenyn i chatten.",
+    "message": "Det här ser du i chatten"
+  },
+  "voicesMenuOverflow": {
+    "description": "Notis under menyplatserna när användaren har fler fästa röster än vad menyn i chatten kan visa (äldre tillstånd); $count$ är hur många som inte får plats, $cap$ är menystorleken.",
+    "message": "$count$ fler fästa röster väntar utanför menyns $cap$ platser.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Singular av voicesMenuOverflow, används när exakt en fäst röst inte får plats i menyn i chatten; $cap$ är menystorleken.",
+    "message": "1 ytterligare fäst röst väntar utanför menyns $cap$ platser.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Sammanfattningsrad under inställningarnas lista för Röster som visar hur mycket av värdens röstmeny i chatten som är fylld; $host$ är assistenten, $used$ hur många platser som är upptagna, $cap$ hur många det finns. Formulerad för att läsas korrekt även vid 1 — Chrome i18n har inga pluralformer.",
+    "message": "$host$-meny: $used$ av $cap$ platser",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Rubrik för gruppen längst ned i inställningarnas lista för Röster som innehåller röster utan något provklipp att spela; $count$ är hur många. Formulerad för att läsas korrekt även vid 1 — Chrome i18n har inga pluralformer.",
+    "message": "Inget prov ännu ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Visas i röstkatalogen i inställningarna när röstlistan är tom för en inloggad användare (t.ex. vid ett nätverksproblem).",
+    "message": "Röster kunde inte läsas in just nu. Försök igen senare."
+  },
+  "voicesNowPlaying": {
+    "description": "Skärmläsarutrop när ett röstprov börjar spelas upp i inställningarnas lista för Röster; $name$ är rösten.",
+    "message": "Spelar upp $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Knapp i inställningarnas kontrollrad för Röster som spelar varje röst som listas just nu, en efter en; $count$ är hur många. Formulerad för att läsas korrekt även vid 1 — Chrome i18n har inga pluralformer.",
+    "message": "Spela alla ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Knapp i inställningarnas kontrollrad för Röster vid ett återbesök: spelar bara de listade rösterna som du inte har lyssnat på ännu; $count$ är hur många. Formulerad för att läsas korrekt även vid 1 — Chrome i18n har inga pluralformer.",
+    "message": "Spela nya ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Rad i inställningarnas kontrollfält för Röster när webbläsaren vägrade spela upp ett prov eftersom sidan ännu inte haft någon användarinteraktion.",
+    "message": "Klicka på en röst för att aktivera ljud."
+  },
+  "voicesPreview": {
+    "description": "Tillgänglighetsetikett för uppspelningsknappen (▶) som låter användaren provlyssna på en rösts kostnadsfria provklipp på en radrad; $name$ är röstens namn.",
+    "message": "Spela upp ett prov av $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Tillgängligt namn för listan Röster i inställningarna (en listbox med alla röster, en rad per röst).",
+    "message": "Röster, ordnade från mörkast till ljusast"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Tillgänglighetsetikett för ett röstkorts fästreglage (på-läge) och en menyplats borttagningsknapp; $name$ är rösten, $host$ assistenten.",
+    "message": "Ta bort $name$ från $host$s meny",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Rad i inställningarnas kontrollfält för Röster när en rösts provklipp inte kunde läsas in eller spelas upp; $name$ är den rösten. Icke-modalt — en serie prov fortsätter förbi den.",
+    "message": "Kunde inte spela upp provet för $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Underrubrik för röstkatalogavsnittet i inställningsfliken AI Chat",
+    "message": "Välj rösten som läser upp svaren på varje webbplats."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Underrubrik under rubriken Röster i inställningarna, för den tonhöjdsordnade raden av röster.",
+    "message": "Varje röst, från mörkast till ljusast. Lyssna och välj."
+  },
+  "voicesSectionTitle": {
+    "description": "Rubrik för röstkatalogavsnittet i inställningsfliken AI Chat",
+    "message": "Röster"
+  },
+  "voicesShelfEveryday": {
+    "description": "Grupprubrik för röster i värdeklassen i inställningarnas röstkatalog. Renderas med versaler via CSS.",
+    "message": "Vardagsröster"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Enradig notis bredvid grupprubriken Vardags i inställningarnas röststudio; det enda stället där studion anger hur mycket längre denna nivå räcker jämfört med HD.",
+    "message": "Naturligt och tydligt — du kan lyssna ungefär 20× längre än med HD."
+  },
+  "voicesShelfHd": {
+    "description": "Grupprubrik för premiumröster (HD) i inställningarnas röstkatalog. Renderas med versaler via CSS.",
+    "message": "HD-röster"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Enradig notis bredvid HD-grupprubriken i inställningarnas röststudio.",
+    "message": "Vårt fylligaste, mest uttrycksfulla ljud."
+  },
+  "voicesShowAll": {
+    "description": "Alternativ i inställningarnas \"Visa\"-filter för Röster: ingen filtrering, alla röster listas.",
+    "message": "Alla röster"
+  },
+  "voicesShowEveryday": {
+    "description": "Alternativ i inställningarnas \"Visa\"-filter för Röster: listar bara standardrösterna (icke-HD).",
+    "message": "Endast standard"
+  },
+  "voicesShowHd": {
+    "description": "Alternativ i inställningarnas \"Visa\"-filter för Röster: listar bara premiumrösterna (HD).",
+    "message": "Endast HD"
+  },
+  "voicesShowLabel": {
+    "description": "Etikett på filtret i inställningarnas kontrollfält för Röster som begränsar vilka röster som visas i listan.",
+    "message": "Visa"
+  },
+  "voicesShowUnheard": {
+    "description": "Alternativ i inställningarnas \"Visa\"-filter för Röster: listar bara rösterna som användaren inte har lyssnat på än.",
+    "message": "Inte lyssnat på än"
+  },
+  "voicesSpeakingNow": {
+    "description": "Statusetikett på värdens aktuella valda röst i inställningarnas röststudio (menyplats och röstkort).",
+    "message": "Talar nu"
+  },
+  "voicesSpeaksWith": {
+    "description": "Ögonbrynsrad ovanför den aktuella röstens namn i inställningarnas röststudio; $host$ är assistenten (t.ex. Pi). Renderas i versaler av CSS.",
+    "message": "$host$ talar med",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Scennotis när värden levererar eget ljud (t.ex. Pi), så att valet av en Say, Pi-röst ersätter värdens.",
+    "message": "$host$ använder sin egen röst tills du väljer en nedan.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Scennotis när värden inte har någon egen röst (t.ex. Claude), så ingenting läses upp förrän en Say, Pi-röst väljs.",
+    "message": "$host$ läser inte upp svar förrän du väljer en nedan.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Rubrik på scenen i inställningarnas röststudio när värden inte har någon SayPi-röst vald; $host$ är assistenten (t.ex. Pi, Claude). Renderas i namn-storlek.",
+    "message": "Välj hur $host$ låter",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Knapp på scenen i inställningarnas röststudio som spelar upp den aktuella röstens kostnadsfria provklipp.",
+    "message": "Lyssna på ett prov"
+  },
+  "voicesStopPlayback": {
+    "description": "Knapp i inställningarnas kontrollrad för Röster som stoppar serien av prov som startades av \"Spela alla\".",
+    "message": "Stoppa"
+  },
+  "voicesSweepPosition": {
+    "description": "Visar aktuell position i inställningarnas kontrollfält för Röster medan \"Spela alla\" går igenom listan; $index$ är rösten som spelas nu och $total$ hur många som är i kö.",
+    "message": "$index$ av $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Tillgänglighetsetikett för jämförelsekontrollen i inställningarnas kontrollrad för Röster, som spelar upp den andra rösten av de två senast hörda; $name$ är den rösten.",
+    "message": "Växla tillbaka till $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Rad i inställningarnas kontrollfält för Röster när \"Spela alla\" trycks på en lista som är för lång att lyssna igenom; $count$ är hur många röster och $minutes$ ungefär hur många minuter de skulle ta. Förkortat \"min\" så att det läses rätt vid 1 — Chrome i18n saknar pluralformer.",
+    "message": "Det är $count$ röster — cirka $minutes$ min. Begränsa listan först.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Tillgänglighetsetikett för knappen ”använd den här rösten” per värd i röstkatalogen i inställningarna; $name$ är rösten, $host$ är assistenten (t.ex. Pi, Claude).",
+    "message": "Använd $name$ på $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Kort etikett på knappen ”använd den här rösten” per värd i den enhetliga röstkatalogen i inställningarna (värden visas bredvid).",
+    "message": "Använd"
+  },
+  "voicesYourVoice": {
+    "description": "Knapp i kontrollraden i inställningarnas lista för Röster som flyttar fokus till raden för den röst som den här värden använder just nu; $name$ är den rösten.",
+    "message": "Din röst: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Fel som uppstår när webbläsaren inte kan allokera tillräckligt med WebAssembly-minne för röstigenkänningsmodellen.",
+    "message": "Röstigenkänning kan inte starta: inte tillräckligt med WebAssembly-minne för röstmodellen. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Fel som uppstår när webbläsaren inte exponerar det initiala WebAssembly-minnet som behövs för att köra röstigenkänningsmodellen.",
+    "message": "Röstigenkänning kan inte starta: WebAssembly-minne är inte tillgängligt i den här webbläsaren."
   }
 }

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "அங்கீகார மோடலில் பட்டியலிடப்படும் நன்மை - அதிகரிக்கப்பட்ட பயன்பாட்டு வரம்புகள்.",
+    "message": "இலவச கணக்குடன் அதிக பயன்பாட்டு வரம்புகள்"
+  },
+  "authBenefitPremium": {
+    "description": "அங்கீகார மோடலில் பட்டியலிடப்படும் நன்மை - chatbot-களில் பிரீமியம் அம்சங்கள்.",
+    "message": "பிரீமியம் அம்சங்கள் மற்றும் chatbot ஆதரவு"
+  },
+  "authBenefitSupport": {
+    "description": "அங்கீகார மோடலில் பட்டியலிடப்படும் நன்மை - முன்னுரிமை ஆதரவு.",
+    "message": "சிக்கல்களுக்கு முன்னுரிமை ஆதரவு"
+  },
+  "authBenefitSync": {
+    "description": "அங்கீகார மோடலில் பட்டியலிடப்படும் நன்மை - அமைப்புகள் ஒத்திசைவு.",
+    "message": "எல்லா இடங்களிலும் குரல் அமைப்புகளை ஒத்திசைக்கவும்"
+  },
+  "authBenefitTTS": {
+    "description": "அங்கீகார மோடலில் பட்டியலிடப்படும் நன்மை - TTS அம்சம்.",
+    "message": "உரையிலிருந்து-குரல் குரல்கள் (கட்டணத் திட்டங்கள்)"
+  },
+  "authBenefitUsage": {
+    "description": "அங்கீகார மோடலில் பட்டியலிடப்படும் நன்மை - பயன்பாட்டு கண்காணிப்பு.",
+    "message": "சாதனங்களுக்கிடையே உங்கள் குரல் பயன்பாட்டை கண்காணிக்கவும்"
+  },
+  "authPromptModalFull": {
+    "description": "மதிப்பு முன்மொழிவுடன் கூடிய முழு மோடல் அங்கீகார கேள்விக்கான விளக்கம்.",
+    "message": "Say, Pi-ஐ நீங்கள் நல்ல அளவில் பயன்படுத்துகிறீர்கள். அதிக வரம்புகள், உரையிலிருந்து-குரல் குரல்கள், மேலும் ஆதரிக்கப்படும் அனைத்து chatbot-களிலும் பிரீமியம் அம்சங்களுக்கு உள்நுழையவும்."
+  },
+  "authPromptModalSoft": {
+    "description": "மென்மையான மோடல் அங்கீகார கேள்விக்கான விளக்கம்.",
+    "message": "அதிக பயன்பாட்டு வரம்புகள் மற்றும் பிரீமியம் குரல் அம்சங்களைப் பெற இலவச Say, Pi கணக்கை உருவாக்குங்கள்."
+  },
+  "authPromptTitle": {
+    "description": "அங்கீகார கேள்வி மோடலுக்கான தலைப்பு.",
+    "message": "மேலும் குரல் அம்சங்களை திறக்கவும்"
+  },
+  "authPromptToast": {
+    "description": "பயனரை உள்நுழைய ஊக்குவிக்கும் டோஸ்ட் அறிவிப்பு.",
+    "message": "அதிக வரம்புகள் மற்றும் பிரீமியம் அம்சங்களுக்கு Say, Pi-க்கு உள்நுழையவும்"
+  },
   "autoReadAloudChatGPT": {
     "description": "குரல் அழைப்பின் போது ChatGPT பதில்களை தானாகக் கன்னடிக்கச் செய்யும்/செயலிழக்கும் என்பதற்கான தேர்வுத்தொகையுக்கான குறி.",
     "message": "தானாக கன்னடித்தல் (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "உரை-க்கு-பேச்சை முடக்கு"
   },
+  "dismiss": {
+    "message": "புரிந்தது",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "நிராகரி"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "கவனம் செலுத்து"
   },
+  "errorVadInitFailed": {
+    "description": "குரல்-செயற்பாட்டு கண்டறிதல் தொடக்கப்பட முடியாதபோது காட்டப்படும் பிழை டோஸ்ட்.",
+    "message": "குரல் கண்டறிதலைத் தொடக்க முடியவில்லை"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "குரல் பதிவேற்றத்தை அமைக்கும் போது எதிர்பாராத பிழை ஏற்பட்டால் காட்டப்படும் பிழை டோஸ்ட்.",
+    "message": "குரல் பதிவேற்றத்தை அமைக்க முடியவில்லை"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "குரல்-கண்டறிதல் கிளையண்ட் பதிவேற்றத்தை தொடங்க முடியாதபோது காட்டப்படும் பிழை டோஸ்ட்.",
+    "message": "குரல் பதிவேற்றத்தை தொடங்க முடியவில்லை"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "குரல்-கண்டறிதல் (VAD) கிளையண்ட் கிடைக்காததால் பதிவேற்றத்தைத் தொடங்க முடியாதபோது காட்டப்படும் பிழை டோஸ்ட்.",
+    "message": "குரல் பதிவேற்றம் கிடைக்கவில்லை"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "கவன நிலையை விட்டு வெளியேறவும்"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "பிரீமியம் (HD) மற்றும் மதிப்பு குரல்கள் இரண்டும் கிடைக்கும் போது குரல் மெனுக்களில் காட்டப்படும் ஒரு வரி குறிப்பு",
+    "message": "HD குரல்கள் உங்கள் மாதாந்திர அளவுத்தொகையை சுமார் 20× வேகமாக பயன்படுத்தும்."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "இதைத் தவிர்த்து ..."
   },
+  "maybeLater": {
+    "description": "அங்கீகார கேள்வியை நீக்குவதற்கான பொத்தான் உரை.",
+    "message": "பிறகு பார்க்கலாம்"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "உங்கள் மைக்ரோஃபோன் அமைப்புகள் தேவையான விவரக்குறிப்புகளைப் பூர்த்தி செய்யவில்லை. \nவேறு மைக்ரோஃபோனைப் பயன்படுத்தவும் அல்லது உங்கள் ஆடியோ அமைப்புகளைச் சரிசெய்யவும்."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "மைக்ரோஃபோனை அணுக முடியவில்லை. \nஉங்கள் சாதன அமைப்புகளைச் சரிபார்த்து, மீண்டும் முயற்சிக்கவும்."
   },
+  "microphonePermissionDeniedError": {
+    "description": "அனுமதி கோரிக்கை முறையின் பிறகு மைக்ரோஃபோன் அனுமதி மறுக்கப்பட்டால் காட்டப்படும் பிழை டோஸ்ட்.",
+    "message": "மைக்ரோஃபோன் அனுமதி வழங்கப்படவில்லை. கோரிக்கையிலும் நீட்டிப்பு அமைப்புகளிலும் அணுகலை அனுமதித்துள்ளீர்களா என்பதை உறுதிசெய்யவும்."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "செம்மை"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "வேகமான பதில், ஆனால் குறைவான துல்லியம். \nகுறுக்கிட வாய்ப்புள்ளது."
   },
+  "moreVoices": {
+    "description": "பக்கத்திலுள்ள குரல் மெனுவிலிருந்து நீட்டிப்பு அமைப்புகளில் உள்ள முழு குரல் பட்டியலுக்குச் செல்லும் மெனு வரி.",
+    "message": "மேலும் குரல்கள்…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "உதவியாளர் பெயர்"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "உள்நுழையவில்லை"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "ChatGPT-ஐ திறக்கும் பொத்தானின் குறிப்பு.",
+    "message": "ChatGPT-ஐ திற"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Claude.ai-யை திறக்கும் பொத்தான் லேபல்.",
+    "message": "Claude-ஐ திறக்கவும்"
+  },
+  "onboarding_ctaPi": {
+    "description": "Pi.ai-யை திறக்கும் பொத்தான் லேபல்.",
+    "message": "Pi-யை திறக்கவும்"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "சூழல் விருப்பம்: மற்றவர்களுடன் இருக்கும் இடம்.",
+    "message": "மற்றவர்களுடன் இருக்கும் இடம்"
+  },
+  "onboarding_envMixed": {
+    "description": "சூழல் விருப்பம்: தனிப்பட்ட மற்றும் பகிரப்பட்ட இடங்களின் கலவை.",
+    "message": "பல இடங்களின் கலவை"
+  },
+  "onboarding_envPrivate": {
+    "description": "சூழல் விருப்பம்: தனிப்பட்ட இடம்.",
+    "message": "தனிப்பட்ட இடம்"
+  },
+  "onboarding_envQuietOff": {
+    "description": "சூழல் கேள்விக்கான பதிலால் quiet mode முடக்கப்பட்டிருக்கும்போது காட்டப்படும் உறுதிப்படுத்தல்.",
+    "message": "சரி — வழக்கமான கேட்கும் மற்றும் ஒலிபரப்பு அமைப்புகளையே வைத்திருப்போம்."
+  },
+  "onboarding_envQuietOn": {
+    "description": "சூழல் பதில் அமைதி முறையை இயக்கும் போது காட்டப்படும் உறுதிப்படுத்தல்.",
+    "message": "அமைதி முறை இயக்கப்பட்டுள்ளது — மெதுவான பேச்சையும் நாங்கள் பிடித்து, மெதுவாக பதிலளிப்போம்; நீங்கள் மறைவாக பேசலாம்."
+  },
+  "onboarding_envTitle": {
+    "description": "பயனர் சூழல் குறித்த வழிகாட்டி கேள்விக்கான தலைப்பு.",
+    "message": "பொதுவாக நீங்கள் எங்கே பேசுவீர்கள்?"
+  },
+  "onboarding_footer": {
+    "description": "முதல் முறை தொடங்கும் வழிகாட்டி பக்கத்தின் அடிக்குறிப்பு உரை.",
+    "message": "Say, Pi அமைப்புகளில் இருந்து இதை எப்போது வேண்டுமானாலும் மீண்டும் பார்க்கலாம். உங்கள் தனியுரிமை முக்கியம் — செயலில் உள்ள அழைப்பின் போது மட்டுமே ஆடியோ பதிவு செய்யப்படும்."
+  },
+  "onboarding_heading": {
+    "description": "முதல் இயக்கத்தின் onboarding பக்கத்தில் உள்ள முதன்மை தலைப்பு.",
+    "message": "🗣️ Say, Pi-க்கு வரவேற்கிறோம்"
+  },
+  "onboarding_intro": {
+    "description": "முதல் இயக்கத்தின் onboarding பக்கத்தில் உள்ள அறிமுகப் பத்தி.",
+    "message": "AI-யுடன் உங்கள் முதல் பேச்சு உரையாடலுக்கு இன்னும் இரண்டு படிகள். பேசுவது தட்டச்சை விட சுமார் 3× வேகமாக இருக்கும் — அமைப்பை செய்து விடலாம்."
+  },
+  "onboarding_micTestButton": {
+    "description": "அபாயமில்லா வழிகாட்டி மைக்ரோஃபோன் சோதனையைத் தொடங்கும் பொத்தான்.",
+    "message": "🎤 உங்கள் மைக்ரோஃபோனைச் சோதிக்கவும்"
+  },
+  "onboarding_micTestDone": {
+    "description": "வழிகாட்டி மைக் சோதனை வெற்றிகரமாக முடிந்த பிறகு காட்டப்படும் நிலை.",
+    "message": "சரி — உங்கள் மைக்ரோஃபோன் வேலை செய்கிறது! 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "வழிகாட்டி மைக் சோதனை உள்ளீட்டை அளவிடும் போது காட்டப்படும் நிலை.",
+    "message": "கேட்கிறது — ஏதாவது சொல்லுங்கள்! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "வழிகாட்டி மைக் சோதனை அனுமதிக்காக காத்திருக்கும்போது காட்டப்படும் நிலை.",
+    "message": "மைக்ரோஃபோன் அனுமதி கேட்கப்படுகிறது…"
+  },
+  "onboarding_micTestStop": {
+    "description": "வழிகாட்டி மைக் சோதனை இயங்கும்போது அதை நிறுத்தும் பொத்தான்.",
+    "message": "சோதனையை நிறுத்து"
+  },
+  "onboarding_step1Body": {
+    "description": "நீட்சியை எப்படி பின் செய்வது என்பதை விளக்கும் முதல் onboarding படியின் உரை.",
+    "message": "உங்கள் உலாவியின் மேல்-வலப்பக்கத்தில் உள்ள பஸில்-பீஸ் 🧩 ஐகானை கிளிக் செய்து, பிறகு Say, Pi அருகிலுள்ள பின் 📌-ஐ அழுத்தவும். இதனால் அழைப்பு பொத்தான் ஒரு கிளிக்கில் கிடைக்கும்."
+  },
+  "onboarding_step1Title": {
+    "description": "முதல் onboarding படியின் தலைப்பு (நீட்சியை பின் செய்வது).",
+    "message": "Say, Pi-யை உங்கள் கருவிப்பட்டையில் பின் செய்யவும்"
+  },
+  "onboarding_step2Body": {
+    "description": "குரல் உரையாடலை எப்படி தொடங்குவது என்பதை விளக்கும் இரண்டாவது onboarding படியின் உரை.",
+    "message": "கீழே உள்ள ஆதரிக்கப்படும் உதவியாளர்களில் ஒன்றுக்குச் செல்லுங்கள்; பின்னர் Say, Pi அழைப்பு பொத்தானைத் தட்டி வணக்கம் சொல்லுங்கள். முதல் முறையில் மைக்ரோஃபோன் அணுகலை கேட்போம் — அது இயல்பானது, மேலும் நீங்கள் அழைப்பில் இருக்கும் நேரத்தில் மட்டுமே நாம் கேட்கிறோம்."
+  },
+  "onboarding_step2Title": {
+    "description": "இரண்டாவது onboarding படியின் தலைப்பு (உரையாடலைத் தொடங்குவது).",
+    "message": "AI அரட்டையைத் திறந்து பேசத் தொடங்கவும்"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "மைக்ரோஃபோன் அனுமதி"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "மைக்கின் அனுமதி தடுக்கப்பட்டிருக்கும் போது காட்டப்படும் மீட்பு வழிகாட்டல்.",
+    "message": "உங்கள் உலாவி மைக்ரோஃபோனை தடுக்கிறது. முகவரி பட்டையில் உள்ள கேமரா அல்லது பூட்டு சின்னத்தைச் சொடுக்கி, Microphone-ஐ \"Allow\" என அமைத்து, பின்னர் மீண்டும் முயற்சிக்கவும். macOS-ல், System Settings → Privacy & Security → Microphone-யும் சரிபார்க்கவும்."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "மைக்கின் அனுமதி மறுக்கப்பட்ட/தடுக்கப்பட்ட நிலையில் மீட்பு பலகையின் தலைப்பு.",
+    "message": "மைக்ரோஃபோன் அணுகல் தடுக்கப்பட்டுள்ளது"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "மைக்கை வேறு இடத்தில் பயன்படுத்திக் கொண்டிருக்கும்போது காட்டப்படும் மீட்பு வழிகாட்டல்.",
+    "message": "வேறொரு செயலி அல்லது தாவல் உங்கள் மைக்ரோஃபோனைப் பயன்படுத்திக் கொண்டிருக்கலாம். பதிவு செய்யக்கூடியவற்றை (வீடியோ அழைப்புகள், குரல் குறிப்புகள்) மூடி, பின்னர் மீண்டும் முயற்சிக்கவும்."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "மைக்கை வேறொரு செயலி பயன்படுத்தும்போது மீட்பு பலகையின் தலைப்பு.",
+    "message": "உங்கள் மைக்ரோஃபோன் பயன்படுத்தப்படுகிறது"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "மைக்ரோஃபோன் சாதனம் எதுவும் இல்லாதபோது காட்டப்படும் மீட்பு வழிகாட்டல்.",
+    "message": "மைக்ரோஃபோனை கண்டுபிடிக்க முடியவில்லை. ஒன்றை இணைக்கவும் (அல்லது உங்கள் ஹெட்செட்டை இணைக்கவும்), அது உங்கள் input சாதனமாகத் தேர்ந்தெடுக்கப்பட்டுள்ளதா என்பதை உறுதிசெய்து, பின்னர் மீண்டும் முயற்சிக்கவும்."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "மைக்ரோஃபோன் சாதனம் எதுவும் இல்லாதபோது மீட்பு பலகையின் தலைப்பு.",
+    "message": "மைக்ரோஃபோன் கிடைக்கவில்லை"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "அறியப்படாத மைக்ரோஃபோன் பிழைக்கான மீட்பு வழிகாட்டல்.",
+    "message": "உங்கள் மைக்ரோஃபோனை அணுகுவதில் ஏதோ தவறு ஏற்பட்டது. அது இணைக்கப்பட்டுள்ளதா, உங்கள் உலாவி அமைப்புகளில் அனுமதி அளிக்கப்பட்டுள்ளதா என்பதைச் சரிபார்த்து, பின்னர் மீண்டும் முயற்சிக்கவும்."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "அறியப்படாத மைக் பிழைக்கான மீட்பு பலகையின் தலைப்பு.",
+    "message": "உங்கள் மைக்ரோஃபோனை அணுக முடியவில்லை"
+  },
+  "permissions_retryButton": {
+    "description": "மைக்ரோஃபோன் அனுமதியை மீண்டும் கோரும் பொத்தானின் லேபிள்.",
+    "message": "மீண்டும் முயற்சிக்கவும்"
+  },
+  "permissions_revokedHeading": {
+    "description": "மைக்ரோஃபோன் அணுகல் முன்பு அனுமதிக்கப்பட்டு பின்னர் திரும்பப் பெறப்பட்டிருந்தால் காட்டப்படும் தலைப்பு.",
+    "message": "உங்கள் மைக்கை மீண்டும் இணைப்போம்"
+  },
+  "permissions_revokedInfo": {
+    "description": "அனுமதி வழங்கப்பட்ட பிறகு மைக்ரோஃபோன் அணுகல் திரும்பப் பெறப்பட்டால் காட்டப்படும் தகவல் உரை.",
+    "message": "உங்கள் மைக்ரோஃபோன் அணுகல் முடக்கப்பட்டுள்ளது — இது பெரும்பாலும் உலாவி அல்லது கணினி புதுப்பிப்புக்குப் பிறகு நடக்கும். கீழே அதை மீண்டும் அனுமதியுங்கள்; நீங்கள் அழைப்பில் இருக்கும்போது $productName$ மீண்டும் கேட்கத் தொடங்கும்.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "சுயவிவரம்"
+  },
+  "quietModeLabel": {
+    "description": "அமைதி/மெளனப் பயன்முறையை இயக்கும் தாவலுக்கான லேபிள்.",
+    "message": "அமைதி பயன்முறை"
+  },
+  "quietModeTooltip": {
+    "description": "அமைதி/மெளனப் பயன்முறை என்ன செய்கிறது என்பதை விளக்கும் கருவிக்குறிப்பு.",
+    "message": "மெதுவாகப் பேசுங்கள் — மெதுவான பேச்சையும் பிடித்து, உதவியாளரின் பதிலின் ஒலி அளவையும் குறைக்கும், அதனால் மற்றவர்கள் அருகில் இருக்கும்போது குரலைப் பயன்படுத்தலாம்."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "அங்கீகாரம் நடந்து கொண்டிருக்கும்போது sign in பொத்தானில் காட்டப்படும் உரை.",
+    "message": "உள்நுழைகிறது..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "ஒலி விளைவுகள்"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "ஆடியோ பின்னூட்டச் சிக்கல்களைத் தடுக்க பயர்பாக்ஸில் ஒலி விளைவுகள் முடக்கப்பட்டுள்ளன."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "முதல் குரல் உரையாடலுக்குப் பிறகு ஒருமுறை காட்டப்படும் வேக-பலன் அறிவிப்பின் தலைப்பு.",
+    "message": "நன்று — பேசுவது தட்டச்சுவதை விட சுமார் 3× வேகமானது."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "சேமிக்கப்பட்ட முழு நிமிடங்களை காட்டும் வேக-பலன் அறிவிப்பின் விருப்பமான இரண்டாவது வரி.",
+    "message": "தட்டச்சு செய்திருந்ததை விட நீங்கள் ஏற்கனவே சுமார் $minutes$ நிமிடங்கள் வேகமாகப் பேசியுள்ளீர்கள்.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "பொத்தானை அழுத்தினால் மட்டுமே சமர்ப்பிக்கவும்"
   },
+  "surveyQuestion": {
+    "description": "ஒருமுறை மட்டும் காட்டப்படும் post-win மைக்ரோ-சர்வேயின் ஒரே கேள்வி.",
+    "message": "இதுவரை குரல் உங்களுக்கு எப்படி வேலை செய்கிறது?"
+  },
+  "surveyRatingLabel": {
+    "description": "சர்வே மதிப்பீட்டு பொத்தானுக்கான அணுகக்கூடிய லேபல்.",
+    "message": "5-இல் $rating$ மதிப்பிடுங்கள்",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "பயனர் post-win சர்வேக்கு பதிலளித்த பிறகு காட்டப்படும் நன்றியுரை.",
+    "message": "நன்றி — இது Say, Pi-யை இன்னும் மேம்படுத்த எங்களுக்கு உதவுகிறது. 🙏"
+  },
   "tabAIChat": {
     "description": "AI உரையாடல் அமைப்புக்கான தாப் லேபல்.",
     "message": "AI உரையாடல்"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "பொதுவான அமைப்புக்கான தாப் லேபல்.",
     "message": "பொது"
+  },
+  "tabVoices": {
+    "description": "குரல் அமைப்புகள் பகுதியுக்கான தாவல் லேபல் (தளத்திற்கேற்ப குரல் பட்டியல்).",
+    "message": "குரல்கள்"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "வரவு"
   },
+  "ttsCreditsRemaining": {
+    "description": "மீதமுள்ள TTS வரம்பை, எழுத்து எண்ணிக்கையாக அல்லாமல், குரல்-ஒன்றிற்கு தனியான கிரெடிட் பூலாக காட்டும் உரை (saypi-api #181 Stage 2).",
+    "message": "$credits$ கிரெடிட்கள் மீதமுள்ளது",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "சஃபாரியில் தற்போது பன்மொழி குரல்கள் ஆதரிக்கப்படவில்லை."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "குரல் தலைமுறை"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "கவனிக்கவும்! $browserName$ இல் $chatbotName$ உடன் பேச்சு பிளேபேக் இன்னும் கிடைக்கவில்லை. நல்ல செய்தி? குரல் உள்ளீடு நன்றாக வேலை செய்கிறது! TTS க்கு, டெஸ்க்டாப்பில் Chrome அல்லது Edge ஐ முயற்சிக்கவும்.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "$browserName$ + $chatbotName$ இல் TTS கிடைக்கவில்லை. குரல் உள்ளீடு வேலை செய்கிறது! TTS க்கு Chrome டெஸ்க்டாப்பை முயற்சிக்கவும்.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "Tts குரல்"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "VAD விவரம்: பேச்சு போன்ற ஆடியோ கண்டறியப்பட்டது, ஆனால் எழுத்தாக்குவதற்கு மிக மெல்லியதாக / குறைந்த நம்பகத்தன்மையுடன் இருந்தது (கிளையண்ட்-சைடு admission-gate drop).",
+    "message": "எழுத்தாக்குவதற்கு ஆடியோ மிகவும் மெல்லியதாக உள்ளது"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "புதிய டேப் மைக்ரோஃபோனை கைப்பற்றியதால் அழைப்பு முடிந்தது என்பதை விளக்கும் VAD விவரம்.",
+    "message": "குரல் உள்ளீடு வேறு ஒரு டேபிற்கு மாற்றப்பட்டது"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1227,41 +1531,9 @@
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "குரல் கிடைக்கவில்லை. \nடெஸ்க்டாப்பில் குரோம் அல்லது பயர்பாக்ஸை முயற்சிக்கவும்."
   },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "கவனிக்கவும்! $browserName$ இல் $chatbotName$ உடன் பேச்சு பிளேபேக் இன்னும் கிடைக்கவில்லை. நல்ல செய்தி? குரல் உள்ளீடு நன்றாக வேலை செய்கிறது! TTS க்கு, டெஸ்க்டாப்பில் Chrome அல்லது Edge ஐ முயற்சிக்கவும்.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "$browserName$ + $chatbotName$ இல் TTS கிடைக்கவில்லை. குரல் உள்ளீடு வேலை செய்கிறது! TTS க்கு Chrome டெஸ்க்டாப்பை முயற்சிக்கவும்.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "புரிந்தது",
-    "description": "Button text to dismiss a notification or dialog."
-  },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
-    "message": "மொபைல் உலாவிகளில் $ சாட்போட்நேம் with உடன் குரல் அம்சங்கள் முழுமையாக ஆதரிக்கப்படாமல் போகலாம். \nசிறந்த அனுபவத்திற்கு டெஸ்க்டாப் உலாவியைப் பயன்படுத்த முயற்சிக்கவும்.",
+    "message": "$chatbotName$ உடன் மொபைல் உலாவிகளில் குரல் அம்சங்கள் முழுமையாக ஆதரிக்கப்படாமல் இருக்கலாம். சிறந்த அனுபவத்திற்காக டெஸ்க்டாப் உலாவியைப் பயன்படுத்த முயற்சிக்கவும்.",
     "placeholders": {
       "chatbotName": {
         "content": "$1",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "வேறு ஒரு டேப் குரல் உள்ளீட்டைக் கைப்பற்றியதால் அந்த டேபில் காட்டப்படும் VAD நிலை.",
+    "message": "இடைநிறுத்தப்பட்டது"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "விவரங்களைக் காண்க"
   },
+  "voiceIntroductionGeneric": {
+    "description": "தேர்ந்தெடுத்த SayPi குரலுக்கு குரல்-சிறப்பு அறிமுக ஸ்கிரிப்ட் இல்லாதபோது (மேலும் சமீபத்திய செய்தியை வாசிக்க எதுவும் இல்லாதபோது) இயக்கப்படும் பொதுவான குரல் அறிமுகம்.",
+    "message": "வணக்கம், நான் $voice$. என் குரல் இப்படிதான் இருக்கும். இந்தக் குரல் உங்களுக்கு பிடிக்கும் என்று நினைக்கிறேன்.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "ஹலோ! \nநடைமுறை! \nநீங்கள்! \nநான் பை, உங்கள் பாலிகிளாட் AI உதவியாளர். \nஎனது கட்டளையில் 32 மொழிகளைக் கொண்டு, உலகெங்கிலும் உள்ள கருத்துக்களையும் கலாச்சாரங்களையும் நாம் ஆராயலாம். \nஇந்தக் குரலைப் பற்றி நீங்கள் என்ன நினைக்கிறீர்கள்?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "குரல் அமைப்புகள்"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "ஒரு குரலுக்குப் விளக்கம் இல்லாத போது அமைப்புகளின் குரல் காடலாக்கில் குரல் வரிக்கான மாற்று துணைத்தலைப்பு; $count$ என்பது அந்தக் குரல் ஆதரிக்கும் மொழிகளின் எண்ணிக்கை.",
+    "message": "$count$ மொழிகளைப் பேசும்",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "'Addison' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை டேக்லைன் (அமைப்புகள் Voices studio; கிளையண்ட்-சைடு voice identity map).",
+    "message": "மகிழ்வானதும் தெளிவாகப் பேசும்"
+  },
+  "voiceTagline_alloy": {
+    "description": "'Alloy' குரலுக்கான எழுத்தாக்கப்பட்ட குணநலன் டேக்லைன் (அமைப்புகள் குரல்கள் ஸ்டூடியோ; கிளையண்ட்-சைடு குரல் அடையாள வரைபடம்).",
+    "message": "சமநிலை, அனைத்துக்கும் ஏற்றது"
+  },
+  "voiceTagline_ash": {
+    "description": "'Ash' குரலுக்கான எழுத்தாக்கப்பட்ட குணநலன் டேக்லைன் (அமைப்புகள் குரல்கள் ஸ்டூடியோ; கிளையண்ட்-சைடு குரல் அடையாள வரைபடம்).",
+    "message": "தாழ்ந்த, சிந்தனையுடன், அமைதியான"
+  },
+  "voiceTagline_ballad": {
+    "description": "'Ballad' குரலுக்கான எழுத்தாக்கப்பட்ட குணநலன் டேக்லைன் (அமைப்புகள் குரல்கள் ஸ்டூடியோ; கிளையண்ட்-சைடு குரல் அடையாள வரைபடம்).",
+    "message": "மென்மையான, இசைபோன்ற"
+  },
+  "voiceTagline_cassidy": {
+    "description": "'Cassidy' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை டேக்லைன் (அமைப்புகள் Voices studio; கிளையண்ட்-சைடு voice identity map).",
+    "message": "நட்பானதும் நேரடியானதும்"
+  },
+  "voiceTagline_cedar": {
+    "description": "'Cedar' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "நிலையான, நம்பிக்கை அளிப்பது"
+  },
+  "voiceTagline_coral": {
+    "description": "'Coral' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "பிரகாசமான, உற்சாகமான ஆற்றல்"
+  },
+  "voiceTagline_echo": {
+    "description": "'Echo' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "தெளிவான, நடுநிலை"
+  },
+  "voiceTagline_fable": {
+    "description": "'Fable' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "கதைசொல்லும் நயம்"
+  },
+  "voiceTagline_finn": {
+    "description": "'Finn' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை டேக்லைன் (அமைப்புகள் Voices studio; கிளையண்ட்-சைடு voice identity map).",
+    "message": "புதியதும் சுறுசுறுப்பானதும்"
+  },
+  "voiceTagline_jamahal": {
+    "description": "'Jamahal' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை டேக்லைன் (அமைப்புகள் Voices studio; கிளையண்ட்-சைடு voice identity map).",
+    "message": "அழுத்தமானதும் கவர்ச்சியானதும்"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "'Jarnathan' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "வெல்வெட் போன்ற இரவுநேர பாரிட்டோன்"
+  },
+  "voiceTagline_jeff": {
+    "description": "'Jeff' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை டேக்லைன் (அமைப்புகள் Voices studio; கிளையண்ட்-சைடு voice identity map).",
+    "message": "எளிமையாகவும் உறுதியாகவும்"
+  },
+  "voiceTagline_jessica": {
+    "description": "'Jessica' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை டேக்லைன் (அமைப்புகள் Voices studio; கிளையண்ட்-சைடு voice identity map).",
+    "message": "சூடான, மெழுகுப்போன்ற நயமை"
+  },
+  "voiceTagline_joey": {
+    "description": "'Joey' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "எளிதான, உரையாடல் போல் அமெரிக்க பாணி"
+  },
+  "voiceTagline_juniper": {
+    "description": "'Juniper' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை டேக்லைன் (அமைப்புகள் Voices studio; கிளையண்ட்-சைடு voice identity map).",
+    "message": "தெளிவான, பிரகாசமான, உயிரோட்டமான"
+  },
+  "voiceTagline_lucy": {
+    "description": "'Lucy' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை டேக்லைன் (அமைப்புகள் Voices studio; கிளையண்ட்-சைடு voice identity map).",
+    "message": "மென்மையானதும் ஒளிமிக்கதும்"
+  },
+  "voiceTagline_marin": {
+    "description": "'Marin' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "வெதுவெதுப்பான, காலை ரேடியோ போன்ற அமைதி"
+  },
+  "voiceTagline_mark": {
+    "description": "'Mark' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை டேக்லைன் (அமைப்புகள் Voices studio; கிளையண்ட்-சைடு voice identity map).",
+    "message": "தெளிவான, நம்பிக்கையான அறிவிப்பாளர்"
+  },
+  "voiceTagline_nova": {
+    "description": "'Nova' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "வேகமான, ஆர்வமுள்ள"
+  },
+  "voiceTagline_onyx": {
+    "description": "'Onyx' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "ஆழமான, ஒலித்திறன் நிறைந்த கம்பீரம்"
+  },
+  "voiceTagline_paola": {
+    "description": "'Paola' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "வெளிப்பாடான இத்தாலிய வெம்மை"
+  },
+  "voiceTagline_sage": {
+    "description": "'Sage' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "மென்மையான குரல் தெளிவு"
+  },
+  "voiceTagline_shimmer": {
+    "description": "'Shimmer' குரலுக்கான ஆசிரியர் உருவாக்கிய தன்மை வாசகம் (அமைப்புகள் Voices studio; கிளையன்ட்-பக்கம் குரல் அடையாள மேப்).",
+    "message": "இலகுவான, காற்றோட்டமான"
+  },
+  "voicesAddToMenuShort": {
+    "description": "அமைப்புகள் Voices ஸ்டுடியோவில் குரல் கார்டின் பின் டாகிளில் (ஆஃப் நிலையில்) காணும் குறுகிய லேபல்; அழுத்தினால் குரல் ஹோஸ்டின் அரட்டைக்குள் மெனுவில் சேர்க்கப்படும்.",
+    "message": "+ மெனு"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "குரல் கார்டின் பின் டாகிளுக்கான அணுகல்தன்மை லேபல் (ஆஃப் நிலையில்); $name$ என்பது குரல், $host$ என்பது உதவியாளர்.",
+    "message": "$host$-இன் மெனுவில் $name$-ஐ சேர்",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "அம்பு விசைகளால் பட்டியலில் நகரும் போது கவனம் (focus) சென்றவுடன் ஒவ்வொரு குரலும் இயக்கப்பட வேண்டுமா என்பதை காட்டும் Voices கட்டுப்பாட்டு பட்டையிலுள்ள தாவலின் (toggle) லேபல்.",
+    "message": "நகரும் போதே இயக்கவும்"
+  },
+  "voicesArrowsLive": {
+    "description": "அமைப்புகள் குரல்கள் பட்டியலில் முதல் 'Playing <voice>' அறிவிப்புடன் இணைக்கப்படும் திரை வாசிப்பான் உறுதிப்படுத்தல்; அம்பு விசைகள் இப்போது கேட்கக்கூடியதாக மாறியுள்ளன என்பதைச் சொல்கிறது. 'Play as you move' மாற்றியின் சொற்றொடரையே பிரதிபலிக்கிறது.",
+    "message": "நீங்கள் நகரும் போது அம்புகள் இப்போது இயக்கப்படும். Esc நிறுத்தும்."
+  },
+  "voicesBuiltinsNote": {
+    "description": "நேட்டிவ் குரல்களுடன் வரும் ஹோஸ்டுகளுக்கான மெனு இடங்களின் கீழே காட்டப்படும் குறிப்பு (எ.கா. Pi-யின் 8 உட்பொதிந்த குரல்கள்), இவற்றை ஸ்டூடியோ மேலாண்மை செய்யாது; $host$ என்பது உதவியாளர்.",
+    "message": "$host$-இன் சொந்த உட்பொதிந்த குரல்களும் அதன் மெனுவில் எப்போதும் காணப்படும்.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "அரட்டைக்குள் குரல் மெனு இல்லாத ஹோஸ்டிற்கான voicesBuiltinsNote மாறுபாடு (Pi 2026-இல் தனது மெனுவை நீக்கியது); அசலின் 'மெனுவில் காணப்படும்' என்ற வாக்குறுதி இங்கே தவறாக இருக்கும்; $host$ என்பது உதவியாளர்.",
+    "message": "$host$-க்கு சொந்த உட்பொதிந்த குரல்களும் உள்ளன, அவை இங்கே பட்டியலிடப்படவில்லை.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டியில் உள்ள முன்னேற்றக் காட்சி; பட்டியலிலுள்ள குரல்களில் பயனர் ஏற்கெனவே எத்தனை கேட்டுள்ளார் என்பதை காட்டும். வெறும் எண்கள், ஆகவே 1 இலும் சரியாக படிக்கும் — Chrome i18n இல் பன்மை வடிவங்கள் இல்லை.",
+    "message": "$total$ இல் $heard$ கேட்டது",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "அமைப்புகள் குரல்கள் பட்டியலில் ஒரு குரல் வரியின் அணுகத்தக்க பெயரின் ஒரு பகுதி; இந்த சுயவிவரம் ஏற்கெனவே கேட்ட குரலை குறிக்கும். காட்சியாக இது குரலின் சவுண்ட்பிரிண்டில் மை அடர்த்தியாக வரையப்படுகிறது; திரை வாசிப்பானால் அதை பார்க்க முடியாது.",
+    "message": "கேட்டது"
+  },
+  "voicesInHostMenu": {
+    "description": "அமைப்புகள் Voices ஸ்டுடியோவில் மெனு ஸ்லாட்கள் வரிசைக்கு மேலே வரும் பகுதி தலைப்பு; $host$ என்பது உதவியாளர்.",
+    "message": "$host$-இன் மெனுவில்",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "அமைப்புகள் Voices ஸ்டுடியோவில் குரல் கார்டின் பின் டாகிளில் (ஆன் நிலையில்) காணும் குறுகிய லேபல்.",
+    "message": "✓ மெனுவில்"
+  },
+  "voicesInUse": {
+    "description": "அமைப்புகள் Voices பட்டியலில், ஹோஸ்டின் தற்போது தேர்ந்தெடுக்கப்பட்ட குரலில் நிரந்தரமாக காட்டும் பேட்ஜ்; பெரிய எழுத்தாக காட்டப்படும். வேண்டுமென்றே 'இப்போது பேசுகிறது' அல்ல: இந்தப் பக்கத்தில் வரிசைகள் மாதிரி கிளிப்புகளை இயக்கும், ஆகவே தேர்ந்தெடுக்கப்பட்டும் அமைதியாக இருக்கும் குரல், வேறு வரிசை இயக்கப்படும்போது பேசுகிறது என்று கூறக்கூடாது.",
+    "message": "பயன்பாட்டில்"
+  },
+  "voicesKeyboardHint": {
+    "description": "அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டியில் உள்ள ஒரு வரி விசைப்பலகை குறிப்பு. குறியீடுகள் விசைகள்: Space, மேல்/கீழ் அம்புகள், மற்றும் Shift+Space.",
+    "message": "கேட்க Space ஐ அழுத்தவும், குரல்களுக்கு இடையில் நகர ↑↓, மீண்டும் மாற்ற ⇧Space."
+  },
+  "voicesLoadError": {
+    "description": "ஒரு ஹோஸ்டின் ஸ்டூடியோவுக்குள் அந்த ஹோஸ்டின் குரல் பட்டியல் ஏற்றப்படாதபோது காட்டப்படும் பிழை நிலை; $host$ என்பது உதவியாளர்.",
+    "message": "$host$-இன் குரல்களை ஏற்ற முடியவில்லை. தயவுசெய்து பின்னர் மீண்டும் முயற்சிக்கவும்.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "ஹோஸ்டின் அரட்டைக்குள் மெனுவில் ஏற்கெனவே அதிகபட்ச எண்ணிக்கையிலான குரல்கள் இருக்கும் போது முடக்கப்பட்ட '+ மெனு' டாகிளில் காட்டப்படும் டூல்டிப்/குறிப்பு.",
+    "message": "மெனு நிரம்பியுள்ளது — மற்றொன்றை சேர்க்க ஒரு குரலை நீக்கவும்"
+  },
+  "voicesMenuHint": {
+    "description": "'In {host}'s menu' தலைப்புக்கு அருகில் வரும் ஒரே வரி குறிப்பு; ஸ்லாட்கள் வரிசை அரட்டைக்குள் உள்ள குரல் மெனுவை பிரதிபலிக்கிறது என்பதை விளக்குகிறது.",
+    "message": "அரட்டையில் நீங்கள் பார்ப்பது"
+  },
+  "voicesMenuOverflow": {
+    "description": "பயனரிடம் அரட்டை மெனு காட்டக்கூடியதைவிட அதிக பின் செய்த குரல்கள் இருக்கும்போது (பழைய நிலை) மெனு இடங்களின் கீழே காட்டப்படும் குறிப்பு; $count$ என்பது பொருந்தாத எண்ணிக்கை, $cap$ என்பது மெனு அளவு.",
+    "message": "மெனுவின் $cap$ இடங்களுக்கு அப்பால் இன்னும் $count$ பின் செய்த குரல்கள் காத்திருக்கின்றன.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "voicesMenuOverflow-இன் ஒருமை வடிவம்; அரட்டை மெனுவில் துல்லியமாக ஒரு பின் செய்த குரல் பொருந்தாதபோது பயன்படுத்தப்படும்; $cap$ என்பது மெனு அளவு.",
+    "message": "மெனுவின் $cap$ இடங்களுக்கு அப்பால் இன்னும் 1 பின் செய்த குரல் காத்திருக்கிறது.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "அமைப்புகள் குரல்கள் பட்டியலுக்குக் கீழே காட்டப்படும் சுருக்க வரி; அரட்டையிலுள்ள ஹோஸ்ட் குரல் மெனுவில் எவ்வளவு நிரம்பியுள்ளது என்பதைச் சொல்லும். $host$ உதவியாளர், $used$ எத்தனை இடங்கள் நிரம்பியுள்ளன, $cap$ மொத்த இடங்கள். 1 இலும் சரியாக படிக்குமாறு சொற்றொடராக்கப்பட்டுள்ளது — Chrome i18n இல் பன்மை வடிவங்கள் இல்லை.",
+    "message": "$host$ இன் மெனு: $cap$ இடங்களில் $used$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "அமைப்புகள் குரல்கள் பட்டியலின் இறுதியில் உள்ள குழுவுக்கான தலைப்பு; இயக்க மாதிரி கிளிப் இல்லாத குரல்கள் இதில் இருக்கும். $count$ எத்தனை என்பதை காட்டும். 1 இலும் சரியாக படிக்குமாறு சொற்றொடராக்கப்பட்டுள்ளது — Chrome i18n இல் பன்மை வடிவங்கள் இல்லை.",
+    "message": "இன்னும் மாதிரி இல்லை ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "உள்நுழைந்த பயனருக்காக குரல் பட்டியல் காலியாக இருக்கும் போது அமைப்புகளின் குரல் காடலாக்கில் காட்டப்படும் (எ.கா. நெட்வொர்க் பிரச்சனை).",
+    "message": "இப்போது குரல்களை ஏற்ற முடியவில்லை. பின்னர் மீண்டும் முயற்சிக்கவும்."
+  },
+  "voicesNowPlaying": {
+    "description": "அமைப்புகள் குரல்கள் பட்டியலில் ஒரு குரலின் மாதிரி கிளிப் இயக்கத் தொடங்கும்போது திரை வாசிப்பான் அறிவிக்கும்; $name$ அந்த குரல்.",
+    "message": "$name$ இயக்கப்படுகிறது",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டியில் உள்ள பொத்தான்; தற்போது பட்டியலிடப்பட்ட எல்லா குரல்களையும் ஒன்றன்பின் ஒன்றாக இயக்கும். $count$ எத்தனை. 1 இலும் சரியாக படிக்குமாறு சொற்றொடராக்கப்பட்டுள்ளது — Chrome i18n இல் பன்மை வடிவங்கள் இல்லை.",
+    "message": "அனைத்தையும் இயக்கு ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "மீண்டும் வரும்போது அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டியில் உள்ள பொத்தான்: நீங்கள் இன்னும் கேட்காத பட்டியலிலுள்ள குரல்களையே மட்டும் இயக்கும். $count$ எத்தனை. 1 இலும் சரியாக படிக்குமாறு சொற்றொடராக்கப்பட்டுள்ளது — Chrome i18n இல் பன்மை வடிவங்கள் இல்லை.",
+    "message": "புதியவற்றை இயக்கு ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "பக்கம் இன்னும் பயனர் தொடர்பு பெறாததால் உலாவி மாதிரி ஒலியை இயங்க விட மறுத்தபோது, அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டையில் காட்டப்படும் வரி.",
+    "message": "ஒலியை இயக்க எந்தக் குரலையும் கிளிக் செய்யவும்."
+  },
+  "voicesPreview": {
+    "description": "ஒரு குரல் வரியில் உள்ள இலவச மாதிரி கிளிப்பை இயக்கும் play (▶) பொத்தானுக்கான அணுகக்கூடிய லேபல்; $name$ என்பது குரலின் பெயர்.",
+    "message": "$name$ குரலின் மாதிரியை இயக்கு",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "அமைப்புகளின் Voices பட்டியலின் அணுகக்கூடிய பெயர் (ஒவ்வொரு வரியிலும் ஒரு குரல் இருக்கும் பட்டியல் பெட்டி).",
+    "message": "குரல்கள், கனமானதிலிருந்து தெளிவானது வரை வரிசைப்படுத்தப்பட்டவை"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "குரல் கார்டின் பின் டாகிளுக்கான (ஆன் நிலையில்) மற்றும் மெனு ஸ்லாட்டின் நீக்கு பொத்தானுக்கான அணுகல்தன்மை லேபல்; $name$ என்பது குரல், $host$ என்பது உதவியாளர்.",
+    "message": "$host$-இன் மெனுவிலிருந்து $name$-ஐ நீக்கு",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "ஒரு குரலின் மாதிரி கிளிப் ஏற்றப்படவோ இயக்கப்படவோ தவறியபோது, அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டையில் காட்டப்படும் வரி; $name$ என்பது அந்தக் குரல். மாடல் அல்ல — மாதிரிகள் தொடரில் இது கடந்தும் தொடர்ந்து இயங்கும்.",
+    "message": "$name$ குரலின் மாதிரியை இயக்க முடியவில்லை.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "அமைப்புகள் AI Chat தாவலில் உள்ள குரல் பட்டியல் பகுதியின் துணைத்தலைப்பு.",
+    "message": "ஒவ்வொரு தளத்திலும் பதில்களை ஒலிப்பாக வாசிக்கும் குரலைத் தேர்வு செய்யுங்கள்."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "சுருதி வரிசைப்படுத்தப்பட்ட குரல் பட்டை (rail)க்காக Voices அமைப்புத் தலைப்பின் கீழ் காட்டப்படும் துணைத்தலைப்பு.",
+    "message": "ஒவ்வொரு குரலும், கனமானதிலிருந்து தெளிவானது வரை. கேட்டு தேர்ந்தெடுக்கவும்."
+  },
+  "voicesSectionTitle": {
+    "description": "அமைப்புகள் AI Chat தாவலில் உள்ள குரல் பட்டியல் பகுதியின் தலைப்பு.",
+    "message": "குரல்கள்"
+  },
+  "voicesShelfEveryday": {
+    "description": "அமைப்புகள் குரல் பட்டியலில் value-tier குரல்களுக்கான குழுத் தலைப்பு. CSS மூலம் uppercase-ஆக ரெண்டர் செய்யப்படுகிறது.",
+    "message": "அன்றாடக் குரல்கள்"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "அமைப்புகள் Voices studio-வில் Everyday குழுத் தலைப்பிற்கு அருகிலுள்ள ஒரே வரி குறிப்பு; HD-யை விட இந்த tier எவ்வளவு அதிகமாக நீள்கிறது என்பதை studio கூறும் ஒரே இடம்.",
+    "message": "இயல்பானதும் தெளிவானதும் — HD-யை விட சுமார் 20× அதிக நேரம் கேட்கலாம்."
+  },
+  "voicesShelfHd": {
+    "description": "அமைப்புகள் குரல் பட்டியலில் பிரீமியம் (HD) குரல்களுக்கான குழுத் தலைப்பு. CSS மூலம் uppercase-ஆக ரெண்டர் செய்யப்படுகிறது.",
+    "message": "HD குரல்கள்"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "அமைப்புகள் Voices studio-வில் HD குழுத் தலைப்பிற்கு அருகிலுள்ள ஒரே வரி குறிப்பு.",
+    "message": "எங்களின் மிக வளமான, மிகவும் வெளிப்பாடான ஒலி."
+  },
+  "voicesShowAll": {
+    "description": "அமைப்புகள் குரல்கள் 'Show' வடிப்பானில் உள்ள விருப்பம்: வடிகட்டல் இல்லை, எல்லா குரல்களும் பட்டியலிடப்படும்.",
+    "message": "அனைத்து குரல்கள்"
+  },
+  "voicesShowEveryday": {
+    "description": "அமைப்புகள் குரல்கள் 'Show' வடிப்பானில் உள்ள விருப்பம்: நிலையான (HD அல்லாத) குரல்களை மட்டும் பட்டியலிடும்.",
+    "message": "சாதாரணம் மட்டும்"
+  },
+  "voicesShowHd": {
+    "description": "அமைப்புகள் குரல்கள் 'Show' வடிப்பானில் உள்ள விருப்பம்: பிரீமியம் (HD) குரல்களை மட்டும் பட்டியலிடும்.",
+    "message": "HD மட்டும்"
+  },
+  "voicesShowLabel": {
+    "description": "அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டையில் உள்ள வடிப்பானின் லேபல்; பட்டியலில் எந்த குரல்கள் காட்டப்பட வேண்டும் என்பதைச் சுருக்குகிறது.",
+    "message": "காட்டு"
+  },
+  "voicesShowUnheard": {
+    "description": "அமைப்புகள் குரல்கள் 'Show' வடிப்பானில் உள்ள விருப்பம்: பயனர் இன்னும் கேட்காத குரல்களை மட்டும் பட்டியலிடும்.",
+    "message": "இன்னும் கேட்காதவை"
+  },
+  "voicesSpeakingNow": {
+    "description": "அமைப்புகள் Voices ஸ்டுடியோவில் (மெனு ஸ்லாட் மற்றும் குரல் கார்டில்) ஹோஸ்டின் தற்போது தேர்ந்தெடுக்கப்பட்ட குரலுக்கான நிலை லேபல்.",
+    "message": "இப்போது பேசுகிறது"
+  },
+  "voicesSpeaksWith": {
+    "description": "அமைப்புகள் Voices ஸ்டுடியோ மேடையில், தற்போதைய குரல் பெயருக்கு மேலே வரும் சுருக்க வரி; $host$ என்பது உதவியாளர் (எ.கா. Pi). CSS மூலம் பெரிய எழுத்தாக காட்டப்படும்.",
+    "message": "$host$ பேசும் குரல்",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "ஹோஸ்ட் தனது சொந்த ஆடியோவை வழங்கும் போது (எ.கா. Pi) காட்டப்படும் மேடை குறிப்பு; ஆகவே Say, Pi குரலைத் தேர்ந்தெடுத்தால் ஹோஸ்டின் குரல் மாற்றப்படும்.",
+    "message": "நீங்கள் கீழே ஒன்றைத் தேர்ந்தெடுக்கும் வரை $host$ தனது சொந்த குரலைப் பயன்படுத்தும்.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "ஹோஸ்டிற்கு தனிப்பட்ட குரல் இல்லாதபோது (எ.கா. Claude) காட்டப்படும் மேடை குறிப்பு; அதனால் Say, Pi குரல் தேர்ந்தெடுக்கப்படும் வரை எதுவும் சத்தமாக வாசிக்கப்படாது.",
+    "message": "நீங்கள் கீழே ஒன்றைத் தேர்ந்தெடுக்கும் வரை $host$ பதில்களை சத்தமாக வாசிக்காது.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "ஹோஸ்டிற்கு SayPi குரல் தேர்ந்தெடுக்கப்படாதபோது அமைப்புகளின் Voices ஸ்டூடியோ மேடையில் காட்டப்படும் தலைப்பு; $host$ என்பது உதவியாளர் (எ.கா. Pi, Claude). பெயர் அளவில் காட்டப்படும்.",
+    "message": "$host$ எப்படி ஒலிக்க வேண்டும் என்பதைத் தேர்ந்தெடுக்கவும்",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "தற்போதைய குரலின் இலவச மாதிரி கிளிப்பை இயக்கும் அமைப்புகளின் Voices ஸ்டூடியோ மேடையில் உள்ள பொத்தான்.",
+    "message": "ஒரு மாதிரியை கேளுங்கள்"
+  },
+  "voicesStopPlayback": {
+    "description": "அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டியில் உள்ள பொத்தான்; 'Play all' மூலம் தொடங்கப்பட்ட மாதிரி இயக்கத்தொடரை நிறுத்தும்.",
+    "message": "நிறுத்து"
+  },
+  "voicesSweepPosition": {
+    "description": "அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டையில் 'Play all' பட்டியலில் நகரும் போது காட்டப்படும் நேரடி நிலை. $index$ என்பது தற்போது ஒலிக்கும் குரல், $total$ என்பது வரிசையில் உள்ள மொத்த எண்ணிக்கை.",
+    "message": "$total$ இல் $index$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டியில் உள்ள ஒப்பீட்டு கட்டுப்பாட்டுக்கான அணுகத்தக்க லேபிள்; கடைசியாக கேட்ட இரண்டு குரல்களில் உள்ள மற்ற குரலை மீண்டும் இயக்கும். $name$ அந்த குரல்.",
+    "message": "$name$ க்கு மீண்டும் மாற்றவும்",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "'Play all' மிக நீளமான பட்டியலில் அழுத்தப்படும்போது அமைப்புகள் குரல்கள் கட்டுப்பாட்டு பட்டையில் காட்டப்படும் வரி; $count$ என்பது குரல்கள் எத்தனை, $minutes$ என்பது அவற்றிற்கு ஆகும் நேரத்தின் தோராயமான நிமிடங்கள். Chrome i18n-க்கு பன்மை வடிவங்கள் இல்லாததால் 1-இலும் சரியாக வாசிக்க 'min' என்ற சுருக்கம் பயன்படுத்தப்பட்டுள்ளது.",
+    "message": "அது $count$ குரல்கள் — சுமார் $minutes$ min. முதலில் பட்டியலைச் சுருக்கவும்.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "அமைப்புகள் குரல் பட்டியலில், ஒவ்வொரு ஹோஸ்ட்-க்கும் இருக்கும் 'இந்தக் குரலைப் பயன்படுத்து' பொத்தானுக்கான அணுகல்தன்மை லேபல்; $name$ என்பது குரல், $host$ என்பது உதவியாளர் (எ.கா. Pi, Claude).",
+    "message": "$host$-இல் $name$-ஐ பயன்படுத்து",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "ஒருங்கிணைந்த அமைப்புகள் குரல் பட்டியலில், ஒவ்வொரு ஹோஸ்ட்-க்கும் இருக்கும் 'இந்தக் குரலைப் பயன்படுத்து' பொத்தானில் காணும் குறுகிய லேபல் (அதன் அருகில் ஹோஸ்ட் காட்டப்படும்).",
+    "message": "பயன்படுத்து"
+  },
+  "voicesYourVoice": {
+    "description": "அமைப்புகள் குரல்கள் பட்டியலின் கட்டுப்பாட்டு பட்டியில் உள்ள பொத்தான்; இந்த ஹோஸ்ட் தற்போது பயன்படுத்தும் குரலின் வரிசைக்கு கவனத்தை நகர்த்தும். $name$ அந்த குரல்.",
+    "message": "உங்கள் குரல்: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "குரல்-கண்டறிதல் மாதிரிக்குப் போதுமான WebAssembly நினைவகத்தை உலாவி ஒதுக்க முடியாதபோது ஏற்படும் பிழை.",
+    "message": "குரல் கண்டறிதல் தொடங்க முடியாது: குரல் மாதிரிக்குப் போதுமான WebAssembly நினைவகம் இல்லை. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "குரல்-கண்டறிதல் மாதிரியை இயக்க தேவையான ஆரம்ப WebAssembly நினைவகத்தை உலாவி வழங்காதபோது ஏற்படும் பிழை.",
+    "message": "குரல் கண்டறிதல் தொடங்க முடியாது: இந்த உலாவியில் WebAssembly நினைவகம் கிடைக்கவில்லை."
   }
 }

--- a/_locales/tl/messages.json
+++ b/_locales/tl/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Benepisyo na nakalista sa auth modal - increased usage limits.",
+    "message": "Mas mataas na limit sa paggamit gamit ang libreng account"
+  },
+  "authBenefitPremium": {
+    "description": "Benepisyo na nakalista sa auth modal - premium features across chatbots.",
+    "message": "Mga premium na feature at suporta sa chatbot"
+  },
+  "authBenefitSupport": {
+    "description": "Benepisyo na nakalista sa auth modal - priority support.",
+    "message": "Priority na suporta para sa mga isyu"
+  },
+  "authBenefitSync": {
+    "description": "Benepisyo na nakalista sa auth modal - settings sync.",
+    "message": "I-sync ang settings ng boses saanman"
+  },
+  "authBenefitTTS": {
+    "description": "Benepisyo na nakalista sa auth modal - TTS feature.",
+    "message": "Mga boses na text-to-speech (mga bayad na plan)"
+  },
+  "authBenefitUsage": {
+    "description": "Benepisyo na nakalista sa auth modal - usage tracking.",
+    "message": "Subaybayan ang paggamit mo ng boses sa iba’t ibang device"
+  },
+  "authPromptModalFull": {
+    "description": "Paglalarawan para sa full modal auth prompt na may value proposition.",
+    "message": "Sulit na sulit ang paggamit mo sa Say, Pi. Mag-sign in para sa mas mataas na limit, mga boses na text-to-speech, at mga premium na feature sa lahat ng suportadong chatbot."
+  },
+  "authPromptModalSoft": {
+    "description": "Paglalarawan para sa soft modal auth prompt.",
+    "message": "Gumawa ng libreng account sa Say, Pi para sa mas mataas na limit sa paggamit at access sa mga premium na feature ng boses."
+  },
+  "authPromptTitle": {
+    "description": "Pamagat para sa auth prompt modal.",
+    "message": "I-unlock ang mas maraming feature ng boses"
+  },
+  "authPromptToast": {
+    "description": "Toast notification na humihikayat sa user na mag-sign in.",
+    "message": "Mag-sign in sa Say, Pi para sa mas mataas na limit at mga premium na feature"
+  },
   "autoReadAloudChatGPT": {
     "description": "Tanda para sa checkbox upang paganahin/huwag paganahin ang awtomatikong pagbabasa ng mga sagot ng ChatGPT habang may tawag na boses.",
     "message": "Awtomatikong Pagbasa (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Huwag paganahin ang text-to-speech"
   },
+  "dismiss": {
+    "message": "Naintindihan ko",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Iwaksi"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Tumok"
   },
+  "errorVadInitFailed": {
+    "description": "Error toast na ipinapakita kapag nabigo ang voice-activity detection na mag-initialize.",
+    "message": "Nabigong i-initialize ang voice detection"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Error toast na ipinapakita kapag may hindi inaasahang error habang sine-set up ang pag-record ng boses.",
+    "message": "Nabigong i-set up ang pag-record ng boses"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Error toast na ipinapakita kapag nabigo ang voice-detection client na simulan ang recording.",
+    "message": "Nabigong simulan ang pag-record ng boses"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Error toast na ipinapakita kapag hindi available ang voice-detection (VAD) client, kaya hindi makapagsimula ang recording.",
+    "message": "Hindi available ang pag-record ng boses"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Lumabas sa Mode ng Pokus"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Isang linyang paalala na ipinapakita sa voice menus kapag parehong available ang premium (HD) at value voices",
+    "message": "Mas mabilis maubos ang buwanang allowance mo nang mga 20× kapag HD voices ang gamit."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Tucking ito ..."
   },
+  "maybeLater": {
+    "description": "Text ng button para isara ang auth prompt.",
+    "message": "Mamaya na lang"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Ang iyong mga setting ng mikropono ay hindi nakakatugon sa mga kinakailangang detalye. \nSubukang gumamit ng ibang mikropono o ayusin ang iyong mga setting ng audio."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Hindi ma-access ang mikropono. \nPakisuri ang mga setting ng iyong device at subukang muli."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Error toast na ipinapakita kapag tinanggihan ang pahintulot sa mikropono pagkatapos ng permission prompt flow.",
+    "message": "Hindi naibigay ang pahintulot sa mikropono. Tiyaking pinayagan mo ang access sa prompt at sa settings ng extension."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "katumpakan"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Pinakamabilis na tugon, ngunit hindi gaanong tumpak. \nMahilig makagambala."
   },
+  "moreVoices": {
+    "description": "Row sa menu na nagli-link mula sa voice menu sa page papunta sa buong voice catalog sa settings ng extension",
+    "message": "Mas maraming boses…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Palayaw ng Katulong"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Hindi naka -sign in"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Label ng button na nagbubukas ng ChatGPT.",
+    "message": "Buksan ang ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Label ng button na nagbubukas ng Claude.ai.",
+    "message": "Buksan ang Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Label ng button na nagbubukas ng Pi.ai.",
+    "message": "Buksan ang Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Opsyon sa kapaligiran: malapit sa ibang tao.",
+    "message": "Malapit sa ibang tao"
+  },
+  "onboarding_envMixed": {
+    "description": "Opsyon sa kapaligiran: halo ng pribado at shared na espasyo.",
+    "message": "Halo-halong lugar"
+  },
+  "onboarding_envPrivate": {
+    "description": "Opsyon sa kapaligiran: pribadong espasyo.",
+    "message": "Sa pribadong lugar"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Kumpirmasyong ipinapakita kapag ang sagot tungkol sa kapaligiran ay hindi nagbubukas ng quiet mode.",
+    "message": "Sige — gagamitin namin ang karaniwang mga setting sa pakikinig at pag-playback."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Kumpirmasyong ipinapakita kapag ang sagot sa kapaligiran ay nag-e-enable ng quiet mode.",
+    "message": "Naka-on ang quiet mode — makikinig kami kahit mas mahina ang boses at mahina ring sasagot, para makapagsalita ka nang hindi halata."
+  },
+  "onboarding_envTitle": {
+    "description": "Heading para sa onboarding na tanong tungkol sa kapaligiran ng user.",
+    "message": "Saan ka karaniwang magsasalita?"
+  },
+  "onboarding_footer": {
+    "description": "Teksto sa footer sa unang beses na onboarding page.",
+    "message": "Maaari mong balikan ito anumang oras mula sa settings ng Say, Pi. Mahalaga ang privacy mo — kinukuha lang ang audio habang may aktibong tawag."
+  },
+  "onboarding_heading": {
+    "description": "Pangunahing heading sa first-run onboarding page.",
+    "message": "🗣️ Maligayang pagdating sa Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Panimulang talata sa first-run onboarding page.",
+    "message": "Dalawang hakbang ka na lang bago ang una mong pasalitang usapan sa isang AI. Mga 3× mas mabilis ang pagsasalita kaysa pag-type — i-setup na natin."
+  },
+  "onboarding_micTestButton": {
+    "description": "Button na nagsisimula ng onboarding microphone test na walang risk.",
+    "message": "🎤 Subukan ang mikropono mo"
+  },
+  "onboarding_micTestDone": {
+    "description": "Status na ipinapakita pagkatapos matagumpay na matapos ang onboarding mic test.",
+    "message": "Ayos — gumagana ang mikropono mo! 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Status na ipinapakita habang sinusukat ng onboarding mic test ang input.",
+    "message": "Nakikinig — magsalita ka! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Status na ipinapakita habang naghihintay ng pahintulot ang onboarding mic test.",
+    "message": "Humihingi ng pahintulot sa mikropono…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Label ng button para ihinto ang onboarding mic test habang tumatakbo.",
+    "message": "Itigil ang test"
+  },
+  "onboarding_step1Body": {
+    "description": "Nilalaman ng unang onboarding step na nagpapaliwanag kung paano i-pin ang extension.",
+    "message": "I-click ang puzzle-piece 🧩 icon sa kanang-itaas ng browser mo, tapos ang pin 📌 sa tabi ng Say, Pi. Para isang click na lang ang call button."
+  },
+  "onboarding_step1Title": {
+    "description": "Pamagat ng unang onboarding step (i-pin ang extension).",
+    "message": "I-pin ang Say, Pi sa toolbar mo"
+  },
+  "onboarding_step2Body": {
+    "description": "Nilalaman ng pangalawang onboarding step na nagpapaliwanag kung paano magsimula ng voice conversation.",
+    "message": "Pumunta sa isa sa mga supported na assistant sa ibaba, tapos i-tap ang Say, Pi call button at bumati. Hihingi kami ng access sa mikropono sa unang beses — normal iyon, at nakikinig lang kami habang aktibo kang nasa tawag."
+  },
+  "onboarding_step2Title": {
+    "description": "Pamagat ng pangalawang onboarding step (magsimula ng usapan).",
+    "message": "Magbukas ng AI chat at magsimulang magsalita"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Pahintulot ng mikropono"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Gabay sa pag-recover kapag naka-block ang pahintulot sa mikropono.",
+    "message": "Binablock ng browser mo ang mikropono. I-click ang camera o lock na icon sa address bar, itakda ang Microphone sa \"Allow\", pagkatapos ay subukan ulit. Sa macOS, tingnan din ang System Settings → Privacy & Security → Microphone."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Pamagat ng recovery panel kapag tinanggihan/naka-block ang pahintulot sa mikropono.",
+    "message": "Naka-block ang access sa mikropono"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Gabay sa pag-recover kapag ginagamit sa ibang lugar ang mikropono.",
+    "message": "Maaaring ginagamit ng ibang app o tab ang mikropono mo. Isara ang anumang posibleng nagre-record (mga video call, voice memo), pagkatapos ay subukan ulit."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Pamagat ng recovery panel kapag ginagamit ang mikropono ng ibang app.",
+    "message": "Ginagamit ang mikropono mo"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Gabay sa pag-recover kapag walang available na mikropono na device.",
+    "message": "Wala kaming nakitang mikropono. Isaksak ang isa (o ikonekta ang headset mo), tiyaking ito ang napili bilang input device, pagkatapos ay subukan ulit."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Pamagat ng recovery panel kapag walang available na mikropono na device.",
+    "message": "Walang nakitang mikropono"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Gabay sa pag-recover para sa hindi kilalang error sa mikropono.",
+    "message": "May nangyaring problema sa pag-access sa mikropono mo. Tingnan kung nakakonekta ito at pinapayagan sa mga setting ng browser mo, pagkatapos ay subukan ulit."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Pamagat ng recovery panel para sa hindi kilalang error sa mikropono.",
+    "message": "Hindi namin ma-access ang mikropono mo"
+  },
+  "permissions_retryButton": {
+    "description": "Label para sa button na muling humihiling ng pahintulot sa mikropono.",
+    "message": "Subukan ulit"
+  },
+  "permissions_revokedHeading": {
+    "description": "Heading na ipinapakita kapag dating pinayagan ang access sa mikropono pero na-revoke na.",
+    "message": "🎙️ Ikonekta ulit ang mikropono mo"
+  },
+  "permissions_revokedInfo": {
+    "description": "Impormasyong text na ipinapakita kapag na-revoke ang access sa mikropono matapos itong mapayagan.",
+    "message": "Naka-off ang access sa mikropono mo — madalas itong mangyari pagkatapos ng update sa browser o system. Payagan ulit ito sa ibaba at makikinig na ulit ang $productName$ kapag nasa tawag ka.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profile"
+  },
+  "quietModeLabel": {
+    "description": "Label para sa toggle na nag-e-enable ng tahimik/whisper mode.",
+    "message": "Tahimik na mode"
+  },
+  "quietModeTooltip": {
+    "description": "Tooltip na nagpapaliwanag kung ano ang ginagawa ng tahimik/whisper mode.",
+    "message": "Magsalita nang mahina — mas naririnig ang mas mahinang boses at binabaan ang lakas ng tugon ng assistant, para magamit mo ang boses kapag may ibang tao."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Teksto para sa button ng pag-sign in habang nagpapatuloy ang authentication.",
+    "message": "Nagla-log in..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Mga tunog na epekto"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Ang mga sound effect ay hindi pinagana sa Firefox upang maiwasan ang mga isyu sa audio feedback."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Headline ng one-time post-win speed-payoff notice na ipinapakita pagkatapos ng unang spoken exchange.",
+    "message": "Ayos — mga 3× na mas mabilis ang pagsasalita kaysa pag-type."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Opsyonal na ikalawang linya ng speed-payoff notice na nagpapakita ng buong minutong natipid.",
+    "message": "Nakakapagsalita ka na ng humigit-kumulang $minutes$ min na mas mabilis kaysa kung tinype mo ito.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Isumite lamang kapag pinindot mo ang pindutan"
   },
+  "surveyQuestion": {
+    "description": "Ang nag-iisang tanong ng one-time post-win micro-survey.",
+    "message": "Kamusta ang boses para sa iyo sa ngayon?"
+  },
+  "surveyRatingLabel": {
+    "description": "Accessible na label para sa button ng rating sa survey.",
+    "message": "I-rate ang $rating$ sa 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Pagkilala na ipinapakita matapos sagutin ng user ang post-win survey.",
+    "message": "Salamat — nakakatulong ito para mas mapabuti ang Say, Pi. 🙏"
+  },
   "tabAIChat": {
     "description": "Label ng tab para sa mga setting ng AI chat.",
     "message": "AI Chat"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Label ng tab para sa mga pangkalahatang setting.",
     "message": "Pangkalahatan"
+  },
+  "tabVoices": {
+    "description": "Label ng tab para sa seksyon ng settings ng mga boses (katalogo ng boses kada site).",
+    "message": "Mga boses"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "mga kredito"
   },
+  "ttsCreditsRemaining": {
+    "description": "Tekstong nagpapakita ng natitirang TTS quota bilang per-voice na credit pool (saypi-api #181 Stage 2), hindi bilang raw characters.",
+    "message": "Natitirang $credits$ credit",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Kasalukuyang hindi sinusuportahan sa Safari ang mga multilingguwal na boses."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Henerasyon ng boses"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Paalala! Ang speech playback ay hindi pa available sa $browserName$ gamit ang $chatbotName$. Ang magandang balita? Gumagana nang napakahusay ang voice input! Para sa TTS, subukan ang Chrome o Edge sa desktop.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "Hindi available ang TTS sa $browserName$ + $chatbotName$. Gumagana ang voice input! Subukan ang Chrome desktop para sa TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS Voice"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Detalye ng VAD kapag may natukoy na audio na parang pagsasalita pero masyadong mahina / mababa ang kumpiyansa para ma-transcribe (client-side admission-gate drop).",
+    "message": "Masyadong mahina ang audio para ma-transcribe"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Detalye ng VAD na nagpapaliwanag na natapos ang tawag dahil inangkin ang mikropono ng mas bagong tab.",
+    "message": "Inilipat ang voice input sa ibang tab"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Hindi magagamit ang boses. \nSubukan ang Chrome o Firefox sa desktop."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Paalala! Ang speech playback ay hindi pa available sa $browserName$ gamit ang $chatbotName$. Ang magandang balita? Gumagana nang napakahusay ang voice input! Para sa TTS, subukan ang Chrome o Edge sa desktop.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "Hindi available ang TTS sa $browserName$ + $chatbotName$. Gumagana ang voice input! Subukan ang Chrome desktop para sa TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Naintindihan ko",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Status ng VAD na ipinapakita sa tab na ang voice input ay inagaw ng ibang tab.",
+    "message": "Naka-pause"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Tingnan ang mga detalye"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Pangkalahatang binibigkas na pagpapakilala na pinapatugtog kapag ang napiling boses ng SayPi ay walang voice-specific na introduction script (at walang kamakailang mensahe na babasahin pabalik).",
+    "message": "Hi, ako si $voice$. Ganito ang tunog ko. Sana magustuhan mo ang boses na ito.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hola! \nПривет! \n你好! \nAko si Pi, ang iyong polyglot AI assistant. \nSa 32 wika sa aking utos, maaari nating tuklasin ang mga ideya at kultura mula sa buong mundo. \nAno sa tingin mo ang boses na ito?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Mga setting ng boses"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Fallback na subtitle para sa voice row sa settings voice catalog kapag walang paglalarawan ang boses; $count$ ang bilang ng mga wikang sinusuportahan ng boses.",
+    "message": "Nakakapagsalita ng $count$ wika",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Nakatalagang tagline ng personalidad para sa boses na 'Addison' (settings Voices studio; client-side voice identity map).",
+    "message": "Masigla at malinaw magsalita"
+  },
+  "voiceTagline_alloy": {
+    "description": "Inakdang tagline ng personalidad para sa boses na 'Alloy' (settings Voices studio; client-side voice identity map).",
+    "message": "Balanseng pangkalahatan"
+  },
+  "voiceTagline_ash": {
+    "description": "Inakdang tagline ng personalidad para sa boses na 'Ash' (settings Voices studio; client-side voice identity map).",
+    "message": "Mababa, mapag-isip, kalmado"
+  },
+  "voiceTagline_ballad": {
+    "description": "Inakdang tagline ng personalidad para sa boses na 'Ballad' (settings Voices studio; client-side voice identity map).",
+    "message": "Malambot at melodiko"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Nakatalagang tagline ng personalidad para sa boses na 'Cassidy' (settings Voices studio; client-side voice identity map).",
+    "message": "Palakaibigan at diretsahan"
+  },
+  "voiceTagline_cedar": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Cedar' (settings Voices studio; client-side voice identity map).",
+    "message": "Matatag at nakapagpapakalma"
+  },
+  "voiceTagline_coral": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Coral' (settings Voices studio; client-side voice identity map).",
+    "message": "Maliwanag, masiglang enerhiya"
+  },
+  "voiceTagline_echo": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Echo' (settings Voices studio; client-side voice identity map).",
+    "message": "Malinis at neutral"
+  },
+  "voiceTagline_fable": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Fable' (settings Voices studio; client-side voice identity map).",
+    "message": "Tono ng pagkukuwento"
+  },
+  "voiceTagline_finn": {
+    "description": "Nakatalagang tagline ng personalidad para sa boses na 'Finn' (settings Voices studio; client-side voice identity map).",
+    "message": "Presko at masigla"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Nakatalagang tagline ng personalidad para sa boses na 'Jamahal' (settings Voices studio; client-side voice identity map).",
+    "message": "May lalim at nakakaakit"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Jarnathan' (settings Voices studio; client-side voice identity map).",
+    "message": "Makinis na baritone sa gabing-gabi"
+  },
+  "voiceTagline_jeff": {
+    "description": "Nakatalagang tagline ng personalidad para sa boses na 'Jeff' (settings Voices studio; client-side voice identity map).",
+    "message": "Diretsahan at kalmado"
+  },
+  "voiceTagline_jessica": {
+    "description": "Nakatalagang tagline ng personalidad para sa boses na 'Jessica' (settings Voices studio; client-side voice identity map).",
+    "message": "Mainit, pulido, may tikas"
+  },
+  "voiceTagline_joey": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Joey' (settings Voices studio; client-side voice identity map).",
+    "message": "Magaan, pang-usapang Amerikano"
+  },
+  "voiceTagline_juniper": {
+    "description": "Nakatalagang tagline ng personalidad para sa boses na 'Juniper' (settings Voices studio; client-side voice identity map).",
+    "message": "Malutong, maliwanag, buhay"
+  },
+  "voiceTagline_lucy": {
+    "description": "Nakatalagang tagline ng personalidad para sa boses na 'Lucy' (settings Voices studio; client-side voice identity map).",
+    "message": "Banayad at nagniningning"
+  },
+  "voiceTagline_marin": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Marin' (settings Voices studio; client-side voice identity map).",
+    "message": "Mainit, kalmadong parang morning radio"
+  },
+  "voiceTagline_mark": {
+    "description": "Nakatalagang tagline ng personalidad para sa boses na 'Mark' (settings Voices studio; client-side voice identity map).",
+    "message": "Malinaw, kumpiyansang tagapagsalaysay"
+  },
+  "voiceTagline_nova": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Nova' (settings Voices studio; client-side voice identity map).",
+    "message": "Mabilis at mausisa"
+  },
+  "voiceTagline_onyx": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Onyx' (settings Voices studio; client-side voice identity map).",
+    "message": "Malalim, matunog na bigat"
+  },
+  "voiceTagline_paola": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Paola' (settings Voices studio; client-side voice identity map).",
+    "message": "Masining na init na Italyano"
+  },
+  "voiceTagline_sage": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Sage' (settings Voices studio; client-side voice identity map).",
+    "message": "Malinaw na banayad magsalita"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Isinulat na tagline ng personalidad para sa boses na 'Shimmer' (settings Voices studio; client-side voice identity map).",
+    "message": "Magaan at mahangin"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Maikling label sa pin toggle ng voice card (off state) sa settings Voices studio; kapag pinindot, idinadagdag ang boses sa in-chat menu ng host.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Accessible label para sa pin toggle ng voice card (off state); $name$ ang boses, $host$ ang assistant.",
+    "message": "Idagdag ang $name$ sa menu ni $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Label sa toggle sa control bar ng Voices na nagsasabi kung ang paglakad sa listahan gamit ang mga arrow key ay nagpapatugtog ng bawat boses habang naaabot ito ng focus.",
+    "message": "I-play habang gumagalaw"
+  },
+  "voicesArrowsLive": {
+    "description": "Kumpirmasyon ng screen reader, idinadagdag sa unang anunsyong 'Playing <voice>' sa listahan ng Voices sa settings, na nagsasabing naririnig na ang mga arrow key. Inuulit ang mismong pananalita ng toggle na 'Play as you move'.",
+    "message": "Tumutugtog na ang mga arrow habang lumilipat ka. Humihinto ang Esc."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Tala sa ilalim ng mga slot ng menu para sa mga host na may native na boses (hal. 8 built-in ni Pi), na hindi pinapamahalaan ng studio; $host$ ang assistant.",
+    "message": "Lagi ring lumalabas sa menu nito ang mga built-in na boses ni $host$.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Bersyon ng voicesBuiltinsNote para sa host na walang in-chat voice menu (tinanggal ni Pi ang menu nito noong 2026), kung saan magiging mali ang pangako ng orihinal na 'lumalabas sa menu nito' ang mga built-in; $host$ ang assistant.",
+    "message": "May sarili ring built-in na mga boses si $host$, na hindi nakalista rito.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Progress readout sa control bar ng Voices sa settings: kung ilang boses sa listahan ang napakinggan na ng user. Hubad na numero, kaya bumabasa nang tama sa 1 — walang plural forms ang Chrome i18n.",
+    "message": "$heard$ sa $total$ narinig",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Bahagi ng accessible name ng row ng boses sa listahan ng Voices sa settings, na nagmamarka ng boses na napakinggan na ng profile na ito. Sa biswal, iginuguhit ito bilang ink density sa soundprint ng boses, na hindi nakikita ng screen reader.",
+    "message": "Narinig"
+  },
+  "voicesInHostMenu": {
+    "description": "Heading ng seksyon sa itaas ng hanay ng mga menu slot sa settings Voices studio; $host$ ang assistant.",
+    "message": "Sa menu ni $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Maikling label sa pin toggle ng voice card (on state) sa settings Voices studio.",
+    "message": "✓ Nasa menu"
+  },
+  "voicesInUse": {
+    "description": "Palagiang badge sa kasalukuyang napiling boses ng host sa listahan ng settings Voices, ginagawang uppercase. Sadyang HINDI 'Kasalukuyang nagsasalita': sa pahinang ito, nagpapatugtog ang mga row ng sample clip, kaya hindi dapat magpahiwatig na nagsasalita ang napili-ngunit-tahimik na boses habang ibang row ang tumutugtog.",
+    "message": "Ginagamit"
+  },
+  "voicesKeyboardHint": {
+    "description": "Isang-linyang keyboard hint sa control bar ng Voices sa settings. Ang mga glyph ay mga key: Space, ang pataas/pababang arrow, at Shift+Space.",
+    "message": "Pindutin ang Space para makinig, ↑↓ para lumipat sa mga boses, ⇧Space para bumalik."
+  },
+  "voicesLoadError": {
+    "description": "Error state sa loob ng studio ng isang host kapag hindi na-load ang voice catalog ng host na iyon; $host$ ang assistant.",
+    "message": "Hindi ma-load ang mga boses ni $host$. Pakisubukang muli mamaya.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/hint sa naka-disable na '+ Menu' toggle kapag nasa maximum na bilang ng mga boses ang in-chat menu ng host.",
+    "message": "Puno na ang menu — mag-alis ng boses para makapagdagdag ng iba"
+  },
+  "voicesMenuHint": {
+    "description": "Isang linyang hint sa tabi ng heading na 'In {host}'s menu', na nagpapaliwanag na ang hanay ng mga slot ay kapareho ng voice menu sa chat.",
+    "message": "Ito ang makikita mo sa chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Tala sa ilalim ng mga slot ng menu kapag mas marami ang naka-pin na boses ng user kaysa sa kayang ipakita ng in-chat menu (legacy state); $count$ ang bilang ng hindi kasya, $cap$ ang laki ng menu.",
+    "message": "May $count$ pang naka-pin na boses na naghihintay lampas sa $cap$ slot ng menu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Isahan ng voicesMenuOverflow, ginagamit kapag eksaktong isang naka-pin na boses ang hindi kasya sa in-chat menu; $cap$ ang laki ng menu.",
+    "message": "May 1 pang naka-pin na boses na naghihintay lampas sa $cap$ slot ng menu.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Buod na linya sa ilalim ng listahan ng Voices sa settings na nagsasabi kung gaano napupuno ang in-chat voice menu ng host; $host$ ang assistant, $used$ kung ilang upuan ang okupado, $cap$ kung ilan lahat. Naka-ayos para bumasa nang tama sa 1 — walang plural forms ang Chrome i18n.",
+    "message": "Menu ni $host$: $used$ sa $cap$ upuan",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Heading para sa grupo sa dulo ng listahan ng Voices sa settings na naglalaman ng mga boses na walang sample clip na mapapatugtog; $count$ kung ilan. Naka-ayos para bumasa nang tama sa 1 — walang plural forms ang Chrome i18n.",
+    "message": "Wala pang sample ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Ipinapakita sa settings voice catalog kapag walang laman ang listahan ng boses para sa naka-sign in na user (hal. problema sa network)",
+    "message": "Hindi ma-load ang mga boses sa ngayon. Pakisubukang muli mamaya."
+  },
+  "voicesNowPlaying": {
+    "description": "Anunsyo ng screen reader kapag nagsimulang tumugtog ang sample clip ng isang boses sa listahan ng Voices sa settings; $name$ ang boses.",
+    "message": "Pinapatugtog ang $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Button sa control bar ng Voices sa settings na pinapatugtog ang bawat kasalukuyang nakalistang boses, sunod-sunod; $count$ kung ilan. Naka-ayos para bumasa nang tama sa 1 — walang plural forms ang Chrome i18n.",
+    "message": "I-play lahat ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Button sa control bar ng Voices sa settings sa pagbabalik-bisita: pinapatugtog lang ang mga nakalistang boses na hindi mo pa napapakinggan; $count$ kung ilan. Naka-ayos para bumasa nang tama sa 1 — walang plural forms ang Chrome i18n.",
+    "message": "I-play ang bago ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Linya sa settings Voices control bar kapag tumanggi ang browser na patugtugin ang sample dahil wala pang pakikipag-ugnayan ang user sa pahina.",
+    "message": "I-click ang alinmang boses para paganahin ang tunog."
+  },
+  "voicesPreview": {
+    "description": "Accessible na label para sa play (▶) button na nagpapatugtog ng libreng sample clip ng isang boses sa voice row; $name$ ang pangalan ng boses.",
+    "message": "I-play ang sample ni $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Accessible name ng listahan ng Voices sa settings (isang listbox ng bawat boses, tig-isang row).",
+    "message": "Mga boses, nakaayos mula pinakamalalim hanggang pinakamatingkad"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Accessible label para sa pin toggle ng voice card (on state) at remove button ng menu slot; $name$ ang boses, $host$ ang assistant.",
+    "message": "Alisin ang $name$ sa menu ni $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Linya sa settings Voices control bar kapag nabigong mag-load o tumugtog ang sample clip ng isang boses; ang $name$ ang boses na iyon. Hindi modal — nagpapatuloy ang sunod-sunod na sample lampas dito.",
+    "message": "Hindi maipatugtog ang sample ni $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Subheading para sa seksyon ng voice catalog sa settings AI Chat tab",
+    "message": "Piliin ang boses na magbabasa nang malakas ng mga sagot sa bawat site."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Subheading sa ilalim ng heading ng Voices settings, para sa rail ng mga boses na nakaayos ayon sa pitch.",
+    "message": "Bawat boses, mula pinakamalalim hanggang pinakamatingkad. Makinig, saka pumili."
+  },
+  "voicesSectionTitle": {
+    "description": "Heading para sa seksyon ng voice catalog sa settings AI Chat tab",
+    "message": "Mga boses"
+  },
+  "voicesShelfEveryday": {
+    "description": "Heading ng grupo para sa value-tier na mga boses sa settings voice catalog. Nirender na uppercase ng CSS.",
+    "message": "Mga pang-araw-araw na boses"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Isang linyang tala katabi ng heading ng grupong Everyday sa settings Voices studio; ang nag-iisang lugar kung saan sinasabi ng studio kung gaano kalayo ang itinatagal ng tier na ito kumpara sa HD.",
+    "message": "Natural at malinaw — makikinig ka nang mga 20× na mas matagal kaysa sa HD."
+  },
+  "voicesShelfHd": {
+    "description": "Heading ng grupo para sa premium (HD) na mga boses sa settings voice catalog. Nirender na uppercase ng CSS.",
+    "message": "Mga HD na boses"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Isang linyang tala katabi ng heading ng grupong HD sa settings Voices studio.",
+    "message": "Pinakamayaman at pinakama-expressive naming tunog."
+  },
+  "voicesShowAll": {
+    "description": "Opsyon sa settings Voices 'Show' filter: walang pag-filter, nakalista ang bawat boses.",
+    "message": "Lahat ng boses"
+  },
+  "voicesShowEveryday": {
+    "description": "Opsyon sa settings Voices 'Show' filter: ilista lang ang mga standard (hindi HD) na boses.",
+    "message": "Pang-araw-araw lang"
+  },
+  "voicesShowHd": {
+    "description": "Opsyon sa settings Voices 'Show' filter: ilista lang ang mga premium (HD) na boses.",
+    "message": "HD lang"
+  },
+  "voicesShowLabel": {
+    "description": "Label sa filter sa settings Voices control bar na nagpapaliit kung aling mga boses ang ipinapakita ng listahan.",
+    "message": "Ipakita"
+  },
+  "voicesShowUnheard": {
+    "description": "Opsyon sa settings Voices 'Show' filter: ilista lang ang mga boses na hindi pa napapakinggan ng user.",
+    "message": "Hindi pa napapakinggan"
+  },
+  "voicesSpeakingNow": {
+    "description": "Label ng estado sa kasalukuyang napiling boses ng host sa settings Voices studio (menu slot at voice card).",
+    "message": "Kasalukuyang nagsasalita"
+  },
+  "voicesSpeaksWith": {
+    "description": "Linyang eyebrow sa itaas ng pangalan ng kasalukuyang boses sa stage ng settings Voices studio; $host$ ang assistant (hal. Pi). Ginagawang uppercase ng CSS.",
+    "message": "nagsasalita si $host$ gamit ang",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Tala sa stage kapag ang host ay may sarili nitong audio (hal. Pi), kaya pinapalitan ng pagpili ng Say, Pi voice ang boses ng host.",
+    "message": "Gagamit si $host$ ng sarili niyang boses hanggang pumili ka ng isa sa ibaba.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Tala sa stage kapag walang sariling boses ang host (hal. Claude), kaya walang babasahing malakas hanggang pumili ng Say, Pi voice.",
+    "message": "Hindi babasahin ni $host$ nang malakas ang mga sagot hanggang pumili ka ng isa sa ibaba.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Headline sa stage ng Voices studio sa settings kapag walang napiling SayPi voice ang host; $host$ ang assistant (hal. Pi, Claude). Nire-render sa laki ng pangalan.",
+    "message": "Piliin kung paano tunog si $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Button sa stage ng Voices studio sa settings na nagpapatugtog ng libreng sample clip ng kasalukuyang boses.",
+    "message": "Makinig sa sample"
+  },
+  "voicesStopPlayback": {
+    "description": "Button sa control bar ng Voices sa settings na humihinto sa sunod-sunod na pag-play ng mga sample na sinimulan ng 'Play all'.",
+    "message": "Ihinto"
+  },
+  "voicesSweepPosition": {
+    "description": "Live na pagbasa ng posisyon sa settings Voices control bar habang nilalakad ng 'Play all' ang listahan; ang $index$ ang boses na kasalukuyang tumutugtog at ang $total$ kung ilan ang naka-queue.",
+    "message": "$index$ sa $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Accessible label para sa compare control sa control bar ng Voices sa settings, na inuulit ang isa pang boses sa huling dalawang narinig; $name$ ang boses na iyon.",
+    "message": "Bumalik sa $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Linya sa settings Voices control bar kapag pinindot ang 'Play all' sa listahang masyadong mahaba para pakinggan; ang $count$ ay kung ilang boses at ang $minutes$ ay tinatayang kung ilang minuto ang aabutin. Pinaikli sa 'min' para mabasang tama sa 1 — walang plural forms ang Chrome i18n.",
+    "message": "$count$ boses iyan — mga $minutes$ min. Pakitipirin muna ang listahan.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Accessible label para sa button na 'gamitin ang boses na ito' kada host sa voice catalog ng settings; $name$ ang boses, $host$ ang assistant (hal. Pi, Claude).",
+    "message": "Gamitin ang $name$ sa $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Maikling label sa button na 'gamitin ang boses na ito' kada host sa pinag-isang voice catalog ng settings (ipinapakita rin ang host sa tabi nito).",
+    "message": "Gamitin"
+  },
+  "voicesYourVoice": {
+    "description": "Button sa control bar sa listahan ng Voices sa settings na inililipat ang focus sa row ng boses na kasalukuyang ginagamit ng host na ito; $name$ ang boses na iyon.",
+    "message": "Boses mo: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Error na ibinabato kapag hindi makapag-allocate ang browser ng sapat na WebAssembly memory para sa voice-detection model.",
+    "message": "Hindi makapagsimula ang voice detection: kulang ang WebAssembly memory para sa voice model. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Error na ibinabato kapag hindi inilalantad ng browser ang initial WebAssembly memory na kailangan para patakbuhin ang voice-detection model.",
+    "message": "Hindi makapagsimula ang voice detection: hindi available ang WebAssembly memory sa browser na ito."
   }
 }

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Kimlik doğrulama modalında listelenen fayda - artırılmış kullanım limitleri.",
+    "message": "Ücretsiz hesapla daha yüksek kullanım limitleri"
+  },
+  "authBenefitPremium": {
+    "description": "Kimlik doğrulama modalında listelenen fayda - sohbet botlarında premium özellikler.",
+    "message": "Premium özellikler ve sohbet botu desteği"
+  },
+  "authBenefitSupport": {
+    "description": "Kimlik doğrulama modalında listelenen fayda - öncelikli destek.",
+    "message": "Sorunlar için öncelikli destek"
+  },
+  "authBenefitSync": {
+    "description": "Kimlik doğrulama modalında listelenen fayda - ayar senkronizasyonu.",
+    "message": "Ses ayarlarını her yerde senkronize edin"
+  },
+  "authBenefitTTS": {
+    "description": "Kimlik doğrulama modalında listelenen fayda - TTS özelliği.",
+    "message": "Metinden konuşmaya sesleri (ücretli planlar)"
+  },
+  "authBenefitUsage": {
+    "description": "Kimlik doğrulama modalında listelenen fayda - kullanım takibi.",
+    "message": "Ses kullanımınızı cihazlar arasında takip edin"
+  },
+  "authPromptModalFull": {
+    "description": "Değer önerisi içeren tam modal kimlik doğrulama istemi açıklaması.",
+    "message": "SayPi'yi harika kullanıyorsunuz. Daha yüksek limitler, metinden konuşmaya sesleri ve desteklenen tüm sohbet botlarında premium özellikler için giriş yapın."
+  },
+  "authPromptModalSoft": {
+    "description": "Yumuşak modal kimlik doğrulama istemi açıklaması.",
+    "message": "Daha yüksek kullanım limitleri ve premium ses özelliklerine erişim için ücretsiz bir SayPi hesabı oluşturun."
+  },
+  "authPromptTitle": {
+    "description": "Kimlik doğrulama istemi modalı başlığı.",
+    "message": "Daha fazla ses özelliğinin kilidini açın"
+  },
+  "authPromptToast": {
+    "description": "Kullanıcıyı giriş yapmaya teşvik eden toast bildirimi.",
+    "message": "Daha yüksek limitler ve premium özellikler için SayPi'ye giriş yapın"
+  },
   "autoReadAloudChatGPT": {
     "description": "Sesli aramalar sırasında ChatGPT yanıtlarının otomatik olarak okunmasını etkinleştirmek/devre dışı bırakmak için onay kutusu etiketi.",
     "message": "Otomatik Okuma (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Metin-konuşma devre dışı bırakın"
   },
+  "dismiss": {
+    "message": "Anladım",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Reddet"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Odaklan"
   },
+  "errorVadInitFailed": {
+    "description": "Ses etkinliği algılama başlatılamadığında gösterilen hata bildirimi.",
+    "message": "Ses algılama başlatılamadı"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Ses kaydı ayarlanırken beklenmeyen bir hata oluştuğunda gösterilen hata bildirimi.",
+    "message": "Ses kaydı ayarlanamadı"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Ses algılama istemcisi kaydı başlatamadığında gösterilen hata bildirimi.",
+    "message": "Ses kaydı başlatılamadı"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Ses algılama (VAD) istemcisi kullanılamadığında, kayıt başlatılamadığı için gösterilen hata bildirimi.",
+    "message": "Ses kaydı kullanılamıyor"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Odak Modundan Çık"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Hem premium (HD) hem de value sesler mevcutken ses menülerinde gösterilen tek satırlık not",
+    "message": "HD sesler aylık kotanı yaklaşık 20× daha hızlı kullanır."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Bunu sıkmak ..."
   },
+  "maybeLater": {
+    "description": "Kimlik doğrulama istemini kapatma düğmesi metni.",
+    "message": "Belki sonra"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Mikrofon ayarlarınız gerekli özellikleri karşılamıyor. \nFarklı bir mikrofon kullanmayı veya ses ayarlarınızı değiştirmeyi deneyin."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Mikrofona erişilemiyor. \nLütfen cihaz ayarlarınızı kontrol edip tekrar deneyin."
   },
+  "microphonePermissionDeniedError": {
+    "description": "İzin istemi akışından sonra mikrofon izni reddedildiğinde gösterilen hata bildirimi.",
+    "message": "Mikrofon izni verilmedi. Lütfen istemde ve uzantı ayarlarında erişime izin verdiğinizden emin olun."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "doğruluk"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "En hızlı yanıt, ancak daha az doğru. \nBölmeye eğilimli."
   },
+  "moreVoices": {
+    "description": "Sayfa içi ses menüsünden uzantı ayarlarındaki tam ses kataloğuna giden menü satırı.",
+    "message": "Daha fazla ses…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Asistan takma adı"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Oturum açmadı"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "ChatGPT'yi açan düğme etiketi.",
+    "message": "ChatGPT'yi aç"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Claude.ai'yi açan düğme etiketi.",
+    "message": "Claude'u aç"
+  },
+  "onboarding_ctaPi": {
+    "description": "Pi.ai'yi açan düğme etiketi.",
+    "message": "Pi'yi aç"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Ortam seçeneği: başka insanların yanında.",
+    "message": "Başkalarının yanında"
+  },
+  "onboarding_envMixed": {
+    "description": "Ortam seçeneği: özel ve paylaşılan alanların karışımı.",
+    "message": "Karışık yerlerde"
+  },
+  "onboarding_envPrivate": {
+    "description": "Ortam seçeneği: özel bir alan.",
+    "message": "Özel bir yerde"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Ortam yanıtı sessiz modu kapalı bıraktığında gösterilen onay.",
+    "message": "Anlaşıldı — standart dinleme ve oynatma ayarlarını koruyacağız."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Ortam yanıtı sessiz modu etkinleştirdiğinde gösterilen onay.",
+    "message": "Sessiz mod açık — daha hafif konuşmayı algılarız ve sessiz yanıt veririz, böylece daha gizli konuşabilirsiniz."
+  },
+  "onboarding_envTitle": {
+    "description": "Kullanıcının ortamıyla ilgili tanıtım sorusunun başlığı.",
+    "message": "Genelde nerede konuşacaksınız?"
+  },
+  "onboarding_footer": {
+    "description": "İlk çalıştırma tanıtım sayfasındaki alt bilgi metni.",
+    "message": "Buna istediğiniz zaman Say, Pi ayarlarından geri dönebilirsiniz. Gizliliğiniz önemli — ses yalnızca etkin bir arama sırasında alınır."
+  },
+  "onboarding_heading": {
+    "description": "İlk çalıştırma tanıtım sayfasındaki ana başlık.",
+    "message": "🗣️ Say, Pi'ye hoş geldiniz"
+  },
+  "onboarding_intro": {
+    "description": "İlk çalıştırma tanıtım sayfasındaki giriş paragrafı.",
+    "message": "Bir yapay zekâyla ilk sesli konuşmanıza iki adım kaldı. Konuşmak yazmaktan yaklaşık 3× daha hızlı, hadi sizi kurulumdan geçirelim."
+  },
+  "onboarding_micTestButton": {
+    "description": "Risksiz tanıtım mikrofon testini başlatan düğme.",
+    "message": "🎤 Mikrofonunuzu test edin"
+  },
+  "onboarding_micTestDone": {
+    "description": "Tanıtım mikrofon testi başarıyla tamamlandıktan sonra gösterilen durum.",
+    "message": "Güzel — mikrofonunuz çalışıyor 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Tanıtım mikrofon testi girişi ölçerken gösterilen durum.",
+    "message": "Dinliyor — bir şey söyleyin 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Tanıtım mikrofon testi izin beklerken gösterilen durum.",
+    "message": "Mikrofon isteniyor…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Tanıtım mikrofon testi çalışırken durdurmak için düğme etiketi.",
+    "message": "Testi durdur"
+  },
+  "onboarding_step1Body": {
+    "description": "Uzantının nasıl sabitleneceğini açıklayan ilk tanıtım adımının metni.",
+    "message": "Tarayıcınızın sağ üstündeki yapboz parçası 🧩 simgesine, sonra Say, Pi'nin yanındaki sabitleme 📌 simgesine tıklayın. Böylece arama düğmesi tek tık uzağınızda kalır."
+  },
+  "onboarding_step1Title": {
+    "description": "İlk tanıtım adımının başlığı (uzantıyı sabitleme).",
+    "message": "Say, Pi'yi araç çubuğunuza sabitleyin"
+  },
+  "onboarding_step2Body": {
+    "description": "Sesli konuşmanın nasıl başlatılacağını açıklayan ikinci tanıtım adımının metni.",
+    "message": "Aşağıdaki desteklenen asistanlardan birine gidin, ardından Say, Pi arama düğmesine dokunup merhaba deyin. İlk seferde mikrofon erişimi isteyeceğiz; bu normal, ve yalnızca aktif bir aramadayken dinleriz."
+  },
+  "onboarding_step2Title": {
+    "description": "İkinci tanıtım adımının başlığı (sohbete başlama).",
+    "message": "Bir AI sohbeti açın ve konuşmaya başlayın"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Mikrofon izni"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Mikrofon izni engellendiğinde kurtarma yönlendirmesi.",
+    "message": "Tarayıcınız mikrofonu engelliyor. Adres çubuğundaki kamera veya kilit simgesine tıklayın, Mikrofon'u \"İzin ver\" olarak ayarlayın, sonra tekrar deneyin. macOS'te ayrıca Sistem Ayarları → Gizlilik ve Güvenlik → Mikrofon'u kontrol edin."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Mikrofon izni reddedildi/engellendiyse kurtarma panelinin başlığı.",
+    "message": "Mikrofon erişimi engellendi"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Mikrofon başka yerde kullanılıyorsa kurtarma yönlendirmesi.",
+    "message": "Başka bir uygulama veya sekme mikrofonunuzu kullanıyor olabilir. Kayıt yapabilecek diğer her şeyi kapatın (görüntülü aramalar, sesli notlar), sonra tekrar deneyin."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Mikrofon başka bir uygulama tarafından kullanılıyorsa kurtarma panelinin başlığı.",
+    "message": "Mikrofonunuz meşgul"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Mikrofon aygıtı yoksa kurtarma yönlendirmesi.",
+    "message": "Bir mikrofon bulamadık. Bir tane takın (veya kulaklığınızı bağlayın), giriş aygıtı olarak seçildiğinden emin olun, sonra tekrar deneyin."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Mikrofon aygıtı yoksa kurtarma panelinin başlığı.",
+    "message": "Mikrofon bulunamadı"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Bilinmeyen bir mikrofon hatası için kurtarma yönlendirmesi.",
+    "message": "Mikrofonunuza erişirken bir şeyler ters gitti. Bağlı olduğunu ve tarayıcı ayarlarında izinli olduğunu kontrol edin, sonra tekrar deneyin."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Bilinmeyen bir mikrofon hatası için kurtarma panelinin başlığı.",
+    "message": "Mikrofonunuza erişemedik"
+  },
+  "permissions_retryButton": {
+    "description": "Mikrofon iznini yeniden isteyen düğmenin etiketi.",
+    "message": "Tekrar dene"
+  },
+  "permissions_revokedHeading": {
+    "description": "Mikrofon erişimi daha önce verilmiş ama sonradan iptal edilmişse gösterilen başlık.",
+    "message": "🎙️ Mikrofonunuzu yeniden bağlayalım"
+  },
+  "permissions_revokedInfo": {
+    "description": "Mikrofon erişimi verildikten sonra iptal edildiyse gösterilen bilgilendirme metni.",
+    "message": "Mikrofon erişiminiz kapatıldı — bu, genellikle tarayıcı veya sistem güncellemesinden sonra olur. Aşağıdan yeniden izin verin; bir görüşmedeyken $productName$ tekrar dinlemeye başlayacak.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Profil"
+  },
+  "quietModeLabel": {
+    "description": "Sessiz/fısıltı modunu etkinleştiren düğmenin etiketi.",
+    "message": "Sessiz mod"
+  },
+  "quietModeTooltip": {
+    "description": "Sessiz/fısıltı modunun ne yaptığını açıklayan ipucu.",
+    "message": "Yumuşak konuşun — daha sessiz konuşmayı algılar ve asistanın yanıt sesini azaltır, böylece başkalarının yanında sesle kullanabilirsiniz."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Kimlik doğrulama sürerken giriş yap düğmesi için metin.",
+    "message": "Giriş yapılıyor..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Ses efektleri"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Sesli geri bildirim sorunlarını önlemek için Firefox'ta ses efektleri devre dışı bırakıldı."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "İlk sesli konuşmadan sonra bir kez gösterilen hız kazanımı bildirisinin başlığı.",
+    "message": "Güzel, konuşmak yazmaktan yaklaşık 3× daha hızlı."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Kazanılan toplam dakikayı gösteren hız kazanımı bildirisinin isteğe bağlı ikinci satırı.",
+    "message": "Bunu yazmak yerine yaklaşık $minutes$ dk daha hızlı konuştunuz.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Yalnızca düğmeye bastığınızda gönderin"
   },
+  "surveyQuestion": {
+    "description": "Tek seferlik, başarı sonrası mikro anketin tek sorusu.",
+    "message": "Şu ana kadar ses nasıl gidiyor?"
+  },
+  "surveyRatingLabel": {
+    "description": "Bir anket puanlama düğmesi için erişilebilir etiket.",
+    "message": "5 üzerinden $rating$ puan ver",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Kullanıcı başarı sonrası anketi yanıtladıktan sonra gösterilen teşekkür.",
+    "message": "Teşekkürler — bu, Say, Pi'yi daha iyi yapmamıza yardımcı oluyor. 🙏"
+  },
   "tabAIChat": {
     "description": "Yapay zeka sohbet ayarları bölümü için sekme etiketi.",
     "message": "Yapay Zeka Sohbeti"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Genel ayarlar bölümü için sekme etiketi.",
     "message": "Genel"
+  },
+  "tabVoices": {
+    "description": "Ses ayarları bölümü için sekme etiketi (siteye özel ses kataloğu).",
+    "message": "Sesler"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "krediler"
   },
+  "ttsCreditsRemaining": {
+    "description": "Kalan TTS kotasını, ham karakter sayısı değil, ses başına kredi havuzu olarak gösteren metin (saypi-api #181 Stage 2).",
+    "message": "$credits$ kredi kaldı",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Çok dilli sesler şu anda Safari'de desteklenmemektedir."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Ses üretimi"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Dikkat! $browserName$ tarayıcısında $chatbotName$ ile konuşma oynatma henüz kullanılamıyor. İyi haber? Sesli giriş harika çalışıyor! TTS için masaüstünde Chrome veya Edge'i deneyin.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "$browserName$ + $chatbotName$ üzerinde TTS kullanılamıyor. Sesli giriş çalışıyor! TTS için Chrome masaüstünü deneyin.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS Sesi"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Konuşmaya benzer ses algılandığında ancak yazıya dökmek için çok zayıf / düşük güvenli olduğunda görünen VAD detayı (istemci tarafı kabul kapısı düşürmesi).",
+    "message": "Yazıya dökmek için ses çok zayıf"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Mikrofon daha yeni bir sekme tarafından alındığı için aramanın bittiğini açıklayan VAD detayı.",
+    "message": "Ses girişi başka bir sekmeye taşındı"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Ses mevcut değil. \nMasaüstünde Chrome veya Firefox'u deneyin."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Dikkat! $browserName$ tarayıcısında $chatbotName$ ile konuşma oynatma henüz kullanılamıyor. İyi haber? Sesli giriş harika çalışıyor! TTS için masaüstünde Chrome veya Edge'i deneyin.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "$browserName$ + $chatbotName$ üzerinde TTS kullanılamıyor. Sesli giriş çalışıyor! TTS için Chrome masaüstünü deneyin.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Anladım",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Ses girişi başka bir sekme tarafından devralınan bir sekmede gösterilen VAD durumu.",
+    "message": "Duraklatıldı"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Ayrıntıları Görüntüle"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Seçili bir Say, Pi sesinin sesine özel bir tanıtım metni olmadığında (ve okunacak yakın tarihli bir mesaj da yokken) çalınan genel sesli tanıtım.",
+    "message": "Merhaba, ben $voice$. Sesim böyle. Umarım bu sesi beğenirsiniz.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Selam! \nПривет! \nişte! \nBen Pi, çok dilli yapay zeka asistanınım. \nEmrimdeki 32 dil sayesinde dünyanın dört bir yanından fikirleri ve kültürleri keşfedebiliyoruz. \nBu ses hakkında ne düşünüyorsunuz?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Ses Ayarları"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Bir sesin açıklaması olmadığında ayarlardaki ses kataloğunda ses satırı için yedek alt başlık; $count$ sesin desteklediği dil sayısıdır.",
+    "message": "$count$ dil konuşur",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "“Addison” sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Aydınlık ve akıcı"
+  },
+  "voiceTagline_alloy": {
+    "description": "'Alloy' sesi için yazılmış kişilik sloganı (ayarlar Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Dengeli ve çok amaçlı"
+  },
+  "voiceTagline_ash": {
+    "description": "'Ash' sesi için yazılmış kişilik sloganı (ayarlar Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Alçak, düşünceli, sakin"
+  },
+  "voiceTagline_ballad": {
+    "description": "'Ballad' sesi için yazılmış kişilik sloganı (ayarlar Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Yumuşak ve melodik"
+  },
+  "voiceTagline_cassidy": {
+    "description": "“Cassidy” sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Sıcakkanlı ve doğrudan"
+  },
+  "voiceTagline_cedar": {
+    "description": "'Cedar' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Dengeli ve güven veren"
+  },
+  "voiceTagline_coral": {
+    "description": "'Coral' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Parlak, pozitif enerji"
+  },
+  "voiceTagline_echo": {
+    "description": "'Echo' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Temiz ve nötr"
+  },
+  "voiceTagline_fable": {
+    "description": "'Fable' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Masalcı bir tını"
+  },
+  "voiceTagline_finn": {
+    "description": "“Finn” sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Taze ve enerjik"
+  },
+  "voiceTagline_jamahal": {
+    "description": "“Jamahal” sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Zengin ve etkileyici"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "'Jarnathan' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Kadifemsi gece baritonu"
+  },
+  "voiceTagline_jeff": {
+    "description": "“Jeff” sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Net ve sakin"
+  },
+  "voiceTagline_jessica": {
+    "description": "“Jessica” sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Sıcak, zarif duruş"
+  },
+  "voiceTagline_joey": {
+    "description": "'Joey' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Rahat, sohbet gibi bir Amerikan"
+  },
+  "voiceTagline_juniper": {
+    "description": "“Juniper” sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Net, canlı, hareketli"
+  },
+  "voiceTagline_lucy": {
+    "description": "“Lucy” sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Yumuşak ve ışıldayan"
+  },
+  "voiceTagline_marin": {
+    "description": "'Marin' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Sıcak, sabah radyosu sakinliği"
+  },
+  "voiceTagline_mark": {
+    "description": "“Mark” sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Net, kendinden emin anlatıcı"
+  },
+  "voiceTagline_nova": {
+    "description": "'Nova' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Hızlı ve meraklı"
+  },
+  "voiceTagline_onyx": {
+    "description": "'Onyx' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Derin, yankılı bir ağırlık"
+  },
+  "voiceTagline_paola": {
+    "description": "'Paola' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Etkileyici İtalyan sıcaklığı"
+  },
+  "voiceTagline_sage": {
+    "description": "'Sage' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Sakin bir netlik"
+  },
+  "voiceTagline_shimmer": {
+    "description": "'Shimmer' sesi için yazılmış kişilik sloganı (Ayarlar > Sesler stüdyosu; istemci tarafı ses kimliği eşlemesi).",
+    "message": "Hafif ve ferah"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Ayarlar Sesler stüdyosunda bir ses kartının sabitleme anahtarındaki kısa etiket (kapalı durum); basınca sesi ana bilgisayarın sohbet içi menüsüne ekler.",
+    "message": "+ Menü"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Bir ses kartının sabitleme anahtarının (kapalı durum) erişilebilir etiketi; $name$ ses, $host$ asistan.",
+    "message": "$name$ sesini $host$ menüsüne ekle",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Sesler kontrol çubuğundaki anahtarın etiketi; ok tuşlarıyla listede gezerken odak her sese geldiğinde o sesi çalıp çalmadığını belirtir.",
+    "message": "Gezindikçe çal"
+  },
+  "voicesArrowsLive": {
+    "description": "Ayarlar Sesler listesinde ilk 'Playing <voice>' duyurusuna eklenen ekran okuyucu onayı; ok tuşlarının az önce duyulur hale geldiğini söyler. 'Hareket ederken çal' anahtarının kendi ifadesini yansıtır.",
+    "message": "Artık hareket ederken ok tuşları çalıyor. Esc durdurur."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Yerel seslerle gelen host'lar için (örn. Pi'nin 8 yerleşiği) menü yuvalarının altında görünen not; stüdyo bunları yönetmez; $host$ asistanın adıdır.",
+    "message": "$host$'un kendi yerleşik sesleri de menüsünde her zaman görünür.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Sohbet içinde ses menüsü olmayan bir host için voicesBuiltinsNote varyantı (Pi 2026'da menüsünü kaldırdı); özgündeki yerleşiklerin 'menüsünde göründüğü' vaadi bu durumda doğru olmaz; $host$ asistanın adıdır.",
+    "message": "$host$'un burada listelenmeyen kendi yerleşik sesleri de var.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Ayarlar Sesler kontrol çubuğundaki ilerleme göstergesi: kullanıcı listelenen seslerin kaçını zaten dinledi. Sadece sayılar, bu yüzden 1 için de doğru okunur — Chrome i18n'de çoğul formlar yoktur.",
+    "message": "$total$ sesten $heard$ dinlendi",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Ayarlar Sesler listesindeki bir ses satırının erişilebilir adının parçası; bu profilin daha önce dinlediği bir sesi işaretler. Görsel olarak bu, sesin ses izinde mürekkep yoğunluğu olarak çizilir; ekran okuyucu bunu göremez.",
+    "message": "Dinlendi"
+  },
+  "voicesInHostMenu": {
+    "description": "Ayarlar Sesler stüdyosunda menü yuvaları satırının üstündeki bölüm başlığı; $host$ asistan.",
+    "message": "$host$ menüsünde",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Ayarlar Sesler stüdyosunda bir ses kartının sabitleme anahtarındaki kısa etiket (açık durum).",
+    "message": "✓ Menüde"
+  },
+  "voicesInUse": {
+    "description": "Ayarlar Sesler listesinde ana bilgisayarın şu anda seçili sesi üzerindeki kalıcı rozet; büyük harfle gösterilir. Bilerek “Şu an konuşuyor” DEĞİL: bu sayfada satırlar örnek kliplerini çalar, bu yüzden seçili ama sessiz bir ses, başka bir satır çalarken konuştuğunu iddia etmemelidir.",
+    "message": "Kullanımda"
+  },
+  "voicesKeyboardHint": {
+    "description": "Ayarlar Sesler kontrol çubuğunda tek satırlık klavye ipucu. Simgeler tuşlardır: Space, yukarı/aşağı okları ve Shift+Space.",
+    "message": "Dinlemek için Space, sesler arasında geçmek için ↑↓, geri dönmek için ⇧Space."
+  },
+  "voicesLoadError": {
+    "description": "Bir host'un stüdyosunda, o host'un ses kataloğu yüklenemediğinde görünen hata durumu; $host$ asistanın adıdır.",
+    "message": "$host$ sesleri yüklenemedi. Lütfen daha sonra tekrar deneyin.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Ana bilgisayarın sohbet içi menüsü zaten azami sayıda ses içerdiğinde, devre dışı “+ Menü” anahtarının üzerindeki araç ipucu/ipucu.",
+    "message": "Menü dolu, eklemek için bir sesi kaldırın"
+  },
+  "voicesMenuHint": {
+    "description": "“$host$ menüsünde” başlığının yanındaki tek satırlık ipucu; yuvalar satırının, sohbet içi ses menüsünü yansıttığını açıklar.",
+    "message": "Sohbette göreceğiniz"
+  },
+  "voicesMenuOverflow": {
+    "description": "Kullanıcının sabitlenmiş ses sayısı, sohbet içi menünün gösterebildiğinden fazla olduğunda (eski durum) menü yuvalarının altında görünen not; $count$ kaç tanesinin sığmadığıdır, $cap$ menü boyutudur.",
+    "message": "Menünün $cap$ yuvasının ötesinde $count$ sabitlenmiş ses daha bekliyor.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "voicesMenuOverflow'un tekil hâli; sohbet içi menüye tam olarak bir sabitlenmiş ses sığmadığında kullanılır; $cap$ menü boyutudur.",
+    "message": "Menünün $cap$ yuvasının ötesinde 1 sabitlenmiş ses daha bekliyor.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Ayarlar Sesler listesinin altındaki özet satırı; ana makinenin sohbet içi ses menüsünün ne kadarının dolu olduğunu söyler; $host$ asistan, $used$ kaç koltuğun dolu olduğu, $cap$ toplam koltuk sayısıdır. 1 için de doğru okunacak şekilde yazılmıştır — Chrome i18n'de çoğul formlar yoktur.",
+    "message": "$host$ menüsü: $cap$ koltuğun $used$ kadarı dolu",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Ayarlar Sesler listesinin sonunda, çalınacak örnek klibi olmayan sesleri tutan grubun başlığı; $count$ kaç tane olduğunu belirtir. 1 için de doğru okunacak şekilde yazılmıştır — Chrome i18n'de çoğul formlar yoktur.",
+    "message": "Henüz örnek yok ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Oturum açmış bir kullanıcı için ses listesi boş olduğunda (ör. ağ sorunu) ayarlardaki ses kataloğunda gösterilir.",
+    "message": "Sesler şu anda yüklenemedi. Lütfen daha sonra tekrar deneyin."
+  },
+  "voicesNowPlaying": {
+    "description": "Ayarlar Sesler listesinde bir sesin örnek klibi çalmaya başladığında ekran okuyucu duyurusu; $name$ sestir.",
+    "message": "$name$ çalıyor",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Ayarlar Sesler kontrol çubuğundaki düğme; şu anda listelenen her sesi art arda çalar; $count$ kaç tane olduğunu belirtir. 1 için de doğru okunacak şekilde yazılmıştır — Chrome i18n'de çoğul formlar yoktur.",
+    "message": "Hepsini çal ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Dönüş ziyaretinde ayarlar Sesler kontrol çubuğundaki düğme: yalnızca henüz dinlemediğiniz listelenen sesleri çalar; $count$ kaç tane olduğunu belirtir. 1 için de doğru okunacak şekilde yazılmıştır — Chrome i18n'de çoğul formlar yoktur.",
+    "message": "Yenileri çal ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Sayfada henüz kullanıcı etkileşimi olmadığı için tarayıcı bir örneği çalmayı reddettiğinde ayarlar Sesler kontrol çubuğunda görünen satır.",
+    "message": "Sesi etkinleştirmek için herhangi bir sese tıklayın."
+  },
+  "voicesPreview": {
+    "description": "Bir ses satırındaki ücretsiz örnek klibi dinleten oynat (▶) düğmesi için erişilebilir etiket; $name$ sesin adıdır.",
+    "message": "$name$ için bir örnek çal",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Ayarlar Sesler listesinin erişilebilir adı (her seste bir satır olacak şekilde tüm seslerin listbox'ı).",
+    "message": "Sesler, en koyudan en parlak olana sıralı"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Bir ses kartının sabitleme anahtarının (açık durum) ve bir menü yuvasının kaldırma düğmesinin erişilebilir etiketi; $name$ ses, $host$ asistan.",
+    "message": "$name$ sesini $host$ menüsünden kaldır",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Bir sesin örnek klibi yüklenemediğinde veya çalınamadığında ayarlar Sesler kontrol çubuğunda görünen satır; $name$ o sestir. Modal değildir — örnekler akışı bunun üzerinden devam eder.",
+    "message": "$name$ örneği çalınamadı.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Ayarlar > AI Chat sekmesinde ses kataloğu bölümünün alt başlığı.",
+    "message": "Her sitede yanıtları sesli okuyan sesi seçin."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Sesler ayarları başlığının altındaki alt başlık; perdeye göre sıralanmış ses rayı için.",
+    "message": "En koyudan en parlak olana tüm sesler. Dinleyip seçin."
+  },
+  "voicesSectionTitle": {
+    "description": "Ayarlar > AI Chat sekmesinde ses kataloğu bölümünün başlığı.",
+    "message": "Sesler"
+  },
+  "voicesShelfEveryday": {
+    "description": "Ayarlar ses kataloğunda uygun fiyatlı katmandaki sesler için grup başlığı. CSS tarafından büyük harfle gösterilir.",
+    "message": "Günlük sesler"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Ayarlar > Sesler stüdyosunda Günlük grup başlığının yanındaki tek satırlık not; bu katmanın HD'ye göre ne kadar daha uzun gittiğini stüdyoda belirten tek yer.",
+    "message": "Doğal ve net — HD'ye göre yaklaşık 20× daha uzun süre dinleyebilirsiniz."
+  },
+  "voicesShelfHd": {
+    "description": "Ayarlar ses kataloğunda premium (HD) sesler için grup başlığı. CSS tarafından büyük harfle gösterilir.",
+    "message": "HD sesler"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Ayarlar > Sesler stüdyosunda HD grup başlığının yanındaki tek satırlık not.",
+    "message": "En zengin, en etkileyici sesimiz."
+  },
+  "voicesShowAll": {
+    "description": "Ayarlar Sesler 'Göster' filtresindeki seçenek: filtre yok, tüm sesler listelenir.",
+    "message": "Tüm sesler"
+  },
+  "voicesShowEveryday": {
+    "description": "Ayarlar Sesler 'Göster' filtresindeki seçenek: yalnızca standart (HD olmayan) sesleri listele.",
+    "message": "Yalnızca günlük"
+  },
+  "voicesShowHd": {
+    "description": "Ayarlar Sesler 'Göster' filtresindeki seçenek: yalnızca premium (HD) sesleri listele.",
+    "message": "Yalnızca HD"
+  },
+  "voicesShowLabel": {
+    "description": "Ayarlar Sesler kontrol çubuğundaki, listede hangi seslerin görüneceğini daraltan filtrenin etiketi.",
+    "message": "Göster"
+  },
+  "voicesShowUnheard": {
+    "description": "Ayarlar Sesler 'Göster' filtresindeki seçenek: yalnızca kullanıcının henüz dinlemediği sesleri listele.",
+    "message": "Henüz dinlenmedi"
+  },
+  "voicesSpeakingNow": {
+    "description": "Ayarlar Sesler stüdyosunda (menü yuvası ve ses kartı) ana bilgisayarın şu anda seçili sesi üzerindeki durum etiketi.",
+    "message": "Şu an konuşuyor"
+  },
+  "voicesSpeaksWith": {
+    "description": "Ayarlar Sesler stüdyo sahnesinde, mevcut sesin adının üstündeki üst başlık satırı; $host$ asistan (örn. Pi). CSS tarafından büyük harfe dönüştürülür.",
+    "message": "$host$ şununla konuşur:",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Host'un kendi sesini sunduğu (örn. Pi) durumda sahne notu; bu yüzden bir Say, Pi sesi seçmek host'un sesinin yerini alır.",
+    "message": "Aşağıdan birini seçene kadar $host$ kendi sesini kullanır.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Host'un kendi sesi olmadığı (örn. Claude) durumda sahne notu; bu yüzden bir Say, Pi sesi seçilene kadar hiçbir şey sesli okunmaz.",
+    "message": "Aşağıdan birini seçene kadar $host$ yanıtları sesli okumaz.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Host için Say, Pi sesi seçilmemişken ayarlardaki Sesler stüdyosu sahnesinin başlığı; $host$ asistanın adıdır (örn. Pi, Claude). İsim boyutunda gösterilir.",
+    "message": "$host$ nasıl seslensin",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Ayarlar Sesler stüdyosu sahnesinde, geçerli sesin ücretsiz örnek klibini çalan düğme.",
+    "message": "Örnek dinle"
+  },
+  "voicesStopPlayback": {
+    "description": "Ayarlar Sesler kontrol çubuğundaki düğme; 'Hepsini çal' ile başlatılan örnekler dizisini durdurur.",
+    "message": "Durdur"
+  },
+  "voicesSweepPosition": {
+    "description": "Ayarlar Sesler kontrol çubuğunda, 'Tümünü çal' listeyi gezerken canlı konum göstergesi; $index$ şu anda çalan sesi, $total$ ise sıradaki toplam sayıyı belirtir.",
+    "message": "$total$ içinde $index$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Ayarlar Sesler kontrol çubuğundaki karşılaştırma denetimi için erişilebilir etiket; son duyulan iki sesten diğerini tekrar çalar; $name$ o sestir.",
+    "message": "$name$ sesine geri dön",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Liste, baştan sona dinlenemeyecek kadar uzunken 'Tümünü çal' basıldığında ayarlar Sesler kontrol çubuğunda görünen satır; $count$ ses sayısıdır, $minutes$ ise kabaca kaç dakika süreceğidir. Chrome i18n’de çoğul formlar olmadığı için kısaltılmış 'min' kullanılmıştır; 1’de de doğru okunur.",
+    "message": "Bu $count$ ses ediyor, yaklaşık $minutes$ dk. Önce listeyi daraltın.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Ayarlar ses kataloğunda, her ana bilgisayar için yer alan “bu sesi kullan” düğmesinin erişilebilir etiketi; $name$ ses, $host$ asistan (örn. Pi, Claude).",
+    "message": "$host$ üzerinde $name$ kullan",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Birleşik ayarlar ses kataloğunda, her ana bilgisayar için yer alan “bu sesi kullan” düğmesindeki kısa etiket (ana bilgisayar yanında gösterilir).",
+    "message": "Kullan"
+  },
+  "voicesYourVoice": {
+    "description": "Ayarlar Sesler listesindeki kontrol çubuğu düğmesi; odağı bu ana makinenin şu anda kullandığı sesin satırına taşır; $name$ o sestir.",
+    "message": "Senin sesin: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Tarayıcı, ses algılama modeli için yeterli WebAssembly belleği ayıramadığında oluşturulan hata.",
+    "message": "Ses algılama başlatılamıyor: ses modeli için yeterli WebAssembly belleği yok. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Tarayıcı, ses algılama modelini çalıştırmak için gereken başlangıç WebAssembly belleğini sağlamadığında oluşturulan hata.",
+    "message": "Ses algılama başlatılamıyor: bu tarayıcıda WebAssembly belleği kullanılamıyor."
   }
 }

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Перевага в модальному вікні автентифікації — збільшені ліміти використання.",
+    "message": "Вищі ліміти використання з безкоштовним акаунтом"
+  },
+  "authBenefitPremium": {
+    "description": "Перевага в модальному вікні автентифікації — преміумможливості в чатботах.",
+    "message": "Преміумможливості та підтримка чатботів"
+  },
+  "authBenefitSupport": {
+    "description": "Перевага в модальному вікні автентифікації — пріоритетна підтримка.",
+    "message": "Пріоритетна підтримка щодо проблем"
+  },
+  "authBenefitSync": {
+    "description": "Перевага в модальному вікні автентифікації — синхронізація налаштувань.",
+    "message": "Синхронізуйте налаштування голосу всюди"
+  },
+  "authBenefitTTS": {
+    "description": "Перевага в модальному вікні автентифікації — функція TTS.",
+    "message": "Голоси перетворення тексту на мовлення (платні плани)"
+  },
+  "authBenefitUsage": {
+    "description": "Перевага в модальному вікні автентифікації — відстеження використання.",
+    "message": "Відстежуйте використання голосу на всіх пристроях"
+  },
+  "authPromptModalFull": {
+    "description": "Опис для повного модального вікна запиту на автентифікацію з пропозицією цінності.",
+    "message": "Ви активно користуєтеся Say, Pi. Увійдіть, щоб отримати вищі ліміти, голоси перетворення тексту на мовлення та преміумможливості в усіх підтримуваних чатботах."
+  },
+  "authPromptModalSoft": {
+    "description": "Опис для м’якого модального вікна запиту на автентифікацію.",
+    "message": "Створіть безкоштовний обліковий запис Say, Pi для вищих лімітів використання та доступу до преміумголосових можливостей."
+  },
+  "authPromptTitle": {
+    "description": "Заголовок модального вікна запиту на автентифікацію.",
+    "message": "Відкрийте більше голосових можливостей"
+  },
+  "authPromptToast": {
+    "description": "Спливаюче повідомлення, що заохочує користувача увійти.",
+    "message": "Увійдіть у Say, Pi для вищих лімітів і преміумфункцій"
+  },
   "autoReadAloudChatGPT": {
     "description": "Позначка для ввімкнення або вимкнення автоматичного озвучування відповідей ChatGPT під час голосових дзвінків.",
     "message": "Автоматичне озвучування (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Вимкнути текст до мови"
   },
+  "dismiss": {
+    "message": "Зрозуміло",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Звільнити"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Зосередитися"
   },
+  "errorVadInitFailed": {
+    "description": "Спливаюче повідомлення про помилку, яке показується, коли не вдається ініціалізувати виявлення голосової активності.",
+    "message": "Не вдалося ініціалізувати виявлення голосу"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Спливаюче повідомлення про помилку, яке показується, коли під час налаштування запису голосу стається неочікувана помилка.",
+    "message": "Не вдалося налаштувати запис голосу"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Спливаюче повідомлення про помилку, яке показується, коли клієнту визначення голосу не вдається почати запис.",
+    "message": "Не вдалося почати запис голосу"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Спливаюче повідомлення про помилку, яке показується, коли клієнт визначення голосу (VAD) недоступний, тому запис не може початися.",
+    "message": "Запис голосу недоступний"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Вийти з режиму фокусу"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Однорядкова примітка, що показується в меню голосів, коли доступні і преміум (HD), і value-голоси",
+    "message": "HD-голоси витрачають ваш місячний ліміт приблизно у 20× швидше."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Відбиваючи це ..."
   },
+  "maybeLater": {
+    "description": "Текст кнопки для закриття запиту на автентифікацію.",
+    "message": "Можливо, пізніше"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Ваші налаштування мікрофона не відповідають необхідним характеристикам. \nСпробуйте використати інший мікрофон або налаштувати параметри звуку."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Неможливо отримати доступ до мікрофона. \nПеревірте налаштування свого пристрою та повторіть спробу."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Спливаюче повідомлення про помилку, яке показується, коли після процесу запиту дозволу було відхилено дозвіл на мікрофон.",
+    "message": "Дозвіл на мікрофон не надано. Переконайтеся, що ви дозволили доступ у запиті та в налаштуваннях розширення."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "точність"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Найшвидша відповідь, але менш точна. \nСхильний до переривання."
   },
+  "moreVoices": {
+    "description": "Рядок меню, що веде з меню голосів на сторінці до повного каталогу голосів у налаштуваннях розширення.",
+    "message": "Більше голосів…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Псевдонім асистента"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Не ввійшов"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Напис на кнопці, яка відкриває ChatGPT.",
+    "message": "Відкрити ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Напис на кнопці, що відкриває Claude.ai.",
+    "message": "Відкрити Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Напис на кнопці, що відкриває Pi.ai.",
+    "message": "Відкрити Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Варіант оточення: поруч з іншими людьми.",
+    "message": "Поруч з іншими людьми"
+  },
+  "onboarding_envMixed": {
+    "description": "Варіант оточення: поєднання приватних і спільних просторів.",
+    "message": "У різних місцях"
+  },
+  "onboarding_envPrivate": {
+    "description": "Варіант оточення: приватний простір.",
+    "message": "У приватному місці"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Підтвердження, яке показується, коли відповідь про середовище залишає тихий режим вимкненим.",
+    "message": "Гаразд — залишимо стандартні налаштування слухання та відтворення."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Підтвердження, що показується, коли відповідь про оточення вмикає тихий режим.",
+    "message": "Тихий режим увімкнено — ми вловлюватимемо тихішу мову й відповідатимемо тихо, щоб ви могли говорити непомітно."
+  },
+  "onboarding_envTitle": {
+    "description": "Заголовок для питання onboarding про оточення користувача.",
+    "message": "Де ви зазвичай розмовляєте?"
+  },
+  "onboarding_footer": {
+    "description": "Текст у нижній частині сторінки першого запуску onboarding.",
+    "message": "Ви можете повернутися до цього будь-коли в налаштуваннях Say, Pi. Ваша приватність важлива — аудіо записується лише під час активного дзвінка."
+  },
+  "onboarding_heading": {
+    "description": "Основний заголовок на сторінці першого запуску (onboarding).",
+    "message": "🗣️ Ласкаво просимо до Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Вступний абзац на сторінці першого запуску (onboarding).",
+    "message": "Вас відділяють два кроки від першої розмови з ШІ вголос. Говорити приблизно у 3× швидше, ніж друкувати — давайте все налаштуємо."
+  },
+  "onboarding_micTestButton": {
+    "description": "Кнопка, що запускає безстресовий тест мікрофона під час onboarding.",
+    "message": "🎤 Перевірити мікрофон"
+  },
+  "onboarding_micTestDone": {
+    "description": "Статус, що показується після успішного завершення тесту мікрофона під час onboarding.",
+    "message": "Чудово — мікрофон працює 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Статус, що показується, поки тест мікрофона під час onboarding вимірює вхідний сигнал.",
+    "message": "Слухаємо — скажіть щось 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Статус, що показується, поки тест мікрофона під час onboarding очікує на дозвіл.",
+    "message": "Запитуємо доступ до мікрофона…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Напис на кнопці для зупинки тесту мікрофона під час onboarding, поки він виконується.",
+    "message": "Зупинити тест"
+  },
+  "onboarding_step1Body": {
+    "description": "Текст першого кроку onboarding з поясненням, як закріпити розширення.",
+    "message": "Натисніть значок пазла 🧩 у правому верхньому куті браузера, потім — шпильку 📌 поруч із Say, Pi. Так кнопка виклику буде за один клік."
+  },
+  "onboarding_step1Title": {
+    "description": "Заголовок першого кроку onboarding (закріпити розширення).",
+    "message": "Закріпіть Say, Pi на панелі інструментів"
+  },
+  "onboarding_step2Body": {
+    "description": "Текст другого кроку onboarding з поясненням, як почати голосову розмову.",
+    "message": "Перейдіть до одного з підтримуваних асистентів нижче, потім натисніть кнопку виклику Say, Pi і привітайтеся. Першого разу ми попросимо доступ до мікрофона — так і має бути, і ми слухаємо лише тоді, коли ви активно в розмові."
+  },
+  "onboarding_step2Title": {
+    "description": "Заголовок другого кроку onboarding (почати розмову).",
+    "message": "Відкрийте чат із ШІ та почніть говорити"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Дозвіл мікрофона"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Підказки для відновлення, коли дозвіл на мікрофон заблоковано.",
+    "message": "Браузер блокує мікрофон. Натисни значок камери або замка в адресному рядку, встанови для «Мікрофон» значення «Дозволити», а потім спробуй ще раз. На macOS також перевір System Settings → Privacy & Security → Microphone."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Заголовок панелі відновлення, коли дозвіл на мікрофон було відхилено/заблоковано.",
+    "message": "Доступ до мікрофона заблоковано"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Підказки для відновлення, коли мікрофон використовується десь іще.",
+    "message": "Можливо, твій мікрофон використовує інша програма або вкладка. Закрий усе, що може записувати (відеодзвінки, голосові нотатки), а потім спробуй ще раз."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Заголовок панелі відновлення, коли мікрофон використовується іншою програмою.",
+    "message": "Мікрофон зайнятий"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Підказки для відновлення, коли немає доступного пристрою мікрофона.",
+    "message": "Нам не вдалося знайти мікрофон. Підключи його (або гарнітуру), переконайся, що його вибрано як пристрій введення, а потім спробуй ще раз."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Заголовок панелі відновлення, коли немає доступного пристрою мікрофона.",
+    "message": "Мікрофон не знайдено"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Підказки для відновлення у разі невідомої помилки мікрофона.",
+    "message": "Щось пішло не так під час доступу до мікрофона. Перевір, що він підключений і дозволений у налаштуваннях браузера, а потім спробуй ще раз."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Заголовок панелі відновлення для невідомої помилки мікрофона.",
+    "message": "Не вдалося отримати доступ до мікрофона"
+  },
+  "permissions_retryButton": {
+    "description": "Текст кнопки, яка повторно запитує дозвіл на мікрофон.",
+    "message": "Спробувати ще раз"
+  },
+  "permissions_revokedHeading": {
+    "description": "Заголовок, що показується, коли доступ до мікрофона раніше було надано, але згодом його відкликано.",
+    "message": "🎙️ Давай знову підключимо твій мікрофон"
+  },
+  "permissions_revokedInfo": {
+    "description": "Інформаційний текст, що показується, коли доступ до мікрофона було відкликано після надання.",
+    "message": "Доступ до мікрофона вимкнено — таке часто трапляється після оновлення браузера або системи. Дозволь його знову нижче, і $productName$ знову слухатиме, коли ти в дзвінку.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Профіл"
+  },
+  "quietModeLabel": {
+    "description": "Підпис для перемикача, який вмикає тихий/шепітний режим.",
+    "message": "Тихий режим"
+  },
+  "quietModeTooltip": {
+    "description": "Підказка, що пояснює, що робить тихий/шепітний режим.",
+    "message": "Говоріть тихіше — він розпізнає тихішу мову та зменшує гучність відповіді асистента, щоб ви могли користуватися голосом поруч з іншими."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Текст для кнопки входу, поки триває автентифікація.",
+    "message": "Вхід..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Звукові ефекти"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Звукові ефекти вимкнено у Firefox, щоб запобігти проблемам зі звуковими відгуками."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Заголовок одноразового повідомлення про виграш у швидкості, яке показується після першого голосового обміну.",
+    "message": "Добре — говорити приблизно у 3 рази швидше, ніж набирати."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Необовʼязковий другий рядок повідомлення про виграш у швидкості, який показує заощаджені цілі хвилини.",
+    "message": "Ви вже виграли приблизно $minutes$ хв порівняно з набором.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Надсилайте лише після натискання кнопки"
   },
+  "surveyQuestion": {
+    "description": "Єдине запитання одноразового мікроопитування після перемоги.",
+    "message": "Як вам поки що працюється з голосом?"
+  },
+  "surveyRatingLabel": {
+    "description": "Доступна мітка для кнопки оцінювання в опитуванні.",
+    "message": "Оцініть $rating$ із 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Подяка, яку показують після того, як користувач відповість на опитування після перемоги.",
+    "message": "Дякуємо — це допомагає нам зробити Say, Pi кращим."
+  },
   "tabAIChat": {
     "description": "Позначення вкладки для розділу налаштувань AI-чат.",
     "message": "AI Чат"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Позначення вкладки для розділу загальних налаштувань.",
     "message": "Загальні"
+  },
+  "tabVoices": {
+    "description": "Підпис вкладки для розділу налаштувань голосів (каталог голосів для кожного сайту).",
+    "message": "Голоси"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "кредити"
   },
+  "ttsCreditsRemaining": {
+    "description": "Текст, що показує залишок квоти TTS як пул кредитів на кожен голос (saypi-api #181 Stage 2), а не сирі символи.",
+    "message": "Залишилось кредитів: $credits$",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Багатомовні голоси наразі не підтримуються в Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Генерування голосу"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Увага! Відтворення мовлення ще не доступне в $browserName$ з $chatbotName$. Хороша новина? Голосовий ввід працює чудово! Для TTS спробуйте Chrome або Edge на робочому столі.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS недоступний у $browserName$ + $chatbotName$. Голосовий ввід працює! Спробуйте Chrome на робочому столі для TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS -голос"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Деталь VAD, коли було виявлено схожий на мовлення звук, але він був надто тихий / з надто низькою впевненістю для транскрибування (відсікання на клієнті на етапі admission-gate).",
+    "message": "Звук надто тихий для транскрибування"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Деталь VAD, що пояснює, що виклик завершився, бо мікрофон було зайнято новішою вкладкою.",
+    "message": "Голосовий ввід перенесено в іншу вкладку"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Голос недоступний. \nСпробуйте Chrome або Firefox на робочому столі."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Увага! Відтворення мовлення ще не доступне в $browserName$ з $chatbotName$. Хороша новина? Голосовий ввід працює чудово! Для TTS спробуйте Chrome або Edge на робочому столі.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS недоступний у $browserName$ + $chatbotName$. Голосовий ввід працює! Спробуйте Chrome на робочому столі для TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Зрозуміло",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Статус VAD, що показується на вкладці, чий голосовий ввід було перехоплено іншою вкладкою.",
+    "message": "Призупинено"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Переглянути деталі"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Загальне озвучене представлення, яке відтворюється, коли вибраний голос SayPi не має власного сценарію представлення (і немає нещодавнього повідомлення, яке можна було б зачитати).",
+    "message": "Привіт, я $voice$. Ось як я звучатиму. Сподіваюся, вам сподобається цей голос.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Холо! \nПривет! \n你好! \nЯ Пі, ваш помічник ШІ-поліглот. \nЗавдяки 32 мовам у моєму розпорядженні ми можемо досліджувати ідеї та культури з усього світу. \nЩо ви думаєте про цей голос?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Налаштування голосу"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Запасний підзаголовок для рядка голосу в каталозі голосів у налаштуваннях, коли голос не має опису; $count$ — кількість мов, які підтримує голос.",
+    "message": "Говорить $count$ мовами",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Авторський слоган характеру для голосу «Addison» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Сонячний і виразний"
+  },
+  "voiceTagline_alloy": {
+    "description": "Авторський слоган характеру для голосу «Alloy» (студія голосів у налаштуваннях; мапа ідентичності голосів на стороні клієнта).",
+    "message": "Збалансований і універсальний"
+  },
+  "voiceTagline_ash": {
+    "description": "Авторський слоган характеру для голосу «Ash» (студія голосів у налаштуваннях; мапа ідентичності голосів на стороні клієнта).",
+    "message": "Низький, задумливий, спокійний"
+  },
+  "voiceTagline_ballad": {
+    "description": "Авторський слоган характеру для голосу «Ballad» (студія голосів у налаштуваннях; мапа ідентичності голосів на стороні клієнта).",
+    "message": "М’який і мелодійний"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Авторський слоган характеру для голосу «Cassidy» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Доброзичливий і прямий"
+  },
+  "voiceTagline_cedar": {
+    "description": "Авторський слоган характеру для голосу «Cedar» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Врівноважений і заспокійливий"
+  },
+  "voiceTagline_coral": {
+    "description": "Авторський слоган характеру для голосу «Coral» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Яскрава, піднесена енергія"
+  },
+  "voiceTagline_echo": {
+    "description": "Авторський слоган характеру для голосу «Echo» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Чистий і нейтральний"
+  },
+  "voiceTagline_fable": {
+    "description": "Авторський слоган характеру для голосу «Fable» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Оповідна інтонація"
+  },
+  "voiceTagline_finn": {
+    "description": "Авторський слоган характеру для голосу «Finn» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Свіжий і енергійний"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Авторський слоган характеру для голосу «Jamahal» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Насичений і магнетичний"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Авторський слоган характеру для голосу «Jarnathan» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Оксамитовий нічний баритон"
+  },
+  "voiceTagline_jeff": {
+    "description": "Авторський слоган характеру для голосу «Jeff» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Простий і врівноважений"
+  },
+  "voiceTagline_jessica": {
+    "description": "Авторський слоган характеру для голосу «Jessica» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Теплий, вишуканий"
+  },
+  "voiceTagline_joey": {
+    "description": "Авторський слоган характеру для голосу «Joey» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Невимушена американська розмовна манера"
+  },
+  "voiceTagline_juniper": {
+    "description": "Авторський слоган характеру для голосу «Juniper» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Чіткий, яскравий, жвавий"
+  },
+  "voiceTagline_lucy": {
+    "description": "Авторський слоган характеру для голосу «Lucy» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Ніжний і світлий"
+  },
+  "voiceTagline_marin": {
+    "description": "Авторський слоган характеру для голосу «Marin» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Теплий, спокій ранкового радіо"
+  },
+  "voiceTagline_mark": {
+    "description": "Авторський слоган характеру для голосу «Mark» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Чіткий, упевнений оповідач"
+  },
+  "voiceTagline_nova": {
+    "description": "Авторський слоган характеру для голосу «Nova» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Швидкий і допитливий"
+  },
+  "voiceTagline_onyx": {
+    "description": "Авторський слоган характеру для голосу «Onyx» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Глибока, резонансна вагомість"
+  },
+  "voiceTagline_paola": {
+    "description": "Авторський слоган характеру для голосу «Paola» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Виразне італійське тепло"
+  },
+  "voiceTagline_sage": {
+    "description": "Авторський слоган характеру для голосу «Sage» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Спокійна, виразна ясність"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Авторський слоган характеру для голосу «Shimmer» (налаштування Voices studio; клієнтська мапа ідентичності голосів).",
+    "message": "Легкий і повітряний"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Короткий напис на перемикачі закріплення на картці голосу (вимкнений стан) у студії Голоси в налаштуваннях; натискання додає голос до меню $host$ у чаті.",
+    "message": "+ Меню"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Доступна назва для перемикача закріплення на картці голосу (вимкнений стан); $name$ — голос, $host$ — асистент.",
+    "message": "Додати $name$ до меню $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Підпис до перемикача на панелі керування Голосами, який вказує, чи відтворюється кожен голос під час переміщення списком клавішами зі стрілками, коли фокус доходить до нього.",
+    "message": "Відтворювати під час переміщення"
+  },
+  "voicesArrowsLive": {
+    "description": "Підтвердження для читача екрана, яке додається до першого оголошення «Відтворюється <голос>» у списку «Голоси» в налаштуваннях, повідомляючи, що клавіші зі стрілками щойно стали озвучуватися. Повторює формулювання перемикача «Відтворювати під час переміщення».",
+    "message": "Стрілки тепер відтворюють під час переміщення. Esc зупиняє."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Примітка під слотами меню для хостів, які мають вбудовані нативні голоси (наприклад, 8 вбудованих у Pi), якими студія не керує; $host$ — асистент.",
+    "message": "Власні вбудовані голоси $host$ теж завжди є в його меню.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Варіант voicesBuiltinsNote для хоста без меню голосів у чаті (Pi прибрав меню у 2026), де обіцянка оригіналу, що вбудовані голоси «з’являються в його меню», була б неправдивою; $host$ — асистент.",
+    "message": "$host$ також має власні вбудовані голоси, але їх тут не показано.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Індикатор прогресу в панелі керування «Голоси» в налаштуваннях: скільки голосів зі списку користувач уже прослухав. Лише числа, тож читається правильно при 1 — у Chrome i18n немає форм множини.",
+    "message": "Прослухано: $heard$ з $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Частина доступної назви рядка голосу в списку «Голоси» в налаштуваннях, що позначає голос, який цей профіль уже прослуховував. Візуально це показано щільністю чорнила на звуковому відбитку голосу, яку читач екрана не бачить.",
+    "message": "Прослухано"
+  },
+  "voicesInHostMenu": {
+    "description": "Заголовок розділу над рядком слотів меню в студії Голоси в налаштуваннях; $host$ — асистент.",
+    "message": "У меню $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Короткий напис на перемикачі закріплення на картці голосу (увімкнений стан) у студії Голоси в налаштуваннях.",
+    "message": "✓ У меню"
+  },
+  "voicesInUse": {
+    "description": "Постійний бейдж на поточному вибраному голосі хоста у списку Голоси в налаштуваннях, відображається великими літерами. Навмисно НЕ «Зараз говорить»: на цій сторінці рядки відтворюють свої демо-кліпи, тож вибраний, але мовчазний голос не повинен заявляти, що говорить, поки інший рядок відтворюється.",
+    "message": "Використовується"
+  },
+  "voicesKeyboardHint": {
+    "description": "Однорядкова підказка щодо клавіатури в панелі керування «Голоси» в налаштуваннях. Символи — це клавіші: Space, стрілки вгору/вниз і Shift+Space.",
+    "message": "Натисніть Space, щоб слухати, ↑↓ щоб переходити між голосами, ⇧Space щоб перемкнутися назад."
+  },
+  "voicesLoadError": {
+    "description": "Стан помилки всередині студії одного хоста, коли не вдалося завантажити каталог голосів цього хоста; $host$ — асистент.",
+    "message": "Не вдалося завантажити голоси $host$. Спробуйте ще раз пізніше.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Підказка/хінт на вимкненому перемикачі «+ Меню», коли меню $host$ у чаті вже має максимально можливу кількість голосів.",
+    "message": "Меню заповнене — вилучіть голос, щоб додати інший"
+  },
+  "voicesMenuHint": {
+    "description": "Однорядкова підказка поруч із заголовком «У меню {host}», яка пояснює, що рядок слотів віддзеркалює меню голосів у чаті.",
+    "message": "Що ви побачите в чаті"
+  },
+  "voicesMenuOverflow": {
+    "description": "Примітка під слотами меню, коли в користувача більше закріплених голосів, ніж може показати меню в чаті (застарілий стан); $count$ — скільки не вмістилося, $cap$ — розмір меню.",
+    "message": "Ще $count$ закріплених голосів чекають за межами $cap$ слотів меню.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Однина для voicesMenuOverflow, використовується, коли рівно один закріплений голос не вміщується в меню в чаті; $cap$ — розмір меню.",
+    "message": "Ще 1 закріплений голос чекає за межами $cap$ слотів меню.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Підсумковий рядок під списком «Голоси» в налаштуваннях, що показує, наскільки заповнене голосове меню хоста в чаті; $host$ — асистент, $used$ — скільки місць зайнято, $cap$ — скільки їх усього. Сформульовано так, щоб читалося правильно при 1 — у Chrome i18n немає форм множини.",
+    "message": "Меню $host$: $used$ з $cap$ місць",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Заголовок групи наприкінці списку «Голоси» в налаштуваннях, що містить голоси без зразка для відтворення; $count$ — скільки їх. Сформульовано так, щоб читалося правильно при 1 — у Chrome i18n немає форм множини.",
+    "message": "Ще немає зразка ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Показується в каталозі голосів у налаштуваннях, коли список голосів порожній для користувача, що увійшов (наприклад, через проблему з мережею).",
+    "message": "Зараз не вдалося завантажити голоси. Спробуйте пізніше."
+  },
+  "voicesNowPlaying": {
+    "description": "Оголошення для читача екрана, коли у списку «Голоси» в налаштуваннях починає відтворюватися зразок голосу; $name$ — це голос.",
+    "message": "Відтворюється $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Кнопка в панелі керування «Голоси» в налаштуваннях, яка відтворює кожен голос із поточного списку один за одним; $count$ — скільки їх. Сформульовано так, щоб читалося правильно при 1 — у Chrome i18n немає форм множини.",
+    "message": "Відтворити всі ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Кнопка в панелі керування «Голоси» в налаштуваннях під час повторного візиту: відтворює лише ті голоси зі списку, які ви ще не слухали; $count$ — скільки їх. Сформульовано так, щоб читалося правильно при 1 — у Chrome i18n немає форм множини.",
+    "message": "Відтворити нові ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Рядок у панелі керування «Голоси» в налаштуваннях, коли браузер відмовився відтворити приклад, бо на сторінці ще не було взаємодії з користувачем.",
+    "message": "Натисніть будь-який голос, щоб увімкнути звук."
+  },
+  "voicesPreview": {
+    "description": "Доступна мітка для кнопки відтворення (▶), яка програє безплатний демо-кліп голосу в рядку голосу; $name$ — назва голосу.",
+    "message": "Відтворити зразок $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Доступна назва списку Голоси в налаштуваннях (listbox усіх голосів, по одному рядку на голос).",
+    "message": "Голоси, упорядковані від найнижчого до найяскравішого"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Доступна назва для перемикача закріплення на картці голосу (увімкнений стан) і кнопки вилучення у слоті меню; $name$ — голос, $host$ — асистент.",
+    "message": "Вилучити $name$ з меню $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Рядок у панелі керування «Голоси» в налаштуваннях, коли не вдалося завантажити або відтворити зразок одного голосу; $name$ — назва цього голосу. Немодально — програвання зразків продовжується далі.",
+    "message": "Не вдалося відтворити зразок голосу $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Підзаголовок розділу каталогу голосів у вкладці налаштувань AI Chat.",
+    "message": "Виберіть голос, який озвучує відповіді на кожному сайті."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Підзаголовок під заголовком налаштувань Голоси, для рейки голосів, упорядкованої за висотою тону.",
+    "message": "Кожен голос, від найнижчого до найяскравішого. Послухайте й виберіть."
+  },
+  "voicesSectionTitle": {
+    "description": "Заголовок розділу каталогу голосів у вкладці налаштувань AI Chat.",
+    "message": "Голоси"
+  },
+  "voicesShelfEveryday": {
+    "description": "Заголовок групи для голосів цінового рівня value у каталозі голосів у налаштуваннях. CSS відображає у верхньому регістрі.",
+    "message": "Повсякденні голоси"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Однорядкова примітка поруч із заголовком групи Everyday у студії Голоси в налаштуваннях; єдине місце, де в студії зазначено, наскільки довше цей рівень працює порівняно з HD.",
+    "message": "Природні й чіткі — можна слухати приблизно у 20× довше, ніж з HD."
+  },
+  "voicesShelfHd": {
+    "description": "Заголовок групи для преміальних (HD) голосів у каталозі голосів у налаштуваннях. CSS відображає у верхньому регістрі.",
+    "message": "HD-голоси"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Однорядкова примітка поруч із заголовком групи HD у студії Голоси в налаштуваннях.",
+    "message": "Найбагатше, найвиразніше звучання."
+  },
+  "voicesShowAll": {
+    "description": "Пункт у фільтрі «Показати» в налаштуваннях «Голоси»: без фільтрації, у списку всі голоси.",
+    "message": "Усі голоси"
+  },
+  "voicesShowEveryday": {
+    "description": "Пункт у фільтрі «Показати» в налаштуваннях «Голоси»: показувати лише стандартні (не HD) голоси.",
+    "message": "Лише стандартні"
+  },
+  "voicesShowHd": {
+    "description": "Пункт у фільтрі «Показати» в налаштуваннях «Голоси»: показувати лише преміум-голоси (HD).",
+    "message": "Лише HD"
+  },
+  "voicesShowLabel": {
+    "description": "Напис на фільтрі в панелі керування «Голоси» в налаштуваннях, який звужує, які голоси показує список.",
+    "message": "Показати"
+  },
+  "voicesShowUnheard": {
+    "description": "Пункт у фільтрі «Показати» в налаштуваннях «Голоси»: показувати лише голоси, які користувач ще не прослуховував.",
+    "message": "Ще не прослухані"
+  },
+  "voicesSpeakingNow": {
+    "description": "Позначка стану на поточному вибраному голосі хоста в студії Голоси в налаштуваннях (слот меню та картка голосу).",
+    "message": "Зараз говорить"
+  },
+  "voicesSpeaksWith": {
+    "description": "Рядок-надпис над назвою поточного голосу на сцені студії Голоси в налаштуваннях; $host$ — асистент (наприклад, Pi). CSS відображає великими літерами.",
+    "message": "$host$ говорить голосом",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Примітка на сцені, коли хост відтворює власне аудіо (наприклад, Pi), тож вибір голосу Say, Pi замінює голос хоста.",
+    "message": "$host$ використовує свій голос, доки ви не виберете один нижче.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Примітка на сцені, коли хост не має власного голосу (наприклад, Claude), тож нічого не читається вголос, доки не вибрано голос Say, Pi.",
+    "message": "$host$ не читатиме відповіді вголос, доки ви не виберете один нижче.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Заголовок на сцені студії голосів у налаштуваннях, коли для хоста не вибрано голос SayPi; $host$ — асистент (наприклад, Pi, Claude). Відображається розміром імені.",
+    "message": "Виберіть, як звучить $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Кнопка на сцені студії голосів у налаштуваннях, яка відтворює безплатний зразок поточного голосу.",
+    "message": "Послухати зразок"
+  },
+  "voicesStopPlayback": {
+    "description": "Кнопка в панелі керування «Голоси» в налаштуваннях, яка зупиняє послідовність зразків, запущену командою «Відтворити всі».",
+    "message": "Зупинити"
+  },
+  "voicesSweepPosition": {
+    "description": "Поточний індикатор позиції в панелі керування «Голоси» в налаштуваннях, поки «Відтворити все» проходить список; $index$ — голос, що зараз відтворюється, а $total$ — скільки в черзі.",
+    "message": "$index$ із $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Доступна мітка для елемента порівняння в панелі керування «Голоси» в налаштуваннях, який відтворює інший голос із двох останніх прослуханих; $name$ — це той голос.",
+    "message": "Перемкнутися назад на $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Рядок у панелі керування «Голоси» в налаштуваннях, коли «Відтворити все» натиснуто для надто довгого списку; $count$ — скільки голосів, а $minutes$ — приблизно скільки хвилин це займе. Скорочено «хв.», щоб читалося коректно при 1 — у Chrome i18n немає множинних форм.",
+    "message": "Це $count$ голосів — приблизно $minutes$ хв. Спершу звузьте список.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Доступна назва для кнопки «використати цей голос» для кожного хоста в каталозі голосів у налаштуваннях; $name$ — голос, $host$ — асистент (наприклад, Pi, Claude).",
+    "message": "Використати $name$ для $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Короткий напис на кнопці «використати цей голос» для кожного хоста в об’єднаному каталозі голосів у налаштуваннях (поруч показано хост).",
+    "message": "Використати"
+  },
+  "voicesYourVoice": {
+    "description": "Кнопка на панелі керування в списку «Голоси» в налаштуваннях, яка переводить фокус на рядок голосу, який зараз використовує цей хост; $name$ — це той голос.",
+    "message": "Ваш голос: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Помилка, яка виникає, коли браузер не може виділити достатньо памʼяті WebAssembly для моделі виявлення голосу.",
+    "message": "Виявлення голосу не може запуститися: недостатньо памʼяті WebAssembly для голосової моделі. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Помилка, яка виникає, коли браузер не надає початкову памʼять WebAssembly, потрібну для запуску моделі виявлення голосу.",
+    "message": "Виявлення голосу не може запуститися: у цьому браузері недоступна памʼять WebAssembly."
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "Lợi ích liệt kê trong hộp thoại đăng nhập - tăng hạn mức sử dụng.",
+    "message": "Hạn mức sử dụng cao hơn với tài khoản miễn phí"
+  },
+  "authBenefitPremium": {
+    "description": "Lợi ích liệt kê trong hộp thoại đăng nhập - tính năng cao cấp trên các chatbot.",
+    "message": "Tính năng cao cấp và hỗ trợ chatbot"
+  },
+  "authBenefitSupport": {
+    "description": "Lợi ích liệt kê trong hộp thoại đăng nhập - hỗ trợ ưu tiên.",
+    "message": "Ưu tiên hỗ trợ khi có sự cố"
+  },
+  "authBenefitSync": {
+    "description": "Lợi ích liệt kê trong hộp thoại đăng nhập - đồng bộ cài đặt.",
+    "message": "Đồng bộ cài đặt giọng nói ở mọi nơi"
+  },
+  "authBenefitTTS": {
+    "description": "Lợi ích liệt kê trong hộp thoại đăng nhập - tính năng TTS.",
+    "message": "Giọng chuyển văn bản thành giọng nói (gói trả phí)"
+  },
+  "authBenefitUsage": {
+    "description": "Lợi ích liệt kê trong hộp thoại đăng nhập - theo dõi mức sử dụng.",
+    "message": "Theo dõi mức sử dụng giọng nói trên các thiết bị"
+  },
+  "authPromptModalFull": {
+    "description": "Mô tả cho hộp thoại đăng nhập đầy đủ kèm đề xuất giá trị.",
+    "message": "Bạn đang dùng SayPi rất hiệu quả. Đăng nhập để có hạn mức cao hơn, giọng chuyển văn bản thành giọng nói và các tính năng cao cấp trên mọi chatbot được hỗ trợ."
+  },
+  "authPromptModalSoft": {
+    "description": "Mô tả cho hộp thoại đăng nhập dạng nhẹ.",
+    "message": "Tạo tài khoản SayPi miễn phí để có hạn mức cao hơn và dùng các tính năng giọng nói cao cấp."
+  },
+  "authPromptTitle": {
+    "description": "Tiêu đề cho hộp thoại đăng nhập.",
+    "message": "Mở khóa thêm tính năng giọng nói"
+  },
+  "authPromptToast": {
+    "description": "Thông báo dạng toast khuyến khích người dùng đăng nhập.",
+    "message": "Đăng nhập SayPi để có hạn mức cao hơn và tính năng cao cấp"
+  },
   "autoReadAloudChatGPT": {
     "description": "Nhãn cho hộp kiểm bật/tắt tính năng đọc tự động các phản hồi của ChatGPT trong cuộc gọi thoại.",
     "message": "Đọc tự động (ChatGPT)"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "Vô hiệu hóa văn bản để nói"
   },
+  "dismiss": {
+    "message": "Hiểu rồi",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "Đuổi đi"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "Tập trung"
   },
+  "errorVadInitFailed": {
+    "description": "Thông báo lỗi hiển thị khi phát hiện hoạt động giọng nói không khởi tạo được.",
+    "message": "Không khởi tạo được phát hiện giọng nói"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "Thông báo lỗi hiển thị khi có lỗi không mong muốn xảy ra trong lúc thiết lập ghi âm giọng nói.",
+    "message": "Không thiết lập được ghi âm giọng nói"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "Thông báo lỗi hiển thị khi máy khách phát hiện giọng nói không thể bắt đầu ghi.",
+    "message": "Không bắt đầu được ghi âm giọng nói"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "Thông báo lỗi hiển thị khi máy khách phát hiện giọng nói (VAD) không khả dụng nên không thể bắt đầu ghi.",
+    "message": "Không thể ghi âm giọng nói"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "Thoát Chế độ Tập Trung"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "Ghi chú một dòng hiển thị trong menu giọng nói khi có cả giọng cao cấp (HD) và giọng tiết kiệm.",
+    "message": "Giọng HD dùng hạn mức hằng tháng của bạn nhanh hơn khoảng 20×."
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "Tucking cái này đi ..."
   },
+  "maybeLater": {
+    "description": "Văn bản nút để đóng lời nhắc đăng nhập.",
+    "message": "Để sau"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "Cài đặt micrô của bạn không đáp ứng các thông số kỹ thuật bắt buộc. \nHãy thử sử dụng micrô khác hoặc điều chỉnh cài đặt âm thanh của bạn."
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "Không thể truy cập micrô. \nVui lòng kiểm tra cài đặt thiết bị của bạn và thử lại."
   },
+  "microphonePermissionDeniedError": {
+    "description": "Thông báo lỗi hiển thị khi quyền micrô bị từ chối sau luồng lời nhắc cấp quyền.",
+    "message": "Bạn chưa cấp quyền micrô. Hãy đảm bảo bạn đã cho phép trong lời nhắc và trong phần cài đặt của tiện ích."
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "chính xác"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "Phản hồi nhanh nhất nhưng kém chính xác hơn. \nDễ bị gián đoạn."
   },
+  "moreVoices": {
+    "description": "Dòng menu liên kết từ menu giọng nói trong trang đến danh mục giọng nói đầy đủ trong phần cài đặt tiện ích.",
+    "message": "Thêm giọng nói…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "Tên gọi trợ lý"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "Không đăng nhập"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "Nhãn nút mở ChatGPT.",
+    "message": "Mở ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "Nhãn nút mở Claude.ai.",
+    "message": "Mở Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "Nhãn nút mở Pi.ai.",
+    "message": "Mở Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "Tùy chọn môi trường: ở gần người khác.",
+    "message": "Gần người khác"
+  },
+  "onboarding_envMixed": {
+    "description": "Tùy chọn môi trường: kết hợp không gian riêng tư và dùng chung.",
+    "message": "Ở nhiều nơi khác nhau"
+  },
+  "onboarding_envPrivate": {
+    "description": "Tùy chọn môi trường: một không gian riêng tư.",
+    "message": "Ở nơi riêng tư"
+  },
+  "onboarding_envQuietOff": {
+    "description": "Xác nhận hiển thị khi câu trả lời về môi trường để chế độ yên lặng tắt.",
+    "message": "Đã rõ — chúng tôi sẽ giữ các cài đặt nghe và phát tiêu chuẩn."
+  },
+  "onboarding_envQuietOn": {
+    "description": "Xác nhận hiển thị khi câu trả lời về môi trường bật chế độ yên lặng.",
+    "message": "Đã bật chế độ yên lặng — chúng tôi sẽ bắt tiếng nói nhỏ hơn và trả lời nhỏ, để bạn có thể trò chuyện kín đáo."
+  },
+  "onboarding_envTitle": {
+    "description": "Tiêu đề cho câu hỏi trong phần giới thiệu về môi trường của người dùng.",
+    "message": "Bạn thường nói chuyện ở đâu?"
+  },
+  "onboarding_footer": {
+    "description": "Văn bản chân trang trên trang giới thiệu khi chạy lần đầu.",
+    "message": "Bạn có thể xem lại mục này bất cứ lúc nào trong phần cài đặt của Say, Pi. Quyền riêng tư của bạn rất quan trọng — âm thanh chỉ được ghi khi đang trong một cuộc gọi."
+  },
+  "onboarding_heading": {
+    "description": "Tiêu đề chính trên trang hướng dẫn lần chạy đầu tiên.",
+    "message": "🗣️ Chào mừng đến với Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "Đoạn giới thiệu trên trang hướng dẫn lần chạy đầu tiên.",
+    "message": "Bạn chỉ còn hai bước nữa là có cuộc trò chuyện đầu tiên với AI bằng giọng nói. Nói nhanh hơn gõ khoảng 3× — cùng thiết lập nhé."
+  },
+  "onboarding_micTestButton": {
+    "description": "Nút bắt đầu bài kiểm tra mic trong phần giới thiệu, không có rủi ro.",
+    "message": "🎤 Thử mic của bạn"
+  },
+  "onboarding_micTestDone": {
+    "description": "Trạng thái hiển thị sau khi bài kiểm tra mic trong phần giới thiệu hoàn tất thành công.",
+    "message": "Ổn rồi — mic của bạn hoạt động! 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "Trạng thái hiển thị khi bài kiểm tra mic trong phần giới thiệu đang đo tín hiệu đầu vào.",
+    "message": "Đang nghe — hãy nói gì đó! 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "Trạng thái hiển thị khi bài kiểm tra mic trong phần giới thiệu đang chờ cấp quyền.",
+    "message": "Đang yêu cầu quyền micro…"
+  },
+  "onboarding_micTestStop": {
+    "description": "Nhãn nút để dừng bài kiểm tra mic trong phần giới thiệu khi đang chạy.",
+    "message": "Dừng thử"
+  },
+  "onboarding_step1Body": {
+    "description": "Nội dung của bước hướng dẫn đầu tiên giải thích cách ghim tiện ích.",
+    "message": "Nhấn biểu tượng mảnh ghép 🧩 ở góc trên bên phải trình duyệt, rồi nhấn ghim 📌 cạnh Say, Pi. Như vậy nút gọi chỉ cách một lần nhấn."
+  },
+  "onboarding_step1Title": {
+    "description": "Tiêu đề của bước hướng dẫn đầu tiên (ghim tiện ích).",
+    "message": "Ghim Say, Pi vào thanh công cụ"
+  },
+  "onboarding_step2Body": {
+    "description": "Nội dung của bước hướng dẫn thứ hai giải thích cách bắt đầu cuộc trò chuyện bằng giọng nói.",
+    "message": "Vào một trong các trợ lý được hỗ trợ bên dưới, rồi nhấn nút gọi Say, Pi và chào một câu. Lần đầu chúng tôi sẽ xin quyền micrô — điều đó là bình thường, và chúng tôi chỉ nghe khi bạn đang trong cuộc gọi."
+  },
+  "onboarding_step2Title": {
+    "description": "Tiêu đề của bước hướng dẫn thứ hai (bắt đầu cuộc trò chuyện).",
+    "message": "Mở một chat AI và bắt đầu nói"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "Cho phép micrô"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "Hướng dẫn khôi phục khi quyền micro bị chặn.",
+    "message": "Trình duyệt của bạn đang chặn micro. Nhấp vào biểu tượng camera hoặc ổ khóa trên thanh địa chỉ, đặt Microphone thành \"Allow\", rồi thử lại. Trên macOS, cũng kiểm tra System Settings → Privacy & Security → Microphone."
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "Tiêu đề của bảng khôi phục khi quyền micro bị từ chối/bị chặn.",
+    "message": "Quyền truy cập micro đang bị chặn"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "Hướng dẫn khôi phục khi micro đang được dùng ở nơi khác.",
+    "message": "Một ứng dụng hoặc thẻ khác có thể đang dùng micro của bạn. Hãy đóng mọi thứ khác có thể đang ghi âm (cuộc gọi video, ghi âm giọng nói), rồi thử lại."
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "Tiêu đề của bảng khôi phục khi micro đang được một ứng dụng khác sử dụng.",
+    "message": "Micro của bạn đang bận"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "Hướng dẫn khôi phục khi không có thiết bị micro khả dụng.",
+    "message": "Chúng tôi không tìm thấy micro. Hãy cắm một cái (hoặc kết nối tai nghe có mic), đảm bảo nó được chọn làm thiết bị đầu vào, rồi thử lại."
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "Tiêu đề của bảng khôi phục khi không có thiết bị micro khả dụng.",
+    "message": "Không tìm thấy micro"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "Hướng dẫn khôi phục cho lỗi micro không xác định.",
+    "message": "Đã xảy ra sự cố khi truy cập micro của bạn. Hãy kiểm tra xem micro đã được kết nối và được cho phép trong cài đặt trình duyệt, rồi thử lại."
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "Tiêu đề của bảng khôi phục cho lỗi micro không xác định.",
+    "message": "Chúng tôi không thể truy cập micro của bạn"
+  },
+  "permissions_retryButton": {
+    "description": "Nhãn cho nút yêu cầu lại quyền micro.",
+    "message": "Thử lại"
+  },
+  "permissions_revokedHeading": {
+    "description": "Tiêu đề hiển thị khi quyền truy cập micro trước đó đã được cấp nhưng sau đó bị thu hồi.",
+    "message": "🎙️ Hãy kết nối lại micro của bạn"
+  },
+  "permissions_revokedInfo": {
+    "description": "Văn bản thông tin hiển thị khi quyền truy cập micro bị thu hồi sau khi đã được cấp.",
+    "message": "Quyền truy cập micro của bạn đã bị tắt — điều này thường xảy ra sau khi cập nhật trình duyệt hoặc hệ thống. Hãy cho phép lại bên dưới và $productName$ sẽ lại lắng nghe khi bạn đang trong cuộc gọi.",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "Hồ sơ"
+  },
+  "quietModeLabel": {
+    "description": "Nhãn cho công tắc bật chế độ yên lặng/thì thầm.",
+    "message": "Chế độ yên lặng"
+  },
+  "quietModeTooltip": {
+    "description": "Chú giải giải thích chế độ yên lặng/thì thầm hoạt động như thế nào.",
+    "message": "Nói khẽ — nhận giọng nói nhỏ hơn và giảm âm lượng phản hồi của trợ lý, để bạn có thể dùng giọng nói khi có người xung quanh."
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "Chữ trên nút đăng nhập khi quá trình xác thực đang diễn ra.",
+    "message": "Đang đăng nhập..."
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "Hiệu ứng âm thanh"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Hiệu ứng âm thanh bị tắt trong Firefox để ngăn sự cố phản hồi âm thanh."
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "Dòng tiêu đề của thông báo một lần về lợi ích tốc độ, hiển thị sau lần trao đổi bằng giọng nói đầu tiên.",
+    "message": "Hay đấy — nói nhanh hơn gõ khoảng 3×."
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "Dòng thứ hai (không bắt buộc) của thông báo lợi ích tốc độ, hiển thị số phút nguyên đã tiết kiệm.",
+    "message": "Bạn đã nói nhanh hơn việc gõ khoảng $minutes$ phút.",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "Chỉ gửi khi bạn nhấn nút"
   },
+  "surveyQuestion": {
+    "description": "Câu hỏi duy nhất của khảo sát siêu ngắn một lần sau khi người dùng đạt được một mốc (post-win).",
+    "message": "Bạn thấy giọng nói dùng đến giờ thế nào?"
+  },
+  "surveyRatingLabel": {
+    "description": "Nhãn hỗ trợ tiếp cận cho nút chấm điểm khảo sát.",
+    "message": "Chấm $rating$ trên 5",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "Lời cảm ơn hiển thị sau khi người dùng trả lời khảo sát post-win.",
+    "message": "Cảm ơn, điều đó giúp chúng tôi cải thiện Say, Pi."
+  },
   "tabAIChat": {
     "description": "Nhãn tab cho phần cài đặt trò chuyện AI.",
     "message": "Trò Chuyện AI"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "Nhãn tab cho phần cài đặt chung.",
     "message": "Chung"
+  },
+  "tabVoices": {
+    "description": "Nhãn tab cho mục cài đặt giọng nói (danh mục giọng theo từng trang).",
+    "message": "Giọng nói"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "Tín dụng"
   },
+  "ttsCreditsRemaining": {
+    "description": "Văn bản hiển thị hạn mức TTS còn lại dưới dạng một nhóm credit theo từng giọng (saypi-api #181 Stage 2), không phải số ký tự thô.",
+    "message": "Còn $credits$ credit",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Giọng nói đa ngôn ngữ hiện không được hỗ trợ trong Safari."
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "Tạo giọng nói"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "Lưu ý! Phát lại giọng nói chưa khả dụng trên $browserName$ với $chatbotName$. Tin tốt? Đầu vào bằng giọng nói hoạt động tuyệt vời! Đối với TTS, hãy thử Chrome hoặc Edge trên máy tính để bàn.",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "TTS không khả dụng trên $browserName$ + $chatbotName$. Đầu vào bằng giọng nói hoạt động! Hãy thử Chrome trên máy tính để bàn cho TTS.",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS Voice"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "Chi tiết VAD khi phát hiện âm thanh giống lời nói nhưng quá nhỏ / độ tin cậy thấp để chuyển thành văn bản (bị chặn phía client ở cổng chấp nhận).",
+    "message": "Âm thanh quá nhỏ để chuyển thành văn bản"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "Chi tiết VAD giải thích cuộc gọi kết thúc vì micrô đã được một tab mới hơn giành quyền.",
+    "message": "Đầu vào giọng nói đã chuyển sang tab khác"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "Giọng nói không có sẵn. \nHãy thử Chrome hoặc Firefox trên máy tính để bàn."
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "Lưu ý! Phát lại giọng nói chưa khả dụng trên $browserName$ với $chatbotName$. Tin tốt? Đầu vào bằng giọng nói hoạt động tuyệt vời! Đối với TTS, hãy thử Chrome hoặc Edge trên máy tính để bàn.",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "TTS không khả dụng trên $browserName$ + $chatbotName$. Đầu vào bằng giọng nói hoạt động! Hãy thử Chrome trên máy tính để bàn cho TTS.",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "Hiểu rồi",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "Trạng thái VAD hiển thị trên một tab có đầu vào giọng nói đã bị một tab khác tiếp quản.",
+    "message": "Đã tạm dừng"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "Xem chi tiết"
   },
+  "voiceIntroductionGeneric": {
+    "description": "Lời giới thiệu chung được phát khi giọng SayPi đã chọn không có kịch bản giới thiệu riêng cho giọng đó (và không có tin nhắn gần đây để đọc lại).",
+    "message": "Chào bạn, tôi là $voice$. Đây là giọng của tôi. Mong bạn thích giọng này.",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "Hoan hô! \nXin chào! \nbạn ơi! \nTôi là Pi, trợ lý AI đa ngôn ngữ của bạn. \nVới 32 ngôn ngữ trong tầm tay của tôi, chúng ta có thể khám phá các ý tưởng và nền văn hóa từ khắp nơi trên thế giới. \nBạn nghĩ gì về giọng nói này?"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "Cài đặt giọng nói"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "Phụ đề dự phòng cho một hàng giọng trong danh mục giọng nói của phần cài đặt khi giọng không có mô tả; $count$ là số ngôn ngữ mà giọng hỗ trợ.",
+    "message": "Nói $count$ ngôn ngữ",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "Dòng mô tả tính cách được viết sẵn cho giọng 'Addison' (studio Giọng nói trong phần cài đặt; bản đồ nhận diện giọng phía máy khách).",
+    "message": "Tươi tắn và diễn đạt mạch lạc"
+  },
+  "voiceTagline_alloy": {
+    "description": "Câu khẩu hiệu tính cách được viết sẵn cho giọng \"Alloy\" (studio Giọng nói trong cài đặt; bản đồ định danh giọng phía máy khách).",
+    "message": "Cân bằng, đa dụng"
+  },
+  "voiceTagline_ash": {
+    "description": "Câu khẩu hiệu tính cách được viết sẵn cho giọng \"Ash\" (studio Giọng nói trong cài đặt; bản đồ định danh giọng phía máy khách).",
+    "message": "Trầm, sâu sắc, điềm tĩnh"
+  },
+  "voiceTagline_ballad": {
+    "description": "Câu khẩu hiệu tính cách được viết sẵn cho giọng \"Ballad\" (studio Giọng nói trong cài đặt; bản đồ định danh giọng phía máy khách).",
+    "message": "Mượt mà, du dương"
+  },
+  "voiceTagline_cassidy": {
+    "description": "Dòng mô tả tính cách được viết sẵn cho giọng 'Cassidy' (studio Giọng nói trong phần cài đặt; bản đồ nhận diện giọng phía máy khách).",
+    "message": "Thân thiện và thẳng thắn"
+  },
+  "voiceTagline_cedar": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Cedar' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Điềm tĩnh và đáng tin cậy"
+  },
+  "voiceTagline_coral": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Coral' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Tươi sáng, giàu năng lượng"
+  },
+  "voiceTagline_echo": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Echo' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Gọn gàng và trung tính"
+  },
+  "voiceTagline_fable": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Fable' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Nhịp điệu kể chuyện"
+  },
+  "voiceTagline_finn": {
+    "description": "Dòng mô tả tính cách được viết sẵn cho giọng 'Finn' (studio Giọng nói trong phần cài đặt; bản đồ nhận diện giọng phía máy khách).",
+    "message": "Tươi mới và tràn đầy năng lượng"
+  },
+  "voiceTagline_jamahal": {
+    "description": "Dòng mô tả tính cách được viết sẵn cho giọng 'Jamahal' (studio Giọng nói trong phần cài đặt; bản đồ nhận diện giọng phía máy khách).",
+    "message": "Trầm ấm và cuốn hút"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Jarnathan' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Baritone mượt mà kiểu đêm muộn"
+  },
+  "voiceTagline_jeff": {
+    "description": "Dòng mô tả tính cách được viết sẵn cho giọng 'Jeff' (studio Giọng nói trong phần cài đặt; bản đồ nhận diện giọng phía máy khách).",
+    "message": "Thẳng thắn và vững vàng"
+  },
+  "voiceTagline_jessica": {
+    "description": "Dòng mô tả tính cách được viết sẵn cho giọng 'Jessica' (studio Giọng nói trong phần cài đặt; bản đồ nhận diện giọng phía máy khách).",
+    "message": "Ấm áp, điềm tĩnh và chỉn chu"
+  },
+  "voiceTagline_joey": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Joey' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Tự nhiên, trò chuyện kiểu Mỹ"
+  },
+  "voiceTagline_juniper": {
+    "description": "Dòng mô tả tính cách được viết sẵn cho giọng 'Juniper' (studio Giọng nói trong phần cài đặt; bản đồ nhận diện giọng phía máy khách).",
+    "message": "Gọn gàng, sáng, giàu biểu cảm"
+  },
+  "voiceTagline_lucy": {
+    "description": "Dòng mô tả tính cách được viết sẵn cho giọng 'Lucy' (studio Giọng nói trong phần cài đặt; bản đồ nhận diện giọng phía máy khách).",
+    "message": "Dịu dàng và trong sáng"
+  },
+  "voiceTagline_marin": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Marin' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Ấm áp, bình thản như radio buổi sáng"
+  },
+  "voiceTagline_mark": {
+    "description": "Dòng mô tả tính cách được viết sẵn cho giọng 'Mark' (studio Giọng nói trong phần cài đặt; bản đồ nhận diện giọng phía máy khách).",
+    "message": "Rõ ràng, tự tin như người dẫn chuyện"
+  },
+  "voiceTagline_nova": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Nova' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Nhanh nhạy và ham khám phá"
+  },
+  "voiceTagline_onyx": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Onyx' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Trầm sâu, vang và uy nghi"
+  },
+  "voiceTagline_paola": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Paola' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Ấm áp kiểu Ý, giàu biểu cảm"
+  },
+  "voiceTagline_sage": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Sage' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Rõ ràng, nhẹ nhàng"
+  },
+  "voiceTagline_shimmer": {
+    "description": "Dòng mô tả tính cách do tác giả viết cho giọng 'Shimmer' (trong phần cài đặt Voices studio; bản đồ nhận diện giọng ở phía máy khách).",
+    "message": "Nhẹ và thoáng"
+  },
+  "voicesAddToMenuShort": {
+    "description": "Nhãn ngắn trên công tắc ghim của thẻ giọng (trạng thái tắt) trong studio Giọng nói của cài đặt; nhấn để thêm giọng vào menu trong chat của host.",
+    "message": "+ Menu"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "Nhãn trợ năng cho công tắc ghim của thẻ giọng (trạng thái tắt); $name$ là giọng, $host$ là trợ lý.",
+    "message": "Thêm $name$ vào menu của $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "Nhãn trên nút gạt trong thanh điều khiển Giọng nói cho biết việc duyệt danh sách bằng phím mũi tên có phát từng giọng khi tiêu điểm đến đó hay không.",
+    "message": "Phát khi bạn di chuyển"
+  },
+  "voicesArrowsLive": {
+    "description": "Xác nhận của trình đọc màn hình, được thêm vào thông báo đầu tiên \"Đang phát <giọng>\" trong danh sách Giọng nói của phần cài đặt, cho biết các phím mũi tên vừa trở nên có âm thanh. Phản chiếu đúng cách diễn đạt của nút bật/tắt \"Phát khi di chuyển\".",
+    "message": "Mũi tên giờ sẽ phát khi bạn di chuyển. Esc sẽ dừng."
+  },
+  "voicesBuiltinsNote": {
+    "description": "Ghi chú dưới các ô trong menu cho các host có giọng nói gốc đi kèm (ví dụ: 8 giọng tích hợp của Pi), mà studio không quản lý; $host$ là trợ lý.",
+    "message": "Các giọng nói tích hợp sẵn của $host$ cũng luôn xuất hiện trong menu của nó.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "Biến thể của voicesBuiltinsNote cho một host không có menu giọng nói trong khung chat (Pi đã ngừng menu vào năm 2026), nơi lời hứa của bản gốc rằng các giọng tích hợp 'xuất hiện trong menu của nó' sẽ không đúng; $host$ là trợ lý.",
+    "message": "$host$ cũng có các giọng nói tích hợp sẵn, nhưng không được liệt kê ở đây.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "Chỉ báo tiến độ trong thanh điều khiển Giọng nói của phần cài đặt: số giọng trong danh sách mà người dùng đã nghe. Chỉ là số nên đọc đúng khi là 1 vì Chrome i18n không có dạng số nhiều.",
+    "message": "Đã nghe $heard$ trên $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "Một phần của tên hỗ trợ tiếp cận của một hàng giọng trong danh sách Giọng nói của phần cài đặt, đánh dấu một giọng mà hồ sơ này đã nghe rồi. Về mặt thị giác, điều này được thể hiện bằng mật độ mực trên \"dấu vân âm\" của giọng, thứ mà trình đọc màn hình không nhìn thấy.",
+    "message": "Đã nghe"
+  },
+  "voicesInHostMenu": {
+    "description": "Tiêu đề mục phía trên hàng các ô menu trong studio Giọng nói của cài đặt; $host$ là trợ lý.",
+    "message": "Trong menu của $host$",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "Nhãn ngắn trên công tắc ghim của thẻ giọng (trạng thái bật) trong studio Giọng nói của cài đặt.",
+    "message": "✓ Trong menu"
+  },
+  "voicesInUse": {
+    "description": "Huy hiệu cố định trên giọng hiện được chọn của host trong danh sách Giọng nói của cài đặt, được hiển thị dạng chữ hoa. Cố ý KHÔNG dùng \"Đang nói\": trên trang này, mỗi hàng phát clip mẫu, nên một giọng được chọn nhưng im lặng không được tự nhận là đang nói khi một hàng khác đang phát.",
+    "message": "Đang dùng"
+  },
+  "voicesKeyboardHint": {
+    "description": "Gợi ý phím tắt một dòng trong thanh điều khiển Giọng nói của phần cài đặt. Các ký hiệu là phím: Space, mũi tên lên/xuống và Shift+Space.",
+    "message": "Nhấn Space để nghe, ↑↓ để chuyển giữa các giọng, ⇧Space để chuyển lại."
+  },
+  "voicesLoadError": {
+    "description": "Trạng thái lỗi bên trong studio của một host khi danh mục giọng nói của host đó không tải được; $host$ là trợ lý.",
+    "message": "Không thể tải giọng nói của $host$. Vui lòng thử lại sau.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "Tooltip/gợi ý trên công tắc \"+ Menu\" bị vô hiệu hóa khi menu trong chat của host đã có số giọng tối đa.",
+    "message": "Menu đã đầy, hãy gỡ một giọng để thêm giọng khác"
+  },
+  "voicesMenuHint": {
+    "description": "Gợi ý một dòng cạnh tiêu đề \"Trong menu của {host}\", giải thích rằng hàng các ô phản chiếu menu giọng trong chat.",
+    "message": "Những gì bạn sẽ thấy trong chat"
+  },
+  "voicesMenuOverflow": {
+    "description": "Ghi chú dưới các ô trong menu khi người dùng ghim nhiều giọng nói hơn số menu trong khung chat có thể hiển thị (trạng thái cũ); $count$ là số lượng không vừa, $cap$ là kích thước menu.",
+    "message": "Còn $count$ giọng nói đã ghim đang chờ ngoài $cap$ vị trí của menu.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "Dạng số ít của voicesMenuOverflow, dùng khi chỉ có đúng một giọng nói đã ghim không vừa trong menu trong khung chat; $cap$ là kích thước menu.",
+    "message": "Còn 1 giọng nói đã ghim đang chờ ngoài $cap$ vị trí của menu.",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "Dòng tóm tắt dưới danh sách Giọng nói trong phần cài đặt cho biết mức độ lấp đầy của menu giọng trong chat của máy chủ; $host$ là trợ lý, $used$ là số vị trí đã dùng, $cap$ là tổng số vị trí. Diễn đạt để đọc đúng khi là 1 vì Chrome i18n không có dạng số nhiều.",
+    "message": "Menu của $host$: $used$ trên $cap$ vị trí",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "Tiêu đề cho nhóm ở cuối danh sách Giọng nói trong phần cài đặt, chứa các giọng chưa có đoạn mẫu để phát; $count$ là số lượng. Diễn đạt để đọc đúng khi là 1 vì Chrome i18n không có dạng số nhiều.",
+    "message": "Chưa có mẫu ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "Hiển thị trong danh mục giọng nói của phần cài đặt khi danh sách giọng nói trống với người dùng đã đăng nhập (ví dụ: sự cố mạng).",
+    "message": "Hiện không tải được giọng nói. Vui lòng thử lại sau."
+  },
+  "voicesNowPlaying": {
+    "description": "Thông báo của trình đọc màn hình khi đoạn mẫu của một giọng bắt đầu phát trong danh sách Giọng nói của phần cài đặt; $name$ là giọng đó.",
+    "message": "Đang phát $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "Nút trong thanh điều khiển Giọng nói của phần cài đặt phát lần lượt mọi giọng đang được liệt kê; $count$ là số lượng. Diễn đạt để đọc đúng khi là 1 vì Chrome i18n không có dạng số nhiều.",
+    "message": "Phát tất cả ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "Nút trong thanh điều khiển Giọng nói của phần cài đặt khi quay lại: chỉ phát các giọng được liệt kê mà bạn chưa nghe; $count$ là số lượng. Diễn đạt để đọc đúng khi là 1 vì Chrome i18n không có dạng số nhiều.",
+    "message": "Phát mới ($count$)",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "Dòng trong thanh điều khiển Giọng nói ở phần cài đặt khi trình duyệt từ chối phát mẫu vì trang chưa có tương tác của người dùng.",
+    "message": "Nhấp vào bất kỳ giọng nào để bật âm thanh."
+  },
+  "voicesPreview": {
+    "description": "Nhãn hỗ trợ tiếp cận cho nút phát (▶) để nghe thử đoạn mẫu miễn phí của một giọng trong một hàng giọng; $name$ là tên của giọng.",
+    "message": "Phát đoạn mẫu của $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "Tên hỗ trợ tiếp cận của danh sách Giọng nói trong cài đặt (một listbox gồm mọi giọng nói, mỗi hàng một giọng).",
+    "message": "Giọng nói, sắp từ trầm nhất đến sáng nhất"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "Nhãn trợ năng cho công tắc ghim của thẻ giọng (trạng thái bật) và nút gỡ trên một ô menu; $name$ là giọng, $host$ là trợ lý.",
+    "message": "Gỡ $name$ khỏi menu của $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "Dòng trong thanh điều khiển Giọng nói ở phần cài đặt khi đoạn mẫu của một giọng không tải được hoặc không phát được; $name$ là giọng đó. Không phải hộp thoại — chuỗi phát mẫu vẫn tiếp tục sau đó.",
+    "message": "Không phát được mẫu của $name$.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "Tiêu đề phụ cho phần danh mục giọng nói trong tab AI Chat của phần cài đặt.",
+    "message": "Chọn giọng đọc to câu trả lời trên từng trang web."
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "Tiêu đề phụ dưới tiêu đề cài đặt Giọng nói, cho dải giọng nói được sắp theo cao độ.",
+    "message": "Mọi giọng nói, từ trầm nhất đến sáng nhất. Nghe rồi chọn."
+  },
+  "voicesSectionTitle": {
+    "description": "Tiêu đề cho phần danh mục giọng nói trong tab AI Chat của phần cài đặt.",
+    "message": "Giọng nói"
+  },
+  "voicesShelfEveryday": {
+    "description": "Tiêu đề nhóm cho các giọng ở phân khúc tiết kiệm trong danh mục giọng nói ở phần cài đặt. Được CSS hiển thị bằng chữ in hoa.",
+    "message": "Giọng hằng ngày"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "Ghi chú một dòng bên cạnh tiêu đề nhóm Everyday trong studio Giọng nói của phần cài đặt; là nơi duy nhất studio nói rõ mức chênh lệch độ dài nghe của phân khúc này so với HD.",
+    "message": "Tự nhiên và rõ ràng, bạn có thể nghe lâu hơn khoảng 20× so với HD."
+  },
+  "voicesShelfHd": {
+    "description": "Tiêu đề nhóm cho các giọng cao cấp (HD) trong danh mục giọng nói ở phần cài đặt. Được CSS hiển thị bằng chữ in hoa.",
+    "message": "Giọng HD"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "Ghi chú một dòng bên cạnh tiêu đề nhóm HD trong studio Giọng nói của phần cài đặt.",
+    "message": "Âm thanh phong phú và biểu cảm nhất."
+  },
+  "voicesShowAll": {
+    "description": "Tùy chọn trong bộ lọc \"Hiện\" của Giọng nói: không lọc, liệt kê mọi giọng.",
+    "message": "Tất cả giọng nói"
+  },
+  "voicesShowEveryday": {
+    "description": "Tùy chọn trong bộ lọc \"Hiện\" của Giọng nói: chỉ liệt kê các giọng tiêu chuẩn (không HD).",
+    "message": "Chỉ thường"
+  },
+  "voicesShowHd": {
+    "description": "Tùy chọn trong bộ lọc \"Hiện\" của Giọng nói: chỉ liệt kê các giọng cao cấp (HD).",
+    "message": "Chỉ HD"
+  },
+  "voicesShowLabel": {
+    "description": "Nhãn trên bộ lọc trong thanh điều khiển Giọng nói ở phần cài đặt, dùng để thu hẹp các giọng được hiển thị trong danh sách.",
+    "message": "Hiện"
+  },
+  "voicesShowUnheard": {
+    "description": "Tùy chọn trong bộ lọc \"Hiện\" của Giọng nói: chỉ liệt kê các giọng mà người dùng chưa nghe thử.",
+    "message": "Chưa nghe"
+  },
+  "voicesSpeakingNow": {
+    "description": "Nhãn trạng thái trên giọng hiện được chọn của host trong studio Giọng nói của cài đặt (ô menu và thẻ giọng).",
+    "message": "Đang nói"
+  },
+  "voicesSpeaksWith": {
+    "description": "Dòng tiêu đề nhỏ phía trên tên giọng hiện tại trên sân khấu studio Giọng nói trong cài đặt; $host$ là trợ lý (ví dụ: Pi). Được CSS hiển thị dạng chữ hoa.",
+    "message": "$host$ nói bằng",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "Ghi chú trên stage khi host tự cung cấp âm thanh (ví dụ: Pi), nên việc chọn một giọng Say, Pi sẽ thay thế giọng của host.",
+    "message": "$host$ dùng giọng của chính mình cho đến khi bạn chọn một giọng bên dưới.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "Ghi chú trên stage khi host không có giọng nói riêng (ví dụ: Claude), nên sẽ không có gì được đọc to cho đến khi chọn một giọng Say, Pi.",
+    "message": "$host$ sẽ không đọc to câu trả lời cho đến khi bạn chọn một giọng bên dưới.",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "Tiêu đề trên khu vực stage của studio Giọng nói trong cài đặt khi host chưa có giọng nói SayPi nào được chọn; $host$ là trợ lý (ví dụ: Pi, Claude). Hiển thị ở cỡ chữ tên.",
+    "message": "Chọn cách $host$ nghe như thế nào",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "Nút trên stage của studio Giọng nói trong cài đặt để phát đoạn clip mẫu miễn phí của giọng nói hiện tại.",
+    "message": "Nghe một đoạn mẫu"
+  },
+  "voicesStopPlayback": {
+    "description": "Nút trong thanh điều khiển Giọng nói của phần cài đặt dừng chuỗi đoạn mẫu được bắt đầu bởi \"Phát tất cả\".",
+    "message": "Dừng"
+  },
+  "voicesSweepPosition": {
+    "description": "Chỉ báo vị trí trực tiếp trong thanh điều khiển Giọng nói ở phần cài đặt khi \"Phát tất cả\" duyệt qua danh sách; $index$ là giọng đang phát và $total$ là số lượng đang được xếp hàng.",
+    "message": "$index$ / $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "Nhãn hỗ trợ tiếp cận cho nút so sánh trong thanh điều khiển Giọng nói của phần cài đặt, phát lại giọng còn lại trong hai giọng nghe gần nhất; $name$ là giọng đó.",
+    "message": "Chuyển lại sang $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "Dòng trong thanh điều khiển Giọng nói ở phần cài đặt khi nhấn \"Phát tất cả\" trên một danh sách quá dài để nghe hết; $count$ là số giọng và $minutes$ là số phút ước tính. Viết tắt \"min\" để đọc đúng khi là 1 — Chrome i18n không có dạng số nhiều.",
+    "message": "Có $count$ giọng, khoảng $minutes$ min. Hãy thu hẹp danh sách trước.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "Nhãn trợ năng cho nút \"dùng giọng này\" theo từng host trong danh mục giọng của cài đặt; $name$ là giọng, $host$ là trợ lý (ví dụ: Pi, Claude).",
+    "message": "Dùng $name$ trên $host$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "Nhãn ngắn trên nút \"dùng giọng này\" theo từng host trong danh mục giọng của cài đặt hợp nhất (host được hiển thị bên cạnh).",
+    "message": "Dùng"
+  },
+  "voicesYourVoice": {
+    "description": "Nút trên thanh điều khiển trong danh sách Giọng nói của phần cài đặt, đưa tiêu điểm đến hàng của giọng mà máy chủ hiện đang dùng; $name$ là giọng đó.",
+    "message": "Giọng của bạn: $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "Lỗi được đưa ra khi trình duyệt không thể cấp phát đủ bộ nhớ WebAssembly cho mô hình phát hiện giọng nói.",
+    "message": "Không thể bắt đầu phát hiện giọng nói: không đủ bộ nhớ WebAssembly cho mô hình giọng nói. $detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "Lỗi được đưa ra khi trình duyệt không cung cấp bộ nhớ WebAssembly ban đầu cần để chạy mô hình phát hiện giọng nói.",
+    "message": "Không thể bắt đầu phát hiện giọng nói: trình duyệt này không hỗ trợ bộ nhớ WebAssembly."
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -279,6 +279,46 @@
       }
     }
   },
+  "authBenefitLimits": {
+    "description": "登录模态框中的权益：提高使用限额。",
+    "message": "免费账户提供更高使用限额"
+  },
+  "authBenefitPremium": {
+    "description": "登录模态框中的权益：覆盖各聊天机器人的高级功能。",
+    "message": "高级功能和聊天机器人支持"
+  },
+  "authBenefitSupport": {
+    "description": "登录模态框中的权益：优先支持。",
+    "message": "问题优先支持"
+  },
+  "authBenefitSync": {
+    "description": "登录模态框中的权益：设置同步。",
+    "message": "在所有地方同步语音设置"
+  },
+  "authBenefitTTS": {
+    "description": "登录模态框中的权益：TTS 功能。",
+    "message": "文字转语音音色（付费套餐）"
+  },
+  "authBenefitUsage": {
+    "description": "登录模态框中的权益：用量追踪。",
+    "message": "跨设备查看语音使用情况"
+  },
+  "authPromptModalFull": {
+    "description": "完整登录提示模态框的说明文案，包含价值主张。",
+    "message": "你对 Say, Pi 的使用非常频繁。登录以获得更高限额、文字转语音音色，以及在所有受支持的聊天机器人上的高级功能。"
+  },
+  "authPromptModalSoft": {
+    "description": "轻提示登录模态框的说明文案。",
+    "message": "创建免费的 Say, Pi 账户，以获得更高使用限额并访问高级语音功能。"
+  },
+  "authPromptTitle": {
+    "description": "登录提示模态框的标题。",
+    "message": "解锁更多语音功能"
+  },
+  "authPromptToast": {
+    "description": "提示用户登录的吐司通知。",
+    "message": "登录 Say, Pi 以获得更高限额和高级功能"
+  },
   "autoReadAloudChatGPT": {
     "description": "用于启用或禁用通话中自动朗读ChatGPT回复的复选框标签。",
     "message": "自动朗读（ChatGPT）"
@@ -449,6 +489,10 @@
     "description": "Label for the option to turn off text-to-speech",
     "message": "禁用文本到语音"
   },
+  "dismiss": {
+    "message": "明白了",
+    "description": "Button text to dismiss a notification or dialog."
+  },
   "dismissAlert": {
     "description": "Label for the button to dismiss a system issue alert.",
     "message": "解雇"
@@ -479,6 +523,22 @@
     "description": "The text of the button to enter immersive mode on desktop.",
     "message": "专注"
   },
+  "errorVadInitFailed": {
+    "description": "当语音活动检测初始化失败时显示的错误提示。",
+    "message": "无法初始化语音检测"
+  },
+  "errorVoiceRecordingSetupFailed": {
+    "description": "在设置语音录制时发生意外错误时显示的错误提示。",
+    "message": "无法设置语音录制"
+  },
+  "errorVoiceRecordingStartFailed": {
+    "description": "当语音检测客户端无法开始录音时显示的错误提示。",
+    "message": "无法开始语音录制"
+  },
+  "errorVoiceRecordingUnavailable": {
+    "description": "当语音检测（VAD）客户端不可用、因此无法开始录音时显示的错误提示。",
+    "message": "语音录制不可用"
+  },
   "exitImmersiveModeLong": {
     "description": "The aria-label and title of the button to exit immersive mode on mobile devices, back to the text-based desktop mode.",
     "message": "退出专注模式"
@@ -500,6 +560,10 @@
         "example": "John"
       }
     }
+  },
+  "hdVoicesAllowanceNote": {
+    "description": "当高级（HD）和超值语音都可用时，在语音菜单中显示的一行提示",
+    "message": "HD 语音会让你更快用完每月额度，约快 20 倍。"
   },
   "instructionLabel_context": {
     "description": "Friendly label for user instruction that provides background information.",
@@ -568,6 +632,10 @@
     "description": "Friendly label for collapsed assistant maintenance message.",
     "message": "把这个塞了..."
   },
+  "maybeLater": {
+    "description": "用于关闭登录提示的按钮文本。",
+    "message": "稍后再说"
+  },
   "microphoneErrorConstraints": {
     "description": "Error message when microphone constraints cannot be satisfied.",
     "message": "您的麦克风设置不符合所需的规格。\n尝试使用不同的麦克风或调整音频设置。"
@@ -608,6 +676,10 @@
     "description": "Generic error message when microphone access fails for unknown reasons.",
     "message": "无法访问麦克风。\n请检查您的设备设置并重试。"
   },
+  "microphonePermissionDeniedError": {
+    "description": "在权限提示流程结束后麦克风权限被拒绝时显示的错误提示。",
+    "message": "未授予麦克风权限。请确保你在授权提示和扩展设置中都已允许访问。"
+  },
   "mode_accuracy": {
     "description": "Highest accuracy mode.",
     "message": "准确性"
@@ -632,6 +704,10 @@
     "description": "Description for the speed transcription mode.",
     "message": "响应速度最快，但准确性较差。\n容易打断。"
   },
+  "moreVoices": {
+    "description": "页面内声音菜单中，跳转到扩展程序设置里完整声音目录的菜单行。",
+    "message": "更多声音…"
+  },
   "nicknameLabel": {
     "description": "Label for the input field to set a custom nickname for the AI assistant.",
     "message": "助手昵称"
@@ -643,6 +719,90 @@
   "notSignedIn": {
     "description": "Text to show when the user is not signed in.",
     "message": "未签名"
+  },
+  "onboarding_ctaChatgpt": {
+    "description": "打开 ChatGPT 的按钮标签。",
+    "message": "打开 ChatGPT"
+  },
+  "onboarding_ctaClaude": {
+    "description": "打开 Claude.ai 的按钮标签。",
+    "message": "打开 Claude"
+  },
+  "onboarding_ctaPi": {
+    "description": "打开 Pi.ai 的按钮标签。",
+    "message": "打开 Pi"
+  },
+  "onboarding_envAroundOthers": {
+    "description": "环境选项：在其他人附近。",
+    "message": "在别人身边"
+  },
+  "onboarding_envMixed": {
+    "description": "环境选项：私密空间与共享空间的混合。",
+    "message": "在不同地方都有"
+  },
+  "onboarding_envPrivate": {
+    "description": "环境选项：私密空间。",
+    "message": "在比较私密的地方"
+  },
+  "onboarding_envQuietOff": {
+    "description": "当环境选择让安静模式保持关闭时显示的确认信息。",
+    "message": "好的，我们会保留标准的监听和播放设置。"
+  },
+  "onboarding_envQuietOn": {
+    "description": "环境答案启用静音模式时显示的确认信息。",
+    "message": "静音模式已开启——我们会更灵敏地捕捉轻声说话，并轻声回复，让你更隐蔽地交流。"
+  },
+  "onboarding_envTitle": {
+    "description": "新手引导中关于用户环境问题的标题。",
+    "message": "你通常会在哪里说话？"
+  },
+  "onboarding_footer": {
+    "description": "首次运行引导页面底部文本。",
+    "message": "你可以随时在 Say, Pi 的设置中再次查看。你的隐私很重要——只有在通话进行中才会采集音频。"
+  },
+  "onboarding_heading": {
+    "description": "首次运行引导页上的主标题。",
+    "message": "🗣️ 欢迎使用 Say, Pi"
+  },
+  "onboarding_intro": {
+    "description": "首次运行引导页上的介绍段落。",
+    "message": "只需两步，你就能和 AI 开始第一次语音对话。说话大约比打字快 3 倍，我们来帮你设置好。"
+  },
+  "onboarding_micTestButton": {
+    "description": "开始无压力的新手引导麦克风测试的按钮。",
+    "message": "🎤 测试你的麦克风"
+  },
+  "onboarding_micTestDone": {
+    "description": "新手引导麦克风测试成功完成后显示的状态。",
+    "message": "很好，你的麦克风能用 🎉"
+  },
+  "onboarding_micTestListening": {
+    "description": "新手引导麦克风测试正在测量输入时显示的状态。",
+    "message": "正在聆听——说点什么吧 🎙️"
+  },
+  "onboarding_micTestRequesting": {
+    "description": "新手引导麦克风测试等待权限时显示的状态。",
+    "message": "正在请求麦克风权限…"
+  },
+  "onboarding_micTestStop": {
+    "description": "麦克风测试运行时用于停止的新手引导按钮标签。",
+    "message": "停止测试"
+  },
+  "onboarding_step1Body": {
+    "description": "第一步引导的正文，说明如何固定扩展程序。",
+    "message": "点击浏览器右上角的拼图 🧩 图标，然后点击 Say, Pi 旁边的图钉 📌。这样通话按钮就只需一次点击即可打开。"
+  },
+  "onboarding_step1Title": {
+    "description": "第一步引导的标题（固定扩展程序）。",
+    "message": "将 Say, Pi 固定到工具栏"
+  },
+  "onboarding_step2Body": {
+    "description": "第二步引导的正文，说明如何开始语音对话。",
+    "message": "前往下方支持的任一助手，然后点击 Say, Pi 的通话按钮并打个招呼。第一次会请求麦克风权限，这是正常的，我们只会在你正在通话时才会监听。"
+  },
+  "onboarding_step2Title": {
+    "description": "第二步引导的标题（开始对话）。",
+    "message": "打开 AI 聊天并开始说话"
   },
   "permissions_errorDomLoadFailure": {
     "description": "Error message sent via runtime message if the DOM fails to load.",
@@ -681,6 +841,56 @@
   "permissions_promptTitle": {
     "description": "Title of the permissions prompt page.",
     "message": "麦克风许可"
+  },
+  "permissions_recoveryDeniedBody": {
+    "description": "当麦克风权限被阻止时的恢复指引。",
+    "message": "你的浏览器正在阻止麦克风。点击地址栏中的摄像头或锁形图标，将“麦克风”设为“允许”，然后再试一次。在 macOS 上，也请检查：系统设置 → 隐私与安全性 → 麦克风。"
+  },
+  "permissions_recoveryDeniedTitle": {
+    "description": "当麦克风权限被拒绝/阻止时，恢复面板的标题。",
+    "message": "麦克风访问被阻止"
+  },
+  "permissions_recoveryInUseBody": {
+    "description": "当麦克风在其他地方被占用时的恢复指引。",
+    "message": "另一个应用或标签页可能正在使用你的麦克风。关闭任何可能在录音的内容（视频通话、语音备忘录），然后再试一次。"
+  },
+  "permissions_recoveryInUseTitle": {
+    "description": "当麦克风被其他应用占用时，恢复面板的标题。",
+    "message": "你的麦克风正忙"
+  },
+  "permissions_recoveryNoDeviceBody": {
+    "description": "当没有可用的麦克风设备时的恢复指引。",
+    "message": "我们找不到麦克风。请插入一个（或连接你的耳机），确认它已被选为输入设备，然后再试一次。"
+  },
+  "permissions_recoveryNoDeviceTitle": {
+    "description": "当没有可用的麦克风设备时，恢复面板的标题。",
+    "message": "未找到麦克风"
+  },
+  "permissions_recoveryUnknownBody": {
+    "description": "用于未知麦克风错误的恢复指引。",
+    "message": "连接麦克风时出了点问题。请确认它已连接，并且在浏览器设置中已被允许，然后再试一次。"
+  },
+  "permissions_recoveryUnknownTitle": {
+    "description": "用于未知麦克风错误的恢复面板标题。",
+    "message": "我们无法访问你的麦克风"
+  },
+  "permissions_retryButton": {
+    "description": "用于重新请求麦克风权限的按钮标签。",
+    "message": "再试一次"
+  },
+  "permissions_revokedHeading": {
+    "description": "当麦克风访问权限之前已授予但后来被撤销时显示的标题。",
+    "message": "让我们重新连接你的麦克风"
+  },
+  "permissions_revokedInfo": {
+    "description": "当麦克风访问权限在已授予后被撤销时显示的说明文本。",
+    "message": "你的麦克风访问权限已关闭，这通常发生在浏览器或系统更新之后。请在下方重新允许，$productName$ 就会在你通话时恢复监听。",
+    "placeholders": {
+      "productName": {
+        "content": "$1",
+        "example": "Say, Pi"
+      }
+    }
   },
   "permissions_statusPermissionDenied": {
     "description": "Status message shown when permission is denied, includes the error name.",
@@ -725,6 +935,14 @@
   "profile": {
     "description": "Label for the user profile section.",
     "message": "轮廓"
+  },
+  "quietModeLabel": {
+    "description": "用于启用安静/耳语模式的开关标签。",
+    "message": "安静模式"
+  },
+  "quietModeTooltip": {
+    "description": "解释安静/耳语模式作用的提示文本。",
+    "message": "轻声说话，会更好地拾取较小的声音并降低助手回复音量，方便你在他人身边使用语音。"
   },
   "quotaCredits": {
     "description": "Unit label for TTS credits",
@@ -826,12 +1044,30 @@
       }
     }
   },
+  "signingIn": {
+    "description": "身份验证进行中时，登录按钮显示的文本。",
+    "message": "正在登录…"
+  },
   "soundEffects": {
     "description": "Label for the checkbox to enable/disable sound effects.",
     "message": "音效"
   },
   "soundEffectsFirefoxDisabled": {
     "message": "Firefox 中禁用声音效果以防止出现音频反馈问题。"
+  },
+  "speedPayoffNoticeHeadline": {
+    "description": "首次语音对话后显示的一次性速度收益提示的标题。",
+    "message": "不错，说话大约比打字快 3 倍。"
+  },
+  "speedPayoffNoticeMinutes": {
+    "description": "速度收益提示的可选第二行，显示节省的整分钟数。",
+    "message": "你已经比打字快了大约 $minutes$ 分钟。",
+    "placeholders": {
+      "minutes": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "sttMinutesRemaining": {
     "description": "Text showing remaining STT quota in minutes.",
@@ -921,6 +1157,24 @@
     "description": "Description for the manual submission mode.",
     "message": "仅在按下按钮时提交"
   },
+  "surveyQuestion": {
+    "description": "一次性“体验成功后”微型问卷的唯一问题。",
+    "message": "到目前为止，语音用起来感觉如何？"
+  },
+  "surveyRatingLabel": {
+    "description": "问卷评分按钮的无障碍标签。",
+    "message": "为 $rating$（满分 5）评分",
+    "placeholders": {
+      "rating": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "surveyThanks": {
+    "description": "用户回答体验成功后问卷后显示的致谢。",
+    "message": "谢谢，这能帮助我们把 Say, Pi 做得更好。"
+  },
   "tabAIChat": {
     "description": "AI 聊天设置部分的标签。",
     "message": "AI 聊天"
@@ -936,6 +1190,10 @@
   "tabGeneral": {
     "description": "常规设置部分的标签。",
     "message": "常规"
+  },
+  "tabVoices": {
+    "description": "“语音”设置部分（按站点的语音目录）的标签。",
+    "message": "语音"
   },
   "toggleThemeToDarkMode": {
     "description": "Label for the button to toggle to dark mode.",
@@ -987,6 +1245,16 @@
     "description": "The term used for the credits currency in the text-to-speech feature.",
     "message": "学分"
   },
+  "ttsCreditsRemaining": {
+    "description": "显示剩余 TTS 配额的文本，以“每种声音的点数池”为单位（saypi-api #181 Stage 2），而不是按字符数。",
+    "message": "剩余 $credits$ 个点数",
+    "placeholders": {
+      "credits": {
+        "content": "$1",
+        "example": "500"
+      }
+    }
+  },
   "ttsDisabledSafari": {
     "description": "Message shown when TTS is disabled in Safari",
     "message": "Safari 目前不支持多语言语音。"
@@ -1027,6 +1295,34 @@
     "description": "Label for the TTS quota remaining display.",
     "message": "语音生成"
   },
+  "ttsUnavailableBrowserChatbot": {
+    "message": "注意！在$browserName$上使用$chatbotName$时，语音播放尚不可用。好消息？语音输入运行良好！对于TTS，请在桌面上尝试Chrome或Edge。",
+    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "ttsUnavailableBrowserChatbotShort": {
+    "message": "$browserName$ + $chatbotName$上TTS不可用。语音输入有效！尝试Chrome桌面版以使用TTS。",
+    "description": "Short notification message when TTS is unavailable but voice input works.",
+    "placeholders": {
+      "browserName": {
+        "content": "$1",
+        "example": "Firefox Mobile"
+      },
+      "chatbotName": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
   "ttsVoice": {
     "description": "Label describing a text-to-speech voice option in the menu",
     "message": "TTS声音"
@@ -1060,6 +1356,10 @@
   "vadDetailActivatingMicrophone": {
     "description": "VAD detail when activating the microphone.",
     "message": "Activating microphone..."
+  },
+  "vadDetailAudioTooFaint": {
+    "description": "当检测到类似语音的音频但音量太弱/置信度太低，无法转写时显示的 VAD 详情（客户端准入门槛丢弃）。",
+    "message": "音频太弱，无法转写"
   },
   "vadDetailCommLinkFailed": {
     "description": "VAD detail when the communication port link fails.",
@@ -1187,6 +1487,10 @@
     "description": "VAD detail indicating VAD service has been shut down.",
     "message": "VAD service shut down."
   },
+  "vadDetailVoiceMovedToOtherTab": {
+    "description": "VAD 详情，用于说明通话结束的原因是麦克风被较新的标签页占用。",
+    "message": "语音输入已移至另一标签页"
+  },
   "vadDetailWaitingForSpeech": {
     "description": "VAD detail when waiting for user to speak.",
     "message": "Waiting for speech"
@@ -1226,38 +1530,6 @@
   "vadErrorBrowserNotSupportedShort": {
     "description": "Short generic error message for notifications when voice features are not supported.",
     "message": "声音不可用。\n在桌面上尝试Chrome或Firefox。"
-  },
-  "ttsUnavailableBrowserChatbot": {
-    "message": "注意！在$browserName$上使用$chatbotName$时，语音播放尚不可用。好消息？语音输入运行良好！对于TTS，请在桌面上尝试Chrome或Edge。",
-    "description": "Message shown when TTS is unavailable due to browser/chatbot combination (Firefox/Safari/mobile browsers + Claude/ChatGPT). Voice input continues to work.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "ttsUnavailableBrowserChatbotShort": {
-    "message": "$browserName$ + $chatbotName$上TTS不可用。语音输入有效！尝试Chrome桌面版以使用TTS。",
-    "description": "Short notification message when TTS is unavailable but voice input works.",
-    "placeholders": {
-      "browserName": {
-        "content": "$1",
-        "example": "Firefox Mobile"
-      },
-      "chatbotName": {
-        "content": "$2",
-        "example": "Claude"
-      }
-    }
-  },
-  "dismiss": {
-    "message": "明白了",
-    "description": "Button text to dismiss a notification or dialog."
   },
   "vadErrorMobileBrowserLimited": {
     "description": "Error message shown when mobile browsers have limited voice feature support with a specific chatbot.",
@@ -1301,6 +1573,10 @@
     "description": "VAD status when a misfire (non-speech) is detected.",
     "message": "Misfire"
   },
+  "vadStatusPreempted": {
+    "description": "当某个标签页的语音输入被另一个标签页接管时，在该标签页上显示的 VAD 状态。",
+    "message": "已暂停"
+  },
   "vadStatusProcessing": {
     "description": "VAD status when processing audio.",
     "message": "Processing"
@@ -1329,6 +1605,16 @@
     "description": "Text for the link to view full quota details on the dashboard.",
     "message": "查看详细信息"
   },
+  "voiceIntroductionGeneric": {
+    "description": "当所选 SayPi 语音没有语音专属介绍脚本（且没有可回读的最近消息）时播放的通用口头介绍。",
+    "message": "你好，我是$voice$。这就是我的声音。希望你喜欢这个声音。",
+    "placeholders": {
+      "voice": {
+        "content": "$1",
+        "example": "Jarnathan"
+      }
+    }
+  },
   "voiceIntroduction_joey": {
     "description": "Introduction for the Joey voice.",
     "message": "你好！\n请注意！ \n嗨好！\n我是 Pi，您的多语言人工智能助手。\n通过我掌握的 32 种语言，我们可以探索世界各地的思想和文化。\n你觉得这个声音怎么样？"
@@ -1348,5 +1634,523 @@
   "voiceSettings": {
     "description": "The text of the menu item to access voice-related settings.",
     "message": "语音设置"
+  },
+  "voiceSpeaksNLanguages": {
+    "description": "当语音在设置语音目录中的条目没有描述时，作为回退副标题显示；$count$ 为该语音支持的语言数量。",
+    "message": "支持 $count$ 种语言",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "33"
+      }
+    }
+  },
+  "voiceTagline_addison": {
+    "description": "为“Addison”语音撰写的人格标语（设置页的语音工作室；客户端语音身份映射）。",
+    "message": "明朗清晰"
+  },
+  "voiceTagline_alloy": {
+    "description": "为“Alloy”声音撰写的人设标语（设置中的声音工作室；客户端声音身份映射）。",
+    "message": "均衡百搭"
+  },
+  "voiceTagline_ash": {
+    "description": "为“Ash”声音撰写的人设标语（设置中的声音工作室；客户端声音身份映射）。",
+    "message": "低沉、沉思、平静"
+  },
+  "voiceTagline_ballad": {
+    "description": "为“Ballad”声音撰写的人设标语（设置中的声音工作室；客户端声音身份映射）。",
+    "message": "顺滑又有旋律感"
+  },
+  "voiceTagline_cassidy": {
+    "description": "为“Cassidy”语音撰写的人格标语（设置页的语音工作室；客户端语音身份映射）。",
+    "message": "友好又直截了当"
+  },
+  "voiceTagline_cedar": {
+    "description": "为“Cedar”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "沉稳又让人安心"
+  },
+  "voiceTagline_coral": {
+    "description": "为“Coral”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "明亮又充满活力"
+  },
+  "voiceTagline_echo": {
+    "description": "为“Echo”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "干净而中性"
+  },
+  "voiceTagline_fable": {
+    "description": "为“Fable”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "讲故事般的韵律"
+  },
+  "voiceTagline_finn": {
+    "description": "为“Finn”语音撰写的人格标语（设置页的语音工作室；客户端语音身份映射）。",
+    "message": "清新有活力"
+  },
+  "voiceTagline_jamahal": {
+    "description": "为“Jamahal”语音撰写的人格标语（设置页的语音工作室；客户端语音身份映射）。",
+    "message": "醇厚有吸引力"
+  },
+  "voiceTagline_jarnathan": {
+    "description": "为“Jarnathan”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "丝绒般的深夜男中音"
+  },
+  "voiceTagline_jeff": {
+    "description": "为“Jeff”语音撰写的人格标语（设置页的语音工作室；客户端语音身份映射）。",
+    "message": "直白稳重"
+  },
+  "voiceTagline_jessica": {
+    "description": "为“Jessica”语音撰写的人格标语（设置页的语音工作室；客户端语音身份映射）。",
+    "message": "温暖从容，质感精致"
+  },
+  "voiceTagline_joey": {
+    "description": "为“Joey”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "轻松自然的美式对话感"
+  },
+  "voiceTagline_juniper": {
+    "description": "为“Juniper”语音撰写的人格标语（设置页的语音工作室；客户端语音身份映射）。",
+    "message": "清脆明亮，生动灵动"
+  },
+  "voiceTagline_lucy": {
+    "description": "为“Lucy”语音撰写的人格标语（设置页的语音工作室；客户端语音身份映射）。",
+    "message": "温柔而明澈"
+  },
+  "voiceTagline_marin": {
+    "description": "为“Marin”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "温暖如晨间电台的平静"
+  },
+  "voiceTagline_mark": {
+    "description": "为“Mark”语音撰写的人格标语（设置页的语音工作室；客户端语音身份映射）。",
+    "message": "清晰自信的旁白"
+  },
+  "voiceTagline_nova": {
+    "description": "为“Nueva”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "敏捷又好奇"
+  },
+  "voiceTagline_onyx": {
+    "description": "为“Onyx”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "低沉浑厚，气场十足"
+  },
+  "voiceTagline_paola": {
+    "description": "为“Paola”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "富有表现力的意式温暖"
+  },
+  "voiceTagline_sage": {
+    "description": "为“Sage”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "轻声细语的清晰感"
+  },
+  "voiceTagline_shimmer": {
+    "description": "为“Shimmer”语音撰写的人设标语（设置中的 Voices 工作室；客户端语音身份映射）。",
+    "message": "轻盈而通透"
+  },
+  "voicesAddToMenuShort": {
+    "description": "设置的“语音”工作室中，语音卡片的置顶切换（关闭状态）上的短标签；按下会把该语音加入主机的聊天内菜单。",
+    "message": "+ 菜单"
+  },
+  "voicesAddVoiceToMenu": {
+    "description": "语音卡片置顶切换（关闭状态）的无障碍标签；$name$ 是语音，$host$ 是助手。",
+    "message": "将 $name$ 添加到 $host$ 的菜单",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesArrowAudition": {
+    "description": "语音控制栏中开关的标签，用于说明用方向键浏览列表时，焦点移到某个语音就会播放该语音。",
+    "message": "移动时播放"
+  },
+  "voicesArrowsLive": {
+    "description": "屏幕阅读器确认信息，会附加在设置的“语音”列表中首次“Playing <voice>”播报后，表示方向键刚刚变为可听。呼应“移动时播放”开关自身的措辞。",
+    "message": "现在移动时方向键会播放。Esc 停止。"
+  },
+  "voicesBuiltinsNote": {
+    "description": "用于提供原生语音的 host（例如 Pi 的 8 个内置语音）时，显示在菜单槽位下方的提示；这些语音不由工作室管理；$host$ 是助手名称。",
+    "message": "$host$ 自带的内置语音也会始终出现在它的菜单中。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesBuiltinsNoteNoMenu": {
+    "description": "voicesBuiltinsNote 的变体，适用于没有聊天内语音菜单的 host（Pi 在 2026 年移除了其菜单），此时原文“会出现在它的菜单中”的承诺不成立；$host$ 是助手名称。",
+    "message": "$host$ 也有它自带的内置语音，但这里不会列出。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesHeardCount": {
+    "description": "设置的“语音”控制栏中的进度读数：用户已试听过列表中多少个语音。为纯数字形式，因此在为 1 时也能读起来自然——Chrome i18n 没有复数形式。",
+    "message": "已听 $heard$ / $total$",
+    "placeholders": {
+      "heard": {
+        "content": "$1",
+        "example": "9"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesHeardMark": {
+    "description": "设置的“语音”列表中某个语音行的无障碍名称的一部分，用于标记此配置文件已试听过的语音。视觉上用语音声纹的墨色浓淡表示，但屏幕阅读器无法看到。",
+    "message": "已听过"
+  },
+  "voicesInHostMenu": {
+    "description": "设置的“语音”工作室中，菜单槽位行上方的分区标题；$host$ 是助手。",
+    "message": "在 $host$ 的菜单中",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesInMenuShort": {
+    "description": "设置的“语音”工作室中，语音卡片的置顶切换（开启状态）上的短标签。",
+    "message": "✓ 在菜单中"
+  },
+  "voicesInUse": {
+    "description": "设置的“语音”列表中，主机当前选定语音的常驻徽标，渲染为大写。刻意不是“正在说话”：此页面的每一行都会播放示例片段，因此已选但静音的语音不能宣称在说话，而此时可能是另一行在播放。",
+    "message": "使用中"
+  },
+  "voicesKeyboardHint": {
+    "description": "设置的“语音”控制栏中的一行键盘提示。图标是按键：空格键、上下方向键，以及 Shift+空格键。",
+    "message": "按空格键试听，↑↓在语音间移动，⇧空格键切回。"
+  },
+  "voicesLoadError": {
+    "description": "在某个 host 的工作室中，当该 host 的语音目录加载失败时的错误状态；$host$ 是助手名称。",
+    "message": "无法加载 $host$ 的语音。请稍后再试。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesMenuFull": {
+    "description": "当主机的聊天内菜单已达到最大语音数量时，禁用的“+ 菜单”切换上的工具提示/提示文案。",
+    "message": "菜单已满，移除一个语音以添加另一个"
+  },
+  "voicesMenuHint": {
+    "description": "“In {host}'s menu”标题旁的一行提示，说明槽位行会镜像聊天中的语音菜单。",
+    "message": "你在聊天中会看到的内容"
+  },
+  "voicesMenuOverflow": {
+    "description": "当用户置顶的语音数量超过聊天内菜单可显示数量（遗留状态）时，显示在菜单槽位下方的提示；$count$ 是放不下的数量，$cap$ 是菜单大小。",
+    "message": "还有 $count$ 个置顶语音在菜单的 $cap$ 个槽位之外等待显示。",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      },
+      "cap": {
+        "content": "$2",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuOverflowOne": {
+    "description": "voicesMenuOverflow 的单数形式，用于恰好有一个置顶语音放不进聊天内菜单时；$cap$ 是菜单大小。",
+    "message": "还有 1 个置顶语音在菜单的 $cap$ 个槽位之外等待显示。",
+    "placeholders": {
+      "cap": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "voicesMenuSummary": {
+    "description": "设置的“语音”列表下方的摘要行，说明该 host 的聊天内语音菜单填充了多少；$host$ 是助手名，$used$ 为已占用席位数，$cap$ 为总席位数。措辞需在为 1 时也读起来自然——Chrome i18n 没有复数形式。",
+    "message": "$host$ 的菜单：$used$ / $cap$ 个席位",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      },
+      "used": {
+        "content": "$2",
+        "example": "3"
+      },
+      "cap": {
+        "content": "$3",
+        "example": "4"
+      }
+    }
+  },
+  "voicesNoSampleGroup": {
+    "description": "设置的“语音”列表末尾分组的标题，包含尚无可播放试听片段的语音；$count$ 为数量。措辞需在为 1 时也读起来自然——Chrome i18n 没有复数形式。",
+    "message": "暂无试听片段（$count$）",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "voicesNoneAvailable": {
+    "description": "当已登录用户在设置的语音目录中看到空的语音列表时显示（例如网络问题）。",
+    "message": "目前无法加载语音。请稍后再试。"
+  },
+  "voicesNowPlaying": {
+    "description": "在设置的“语音”列表中，当某个语音的试听片段开始播放时的屏幕阅读器播报；$name$ 是该语音。",
+    "message": "正在播放 $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Onyx"
+      }
+    }
+  },
+  "voicesPlayAllN": {
+    "description": "设置的“语音”控制栏中的按钮，会按顺序依次播放当前列出的所有语音；$count$ 为数量。措辞需在为 1 时也读起来自然——Chrome i18n 没有复数形式。",
+    "message": "播放全部（$count$）",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "22"
+      }
+    }
+  },
+  "voicesPlayNewN": {
+    "description": "在再次访问时出现在设置的“语音”控制栏中的按钮：只播放列表中你尚未试听过的语音；$count$ 为数量。措辞需在为 1 时也读起来自然——Chrome i18n 没有复数形式。",
+    "message": "播放新的（$count$）",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "13"
+      }
+    }
+  },
+  "voicesPlaybackBlocked": {
+    "description": "当页面尚未发生用户交互，浏览器拒绝播放示例时，显示在设置的“声音”控制栏中的一行提示。",
+    "message": "点击任意声音以启用音频。"
+  },
+  "voicesPreview": {
+    "description": "用于播放（▶）按钮的无障碍标签，该按钮可试听语音行中的免费示例片段；$name$ 为语音名称。",
+    "message": "播放 $name$ 的示例",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      }
+    }
+  },
+  "voicesRailLabel": {
+    "description": "设置中语音列表的无障碍名称（包含所有语音的列表框，每行一个）。",
+    "message": "语音，按从低沉到明亮排序"
+  },
+  "voicesRemoveVoiceFromMenu": {
+    "description": "语音卡片置顶切换（开启状态）以及菜单槽位移除按钮的无障碍标签；$name$ 是语音，$host$ 是助手。",
+    "message": "从 $host$ 的菜单移除 $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Nova"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesSampleFailed": {
+    "description": "当某个声音的示例片段加载或播放失败时，显示在设置的“声音”控制栏中的一行提示；$name$ 是该声音名称。非模态——示例连续播放会继续跳过它。",
+    "message": "无法播放 $name$ 的示例。",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesSectionDescription": {
+    "description": "设置中 AI Chat 选项卡里声音目录部分的副标题。",
+    "message": "为每个网站选择朗读回复的声音。"
+  },
+  "voicesSectionDescriptionListen": {
+    "description": "语音设置标题下的副标题，用于按音高排序的语音轨道。",
+    "message": "每一种声音，从低沉到明亮。先听，再选。"
+  },
+  "voicesSectionTitle": {
+    "description": "设置中 AI Chat 选项卡里声音目录部分的标题。",
+    "message": "声音"
+  },
+  "voicesShelfEveryday": {
+    "description": "设置的声音目录中，超值档声音的分组标题。由 CSS 渲染为全大写。",
+    "message": "日常声音"
+  },
+  "voicesShelfEverydayBlurb": {
+    "description": "设置的声音工作室中，日常分组标题旁的一行说明；这是工作室中唯一说明这一档比 HD 可用时长更长的地方。",
+    "message": "自然清晰，你可以比使用 HD 多听约 20 倍。"
+  },
+  "voicesShelfHd": {
+    "description": "设置的声音目录中，高级（HD）声音的分组标题。由 CSS 渲染为全大写。",
+    "message": "HD 声音"
+  },
+  "voicesShelfHdBlurb": {
+    "description": "设置的声音工作室中，HD 分组标题旁的一行说明。",
+    "message": "最饱满、最富表现力的声音。"
+  },
+  "voicesShowAll": {
+    "description": "设置的“声音”中“显示”过滤器的选项：不筛选，列出所有声音。",
+    "message": "所有声音"
+  },
+  "voicesShowEveryday": {
+    "description": "设置的“声音”中“显示”过滤器的选项：只列出标准（非 HD）声音。",
+    "message": "仅日常"
+  },
+  "voicesShowHd": {
+    "description": "设置的“声音”中“显示”过滤器的选项：只列出高级（HD）声音。",
+    "message": "仅 HD"
+  },
+  "voicesShowLabel": {
+    "description": "设置的“声音”控制栏中过滤器的标签，用于缩小列表中显示哪些声音。",
+    "message": "显示"
+  },
+  "voicesShowUnheard": {
+    "description": "设置的“声音”中“显示”过滤器的选项：只列出用户还未试听过的声音。",
+    "message": "尚未听过"
+  },
+  "voicesSpeakingNow": {
+    "description": "设置的“语音”工作室中，主机当前选定语音的状态标签（菜单槽位和语音卡片上）。",
+    "message": "正在说话"
+  },
+  "voicesSpeaksWith": {
+    "description": "设置中“语音”工作室舞台上，当前语音名称上方的眉题行；$host$ 是助手（例如 Pi）。由 CSS 渲染为大写。",
+    "message": "$host$ 使用的声音",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteReplace": {
+    "description": "当 host 会提供自己的音频（例如 Pi）时的舞台提示，因此选择一个 Say, Pi 语音会替换 host 的声音。",
+    "message": "在你从下方选择之前，$host$ 会使用它自己的声音。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStageEmptyNoteSilent": {
+    "description": "当 host 本身没有语音（例如 Claude）时的舞台提示，因此在选择 Say, Pi 语音之前不会朗读任何内容。",
+    "message": "在你从下方选择之前，$host$ 不会朗读回复。",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesStageEmptyTitle": {
+    "description": "在设置的语音工作室舞台上，当该 host 尚未选择任何 SayPi 语音时显示的标题；$host$ 是助手（例如 Pi、Claude）。以名称字号渲染。",
+    "message": "选择 $host$ 的声音",
+    "placeholders": {
+      "host": {
+        "content": "$1",
+        "example": "Pi"
+      }
+    }
+  },
+  "voicesStagePlay": {
+    "description": "设置的语音工作室舞台上的按钮，用于播放当前语音的免费示例片段。",
+    "message": "试听示例"
+  },
+  "voicesStopPlayback": {
+    "description": "设置的“语音”控制栏中的按钮，用于停止由“播放全部”开始的连续试听。",
+    "message": "停止"
+  },
+  "voicesSweepPosition": {
+    "description": "在设置的“声音”控制栏中，“全部播放”遍历列表时显示的实时位置读数；$index$ 是当前正在播放的声音，$total$ 是队列中的总数。",
+    "message": "$index$ / $total$",
+    "placeholders": {
+      "index": {
+        "content": "$1",
+        "example": "6"
+      },
+      "total": {
+        "content": "$2",
+        "example": "22"
+      }
+    }
+  },
+  "voicesSwitchBackTo": {
+    "description": "设置的“语音”控制栏中“对比”控件的无障碍标签，会重放最近听过的两个语音中的另一个；$name$ 是该语音。",
+    "message": "切回 $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Coral"
+      }
+    }
+  },
+  "voicesTooManyToPlay": {
+    "description": "当在过长的列表上按下“全部播放”时，显示在设置的“声音”控制栏中的一行提示；$count$ 是声音数量，$minutes$ 是大致所需分钟数。用缩写“min”以便在为 1 时也能读通顺——Chrome i18n 没有复数形式。",
+    "message": "这有 $count$ 个声音，约 $minutes$ min。请先缩小列表。",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "34"
+      },
+      "minutes": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "voicesUseOnHost": {
+    "description": "设置语音目录中，每个主机对应的“使用此语音”按钮的无障碍标签；$name$ 是语音，$host$ 是助手（例如 Pi、Claude）。",
+    "message": "在 $host$ 上使用 $name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      },
+      "host": {
+        "content": "$2",
+        "example": "Claude"
+      }
+    }
+  },
+  "voicesUseShort": {
+    "description": "在统一设置的语音目录中，每个主机对应的“使用此语音”按钮上的短标签（旁边会显示主机）。",
+    "message": "使用"
+  },
+  "voicesYourVoice": {
+    "description": "设置的“语音”列表中控制栏按钮，将焦点移到此 host 当前使用的语音所在行；$name$ 是该语音。",
+    "message": "你的语音：$name$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Marin"
+      }
+    }
+  },
+  "webAssemblyInsufficientMemory": {
+    "description": "当浏览器无法为语音检测模型分配足够的 WebAssembly 内存时抛出的错误。",
+    "message": "无法开始语音检测：WebAssembly 内存不足以运行语音模型。$detail$",
+    "placeholders": {
+      "detail": {
+        "content": "$1",
+        "example": "Required: 32768KB, Available: 16384KB"
+      }
+    }
+  },
+  "webAssemblyMemoryUnavailable": {
+    "description": "当浏览器未提供运行语音检测模型所需的初始 WebAssembly 内存时抛出的错误。",
+    "message": "无法开始语音检测：此浏览器中 WebAssembly 内存不可用。"
   }
 }

--- a/e2e/specs/settings-layout.e2e.ts
+++ b/e2e/specs/settings-layout.e2e.ts
@@ -1,3 +1,6 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "@playwright/test";
 import { test, expect } from "../fixtures/extension";
 
 /**
@@ -17,7 +20,34 @@ import { test, expect } from "../fixtures/extension";
 
 const TABS = ["general", "chat", "dictation", "voices", "about"] as const;
 
+/** Phone width, the last mobile width, and the first desktop width. 736px is
+ *  where the header is tightest: the mobile rules stop hiding the
+ *  unauthenticated blurb, but there is no spare room yet. */
+const WIDTHS = [390, 735, 736] as const;
+
 test.use({ showScrollbars: true });
+
+/**
+ * Walk every tab at every small viewport and require no horizontal overflow.
+ * `label` names the locale under test so a failure says which language broke.
+ */
+async function expectNoOverflowAtSmallViewports(page: Page, label: string) {
+  for (const width of WIDTHS) {
+    await page.setViewportSize({ width, height: 844 });
+    for (const tab of TABS) {
+      await page.locator(`.tab-button[data-tab="${tab}"]`).click();
+      const panel = page.locator(`#tab-${tab}`);
+      await expect(panel).toBeVisible();
+      const overflow = await page.evaluate(
+        () => document.body.scrollWidth - document.documentElement.clientWidth,
+      );
+      expect(
+        overflow,
+        `horizontal overflow of ${overflow}px on ${tab} at ${width}px in ${label}`,
+      ).toBeLessThanOrEqual(0);
+    }
+  }
+}
 
 test.describe("settings page layout", () => {
   test("keeps the header anchored across tab switches (no scrollbar shunt)", async ({
@@ -93,23 +123,76 @@ test.describe("settings page layout", () => {
     await page.goto(`chrome-extension://${extensionId}/settings.html`);
     await page.waitForSelector(".settings-header .profile-banner");
 
-    for (const width of [390, 735, 736]) {
-      await page.setViewportSize({ width, height: 844 });
-      for (const tab of TABS) {
-        await page.locator(`.tab-button[data-tab="${tab}"]`).click();
-        const panel = page.locator(`#tab-${tab}`);
-        await expect(panel).toBeVisible();
-        const overflow = await page.evaluate(
-          () =>
-            document.body.scrollWidth - document.documentElement.clientWidth,
-        );
-        expect(
-          overflow,
-          `horizontal overflow of ${overflow}px on ${tab} at ${width}px`,
-        ).toBeLessThanOrEqual(0);
-      }
-    }
+    await expectNoOverflowAtSmallViewports(page, "en");
 
     await page.close();
   });
 });
+
+/**
+ * The same fit guarantee, in a language whose strings are much longer than
+ * English.
+ *
+ * English fit at 736px with ~100px to spare, so the guard above stayed green
+ * while German overflowed by 156px, Greek by 160px, Tamil by 78px and Finnish
+ * by 69px — on every tab, because the offender is the shared header. The
+ * mechanism was the header's identity group defaulting to `min-width: auto`,
+ * which floored the row at the unwrapped width of the "log in to access..."
+ * blurb; see the `.profile-identity` rule in src/popup/tabs.css.
+ *
+ * `--lang` does not change the extension's language, and neither does the
+ * browser UI locale in a headless run: chrome.i18n picks the catalog at load
+ * time. So swap the *built* English catalog for the locale under test, then
+ * prove the swap took by reading a translated string off the page — a silent
+ * fallback to English is exactly what would make this test lie.
+ */
+const BUILT_EN = resolve(
+  import.meta.dirname,
+  "../../.output/chrome-mv3-dev/_locales/en/messages.json",
+);
+const catalogPath = (locale: string) =>
+  resolve(import.meta.dirname, `../../_locales/${locale}/messages.json`);
+
+// de and el are the two worst offenders measured; between them they cover a
+// long-compound language and a non-Latin script.
+for (const locale of ["de", "el"] as const) {
+  test.describe(`settings page layout (${locale} catalog)`, () => {
+    // beforeAll runs before the test-scoped `context` fixture launches the
+    // browser, so the extension is loaded with the swapped catalog already in
+    // place. Nothing races it: this project runs e2e with workers: 1.
+    test.beforeAll(() => {
+      writeFileSync(BUILT_EN, readFileSync(catalogPath(locale)));
+    });
+
+    // Restore from the source catalog, not from a snapshot taken here: the
+    // build copies _locales verbatim, so this is exact and cannot bake in a
+    // stale swap left behind by an interrupted run.
+    test.afterAll(() => {
+      writeFileSync(BUILT_EN, readFileSync(catalogPath("en")));
+    });
+
+    test("fits small viewports without horizontal overflow", async ({
+      context,
+      extensionId,
+      serviceWorker,
+    }) => {
+      await serviceWorker.evaluate(() =>
+        chrome.storage.local.set({ shareData: false }),
+      );
+      const page = await context.newPage();
+      await page.goto(`chrome-extension://${extensionId}/settings.html`);
+      await page.waitForSelector(".settings-header .profile-banner");
+
+      const expected = JSON.parse(readFileSync(catalogPath(locale), "utf8"))
+        .signIn.message as string;
+      await expect(
+        page.locator("#auth-button"),
+        `the ${locale} catalog did not take — the page is still English, so this test would prove nothing`,
+      ).toHaveText(expected);
+
+      await expectNoOverflowAtSmallViewports(page, locale);
+
+      await page.close();
+    });
+  });
+}

--- a/entrypoints/settings/components/HeaderView.tsx
+++ b/entrypoints/settings/components/HeaderView.tsx
@@ -9,6 +9,11 @@
  *
  * The dead `text-normal` class is dropped (not a Tailwind v2 utility — it never
  * styled anything).
+ *
+ * `profile-identity` is the one addition: a stable hook for the `min-width: 0`
+ * in tabs.css that lets the identity group shrink, so long translations
+ * ellipsize instead of shoving the sign-in button off the page. It is a name
+ * for a box that only had structure before (`> .flex > .flex`).
  */
 export function HeaderView() {
   return (
@@ -23,7 +28,7 @@ export function HeaderView() {
         >
           <img class="logo mr-2" data-icon="bubble-green.svg" alt="Say, Pi" />
         </a>
-        <div class="flex items-center flex-grow">
+        <div class="flex items-center flex-grow profile-identity">
           <span class="label-text hidden" data-i18n="profile">
             Profile
           </span>

--- a/src/popup/tabs.css
+++ b/src/popup/tabs.css
@@ -203,6 +203,19 @@ section.hidden {
   font-weight: 600;
   color: #0f172a;
 }
+/* The identity group (status/name + divider + the unauthenticated blurb) is a
+   flex ITEM of the header row, so its default `min-width: auto` floors it at
+   its own min-content width — and that min-content includes the full,
+   unwrapped `.unauthenticated-inline` string below. In English that floor
+   (~517px) fits the 720px row; in German it is 750px, so the row could not
+   shrink and the sign-in button was pushed 156px past a 736px viewport (every
+   tab, since the header is shared). Greek/Tamil/Finnish overflowed the same
+   way. Letting the group shrink is what finally arms the ellipsis the blurb
+   has always declared. */
+.settings-header .profile-banner .profile-identity { min-width: 0; }
+/* ...and the sign-in button is the row's actionable control: let the blurb
+   absorb the squeeze rather than wrapping the button's label. */
+.settings-header .profile-banner #auth-button { flex-shrink: 0; }
 .settings-header .profile-banner .unauthenticated-inline {
   margin-left: 12px;
   margin-right: 12px;

--- a/tools/i18n/translate-missing.py
+++ b/tools/i18n/translate-missing.py
@@ -40,7 +40,12 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 LOCALES = REPO / "_locales"
-MODEL = os.environ.get("TRANSLATE_MODEL", "gpt-5.2")
+# Measured 2026-08-04 on the real catalog: luna at zero reasoning effort is 2.7x
+# faster than gpt-5.2 for the same placeholder fidelity, at a third of a cent per
+# batch. NOTE: this model rejects reasoning_effort="minimal" — the accepted value
+# is "none". Re-check fidelity with --repair --dry-run after changing either.
+MODEL = os.environ.get("TRANSLATE_MODEL", "gpt-5.6-luna")
+REASONING_EFFORT = os.environ.get("TRANSLATE_REASONING_EFFORT", "none")
 BATCH = 12
 PLACEHOLDER = re.compile(r"\$[A-Za-z0-9_]+\$")
 # Braces are a second substitution syntax used by a few strings ({settingsLink}).
@@ -126,6 +131,8 @@ def translate_batch(entries: dict, language: str, key: str) -> dict:
             {"role": "user", "content": json.dumps(entries, ensure_ascii=False)},
         ],
     }
+    if REASONING_EFFORT:
+        payload["reasoning_effort"] = REASONING_EFFORT
     out = json.loads(strip_fence(call(payload, key)))
     missing = set(entries) - set(out)
     if missing:
@@ -185,6 +192,8 @@ def repair(en: dict, targets: list[str], key: str, dry: bool) -> int:
                     {"role": "user", "content": en[k]["message"]},
                 ],
             }
+            if REASONING_EFFORT:
+                payload["reasoning_effort"] = REASONING_EFFORT
             msg = strip_fence(call(payload, key)).strip().strip('"')
             if tokens(msg) != tokens(en[k]["message"]):
                 print(f"  ✘ {loc}/{k}: repair still wrong — got {sorted(tokens(msg))}", file=sys.stderr)

--- a/tools/i18n/translate-missing.py
+++ b/tools/i18n/translate-missing.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Fill in the messages.json keys a locale is missing, and nothing else.
+
+Why this exists
+---------------
+`i18n-translate-chrome.sh` shells out to translate-cli, which flattens the whole
+catalog — including `description` text and, fatally, the `placeholders` block —
+into translatable records. `placeholders.content` is literally `"$1"` and
+`placeholders.example` is a sample value; neither is prose, and translate-cli
+cannot map them back afterwards. Two full runs against the real catalog died
+this way:
+
+    process failed: request failed: context deadline exceeded
+    process failed: the key voicesInHostMenu/placeholders/host.example is not in the input
+
+and — the dangerous part — translate-cli exits 0 after printing those, so the
+wrapper's `set -euo pipefail` never fires and the caller is told the run
+succeeded while zero files changed.
+
+This script translates only what is prose (`message`, `description`), copies
+`placeholders` verbatim from English, validates every `$placeholder$` token
+survived, and fails loudly if anything is wrong.
+
+Usage
+-----
+    OPENAI_API_KEY=... python3 tools/i18n/translate-missing.py [--locale de] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+LOCALES = REPO / "_locales"
+MODEL = os.environ.get("TRANSLATE_MODEL", "gpt-5.2")
+BATCH = 12
+PLACEHOLDER = re.compile(r"\$[A-Za-z0-9_]+\$")
+# Braces are a second substitution syntax used by a few strings ({settingsLink}).
+BRACE = re.compile(r"\{[A-Za-z0-9_]+\}")
+
+# Chrome's locale dir names are not all BCP-47; give the model the real language.
+LANGUAGE = {
+    "ar": "Arabic", "bg": "Bulgarian", "bn": "Bengali", "cs": "Czech", "da": "Danish",
+    "de": "German", "el": "Greek", "es": "Spanish", "fi": "Finnish", "fr": "French",
+    "he": "Hebrew", "hi": "Hindi", "hr": "Croatian", "hu": "Hungarian",
+    "id": "Indonesian", "it": "Italian", "ja": "Japanese", "ko": "Korean",
+    "ms": "Malay", "nl": "Dutch", "no": "Norwegian", "pl": "Polish",
+    "pt_BR": "Brazilian Portuguese", "pt_PT": "European Portuguese", "ro": "Romanian",
+    "ru": "Russian", "sk": "Slovak", "sv": "Swedish", "ta": "Tamil",
+    "th": "Thai", "tl": "Tagalog (Filipino)", "tr": "Turkish", "uk": "Ukrainian",
+    "vi": "Vietnamese", "zh_CN": "Simplified Chinese", "zh_TW": "Traditional Chinese",
+}
+
+
+def language_for(loc: str) -> str:
+    """Fail loudly rather than asking the model to translate into "bg"."""
+    if loc not in LANGUAGE:
+        raise KeyError(
+            f"locale '{loc}' has no language name — add it to LANGUAGE. Sending a bare "
+            f"locale code produces silently wrong or English output."
+        )
+    return LANGUAGE[loc]
+
+SYSTEM = """You are localising a browser extension called "Say, Pi" that adds voice to AI chatbots.
+
+Translate the "message" and "description" fields of each entry into {language}.
+
+Rules, in order of importance:
+1. Keep every $placeholder$ token and every {{braced}} token EXACTLY as written, including
+   the delimiters. They are substitution points, not words. Reposition them if the target
+   language's grammar requires it, but never translate, rename or drop one.
+2. Never translate the product name "Say, Pi", or the assistant names Pi, Claude, ChatGPT.
+3. "message" is user-visible UI text: match the register of the English — warm, calm, plain,
+   sentence case, no exclamation marks. Keep it SHORT; these sit in a narrow settings column.
+4. "description" is a note for translators and is never shown to users. Translate it plainly.
+5. Counts are written to read correctly at one as well as many, because Chrome i18n has no
+   plural forms. Preserve that property.
+
+Return a JSON object with exactly the same keys as the input, each holding "message" and
+"description". No commentary, no markdown fence."""
+
+
+def tokens(text: str) -> set[str]:
+    return set(PLACEHOLDER.findall(text)) | set(BRACE.findall(text))
+
+
+def call(payload: dict, key: str, retries: int = 4) -> str:
+    body = json.dumps(payload).encode()
+    last = None
+    for attempt in range(retries):
+        req = urllib.request.Request(
+            "https://api.openai.com/v1/chat/completions",
+            data=body,
+            headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=180) as r:
+                return json.load(r)["choices"][0]["message"]["content"]
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+            last = e
+            time.sleep(2 * (attempt + 1))
+    raise RuntimeError(f"API failed after {retries} attempts: {last}")
+
+
+def strip_fence(s: str) -> str:
+    s = s.strip()
+    if s.startswith("```"):
+        s = re.sub(r"^```[a-zA-Z]*\n", "", s)
+        s = re.sub(r"\n```$", "", s)
+    return s
+
+
+def translate_batch(entries: dict, language: str, key: str) -> dict:
+    payload = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": SYSTEM.format(language=language)},
+            {"role": "user", "content": json.dumps(entries, ensure_ascii=False)},
+        ],
+    }
+    out = json.loads(strip_fence(call(payload, key)))
+    missing = set(entries) - set(out)
+    if missing:
+        raise RuntimeError(f"model dropped keys: {sorted(missing)}")
+    return out
+
+
+REPAIR_SYSTEM = """You are repairing one broken localised string in a browser extension.
+
+The English source contains substitution tokens written as $token$ or {{token}}. A previous
+translation pass corrupted them — translating, transliterating or dropping them — which breaks
+substitution at runtime and shows users raw text.
+
+Retranslate the English message into {language}. Every token must appear EXACTLY as in the English,
+character for character, including the delimiters. Reposition them if grammar requires; never
+translate, rename, transliterate or drop one. Do not translate "Say, Pi", Pi, Claude or ChatGPT.
+Match the register of the English.
+
+Return ONLY the translated message as a bare string, no JSON, no quotes, no commentary."""
+
+
+def repair(en: dict, targets: list[str], key: str, dry: bool) -> int:
+    """Re-translate messages whose substitution tokens no longer match English."""
+    broken = []
+    for loc in targets:
+        path = LOCALES / loc / "messages.json"
+        if not path.exists():
+            continue
+        cur = json.loads(path.read_text())
+        for k, v in cur.items():
+            if k not in en or not isinstance(v, dict):
+                continue
+            if tokens(en[k].get("message", "")) != tokens(v.get("message", "")):
+                broken.append((loc, k))
+    if not broken:
+        print("No placeholder corruption found.")
+        return 0
+    print(f"{len(broken)} corrupted string(s):")
+    for loc, k in broken:
+        print(f"  {loc}/{k}: expected {sorted(tokens(en[k]['message']))}")
+    if dry:
+        return 0
+
+    failures = 0
+    by_loc: dict[str, list[str]] = {}
+    for loc, k in broken:
+        by_loc.setdefault(loc, []).append(k)
+    for loc, keys in by_loc.items():
+        path = LOCALES / loc / "messages.json"
+        cur = json.loads(path.read_text())
+        language = language_for(loc)
+        for k in keys:
+            payload = {
+                "model": MODEL,
+                "messages": [
+                    {"role": "system", "content": REPAIR_SYSTEM.format(language=language)},
+                    {"role": "user", "content": en[k]["message"]},
+                ],
+            }
+            msg = strip_fence(call(payload, key)).strip().strip('"')
+            if tokens(msg) != tokens(en[k]["message"]):
+                print(f"  ✘ {loc}/{k}: repair still wrong — got {sorted(tokens(msg))}", file=sys.stderr)
+                failures += 1
+                continue
+            cur[k]["message"] = msg
+            print(f"  ✓ {loc}/{k}: {msg[:70]}")
+        path.write_text(json.dumps({k: cur[k] for k in sorted(cur)}, ensure_ascii=False, indent=2) + "\n")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--locale", action="append", help="limit to these locales")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--repair", action="store_true",
+                    help="re-translate strings whose $placeholder$ tokens diverge from English")
+    args = ap.parse_args()
+
+    key = os.environ.get("OPENAI_API_KEY", "")
+    if not key and not args.dry_run:
+        print("OPENAI_API_KEY is not set", file=sys.stderr)
+        return 1
+
+    en = json.loads((LOCALES / "en" / "messages.json").read_text())
+    targets = args.locale or sorted(
+        d.name for d in LOCALES.iterdir() if d.is_dir() and d.name != "en"
+    )
+
+    if args.repair:
+        return repair(en, targets, key, args.dry_run)
+
+    failures = 0
+    for loc in targets:
+        path = LOCALES / loc / "messages.json"
+        if not path.exists():
+            print(f"  {loc}: no messages.json, skipping")
+            continue
+        cur = json.loads(path.read_text())
+        missing = [k for k in en if k not in cur]
+        if not missing:
+            print(f"  {loc}: already complete")
+            continue
+        language = language_for(loc)
+        print(f"  {loc} ({language}): {len(missing)} missing", flush=True)
+        if args.dry_run:
+            continue
+
+        added = {}
+        for i in range(0, len(missing), BATCH):
+            chunk = missing[i : i + BATCH]
+            src = {
+                k: {"message": en[k]["message"], "description": en[k].get("description", "")}
+                for k in chunk
+            }
+            got = translate_batch(src, language, key)
+            for k in chunk:
+                msg = got[k]["message"]
+                want, have = tokens(en[k]["message"]), tokens(msg)
+                if want != have:
+                    print(
+                        f"    ✘ {loc}/{k}: placeholder mismatch — expected {sorted(want)}, got {sorted(have)}",
+                        file=sys.stderr,
+                    )
+                    failures += 1
+                    continue
+                entry = {"description": got[k].get("description") or en[k].get("description", ""),
+                         "message": msg}
+                if "placeholders" in en[k]:
+                    entry["placeholders"] = en[k]["placeholders"]  # verbatim, never translated
+                added[k] = entry
+            print(f"    {min(i + BATCH, len(missing))}/{len(missing)}", flush=True)
+
+        # Insert alphabetically so existing lines never move — a reviewable diff.
+        merged = dict(cur)
+        merged.update(added)
+        ordered = {k: merged[k] for k in sorted(merged)}
+        path.write_text(json.dumps(ordered, ensure_ascii=False, indent=2) + "\n")
+        print(f"    wrote {len(added)} keys")
+
+    if failures:
+        print(f"\n{failures} placeholder mismatches — NOT clean", file=sys.stderr)
+        return 1
+    print("\nAll locales complete, every placeholder preserved.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Every locale carried 251 of English's 394 keys. 144 user-visible strings — the whole audition room among them — fell back to English in **31 languages**. This translates them, and fixes two pre-existing defects the work uncovered.

## The translations

4,464 strings, of which 992 carry `$placeholder$` tokens that must survive byte-exact.

Audited afterwards: **12,214 strings, 0 placeholder mismatches, 0 keys lost, 0 keys still missing, 0 left in English.** `i18n-validate` passes.

## The repo's translation tooling is broken, and fails silently

`npm run translate` → `i18n-translate-chrome.sh` → `translate-cli`. Two full runs against the real catalog died:

```
process failed: request failed: context deadline exceeded
process failed: the key voicesInHostMenu/placeholders/host.example is not in the input
✓ Translation cycle complete.
```

It **exits 0 after printing those**, so `set -euo pipefail` never fires and `i18n-translate-all.py` reports success — while zero files change. Had the exit code been trusted, 144 English strings would have shipped behind a green checkmark.

Root cause: it flattens the catalog into **985 records from 394 keys**, because it also translates `description` notes *and the `placeholders` block* — where `content` is literally `"$1"` and `example` is a sample value. Neither is prose, and it can't map them back.

`tools/i18n/translate-missing.py` replaces it for this job: prose only, `placeholders` copied verbatim, every token asserted, non-zero exit if any is lost. `--repair` re-translates strings whose tokens already diverged. Unmapped locales raise rather than translating into "bg" — which would have silently poisoned `bg`, `hr`, `sk`, `ta`, `tl`.

Model is `gpt-5.6-luna` at `reasoning_effort: "none"`, chosen by measurement: 3.2s per batch vs 8.8s for gpt-5.2, identical fidelity, ~$0.0007 a batch. For an unattended run with no resume, latency *variance* matters more than peak quality. (This model rejects `reasoning_effort: "minimal"`; the accepted value is `"none"`.)

## Fix 1 — four strings had their placeholders translated

Broken on main, in production today:

```
pl/vadDetailSpeechEndedDuration   $duration$      -> "$ czas trwania"
ta/vadErrorMobileBrowserLimited   $chatbotName$   -> "$ சாட்போட்நேம் with"
ar/sttMinutesRemaining            dropped $plural$
de/vadErrorMobileBrowserLimited   dropped $chatbotName$
```

Substitution silently fails for these — users see raw text. Note `i18n-validate` does **not** catch this: it validates placeholder *declarations*, not whether the token survived translation.

## Fix 2 — the settings header overflowed 156px in every long locale

Found by testing the translations in a real browser. On **every tab**, not just Voices:

```
en 0px | de 156px | el 160px | ta 78px | fi 69px | zh_CN 0px
```

The offender is `#auth-button` at `right=892` in a 736px viewport. Mechanism, measured rather than guessed: the header's identity group is a flex item with default `min-width: auto`, so its automatic minimum is its own min-content — which includes the `nowrap` blurb at full unwrapped width. 517px in English fits; 750px in German doesn't, so the row can't shrink. Two declarations fix it, and the blurb's long-declared ellipsis finally arms.

**Why CI never saw it:** `settings-layout.e2e.ts` only ever ran English. English fits, so the guard stayed green over five broken locales. It now runs the same sweep against the `de` and `el` catalogs, asserting the locale actually applied before measuring — proven to fail on the unfixed CSS while the English case passes in the same run, which is precisely the blind spot.

## Verification

`tsc`, **2667 vitest**, jest, `i18n-validate`, **28 e2e** — all green.

Known, orthogonal: intermittent 60s timeouts in unrelated e2e specs on a loaded machine, reproduced on unmodified HEAD. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5tQbn1thvBTD3eM3bUAMc