### PR TITLE
fix(pi): give new replies to the observer that can actually speak them (#597)

### DIFF
--- a/src/dom/ChatHistory.ts
+++ b/src/dom/ChatHistory.ts
@@ -53,7 +53,15 @@ class ChatHistoryRootElementObserver extends BaseObserver {
     selector: string,
     speechSynthesis: SpeechSynthesisModule,
     private chatbot: Chatbot,
-    initialRun: boolean = true
+    initialRun: boolean = true,
+    /**
+     * Called once the present/most-recent container has been found and labelled,
+     * so its OWNER can take over observing it. Only the owner (the speech
+     * manager) can attach the additions observer, which is the sole path that
+     * SYNTHESISES speech for a new reply — see {@link ensureRecentMessages}.
+     * Without it this observer falls back to decoration-only.
+     */
+    private onRecentContainer?: (container: HTMLElement) => void
   ) {
     super(chatHistoryElement, selector);
     this.speechSynthesis = speechSynthesis;
@@ -153,7 +161,22 @@ class ChatHistoryRootElementObserver extends BaseObserver {
     recentContainer.classList.add("chat-history", "present-messages");
     if (this.recentMessageObserver) {
       this.recentMessageObserver.disconnect();
+      this.recentMessageObserver = null;
     }
+
+    if (this.onRecentContainer) {
+      // Hand the container to its owner, which observes it with the ADDITIONS
+      // observer. That distinction is the whole point: an old-message observer
+      // only ever replays speech already in the history, so if it owned this
+      // container a brand-new reply would be decorated "incomplete" (a Generate
+      // Audio button) and the user's chosen voice would never speak — the past
+      // container's semantics silently applied to the present one (#597).
+      this.onRecentContainer(recentContainer as HTMLElement);
+      return;
+    }
+
+    // No owner (direct construction): degrade to decoration-only, so the most
+    // recent message still gets its controls.
     this.recentMessageObserver = new ChatHistoryOldMessageObserver(
       this.chatHistoryElement,
       `${recentContainer.tagName.toLowerCase()}.chat-history.present-messages`,

--- a/src/tts/ChatHistoryManager.ts
+++ b/src/tts/ChatHistoryManager.ts
@@ -36,6 +36,8 @@ export class ChatHistorySpeechManager implements ResourceReleasable {
   private observers: Observer[] = [];
 
   private newMessageObserver: ChatHistoryAdditionsObserver | null = null;
+  /** The present container `newMessageObserver` is bound to, for idempotence. */
+  private observedPresentContainer: Element | null = null;
   private static pendingSpeeches: Map<
     string,
     {
@@ -183,7 +185,16 @@ export class ChatHistorySpeechManager implements ResourceReleasable {
       chatHistoryElement,
       "#saypi-chat-history",
       this.speechSynthesis,
-      this.chatbot
+      this.chatbot,
+      true,
+      // pi.ai mounts the present container AFTER the chat history is decorated,
+      // so the one-shot setup below finds nothing to observe on first run. Take
+      // the container as soon as it appears (or is replaced) — otherwise new
+      // replies never reach the additions observer, and therefore never get a
+      // SayPi voice (#597).
+      () => {
+        void this.registerPresentChatHistoryListener(chatHistoryElement);
+      }
     );
     rootChatHistoryObserver.observe({
       childList: true,
@@ -192,22 +203,45 @@ export class ChatHistorySpeechManager implements ResourceReleasable {
     this.observers.push(rootChatHistoryObserver);
   }
 
+  /**
+   * Give the present/most-recent container to the additions observer — the only
+   * observer that synthesises speech for a new reply.
+   *
+   * Re-runnable, because the container is not always there when the manager is
+   * built: pi.ai mounts it later (and can replace it), so the root observer
+   * calls back when it appears. Idempotent per container element — a second
+   * call for the same container keeps the observer already watching it, so the
+   * constructor's call and the root observer's callback can't produce two
+   * observers racing to stream the same message.
+   */
   async registerPresentChatHistoryListener(
     chatHistoryElement: HTMLElement
-  ): Promise<ChatHistoryAdditionsObserver> {
+  ): Promise<ChatHistoryAdditionsObserver | null> {
     const selector = ".chat-history.present-messages";
+    const recentContainer = findRootAncestor(chatHistoryElement).querySelector(
+      selector
+    ) as HTMLElement | null;
+    // Nothing to observe yet; the root observer calls back when it mounts.
+    if (!recentContainer) return null;
+    if (recentContainer === this.observedPresentContainer) {
+      return this.newMessageObserver;
+    }
+    this.observedPresentContainer = recentContainer;
+    this.releaseObserver(this.newMessageObserver);
+    this.newMessageObserver = null;
+
+    // One-shot pass over what is ALREADY on screen: decorate it and replay any
+    // speech from history. These messages become the additions observer's
+    // ignore list, so arriving mid-thread never re-reads what the user has
+    // already seen.
     const existingMessagesObserver = new ChatHistoryOldMessageObserver(
       chatHistoryElement,
       selector,
       this.speechSynthesis,
       this.chatbot
     );
-    const recentContainer = findRootAncestor(chatHistoryElement).querySelector(
-      selector
-    ) as HTMLElement | null;
-    const initialMessages = recentContainer
-      ? await existingMessagesObserver.runOnce(recentContainer)
-      : [];
+    const initialMessages =
+      await existingMessagesObserver.runOnce(recentContainer);
     if (initialMessages.length > 0) {
       logger.debug(
         `Found ${initialMessages.length} recent assistant message(s)`
@@ -229,7 +263,18 @@ export class ChatHistorySpeechManager implements ResourceReleasable {
       attributeOldValue: true, // Enable tracking of old attribute values for debugging
     });
     this.observers.push(newMessagesObserver);
+    this.newMessageObserver = newMessagesObserver;
     return newMessagesObserver;
+  }
+
+  /** Disconnect an observer this manager owns and stop tracking it. */
+  private releaseObserver(observer: Observer | null): void {
+    if (!observer) return;
+    observer.disconnect();
+    const index = this.observers.indexOf(observer);
+    if (index >= 0) {
+      this.observers.splice(index, 1);
+    }
   }
 
   // Register event listeners and store them for later removal
@@ -375,12 +420,13 @@ export class ChatHistorySpeechManager implements ResourceReleasable {
   // Constructor
   constructor(private chatbot: Chatbot, chatHistoryElement: HTMLElement) {
     this.addIdChatHistory(chatHistoryElement);
+    // Registers the root observer, which calls back to set up the present
+    // container — immediately if it is already mounted, later on the host that
+    // defers it (pi.ai). The explicit call below covers hosts whose present
+    // container IS the chat history element (Claude/ChatGPT), which the root
+    // observer deliberately leaves alone.
     this.registerPastChatHistoryListener(chatHistoryElement);
-    this.registerPresentChatHistoryListener(chatHistoryElement).then(
-      (observer) => {
-        this.newMessageObserver = observer;
-      }
-    );
+    void this.registerPresentChatHistoryListener(chatHistoryElement);
     this.registerSpeechStreamListeners(chatHistoryElement);
     this.registerMessageErrorListeners();
     this.registerMessageChargeListeners();

--- a/test/tts/ChatHistoryManager-newMessageStreaming.spec.ts
+++ b/test/tts/ChatHistoryManager-newMessageStreaming.spec.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ChatHistorySpeechManager } from "../../src/tts/ChatHistoryManager";
+import {
+  SpeechSynthesisModule,
+  TextAddedEvent,
+} from "../../src/tts/SpeechSynthesisModule";
+import EventBus from "../../src/events/EventBus";
+import { PiAIChatbot } from "../../src/chatbots/Pi";
+import {
+  audioProviders,
+  SayPiSpeech,
+  SpeechSynthesisVoiceRemote,
+  SpeechUtterance,
+} from "../../src/tts/SpeechModel";
+
+vi.mock("../../src/ConfigModule", () => ({
+  config: {
+    appServerUrl: "https://app.example.com",
+    apiServerUrl: "https://api.saypi.ai",
+    GA_MEASUREMENT_ID: "GA_MEASUREMENT_ID",
+    GA_API_SECRET: "GA_API_SECRET",
+    GA_ENDPOINT: "GA_ENDPOINT",
+  },
+}));
+
+/**
+ * Who owns a BRAND-NEW assistant message on pi.ai.
+ *
+ * Only `ChatHistoryAdditionsObserver` synthesises speech; the "old message"
+ * observers replay from the speech history and mark a message
+ * `speech-incomplete` when there is nothing to replay. So whichever observer
+ * reaches a new message first decides whether the user's chosen SayPi voice
+ * ever speaks.
+ *
+ * pi.ai mounts the chat history's past/present containers AFTER the chat
+ * history element itself is found and decorated (#309), which is why the
+ * present container is set up reactively. These specs pin the part #309 left
+ * open: the reactive setup must hand the present container to the ADDITIONS
+ * observer, not only to an old-message observer.
+ */
+describe("new assistant messages on a deferred present container", () => {
+  const mockVoice: SpeechSynthesisVoiceRemote = {
+    id: "shimmer",
+    name: "Shimmer",
+    lang: "en",
+    localService: false,
+    default: false,
+    price: 0.3,
+    price_per_thousand_chars_in_usd: 0.3,
+    price_per_thousand_chars_in_credits: 300,
+    powered_by: "OpenAI",
+    voiceURI: "",
+  };
+
+  let chatHistory: HTMLElement;
+  let manager: ChatHistorySpeechManager;
+  let createSpeechStreamOrPlaceholder: ReturnType<typeof vi.fn>;
+  /** Every chunk handed to the synthesiser, i.e. what the user would hear. */
+  let spokenText: string[];
+  let textAddedListener: (event: TextAddedEvent) => void;
+
+  const settle = () => new Promise((r) => setTimeout(r, 50));
+
+  const assistantMessage = (text: string): HTMLElement => {
+    const message = document.createElement("div");
+    message.classList.add("break-anywhere");
+    const flex = document.createElement("div");
+    flex.classList.add("flex", "items-center");
+    const content = document.createElement("div");
+    content.classList.add("w-full");
+    const paragraph = document.createElement("div");
+    paragraph.classList.add("whitespace-pre-wrap");
+    paragraph.appendChild(document.createTextNode(text));
+    content.appendChild(paragraph);
+    flex.appendChild(content);
+    message.appendChild(flex);
+    return message;
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    chatHistory = document.createElement("div");
+    chatHistory.classList.add("t-body-chat");
+    document.body.appendChild(chatHistory);
+
+    const utterance: SpeechUtterance = new SayPiSpeech(
+      "utterance-id",
+      "en",
+      mockVoice,
+      "https://api.saypi.ai/speak/utterance-id/stream"
+    );
+    createSpeechStreamOrPlaceholder = vi.fn(async () => utterance);
+
+    spokenText = [];
+    textAddedListener = (event: TextAddedEvent) => spokenText.push(event.text);
+    EventBus.on("saypi:tts:text:added", textAddedListener);
+
+    vi.spyOn(SpeechSynthesisModule, "getInstance").mockReturnValue({
+      // A SayPi voice is selected for Pi — the state this bug is about.
+      getActiveAudioProvider: vi.fn(async () => audioProviders.SayPi),
+      createSpeechStreamOrPlaceholder,
+      createSpeech: vi.fn(),
+      speak: vi.fn(),
+    } as unknown as SpeechSynthesisModule);
+  });
+
+  afterEach(() => {
+    EventBus.off("saypi:tts:text:added", textAddedListener);
+    manager?.teardown();
+    vi.restoreAllMocks();
+  });
+
+  /** Mount pi.ai's containers the way pi.ai does: after the manager exists. */
+  const mountContainersLate = (): HTMLElement => {
+    const spacer = document.createElement("div");
+    spacer.className = "relative shrink-0 h-1 z-30";
+    chatHistory.appendChild(spacer);
+
+    const past = document.createElement("div");
+    past.className = "space-y-6";
+    past.appendChild(assistantMessage("an older message"));
+    chatHistory.appendChild(past);
+
+    const present = document.createElement("div");
+    present.className = "pb-6 lg:pb-8";
+    chatHistory.appendChild(present);
+    return present;
+  };
+
+  it("streams speech for a message that arrives in a late-mounted present container", async () => {
+    manager = new ChatHistorySpeechManager(new PiAIChatbot(), chatHistory);
+    const present = mountContainersLate();
+    await settle();
+
+    // A reply arrives empty and is written into, the way a host streams one.
+    const reply = assistantMessage("");
+    present.appendChild(reply);
+    await settle();
+    reply.querySelector(".whitespace-pre-wrap")!.textContent = "Apple.";
+    await settle();
+
+    expect(createSpeechStreamOrPlaceholder).toHaveBeenCalledWith(
+      audioProviders.SayPi,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(reply.dataset.utteranceId).toBe("utterance-id");
+    expect(reply.classList.contains("speech-incomplete")).toBe(false);
+    // The point of all of it: the words reach the synthesiser, so the voice the
+    // user chose is what says them.
+    expect(spokenText.join("")).toContain("Apple.");
+  });
+
+  it("decorates, without re-reading, a thread swapped into the REUSED present container", async () => {
+    // pi.ai keeps the same present container across in-app thread switches and
+    // swaps the new thread's messages in several levels deep (#324). Those
+    // messages are already written, so they must get their controls but must
+    // not be read aloud as if they had just arrived.
+    manager = new ChatHistorySpeechManager(new PiAIChatbot(), chatHistory);
+    const present = mountContainersLate();
+    await settle();
+
+    const thread = document.createElement("div");
+    present.appendChild(thread);
+    const swappedIn = assistantMessage("a message from the other thread");
+    thread.appendChild(swappedIn);
+    await settle();
+
+    expect(swappedIn.classList.contains("assistant-message")).toBe(true);
+    // Its text is already written, so nothing is fed to the synthesiser: the
+    // message reads as an arrival, but there is no speech to make from it.
+    expect(spokenText).toEqual([]);
+  });
+
+  it("still replays (never synthesises) for messages added to the past container", async () => {
+    manager = new ChatHistorySpeechManager(new PiAIChatbot(), chatHistory);
+    mountContainersLate();
+    await settle();
+
+    const past = chatHistory.querySelector(".past-messages") as HTMLElement;
+    past.appendChild(assistantMessage("an even older message"));
+    await settle();
+
+    expect(createSpeechStreamOrPlaceholder).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #597.

## The symptom

Pick Shimmer for Pi in Settings → Voices; the studio says IN USE. Talk to Pi on pi.ai/talk and Pi answers in her own native voice. The chosen voice is never heard — each new reply gets a "Generate Audio" button instead.

The same voice, same account, same build works on claude.ai. Voice preference, auth, catalog and the API are all fine; the message never reaches the synthesiser at all.

## Why

Only `ChatHistoryAdditionsObserver` synthesises speech. The old-message observers replay from the speech history and, finding nothing for a brand-new message, mark it `speech-incomplete`. So whichever observer reaches a new reply first decides whether the user's voice ever speaks.

`registerPresentChatHistoryListener()` ran **once**, from the manager's constructor. pi.ai mounts its present container after that (the very thing #309 documents), so the additions observer resolved a null target and died silently — permanently, for the life of that chat history.

#309 restored *decoration* of the most-recent message by attaching a `ChatHistoryOldMessageObserver` to the present container as it appeared. That fixed the missing controls and, in the same stroke, gave the present container the past container's semantics: every new reply treated as history. Hence a Generate-Audio button where the voice should have been.

Measured on the live host: a reply is mounted, decorated `assistant-message`, then `speech-incomplete` within ~10 ms — far too fast for a synthesis round-trip — and no `/speak` request is ever made.

## The change

The root observer no longer *keeps* the present container; it hands it to its owner as soon as it appears (or is replaced), and the manager binds the additions observer to it. `registerPresentChatHistoryListener` becomes re-runnable and idempotent per container element, so the constructor's call and the callback can't leave two observers racing to stream the same message. The one-shot pass over what is already on screen still seeds the ignore list, so arriving mid-thread doesn't re-read what the user has already seen.

Constructed without an owner (the #309 specs do this), the root observer degrades to decoration-only exactly as before.

## Tests

Fail-first. The headline spec fails on `main` — nothing ever reaches the synthesiser — and passes here. Two guard specs pin what this change could have broken:

- a thread swapped into the **reused** present container is decorated but not re-read (#324)
- messages added to the past container still only ever replay, never synthesise

`tsc --noEmit`, Jest and the full Vitest suite (239 files / 2670 tests) are green.

## Verification still owed

Layers 0–2 only. This is host-DOM behaviour, so it wants a real-host pass on pi.ai with a SayPi voice selected before it's trusted — the founder's browser is the only place with the auth to prove the voice actually speaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgkAqzyjN5xtxR5fKxRPR2