### PR TITLE
Make Pi voice settings readable and return native playback

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "خطأ يُرمى عندما لا يوفّر المتصفح ذاكرة WebAssembly الأولية اللازمة لتشغيل نموذج اكتشاف الصوت.",
     "message": "لا يمكن بدء اكتشاف الصوت: ذاكرة WebAssembly غير متاحة في هذا المتصفح."
+  },
+  "voicesSavedUnavailable": {
+    "message": "صوتك المحفوظ غير متاح حاليًا. حاول مرة أخرى لاحقًا، أو اختر صوتًا آخر.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1628,14 +1628,18 @@
     "message": "صوت قبالة"
   },
   "voiceOverriddenBySayPi": {
-    "description": "يظهر فوق شبكة أصوات المساعد في صفحة إعداداته عندما يتولى صوت من Say, Pi تشغيل الردود، لذلك لا يكون صوت المساعد الأصلي المميز هو المسموع؛ $voice$ هو اسم صوت Say, Pi، مثل Shimmer.",
-    "message": "يتحدث Say, Pi بصوت $voice$ — الأصوات أدناه غير مستخدمة.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "يتحدث Say, Pi بصوت $voice$. اختر أحد أصوات Pi أدناه للعودة إليه.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "تغيير الصوت",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Грешка, хвърляна когато браузърът не предоставя началната WebAssembly памет, нужна за изпълнение на модела за засичане на глас.",
     "message": "Засичането на глас не може да стартира: в този браузър не е налична памет за WebAssembly."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Запазеният ти глас в момента не е наличен. Опитай отново по-късно или избери друг глас.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Гласувайте"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Показва се над мрежата с вградени гласове на асистента в страницата с настройки, когато глас на Say, Pi е поел възпроизвеждането, така че маркираният вграден глас на асистента не е този, който потребителят чува; $voice$ е името на гласа на Say, Pi, например Shimmer.",
-    "message": "Say, Pi говори с $voice$ — гласовете по-долу не се използват.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi говори с гласа $voice$. Изберете глас на Pi по-долу, за да се върнете към него.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Промяна на гласа",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -1628,14 +1628,18 @@
     "message": "ভয়েস অফ"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Say, Pi-এর কোনো ভয়েস প্লেব্যাকের দায়িত্ব নিলে সহকারীর সেটিংস পৃষ্ঠায় নিজস্ব ভয়েসগুলোর গ্রিডের ওপরে দেখানো হয়, তাই সহকারীর হাইলাইট করা নিজস্ব ভয়েসটি ব্যবহারকারী শুনছেন না; $voice$ হলো Say, Pi-এর ভয়েসের নাম, যেমন Shimmer।",
-    "message": "Say, Pi $voice$ হিসেবে কথা বলছে — নিচের ভয়েসগুলো ব্যবহার হচ্ছে না।",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi $voice$ কণ্ঠে কথা বলছে। ফিরে যেতে নিচে Pi-এর একটি কণ্ঠ বেছে নিন।",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "কণ্ঠ পরিবর্তন করুন",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "ভয়েস-ডিটেকশন মডেল চালাতে প্রয়োজনীয় প্রাথমিক WebAssembly মেমরি ব্রাউজার সরবরাহ না করলে যে ত্রুটি দেখায়।",
     "message": "ভয়েস ডিটেকশন শুরু করা যাচ্ছে না: এই ব্রাউজারে WebAssembly মেমরি উপলব্ধ নয়।"
+  },
+  "voicesSavedUnavailable": {
+    "message": "আপনার সংরক্ষিত কণ্ঠ এখন উপলব্ধ নেই। পরে আবার চেষ্টা করুন, অথবা অন্য কণ্ঠ বেছে নিন।",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Voice off"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Zobrazuje se nad vlastní mřížkou hlasů asistenta na stránce nastavení, když Say, Pi převezme přehrávání, takže zvýrazněný nativní hlas asistenta není hlas, který uživatel slyší; $voice$ je název hlasu Say, Pi, například Shimmer.",
-    "message": "Say, Pi mluví hlasem $voice$ — hlasy níže se nepoužívají.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi mluví hlasem $voice$. Pro návrat k hlasům Pi vyberte některý níže.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Změnit hlas",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Chyba vyhozená, když prohlížeč neposkytuje počáteční paměť WebAssembly potřebnou pro spuštění modelu detekce hlasu.",
     "message": "Detekci hlasu nelze spustit: v tomto prohlížeči není k dispozici paměť WebAssembly."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Váš uložený hlas je momentálně nedostupný. Zkuste to později nebo vyberte jiný hlas.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Stemme væk"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Vises over assistentens eget stemmegitter på indstillingssiden, når en Say, Pi-stemme har overtaget afspilningen, så assistentens fremhævede indbyggede stemme ikke er den, brugeren hører; $voice$ er navnet på Say, Pi-stemmen, f.eks. Shimmer.",
-    "message": "Say, Pi taler med $voice$ — stemmerne nedenfor bruges ikke.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi taler med stemmen $voice$. Vælg en Pi-stemme nedenfor for at skifte tilbage.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Skift stemme",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Fejl, der kastes, når browseren ikke eksponerer den indledende WebAssembly-hukommelse, der er nødvendig for at køre stemmedetektionsmodellen.",
     "message": "Stemmedetektion kan ikke starte: WebAssembly-hukommelse er ikke tilgængelig i denne browser."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Din gemte stemme er ikke tilgængelig lige nu. Prøv igen senere, eller vælg en anden stemme.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Fehler, der ausgelöst wird, wenn der Browser den initialen WebAssembly-Speicher nicht bereitstellt, der zum Ausführen des Spracherkennungsmodells benötigt wird.",
     "message": "Spracherkennung kann nicht starten: WebAssembly-Speicher ist in diesem Browser nicht verfügbar."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Deine gespeicherte Stimme ist gerade nicht verfügbar. Versuche es später erneut oder wähle eine andere Stimme.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Stimme ab"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Wird auf der Einstellungsseite über dem Stimmenraster des Assistenten angezeigt, wenn eine Say, Pi-Stimme die Wiedergabe übernommen hat und die hervorgehobene integrierte Stimme des Assistenten daher nicht zu hören ist; $voice$ ist der Name der Say, Pi-Stimme, z. B. Shimmer.",
-    "message": "Say, Pi spricht mit $voice$ – die folgenden Stimmen werden nicht verwendet.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi spricht mit der Stimme $voice$. Wähle unten eine Pi-Stimme, um zurückzuwechseln.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Stimme ändern",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Εκφοβίζω"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Εμφανίζεται πάνω από το πλέγμα φωνών του βοηθού στη σελίδα ρυθμίσεων, όταν μια φωνή του Say, Pi έχει αναλάβει την αναπαραγωγή, επομένως η επιλεγμένη ενσωματωμένη φωνή του βοηθού δεν είναι αυτή που ακούει ο χρήστης· το $voice$ είναι το όνομα της φωνής του Say, Pi, π.χ. Shimmer.",
-    "message": "Το Say, Pi μιλά με τη φωνή $voice$ — οι παρακάτω φωνές δεν χρησιμοποιούνται.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Το Say, Pi μιλά με τη φωνή $voice$. Επιλέξτε μια φωνή του Pi παρακάτω για να επιστρέψετε σε αυτή.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Αλλαγή φωνής",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Σφάλμα που προκύπτει όταν το πρόγραμμα περιήγησης δεν εκθέτει την αρχική μνήμη WebAssembly που απαιτείται για την εκτέλεση του μοντέλου ανίχνευσης φωνής.",
     "message": "Η ανίχνευση φωνής δεν μπορεί να ξεκινήσει: η μνήμη WebAssembly δεν είναι διαθέσιμη σε αυτό το πρόγραμμα περιήγησης."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Η αποθηκευμένη φωνή σου δεν είναι διαθέσιμη αυτή τη στιγμή. Δοκίμασε ξανά αργότερα ή επίλεξε άλλη φωνή.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -977,14 +977,18 @@
     "description": "Menu row linking from the in-page voice menu to the full voice catalog in the extension settings"
   },
   "voiceOverriddenBySayPi": {
-    "message": "Say, Pi is speaking as $voice$ — the voices below aren't in use.",
-    "description": "Shown above the assistant's own voice grid on its settings page when a Say, Pi voice has taken over playback, so the assistant's highlighted native voice is not what the user hears; $voice$ is the Say, Pi voice name, e.g. Shimmer.",
+    "message": "Say, Pi is speaking as $voice$. Choose a Pi voice below to switch back.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Change voice",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicesSectionTitle": {
     "message": "Voices",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2177,5 +2177,9 @@
   "maybeLater": {
     "message": "Maybe Later",
     "description": "Button text to dismiss auth prompt."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Your saved voice is unavailable right now. Try again later, or choose another voice.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Salir"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Se muestra sobre la cuadrícula de voces del asistente en su página de ajustes cuando una voz de Say, Pi se ha impuesto para la reproducción, por lo que la voz nativa destacada del asistente no es la que oye el usuario; $voice$ es el nombre de la voz de Say, Pi, por ejemplo, Shimmer.",
-    "message": "Say, Pi habla con $voice$; las voces de abajo no se usan.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi habla con la voz $voice$. Elige una voz de Pi abajo para volver a usarla.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Cambiar voz",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Error que se lanza cuando el navegador no expone la memoria inicial de WebAssembly necesaria para ejecutar el modelo de detección de voz.",
     "message": "No se puede iniciar la detección de voz: la memoria de WebAssembly no está disponible en este navegador."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Tu voz guardada no está disponible en este momento. Inténtalo de nuevo más tarde o elige otra voz.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Äänestää"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Näytetään avustajan asetussivun oman äänivalikoiman yläpuolella, kun Say, Pi -ääni on ottanut toiston käyttöön, joten avustajan korostettu oma ääni ei ole käyttäjän kuulema; $voice$ on Say, Pi -äänen nimi, esimerkiksi Shimmer.",
-    "message": "Say, Pi puhuu äänellä $voice$ — alla olevat äänet eivät ole käytössä.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi puhuu äänellä $voice$. Vaihda takaisin valitsemalla Pi-ääni alta.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Vaihda ääntä",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Virhe, joka heitetään, kun selain ei tarjoa alkuperäistä WebAssembly-muistia, jota tarvitaan puheentunnistusmallin ajamiseen.",
     "message": "Puheentunnistus ei voi käynnistyä: WebAssembly-muisti ei ole käytettävissä tässä selaimessa."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Tallentamasi ääni ei ole juuri nyt saatavilla. Yritä myöhemmin uudelleen tai valitse toinen ääni.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Exprimer"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Affiché au-dessus de la grille des voix de l’assistant dans sa page de réglages lorsqu’une voix de Say, Pi prend en charge la lecture, de sorte que la voix native sélectionnée de l’assistant n’est pas celle que l’utilisateur entend ; $voice$ est le nom de la voix de Say, Pi, par exemple Shimmer.",
-    "message": "Say, Pi parle avec $voice$ — les voix ci-dessous ne sont pas utilisées.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi parle avec la voix $voice$. Choisissez une voix de Pi ci-dessous pour y revenir.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Changer de voix",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Erreur levée lorsque le navigateur n’expose pas la mémoire WebAssembly initiale nécessaire pour exécuter le modèle de détection vocale.",
     "message": "La détection vocale ne peut pas démarrer : la mémoire WebAssembly n’est pas disponible dans ce navigateur."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Votre voix enregistrée est indisponible pour le moment. Réessayez plus tard ou choisissez une autre voix.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -1628,14 +1628,18 @@
     "message": "गूंजना"
   },
   "voiceOverriddenBySayPi": {
-    "description": "सहायक के सेटिंग पेज पर अपनी आवाज़ों के ग्रिड के ऊपर दिखाया जाता है, जब Say, Pi की आवाज़ ने बोलने की जगह ले ली हो और सहायक की चुनी हुई मूल आवाज़ वह न हो जो उपयोगकर्ता सुनता है; $voice$ Say, Pi की आवाज़ का नाम है, जैसे Shimmer।",
-    "message": "Say, Pi $voice$ की आवाज़ में बोल रहा है — नीचे दी गई आवाज़ें उपयोग में नहीं हैं।",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi $voice$ की आवाज़ में बोल रहा है। वापस जाने के लिए नीचे Pi की कोई आवाज़ चुनें।",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "आवाज़ बदलें",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "एरर, जब ब्राउज़र वॉइस-डिटेक्शन मॉडल चलाने के लिए ज़रूरी शुरुआती WebAssembly मेमोरी उपलब्ध नहीं कराता।",
     "message": "वॉइस डिटेक्शन शुरू नहीं हो सकता: इस ब्राउज़र में WebAssembly मेमोरी उपलब्ध नहीं है।"
+  },
+  "voicesSavedUnavailable": {
+    "message": "आपकी सहेजी गई आवाज़ अभी उपलब्ध नहीं है। बाद में फिर से कोशिश करें या दूसरी आवाज़ चुनें।",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Pogreška koja se javlja kada preglednik ne izlaže početnu WebAssembly memoriju potrebnu za pokretanje modela za detekciju glasa.",
     "message": "Detekcija glasa se ne može pokrenuti: WebAssembly memorija nije dostupna u ovom pregledniku."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Tvoj spremljeni glas trenutačno nije dostupan. Pokušaj ponovno kasnije ili odaberi drugi glas.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Odbiti"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Prikazuje se iznad mreže izvornih glasova asistenta na stranici s postavkama kada je glas Say, Pi preuzeo reprodukciju, pa označeni izvorni glas asistenta nije ono što korisnik čuje; $voice$ je naziv glasa Say, Pi, npr. Shimmer.",
-    "message": "Say, Pi govori glasom $voice$ — navedeni glasovi nisu u upotrebi.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi govori glasom $voice$. Za povratak odaberite jedan od Pi glasova u nastavku.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Promijeni glas",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Lehangol"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Az asszisztens beállítási oldalán, a saját hangjait tartalmazó rács felett jelenik meg, amikor egy Say, Pi-hang veszi át a lejátszást, ezért a felhasználó nem az asszisztens kiemelt natív hangját hallja; a $voice$ a Say, Pi hangjának neve, például Shimmer.",
-    "message": "A Say, Pi a(z) $voice$ hangján beszél — az alábbi hangok nincsenek használatban.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "A Say, Pi a(z) $voice$ hangján beszél. A visszaváltáshoz válasszon alább egy Pi-hangot.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Hang módosítása",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Hiba, amely akkor keletkezik, ha a böngésző nem teszi elérhetővé a hangérzékelő modell futtatásához szükséges kezdeti WebAssembly-memóriát.",
     "message": "A hangérzékelés nem indítható el: ebben a böngészőben nem érhető el a WebAssembly-memória."
+  },
+  "voicesSavedUnavailable": {
+    "message": "A mentett hangod jelenleg nem érhető el. Próbáld újra később, vagy válassz másik hangot.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Menyuarakan"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Ditampilkan di atas daftar suara bawaan asisten pada halaman pengaturan saat suara Say, Pi mengambil alih pemutaran, sehingga suara bawaan asisten yang disorot bukan suara yang didengar pengguna; $voice$ adalah nama suara Say, Pi, misalnya Shimmer.",
-    "message": "Say, Pi berbicara dengan suara $voice$ — suara di bawah tidak digunakan.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi berbicara dengan suara $voice$. Pilih suara Pi di bawah untuk beralih kembali.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Ganti suara",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Error yang muncul ketika browser tidak menyediakan memori WebAssembly awal yang diperlukan untuk menjalankan model pendeteksi suara.",
     "message": "Pendeteksian suara tidak dapat dimulai: memori WebAssembly tidak tersedia di browser ini."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Suara yang Anda simpan sedang tidak tersedia. Coba lagi nanti, atau pilih suara lain.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Errore generato quando il browser non espone la memoria WebAssembly iniziale necessaria per eseguire il modello di rilevamento vocale.",
     "message": "Impossibile avviare il rilevamento vocale: la memoria WebAssembly non è disponibile in questo browser."
+  },
+  "voicesSavedUnavailable": {
+    "message": "La voce che hai salvato non è disponibile al momento. Riprova più tardi o scegli un’altra voce.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Voce"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Mostrato sopra la griglia delle voci dell'assistente nella pagina delle impostazioni quando una voce di Say, Pi ha preso il controllo della riproduzione, quindi la voce nativa evidenziata dell'assistente non è quella che l'utente sente; $voice$ è il nome della voce di Say, Pi, ad esempio Shimmer.",
-    "message": "Say, Pi parla con $voice$ — le voci sotto non sono in uso.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi parla con la voce $voice$. Scegli una voce di Pi qui sotto per tornare a usarla.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Cambia voce",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1628,14 +1628,18 @@
     "message": "声をかけます"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Say, Pi の音声が再生を引き継いだときに、アシスタントの設定ページにある固有音声一覧の上に表示されます。ユーザーが聞くのは、アシスタントでハイライトされた標準音声ではありません。$voice$ は Say, Pi の音声名です（例: Shimmer）。",
-    "message": "Say, Pi が $voice$ として話しています — 以下の音声は使用されていません。",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi が $voice$ の音声で話しています。元に戻すには、下から Pi の音声を選んでください。",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "音声を変更",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "音声検出モデルの実行に必要な初期 WebAssembly メモリがブラウザで公開されていない場合に投げられるエラー。",
     "message": "音声検出を開始できません: このブラウザでは WebAssembly メモリを利用できません。"
+  },
+  "voicesSavedUnavailable": {
+    "message": "保存した音声は現在利用できません。しばらくしてからもう一度試すか、別の音声を選んでください。",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "브라우저가 음성 감지 모델을 실행하는 데 필요한 초기 WebAssembly 메모리를 제공하지 않을 때 발생하는 오류.",
     "message": "음성 감지를 시작할 수 없어요: 이 브라우저에서는 WebAssembly 메모리를 사용할 수 없어요."
+  },
+  "voicesSavedUnavailable": {
+    "message": "저장한 음성을 지금은 사용할 수 없습니다. 나중에 다시 시도하거나 다른 음성을 선택하세요.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1628,14 +1628,18 @@
     "message": "목소리"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Say, Pi 음성이 재생을 대신할 때 어시스턴트 설정 페이지의 자체 음성 목록 위에 표시됩니다. 따라서 어시스턴트에서 강조된 기본 음성은 실제로 들리지 않습니다. $voice$는 Say, Pi 음성 이름입니다(예: Shimmer).",
-    "message": "Say, Pi가 $voice$ 음성으로 말하고 있습니다 — 아래 음성은 사용되지 않습니다.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi가 $voice$ 음성으로 말하고 있습니다. 다시 전환하려면 아래에서 Pi 음성을 선택하세요.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "음성 변경",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Suara"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Dipaparkan di atas grid suara pembantu sendiri pada halaman tetapannya apabila suara Say, Pi mengambil alih main balik, jadi suara asli pembantu yang disorot bukan suara yang didengar pengguna; $voice$ ialah nama suara Say, Pi, contohnya Shimmer.",
-    "message": "Say, Pi sedang bercakap menggunakan $voice$ — suara di bawah tidak digunakan.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi sedang bercakap menggunakan suara $voice$. Pilih suara Pi di bawah untuk beralih semula.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Tukar suara",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Ralat yang dibuang apabila pelayar tidak mendedahkan memori WebAssembly awal yang diperlukan untuk menjalankan model pengesanan suara.",
     "message": "Pengesanan suara tidak boleh bermula: memori WebAssembly tidak tersedia dalam pelayar ini."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Suara yang anda simpan tidak tersedia buat masa ini. Cuba lagi kemudian, atau pilih suara lain.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Fout die wordt opgegooid wanneer de browser het initiële WebAssembly-geheugen dat nodig is om het spraakdetectiemodel te draaien niet aanbiedt.",
     "message": "Spraakdetectie kan niet starten: WebAssembly-geheugen is niet beschikbaar in deze browser."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Je opgeslagen stem is op dit moment niet beschikbaar. Probeer het later opnieuw of kies een andere stem.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Stemmen"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Wordt boven het eigen stemoverzicht van de assistent op de instellingenpagina weergegeven wanneer een Say, Pi-stem het afspelen heeft overgenomen. De gemarkeerde ingebouwde stem van de assistent is dan niet te horen; $voice$ is de naam van de Say, Pi-stem, bijvoorbeeld Shimmer.",
-    "message": "Say, Pi spreekt met $voice$ — de onderstaande stemmen worden niet gebruikt.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi spreekt met de stem $voice$. Kies hieronder een Pi-stem om terug te schakelen.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Stem wijzigen",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Błąd zgłaszany, gdy przeglądarka nie udostępnia początkowej pamięci WebAssembly potrzebnej do uruchomienia modelu wykrywania głosu.",
     "message": "Nie można uruchomić wykrywania głosu: pamięć WebAssembly jest niedostępna w tej przeglądarce."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Twój zapisany głos jest teraz niedostępny. Spróbuj ponownie później lub wybierz inny głos.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Głos"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Wyświetlane nad własną siatką głosów asystenta na stronie ustawień, gdy głos Say, Pi przejął odtwarzanie, więc wyróżniony natywny głos asystenta nie jest tym, który słyszy użytkownik; $voice$ to nazwa głosu Say, Pi, np. Shimmer.",
-    "message": "Say, Pi mówi głosem $voice$ — poniższe głosy nie są używane.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi mówi głosem $voice$. Wybierz poniżej głos Pi, aby do niego wrócić.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Zmień głos",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Voz fora"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Exibido acima da grade de vozes do próprio assistente na página de configurações quando uma voz do Say, Pi assumiu a reprodução, portanto a voz nativa destacada do assistente não é a que o usuário ouve; $voice$ é o nome da voz do Say, Pi, por exemplo, Shimmer.",
-    "message": "Say, Pi está falando com $voice$ — as vozes abaixo não estão em uso.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi está falando com a voz $voice$. Escolha uma voz do Pi abaixo para voltar a usá-la.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Mudar voz",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Erro lançado quando o navegador não expõe a memória inicial do WebAssembly necessária para executar o modelo de detecção de voz.",
     "message": "A detecção de voz não pode iniciar: a memória do WebAssembly não está disponível neste navegador."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Sua voz salva está indisponível no momento. Tente novamente mais tarde ou escolha outra voz.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Eroare aruncată când browserul nu expune memoria WebAssembly inițială necesară pentru a rula modelul de detectare vocală.",
     "message": "Detectarea vocală nu poate porni: memoria WebAssembly nu este disponibilă în acest browser."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Vocea ta salvată nu este disponibilă momentan. Încearcă din nou mai târziu sau alege altă voce.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Voce oprit"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Afișat deasupra grilei cu vocile proprii ale asistentului în pagina de setări, când o voce Say, Pi a preluat redarea, astfel încât vocea nativă evidențiată a asistentului nu este cea auzită de utilizator; $voice$ este numele vocii Say, Pi, de exemplu Shimmer.",
-    "message": "Say, Pi vorbește cu $voice$ — vocile de mai jos nu sunt folosite.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi vorbește cu vocea $voice$. Alegeți o voce Pi de mai jos pentru a reveni.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Schimbă vocea",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Ошибка, возникающая, когда браузер не предоставляет начальную память WebAssembly, необходимую для запуска модели распознавания голоса.",
     "message": "Распознавание голоса не может запуститься: в этом браузере недоступна память WebAssembly."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Сохранённый голос сейчас недоступен. Попробуйте позже или выберите другой голос.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Голос"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Показывается над сеткой собственных голосов ассистента на странице его настроек, когда голос Say, Pi заменяет голос ассистента, поэтому выбранный встроенный голос ассистента не слышен; $voice$ — название голоса Say, Pi, например Shimmer.",
-    "message": "Say, Pi говорит голосом $voice$ — голоса ниже не используются.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi говорит голосом $voice$. Выберите голос Pi ниже, чтобы вернуться к нему.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Изменить голос",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Chyba vyhodená, keď prehliadač neposkytuje počiatočnú pamäť WebAssembly potrebnú na spustenie modelu detekcie hlasu.",
     "message": "Detekciu hlasu sa nepodarilo spustiť: pamäť WebAssembly nie je v tomto prehliadači dostupná."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Váš uložený hlas je momentálne nedostupný. Skúste to neskôr alebo vyberte iný hlas.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Vypnúť"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Zobrazuje sa nad vlastnou mriežkou hlasov asistenta na stránke nastavení, keď hlas Say, Pi prevezme prehrávanie, takže zvýraznený natívny hlas asistenta nie je tým, ktorý používateľ počuje; $voice$ je názov hlasu Say, Pi, napr. Shimmer.",
-    "message": "Say, Pi hovorí hlasom $voice$ — hlasy nižšie sa nepoužívajú.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi hovorí hlasom $voice$. Ak sa chcete vrátiť k hlasom Pi, vyberte niektorý nižšie.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Zmeniť hlas",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Fel som uppstår när webbläsaren inte exponerar det initiala WebAssembly-minnet som behövs för att köra röstigenkänningsmodellen.",
     "message": "Röstigenkänning kan inte starta: WebAssembly-minne är inte tillgängligt i den här webbläsaren."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Din sparade röst är inte tillgänglig just nu. Försök igen senare eller välj en annan röst.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Rösta sig"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Visas ovanför assistentens egna röstfält på inställningssidan när en Say, Pi-röst har tagit över uppspelningen, så att assistentens markerade inbyggda röst inte är den användaren hör; $voice$ är namnet på Say, Pi-rösten, till exempel Shimmer.",
-    "message": "Say, Pi talar med $voice$ – rösterna nedan används inte.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi talar med rösten $voice$. Välj en Pi-röst nedan för att byta tillbaka.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Byt röst",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "குரல்-கண்டறிதல் மாதிரியை இயக்க தேவையான ஆரம்ப WebAssembly நினைவகத்தை உலாவி வழங்காதபோது ஏற்படும் பிழை.",
     "message": "குரல் கண்டறிதல் தொடங்க முடியாது: இந்த உலாவியில் WebAssembly நினைவகம் கிடைக்கவில்லை."
+  },
+  "voicesSavedUnavailable": {
+    "message": "நீங்கள் சேமித்த குரல் தற்போது கிடைக்கவில்லை. பின்னர் மீண்டும் முயற்சிக்கவும் அல்லது வேறொரு குரலைத் தேர்ந்தெடுக்கவும்.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -1628,14 +1628,18 @@
     "message": "குரல் அணைக்கவும்"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Say, Pi குரல் இயக்கத்தை எடுத்துக்கொண்டால், உதவியாளரின் அமைப்புப் பக்கத்தில் அதன் சொந்தக் குரல் கட்டத்தின் மேலே காட்டப்படும். ஆகவே, உதவியாளரால் முன்னிலைப்படுத்தப்பட்ட சொந்தக் குரலைப் பயனர் கேட்கமாட்டார்; $voice$ என்பது Say, Pi குரலின் பெயர், எடுத்துக்காட்டாக Shimmer.",
-    "message": "Say, Pi $voice$ குரலில் பேசுகிறது — கீழுள்ள குரல்கள் பயன்பாட்டில் இல்லை.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi $voice$ குரலில் பேசுகிறது. மீண்டும் Pi குரலுக்கு மாற, கீழே ஒரு Pi குரலைத் தேர்வுசெய்யவும்.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "குரலை மாற்று",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/tl/messages.json
+++ b/_locales/tl/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Boses"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Ipinapakita sa itaas ng sariling grid ng boses ng assistant sa pahina ng mga setting kapag isang boses ng Say, Pi ang pumalit sa pag-playback, kaya hindi ang naka-highlight na katutubong boses ng assistant ang naririnig ng user; ang $voice$ ay pangalan ng boses ng Say, Pi, gaya ng Shimmer.",
-    "message": "Si Say, Pi ang nagsasalita gamit ang $voice$ — hindi ginagamit ang mga boses sa ibaba.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Nagsasalita ang Say, Pi gamit ang boses na $voice$. Pumili ng boses ng Pi sa ibaba para bumalik dito.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Palitan ang boses",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/tl/messages.json
+++ b/_locales/tl/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Error na ibinabato kapag hindi inilalantad ng browser ang initial WebAssembly memory na kailangan para patakbuhin ang voice-detection model.",
     "message": "Hindi makapagsimula ang voice detection: hindi available ang WebAssembly memory sa browser na ito."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Hindi available ngayon ang naka-save mong boses. Subukang muli mamaya, o pumili ng ibang boses.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Tarayıcı, ses algılama modelini çalıştırmak için gereken başlangıç WebAssembly belleğini sağlamadığında oluşturulan hata.",
     "message": "Ses algılama başlatılamıyor: bu tarayıcıda WebAssembly belleği kullanılamıyor."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Kayıtlı sesiniz şu anda kullanılamıyor. Daha sonra tekrar deneyin veya başka bir ses seçin.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Seslendirmek"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Say, Pi sesi oynatmayı devraldığında asistanın ayarlar sayfasındaki kendi ses ızgarasının üzerinde gösterilir; bu nedenle asistanın vurgulanan yerleşik sesi kullanıcının duyduğu ses değildir. $voice$, Shimmer gibi Say, Pi sesinin adıdır.",
-    "message": "Say, Pi $voice$ olarak konuşuyor — aşağıdaki sesler kullanılmıyor.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi, $voice$ sesiyle konuşuyor. Geri dönmek için aşağıdan bir Pi sesi seçin.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Sesi değiştir",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Озвучувати"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Показується над сіткою власних голосів асистента на його сторінці налаштувань, коли голос Say, Pi замінив відтворення, тому вибраний вбудований голос асистента не чути; $voice$ — назва голосу Say, Pi, наприклад Shimmer.",
-    "message": "Say, Pi говорить голосом $voice$ — наведені нижче голоси не використовуються.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi говорить голосом $voice$. Виберіть голос Pi нижче, щоб повернутися до нього.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Змінити голос",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Помилка, яка виникає, коли браузер не надає початкову памʼять WebAssembly, потрібну для запуску моделі виявлення голосу.",
     "message": "Виявлення голосу не може запуститися: у цьому браузері недоступна памʼять WebAssembly."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Збережений голос зараз недоступний. Спробуйте пізніше або виберіть інший голос.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -1628,14 +1628,18 @@
     "message": "Giọng nói tắt"
   },
   "voiceOverriddenBySayPi": {
-    "description": "Hiển thị phía trên lưới giọng nói riêng của trợ lý trong trang cài đặt khi giọng Say, Pi thay thế giọng phát, vì vậy giọng gốc được trợ lý đánh dấu không phải là giọng người dùng nghe thấy; $voice$ là tên giọng Say, Pi, ví dụ Shimmer.",
-    "message": "Say, Pi đang nói bằng giọng $voice$ — các giọng bên dưới không được dùng.",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi đang nói bằng giọng $voice$. Chọn một giọng Pi bên dưới để chuyển lại.",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "Đổi giọng",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "Lỗi được đưa ra khi trình duyệt không cung cấp bộ nhớ WebAssembly ban đầu cần để chạy mô hình phát hiện giọng nói.",
     "message": "Không thể bắt đầu phát hiện giọng nói: trình duyệt này không hỗ trợ bộ nhớ WebAssembly."
+  },
+  "voicesSavedUnavailable": {
+    "message": "Giọng nói bạn đã lưu hiện không khả dụng. Hãy thử lại sau hoặc chọn giọng khác.",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1628,14 +1628,18 @@
     "message": "发出声音"
   },
   "voiceOverriddenBySayPi": {
-    "description": "当 Say, Pi 的语音接管播放时，显示在助手设置页自身语音网格上方；助手突出显示的原生语音并不是用户听到的语音；$voice$ 是 Say, Pi 的语音名称，例如 Shimmer。",
-    "message": "Say, Pi 正在使用 $voice$ 朗读 — 以下语音未在使用。",
+    "description": "Shown above Pi’s native voice grid when Say, Pi provides the current voice. Explains how choosing a Pi card returns to native playback; $voice$ is the current Say, Pi voice name.",
+    "message": "Say, Pi 正在使用 $voice$ 朗读。请选择下方的 Pi 语音以切换回去。",
     "placeholders": {
       "voice": {
         "content": "$1",
         "example": "Shimmer"
       }
     }
+  },
+  "voicesChangeVoice": {
+    "message": "更改语音",
+    "description": "Action beside the current voice that opens the full voice catalog."
   },
   "voicePaused": {
     "description": "Text shown when voice is paused due to insufficient credits",

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -2180,5 +2180,9 @@
   "webAssemblyMemoryUnavailable": {
     "description": "当浏览器未提供运行语音检测模型所需的初始 WebAssembly 内存时抛出的错误。",
     "message": "无法开始语音检测：此浏览器中 WebAssembly 内存不可用。"
+  },
+  "voicesSavedUnavailable": {
+    "message": "你保存的语音暂时不可用。请稍后重试，或选择其他语音。",
+    "description": "Saved voice cannot currently be resolved; its preference is preserved."
   }
 }

--- a/doc/specs/2026-09-05-pi-voice-return.md
+++ b/doc/specs/2026-09-05-pi-voice-return.md
@@ -12,7 +12,11 @@ used with offscreen playback. No new audio event or provider contract is needed.
 Stored native Pi ids are cleared on native card clicks too, so an old persisted
 Pi voice cannot override the card just chosen. Native provider identity also
 determines whether an override notice belongs on the page; a non-null stored
-voice alone does not.
+voice alone does not. When the stored id exists but its voice cannot currently
+resolve, the page says the saved voice is unavailable and keeps Change voice
+accessible; it does not describe Pi as the active provider. Initial, auth and
+external preference reads share a revision guard, so an older read cannot put a
+SayPi notice back after the user has chosen a native voice.
 
 The notice uses Pi’s compiled `text-text-secondary` theme utility rather than
 inheriting the grid’s foreground, which was black even in dark mode. A nearby
@@ -24,5 +28,11 @@ repaired if Pi replaces its grid children.
 The DOM regression suite proves native-provider classification, theme-color
 inheritance, direct navigation, native-card click handling, failed persistence,
 and replacement-node recovery. The existing audio tests cover provider-based
-muting and release. Real-host confirmation belongs to the combined release E2E
-pass; this slice itself spends no real-host turns.
+muting and release. `e2e/specs/pi-voice-settings.e2e.ts` adds a real development
+extension and isolated Chromium profile against the local Pi settings fixture:
+it verifies real preference writes, native card handling, catalog navigation,
+and notice contrast in light/dark themes, plus return from an unresolved saved
+voice. The fixture leaves `/talk` unchanged. Its host-theme attribute is separate
+from SayPi's theme classes, and the test asserts the actual background before
+measuring contrast so a mislabeled light rendering cannot pass as dark coverage.
+This slice spends no real-host turns.

--- a/doc/specs/2026-09-05-pi-voice-return.md
+++ b/doc/specs/2026-09-05-pi-voice-return.md
@@ -20,6 +20,8 @@ voice alone does not. When the stored id exists but its voice cannot currently
 resolve, an authenticated user sees the saved-unavailable notice and Change
 voice. A signed-out user instead sees the existing translated sign-in prompt
 and a Sign In action leading to Settings, without changing their saved choice.
+This also applies when cached remote metadata can still resolve after sign-out:
+the saved voice is not currently speaking merely because its name is available.
 Initial, auth and
 external preference reads share a revision guard, so an older read cannot put a
 SayPi notice back after the user has chosen a native voice.
@@ -37,8 +39,8 @@ and replacement-node recovery. The existing audio tests cover provider-based
 muting and release. `e2e/specs/pi-voice-settings.e2e.ts` adds a real development
 extension and isolated Chromium profile against the local Pi settings fixture:
 it verifies real preference writes, native card handling, catalog navigation,
-and notice contrast in light/dark themes, sign-in guidance for an unresolved
-saved voice, and a native pick sealing the pending default with no override.
+and notice contrast in light/dark themes, sign-in guidance for both resolved and
+unresolved saved voices, and a native pick sealing the pending default with no override.
 The fixture leaves `/talk` unchanged. Its host-theme attribute is separate
 from SayPi's theme classes, and the test asserts the actual background before
 measuring contrast so a mislabeled light rendering cannot pass as dark coverage.

--- a/doc/specs/2026-09-05-pi-voice-return.md
+++ b/doc/specs/2026-09-05-pi-voice-return.md
@@ -5,6 +5,10 @@ SayPi voice selected, choosing one of Pi’s native cards used to update Pi’s
 preference while leaving SayPi in charge of playback. The page now treats that
 click as a deliberate return to Pi: Pi keeps its own click handler and selected
 card, while SayPi clears its stored voice with `unsetVoice(pi)`.
+This explicit native choice also cancels Pi's pending first-install default,
+even when no override has been stored yet: signing in later must not replace
+the voice the user just chose with Marin. Merely viewing the grid leaves the
+pending default intact.
 
 That existing preference path clears the converter’s selected voice and changes
 the audio provider back to Pi. `AudioModule` then releases the host-element mute
@@ -13,8 +17,10 @@ Stored native Pi ids are cleared on native card clicks too, so an old persisted
 Pi voice cannot override the card just chosen. Native provider identity also
 determines whether an override notice belongs on the page; a non-null stored
 voice alone does not. When the stored id exists but its voice cannot currently
-resolve, the page says the saved voice is unavailable and keeps Change voice
-accessible; it does not describe Pi as the active provider. Initial, auth and
+resolve, an authenticated user sees the saved-unavailable notice and Change
+voice. A signed-out user instead sees the existing translated sign-in prompt
+and a Sign In action leading to Settings, without changing their saved choice.
+Initial, auth and
 external preference reads share a revision guard, so an older read cannot put a
 SayPi notice back after the user has chosen a native voice.
 
@@ -31,8 +37,9 @@ and replacement-node recovery. The existing audio tests cover provider-based
 muting and release. `e2e/specs/pi-voice-settings.e2e.ts` adds a real development
 extension and isolated Chromium profile against the local Pi settings fixture:
 it verifies real preference writes, native card handling, catalog navigation,
-and notice contrast in light/dark themes, plus return from an unresolved saved
-voice. The fixture leaves `/talk` unchanged. Its host-theme attribute is separate
+and notice contrast in light/dark themes, sign-in guidance for an unresolved
+saved voice, and a native pick sealing the pending default with no override.
+The fixture leaves `/talk` unchanged. Its host-theme attribute is separate
 from SayPi's theme classes, and the test asserts the actual background before
 measuring contrast so a mislabeled light rendering cannot pass as dark coverage.
 This slice spends no real-host turns.

--- a/doc/specs/2026-09-05-pi-voice-return.md
+++ b/doc/specs/2026-09-05-pi-voice-return.md
@@ -1,0 +1,28 @@
+# Returning to Pi’s own voice
+
+Pi’s Voice settings is where people expect a voice choice to take effect. With a
+SayPi voice selected, choosing one of Pi’s native cards used to update Pi’s
+preference while leaving SayPi in charge of playback. The page now treats that
+click as a deliberate return to Pi: Pi keeps its own click handler and selected
+card, while SayPi clears its stored voice with `unsetVoice(pi)`.
+
+That existing preference path clears the converter’s selected voice and changes
+the audio provider back to Pi. `AudioModule` then releases the host-element mute
+used with offscreen playback. No new audio event or provider contract is needed.
+Stored native Pi ids are cleared on native card clicks too, so an old persisted
+Pi voice cannot override the card just chosen. Native provider identity also
+determines whether an override notice belongs on the page; a non-null stored
+voice alone does not.
+
+The notice uses Pi’s compiled `text-text-secondary` theme utility rather than
+inheriting the grid’s foreground, which was black even in dark mode. A nearby
+Change voice button opens SayPi’s catalog. Native cards keep their normal
+appearance because they are an active return path, and the notice explains that
+choosing one switches playback back to Pi. Both the notice and catalog link are
+repaired if Pi replaces its grid children.
+
+The DOM regression suite proves native-provider classification, theme-color
+inheritance, direct navigation, native-card click handling, failed persistence,
+and replacement-node recovery. The existing audio tests cover provider-based
+muting and release. Real-host confirmation belongs to the combined release E2E
+pass; this slice itself spends no real-host turns.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -193,6 +193,7 @@ instead of silently calling the real internet.
 | `support/mock-servers.ts` | self-signed HTTPS page server (Host-routed Pi/Claude pages) + saypi-api (`/transcribe`, hit/content-type diagnostics + per-test reset route, `/voices` catalog + `/voices/<id>/sample` clips, GA catch-all) |
 | `support/voice-catalog.ts` | the `GET /voices` fixture: a seven-voice catalog shaped to exercise the Voices rail (both tiers, a duplicate-named pair, a clipless voice, measurable pitch spread) |
 | `support/mock-pi-page.html` | minimal Pi.ai-shaped DOM the content script decorates |
+| `support/mock-pi-voice-settings.html` | route-specific Pi native voice grid for `/profile/settings`, with light/dark host colors and a persistent native selection handler |
 | `support/mock-claude-page.html` | minimal claude.ai stand-in (defines no `--black`) for the host-CSS contrast spec |
 | `support/mock-hey-pi-page.html` | Pi's logged-out marketing splash stand-in — an ordinary form field, no composer — for the chat-adjacent dictation spec (#559) |
 | `support/transcribe-response.ts` | the STT contract: shape of the `/transcribe` response |
@@ -203,6 +204,16 @@ instead of silently calling the real internet.
 | `support/lifecycle.ts` | MV3 lifecycle drivers (`evictServiceWorker`, `reacquireServiceWorker`, `isWorkerDead`, `triggerOffscreenShutdown`, `hasOffscreenDocument`, `getConnectedTabCount`) — see the section below |
 | `support/lifecycle-targets.ts` | pure CDP-target predicates (`isExtensionServiceWorkerTarget`, `pickExtensionServiceWorkerTarget`); unit-tested in the **required** gate (`test/e2e/lifecycle-targets.spec.ts`) |
 | `specs/*.e2e.ts` | the tests |
+
+`specs/pi-voice-settings.e2e.ts` exercises the actual content script on Pi's
+mock settings route: a stored SayPi voice appears in a readable notice in both
+themes, Change voice opens the candidate catalog without changing the stored
+choice, and a native Pi card both runs Pi's own selection handler and clears the
+SayPi override in real `chrome.storage.local`. It also covers a native id arriving
+through a storage change, without treating it as a SayPi override, and returning
+to Pi from an unresolved saved voice. The test
+attaches light/dark screenshots; it measures contrast from the built extension
+CSS and representative host-theme utilities rather than keeping pixel baselines.
 
 ## The dual-env gotcha (read this before editing launch/build config)
 

--- a/e2e/specs/pi-voice-settings.e2e.ts
+++ b/e2e/specs/pi-voice-settings.e2e.ts
@@ -1,0 +1,150 @@
+import { test, expect } from "../fixtures/extension";
+import { MOCK_VOICE_IDS } from "../support/voice-catalog";
+
+/**
+ * The real content script on the hermetic Pi settings route: stored voice →
+ * readable notice → catalog action / native selection → real storage write.
+ * Pi's native card handler owns its selection separately in localStorage.
+ * No extension modules or DOM hooks are injected by this test.
+ */
+test.describe("Pi voice settings return path", () => {
+  for (const theme of ["light", "dark"] as const) {
+    test(`shows the current voice and returns to Pi in ${theme} mode`, async ({
+      context, serviceWorker, extensionId,
+    }, testInfo) => {
+      await serviceWorker.evaluate(async (ids) => {
+        await chrome.storage.local.set({
+          prefs_migration_completed: true,
+          shareData: false,
+          saypi_voice_default_pending_hosts: [],
+          voicePreferences: { pi: ids.onyx, claude: ids.alloy },
+        });
+      }, MOCK_VOICE_IDS);
+
+      const page = await context.newPage();
+      const errors: string[] = [];
+      page.on("pageerror", (error) => errors.push(error.message));
+      await page.goto(`https://pi.ai/profile/settings?theme=${theme}`);
+      const notice = page.locator(".saypi-voice-override-notice");
+      await expect(notice).toContainText("Onyx", { timeout: 20_000 });
+      await expect(notice).toContainText("Choose a Pi voice below to switch back.");
+      const change = notice.getByRole("button", { name: "Change voice" });
+      await expect(change).toBeVisible();
+
+      // Read actual computed styles from the extension's built CSS plus Pi's
+      // host-theme utility. A missing foreground on dark Pi used to be black.
+      const contrast = await notice.evaluate((element) => {
+        const color = getComputedStyle(element).color;
+        const background = getComputedStyle(document.body).backgroundColor;
+        const luminance = (css: string) => {
+          const rgb = css.match(/[\d.]+/g)!.slice(0, 3).map(Number);
+          const linear = rgb.map((value) => {
+            const s = value / 255;
+            return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+          });
+          return linear[0] * 0.2126 + linear[1] * 0.7152 + linear[2] * 0.0722;
+        };
+        const foregroundL = luminance(color);
+        const backgroundL = luminance(background);
+        return {
+          background,
+          ratio: (Math.max(foregroundL, backgroundL) + 0.05) /
+            (Math.min(foregroundL, backgroundL) + 0.05),
+          opacity: getComputedStyle(element).opacity,
+          actionColor: getComputedStyle(element.querySelector("button")!).color,
+          color,
+        };
+      });
+      expect(contrast.background).toBe(theme === "dark" ? "rgb(18, 18, 18)" : "rgb(245, 243, 236)");
+      expect(contrast.ratio).toBeGreaterThanOrEqual(4.5);
+      expect(contrast.opacity).toBe("1");
+      expect(contrast.actionColor).toBe(contrast.color);
+      const screenshotPath = testInfo.outputPath(`pi-voice-settings-${theme}.png`);
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+      await testInfo.attach(`Pi voice settings — ${theme}`, {
+        path: screenshotPath,
+        contentType: "image/png",
+      });
+
+      // Exercise the real content → background navigation action. Inspect only
+      // the new candidate tab's URL; this spec stays on the mock Pi host page.
+      const catalogOpened = context.waitForEvent("page");
+      await change.click();
+      const catalog = await catalogOpened;
+      await catalog.waitForURL(`chrome-extension://${extensionId}/settings.html`);
+      await expect.poll(() => serviceWorker.evaluate(async () =>
+        (await chrome.storage.local.get("voicePreferences")).voicePreferences,
+      )).toEqual({ pi: MOCK_VOICE_IDS.onyx, claude: MOCK_VOICE_IDS.alloy });
+      await catalog.close();
+
+      const native = page.getByRole("button", { name: "Pi 2", exact: true });
+      await native.click();
+      await expect(native).toHaveAttribute("aria-pressed", "true");
+      await expect.poll(() => page.evaluate(() => localStorage.getItem("mock-pi-native-voice"))).toBe("voice2");
+      await expect.poll(() => serviceWorker.evaluate(async () =>
+        (await chrome.storage.local.get("voicePreferences")).voicePreferences,
+      )).toEqual({ claude: MOCK_VOICE_IDS.alloy });
+      await expect(notice).toHaveCount(0);
+
+      // Returning to the page must retain Pi's native choice, with no automatic
+      // restoration of SayPi's override and the catalog door still available.
+      await page.reload();
+      await expect(page.locator("#saypi-voice-settings .saypi-more-voices")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Pi 2", exact: true })).toHaveAttribute("aria-pressed", "true");
+      await expect(notice).toHaveCount(0);
+      expect(errors).toEqual([]);
+    });
+  }
+
+  test("a stored native Pi voice is not presented as a SayPi override", async ({ context, serviceWorker }) => {
+    await serviceWorker.evaluate(() => chrome.storage.local.set({
+      prefs_migration_completed: true,
+      shareData: false,
+      saypi_voice_default_pending_hosts: [],
+      voicePreferences: { pi: "voice4" },
+    }));
+    const page = await context.newPage();
+    await page.goto("https://pi.ai/profile/settings?theme=dark");
+    await expect(page.locator("#saypi-voice-settings .saypi-more-voices")).toBeVisible({ timeout: 20_000 });
+    // First observe an actual resolved remote voice, then replace it with the
+    // native id through real storage. Waiting for the notice to disappear now
+    // proves the provider classification ran; merely checking its absence
+    // immediately after the door paints could beat the initial storage read.
+    const notice = page.locator(".saypi-voice-override-notice");
+    await serviceWorker.evaluate((id) => chrome.storage.local.set({ voicePreferences: { pi: id } }), MOCK_VOICE_IDS.onyx);
+    await expect(notice).toContainText("Onyx");
+    await serviceWorker.evaluate(() => chrome.storage.local.set({ voicePreferences: { pi: "voice4" } }));
+    await expect(notice).toHaveCount(0);
+    // The native return is a write through the live content-script preference
+    // module even when an older native id is stored (no remote override).
+    await page.getByRole("button", { name: "Pi 3", exact: true }).click();
+    await expect.poll(() => serviceWorker.evaluate(async () =>
+      (await chrome.storage.local.get("voicePreferences")).voicePreferences,
+    )).toEqual({});
+    await expect(notice).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Pi 3", exact: true })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("an unresolved saved voice stays visible and can be relinquished", async ({ context, serviceWorker }) => {
+    await serviceWorker.evaluate(() => chrome.storage.local.set({
+      prefs_migration_completed: true,
+      shareData: false,
+      saypi_voice_default_pending_hosts: [],
+      voicePreferences: { pi: "e2e-unavailable" },
+    }));
+    const page = await context.newPage();
+    await page.goto("https://pi.ai/profile/settings?theme=dark");
+    const notice = page.locator(".saypi-voice-override-notice");
+    await expect(notice).toContainText("Your saved voice is unavailable right now.", { timeout: 20_000 });
+    await expect(notice).not.toContainText("is speaking");
+    await expect(notice.getByRole("button", { name: "Change voice" })).toBeVisible();
+    await expect.poll(() => serviceWorker.evaluate(async () =>
+      (await chrome.storage.local.get("voicePreferences")).voicePreferences,
+    )).toEqual({ pi: "e2e-unavailable" });
+    await page.getByRole("button", { name: "Pi 2", exact: true }).click();
+    await expect.poll(() => serviceWorker.evaluate(async () =>
+      (await chrome.storage.local.get("voicePreferences")).voicePreferences,
+    )).toEqual({});
+    await expect(notice).toHaveCount(0);
+  });
+});

--- a/e2e/specs/pi-voice-settings.e2e.ts
+++ b/e2e/specs/pi-voice-settings.e2e.ts
@@ -1,5 +1,18 @@
 import { test, expect } from "../fixtures/extension";
 import { MOCK_VOICE_IDS } from "../support/voice-catalog";
+import type { Worker } from "@playwright/test";
+
+async function seedSignedInUser(serviceWorker: Worker): Promise<void> {
+  await serviceWorker.evaluate(async () => {
+    const expiresAt = Date.now() + 60 * 60 * 1000;
+    // Unsigned test data for the hermetic API, never a real account credential.
+    const claims = btoa(JSON.stringify({ sub: "e2e-pi-user", exp: expiresAt / 1000 }));
+    await chrome.storage.local.set({
+      jwtToken: `e30.${claims}.hermetic`,
+      tokenExpiresAt: expiresAt,
+    });
+  });
+}
 
 /**
  * The real content script on the hermetic Pi settings route: stored voice →
@@ -12,6 +25,7 @@ test.describe("Pi voice settings return path", () => {
     test(`shows the current voice and returns to Pi in ${theme} mode`, async ({
       context, serviceWorker, extensionId,
     }, testInfo) => {
+      await seedSignedInUser(serviceWorker);
       await serviceWorker.evaluate(async (ids) => {
         await chrome.storage.local.set({
           prefs_migration_completed: true,
@@ -97,6 +111,7 @@ test.describe("Pi voice settings return path", () => {
   }
 
   test("a stored native Pi voice is not presented as a SayPi override", async ({ context, serviceWorker }) => {
+    await seedSignedInUser(serviceWorker);
     await serviceWorker.evaluate(() => chrome.storage.local.set({
       prefs_migration_completed: true,
       shareData: false,
@@ -125,35 +140,40 @@ test.describe("Pi voice settings return path", () => {
     await expect(page.getByRole("button", { name: "Pi 3", exact: true })).toHaveAttribute("aria-pressed", "true");
   });
 
-  test("a signed-out saved voice offers sign-in and can be relinquished", async ({ context, serviceWorker, extensionId }) => {
-    await serviceWorker.evaluate(() => chrome.storage.local.set({
-      prefs_migration_completed: true,
-      shareData: false,
-      saypi_voice_default_pending_hosts: [],
-      voicePreferences: { pi: "e2e-unavailable" },
-    }));
-    const page = await context.newPage();
-    await page.goto("https://pi.ai/profile/settings?theme=dark");
-    const notice = page.locator(".saypi-voice-override-notice");
-    await expect(notice).toContainText("Sign in for text-to-speech", { timeout: 20_000 });
-    await expect(notice).not.toContainText("unavailable right now");
-    await expect(notice).not.toContainText("is speaking");
-    const signIn = notice.getByRole("button", { name: "Sign In", exact: true });
-    await expect(signIn).toBeVisible();
-    const settingsOpened = context.waitForEvent("page");
-    await signIn.click();
-    const settings = await settingsOpened;
-    await settings.waitForURL(`chrome-extension://${extensionId}/settings.html`);
-    await expect.poll(() => serviceWorker.evaluate(async () =>
-      (await chrome.storage.local.get("voicePreferences")).voicePreferences,
-    )).toEqual({ pi: "e2e-unavailable" });
-    await settings.close();
-    await page.getByRole("button", { name: "Pi 2", exact: true }).click();
-    await expect.poll(() => serviceWorker.evaluate(async () =>
-      (await chrome.storage.local.get("voicePreferences")).voicePreferences,
-    )).toEqual({});
-    await expect(notice).toHaveCount(0);
-  });
+  for (const [state, voiceId] of [
+    ["unresolved", "e2e-unavailable"],
+    ["resolved", MOCK_VOICE_IDS.onyx],
+  ] as const) {
+    test(`a signed-out ${state} saved voice offers sign-in and can be relinquished`, async ({ context, serviceWorker, extensionId }) => {
+      await serviceWorker.evaluate((id) => chrome.storage.local.set({
+        prefs_migration_completed: true,
+        shareData: false,
+        saypi_voice_default_pending_hosts: [],
+        voicePreferences: { pi: id },
+      }), voiceId);
+      const page = await context.newPage();
+      await page.goto("https://pi.ai/profile/settings?theme=dark");
+      const notice = page.locator(".saypi-voice-override-notice");
+      await expect(notice).toContainText("Sign in for text-to-speech", { timeout: 20_000 });
+      await expect(notice).not.toContainText("unavailable right now");
+      await expect(notice).not.toContainText("is speaking");
+      const signIn = notice.getByRole("button", { name: "Sign In", exact: true });
+      await expect(signIn).toBeVisible();
+      const settingsOpened = context.waitForEvent("page");
+      await signIn.click();
+      const settings = await settingsOpened;
+      await settings.waitForURL(`chrome-extension://${extensionId}/settings.html`);
+      await expect.poll(() => serviceWorker.evaluate(async () =>
+        (await chrome.storage.local.get("voicePreferences")).voicePreferences,
+      )).toEqual({ pi: voiceId });
+      await settings.close();
+      await page.getByRole("button", { name: "Pi 2", exact: true }).click();
+      await expect.poll(() => serviceWorker.evaluate(async () =>
+        (await chrome.storage.local.get("voicePreferences")).voicePreferences,
+      )).toEqual({});
+      await expect(notice).toHaveCount(0);
+    });
+  }
 
   test("an explicit native pick seals a pending first-install default even without an override", async ({ context, serviceWorker }) => {
     await serviceWorker.evaluate(() => chrome.storage.local.set({

--- a/e2e/specs/pi-voice-settings.e2e.ts
+++ b/e2e/specs/pi-voice-settings.e2e.ts
@@ -125,7 +125,7 @@ test.describe("Pi voice settings return path", () => {
     await expect(page.getByRole("button", { name: "Pi 3", exact: true })).toHaveAttribute("aria-pressed", "true");
   });
 
-  test("an unresolved saved voice stays visible and can be relinquished", async ({ context, serviceWorker }) => {
+  test("a signed-out saved voice offers sign-in and can be relinquished", async ({ context, serviceWorker, extensionId }) => {
     await serviceWorker.evaluate(() => chrome.storage.local.set({
       prefs_migration_completed: true,
       shareData: false,
@@ -135,16 +135,51 @@ test.describe("Pi voice settings return path", () => {
     const page = await context.newPage();
     await page.goto("https://pi.ai/profile/settings?theme=dark");
     const notice = page.locator(".saypi-voice-override-notice");
-    await expect(notice).toContainText("Your saved voice is unavailable right now.", { timeout: 20_000 });
+    await expect(notice).toContainText("Sign in for text-to-speech", { timeout: 20_000 });
+    await expect(notice).not.toContainText("unavailable right now");
     await expect(notice).not.toContainText("is speaking");
-    await expect(notice.getByRole("button", { name: "Change voice" })).toBeVisible();
+    const signIn = notice.getByRole("button", { name: "Sign In", exact: true });
+    await expect(signIn).toBeVisible();
+    const settingsOpened = context.waitForEvent("page");
+    await signIn.click();
+    const settings = await settingsOpened;
+    await settings.waitForURL(`chrome-extension://${extensionId}/settings.html`);
     await expect.poll(() => serviceWorker.evaluate(async () =>
       (await chrome.storage.local.get("voicePreferences")).voicePreferences,
     )).toEqual({ pi: "e2e-unavailable" });
+    await settings.close();
     await page.getByRole("button", { name: "Pi 2", exact: true }).click();
     await expect.poll(() => serviceWorker.evaluate(async () =>
       (await chrome.storage.local.get("voicePreferences")).voicePreferences,
     )).toEqual({});
     await expect(notice).toHaveCount(0);
+  });
+
+  test("an explicit native pick seals a pending first-install default even without an override", async ({ context, serviceWorker }) => {
+    await serviceWorker.evaluate(() => chrome.storage.local.set({
+      prefs_migration_completed: true,
+      shareData: false,
+      saypi_voice_default_pending_hosts: ["pi", "claude"],
+      voicePreferences: {},
+    }));
+    const page = await context.newPage();
+    await page.goto("https://pi.ai/profile/settings");
+    await expect(page.locator("#saypi-voice-settings .saypi-more-voices")).toBeVisible({ timeout: 20_000 });
+    // Viewing settings does not opt the user out. Choosing a native card does.
+    await expect.poll(() => serviceWorker.evaluate(async () =>
+      (await chrome.storage.local.get("saypi_voice_default_pending_hosts")).saypi_voice_default_pending_hosts.sort(),
+    )).toEqual(["claude", "pi"]);
+    await page.getByRole("button", { name: "Pi 2", exact: true }).click();
+    await expect.poll(() => serviceWorker.evaluate(async () =>
+      (await chrome.storage.local.get("saypi_voice_default_pending_hosts")).saypi_voice_default_pending_hosts,
+    )).toEqual(["claude"]);
+    await expect(page.getByRole("button", { name: "Pi 2", exact: true })).toHaveAttribute("aria-pressed", "true");
+    await page.reload();
+    await expect(page.locator("#saypi-voice-settings .saypi-more-voices")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Pi 2", exact: true })).toHaveAttribute("aria-pressed", "true");
+    await expect.poll(() => serviceWorker.evaluate(async () => chrome.storage.local.get([
+      "voicePreferences", "saypi_voice_default_pending_hosts",
+    ]))).toEqual({ voicePreferences: {}, saypi_voice_default_pending_hosts: ["claude"] });
+    await expect(page.locator(".saypi-voice-override-notice")).toHaveCount(0);
   });
 });

--- a/e2e/support/mock-pi-voice-settings.html
+++ b/e2e/support/mock-pi-voice-settings.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Pi voice settings mock</title>
+    <style>
+      /* Native grid shape/classes mirror the recorded Pi settings fixture.
+         The theme utilities are representative host colors, not SayPi CSS.
+         Deliberately leave body text black in dark mode: Pi's grid does not
+         supply a foreground, so injected copy must choose the host utility. */
+      body { margin: 0; background: #f5f3ec; color: #000; font: 16px Arial, sans-serif; }
+      html[data-pi-theme="dark"] body { background: #121212; }
+      .text-text-secondary { color: #514d43; }
+      html[data-pi-theme="dark"] .text-text-secondary { color: #c1bfb5; }
+      .mx-auto { margin: 0 auto; }
+      .max-w-2xl { max-width: 672px; }
+      .px-6 { padding: 24px; }
+      .grid { display: grid; grid-template-columns: 1fr 1fr; }
+      .gap-4 { gap: 16px; }
+      button.native-voice { min-height: 56px; border: 1px solid #777; border-radius: 10px; padding: 0 24px; text-align: left; background: transparent; font: inherit; cursor: pointer; }
+      button.native-voice[aria-pressed="true"] { background: #e0dccf; }
+      html[data-pi-theme="dark"] button.native-voice[aria-pressed="true"] { background: #383630; }
+    </style>
+  </head>
+  <body>
+    <main id="__next"><div id="mock-mount"></div></main>
+    <script>
+      // Pi owns its theme independently of SayPi's body classes. Keeping this
+      // on a host attribute prevents SayPi's default theme initialization from
+      // silently turning the dark test into a second light test.
+      document.documentElement.dataset.piTheme = new URLSearchParams(location.search).get("theme") || "light";
+      window.addEventListener("load", function () {
+        setTimeout(function () {
+          var column = document.createElement("div");
+          column.className = "mx-auto w-full max-w-2xl px-6";
+          var heading = document.createElement("h1");
+          heading.className = "text-text-secondary";
+          heading.textContent = "Voice settings";
+          var grid = document.createElement("div");
+          grid.className = "grid grid-cols-1 gap-4 sm:grid-cols-2";
+          var selected = localStorage.getItem("mock-pi-native-voice") || "voice4";
+          for (var i = 1; i <= 8; i++) {
+            var card = document.createElement("button");
+            card.type = "button";
+            card.className = "native-voice inline-flex items-center whitespace-nowrap transition-colors h-[56px] w-full min-w-0 max-w-[22.0625rem] rounded-[10px] border border-divider-stroke px-[24px] py-0 bg-secondary-default text-text-secondary";
+            card.dataset.nativeVoice = "voice" + i;
+            card.setAttribute("aria-pressed", String(card.dataset.nativeVoice === selected));
+            var label = document.createElement("span");
+            label.className = "text-action-m relative min-w-0 flex-1 truncate text-left";
+            label.textContent = "Pi " + i;
+            card.appendChild(label);
+            card.addEventListener("click", function () {
+              localStorage.setItem("mock-pi-native-voice", this.dataset.nativeVoice);
+              grid.querySelectorAll("[data-native-voice]").forEach(function (button) {
+                button.setAttribute("aria-pressed", String(button.dataset.nativeVoice === localStorage.getItem("mock-pi-native-voice")));
+              });
+            });
+            grid.appendChild(card);
+          }
+          column.append(heading, grid);
+          document.getElementById("mock-mount").appendChild(column);
+        }, 300);
+      });
+    </script>
+  </body>
+</html>

--- a/e2e/support/mock-servers.ts
+++ b/e2e/support/mock-servers.ts
@@ -13,6 +13,7 @@ import {
 const pems = await selfsigned.generate([{ name: "commonName", value: "saypi-e2e" }], { days: 1 });
 const tls = { key: pems.private, cert: pems.cert };
 const PI_PAGE = readFileSync(resolve(import.meta.dirname, "mock-pi-page.html"), "utf8");
+const PI_VOICE_SETTINGS_PAGE = readFileSync(resolve(import.meta.dirname, "mock-pi-voice-settings.html"), "utf8");
 const CLAUDE_PAGE = readFileSync(resolve(import.meta.dirname, "mock-claude-page.html"), "utf8");
 const HEY_PI_PAGE = readFileSync(resolve(import.meta.dirname, "mock-hey-pi-page.html"), "utf8");
 
@@ -70,7 +71,9 @@ export async function startMockServers(): Promise<MockServers> {
       ? HEY_PI_PAGE
       : host.includes("claude.ai")
         ? CLAUDE_PAGE
-        : PI_PAGE;
+        : new URL(req.url ?? "/", "https://pi.ai").pathname === "/profile/settings"
+          ? PI_VOICE_SETTINGS_PAGE
+          : PI_PAGE;
     res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     res.end(page);
   });

--- a/src/chatbots/PiVoiceSettings.ts
+++ b/src/chatbots/PiVoiceSettings.ts
@@ -189,14 +189,20 @@ export class PiVoiceSettings extends VoiceSelector {
       existing?.remove();
       return;
     }
-    const text = this.savedVoiceUnavailable
-      ? getMessage("voicesSavedUnavailable")
-      : getMessage("voiceOverriddenBySayPi", [this.overridingVoice!.name]);
+    const requiresSignIn = this.ttsRequiresSignIn(this.savedVoiceUnavailable);
+    const text = requiresSignIn
+      ? getMessage("signInForTTS")
+      : this.savedVoiceUnavailable
+        ? getMessage("voicesSavedUnavailable")
+        : getMessage("voiceOverriddenBySayPi", [this.overridingVoice!.name]);
+    const actionText = getMessage(requiresSignIn ? "signIn" : "voicesChangeVoice");
     if (existing) {
       // No data-i18n anywhere on it: the text is substituted, and replaceI18n
       // would erase the voice name on the next settings paint.
       const copy = existing.querySelector(".saypi-voice-override-copy");
       if (copy && copy.textContent !== text) copy.textContent = text;
+      const action = existing.querySelector(".saypi-change-voice");
+      if (action && action.textContent !== actionText) action.textContent = actionText;
       return;
     }
     const notice = document.createElement("div");
@@ -210,7 +216,7 @@ export class PiVoiceSettings extends VoiceSelector {
     const change = document.createElement("button");
     change.type = "button";
     change.className = "saypi-change-voice";
-    change.textContent = getMessage("voicesChangeVoice");
+    change.textContent = actionText;
     change.addEventListener("click", () => openSettings("voices/pi"));
     notice.append(copy, change);
     grid.prepend(notice);
@@ -223,6 +229,8 @@ export class PiVoiceSettings extends VoiceSelector {
       // changes the audio provider back to Pi and releases the host mute.
       // Clear stored native ids too, so the converter cannot restore an older
       // Pi voice over the card the user just selected.
+      // Even with no stored override, this explicit native choice seals Pi's
+      // pending first-install default so signing in cannot replace it with Marin.
       await this.userPreferences.unsetVoice(this.chatbot);
       if (revision === this.selectionRevision) {
         await this.applySelectedVoice(null);

--- a/src/chatbots/PiVoiceSettings.ts
+++ b/src/chatbots/PiVoiceSettings.ts
@@ -73,31 +73,57 @@ export class PiVoiceSettings extends VoiceSelector {
    * The SayPi voice currently overriding Pi's own, as last rendered.
    *
    * A render cache, not the state of record — the stored preference is still
-   * the only source of truth, fetched by the base's `refreshMenu`. It exists
+   * the only source of truth, fetched by `refreshOverrideNotice`. It exists
    * because Pi's React drops our foreign children and the re-injection runs
    * from a MutationObserver callback, which is synchronous and has no chance to
    * re-read storage: without this, a healed notice would come back blank.
    */
   private overridingVoice: SpeechSynthesisVoiceRemote | null = null;
+  private savedVoiceUnavailable = false;
+  private selectionRevision = 0;
 
   getId(): string {
     return "saypi-voice-settings";
   }
 
-  // Also reached on auth changes via the base refreshMenu → re-ensure SayPi's
-  // marks on the grid, never draw inline voice rows (door-first).
+  // This surface renders only the current choice. Catalog and pin fetches from
+  // the base refresh are unnecessary here; auth and storage updates share the
+  // same guarded read as initial load.
+  override async refreshMenu(): Promise<void> {
+    await this.refreshOverrideNotice();
+  }
+
+  protected override async refreshSelectedVoice(): Promise<void> {
+    await this.refreshOverrideNotice();
+  }
+
+  // Fulfil the base selector's render contract without adding catalog rows.
   protected override renderMenu(
     _voices: SpeechSynthesisVoiceRemote[],
     storedVoice: SpeechSynthesisVoiceRemote | null
   ): void {
-    this.applySelectedVoice(storedVoice);
+    void this.applySelectedVoice(storedVoice);
   }
 
   // No per-row selection to reflect on a door-only surface — but the grid's
   // whole meaning changes when a SayPi voice takes over, so that much is.
-  protected override applySelectedVoice(
+  protected override async applySelectedVoice(
     voice: SpeechSynthesisVoiceRemote | null
-  ): void {
+  ): Promise<void> {
+    const revision = ++this.selectionRevision;
+    let unavailable = false;
+    if (!voice) {
+      try {
+        // An unresolved saved remote id still reserves SayPi playback. A null
+        // catalog result must not make this page claim that Pi is speaking.
+        unavailable = await this.userPreferences.hasVoice(this.chatbot);
+      } catch (error) {
+        console.debug("[SayPi] Could not read Pi's saved voice preference", error);
+        return;
+      }
+      if (revision !== this.selectionRevision) return;
+    }
+    this.savedVoiceUnavailable = unavailable;
     // A persisted Pi voice is a native choice too. Use the same provider
     // resolution as playback, rather than treating every stored object as an
     // override (or mistaking `default`, which is catalog metadata, for one).
@@ -115,9 +141,11 @@ export class PiVoiceSettings extends VoiceSelector {
    * can't say what's speaking should still show its door.
    */
   private async refreshOverrideNotice(): Promise<void> {
+    const revision = ++this.selectionRevision;
     try {
       const voice = await this.userPreferences.getVoice(this.chatbot);
-      this.applySelectedVoice(voice ?? null);
+      if (revision !== this.selectionRevision) return;
+      await this.applySelectedVoice(voice ?? null);
     } catch (error) {
       console.debug("[SayPi] Could not read the voice in use for Pi", error);
     }
@@ -157,13 +185,13 @@ export class PiVoiceSettings extends VoiceSelector {
     const existing = grid.querySelector<HTMLElement>(
       ".saypi-voice-override-notice"
     );
-    if (!this.overridingVoice) {
+    if (!this.overridingVoice && !this.savedVoiceUnavailable) {
       existing?.remove();
       return;
     }
-    const text = getMessage("voiceOverriddenBySayPi", [
-      this.overridingVoice.name,
-    ]);
+    const text = this.savedVoiceUnavailable
+      ? getMessage("voicesSavedUnavailable")
+      : getMessage("voiceOverriddenBySayPi", [this.overridingVoice!.name]);
     if (existing) {
       // No data-i18n anywhere on it: the text is substituted, and replaceI18n
       // would erase the voice name on the next settings paint.
@@ -189,13 +217,16 @@ export class PiVoiceSettings extends VoiceSelector {
   }
 
   private async useNativeVoice(): Promise<void> {
+    const revision = ++this.selectionRevision;
     try {
       // Pi owns which native card was chosen. Clearing our preference also
       // changes the audio provider back to Pi and releases the host mute.
       // Clear stored native ids too, so the converter cannot restore an older
       // Pi voice over the card the user just selected.
       await this.userPreferences.unsetVoice(this.chatbot);
-      this.applySelectedVoice(null);
+      if (revision === this.selectionRevision) {
+        await this.applySelectedVoice(null);
+      }
     } catch (error) {
       // Keep the notice honest if storage fails: SayPi is still the provider.
       console.debug("[SayPi] Could not return to Pi's own voice", error);

--- a/src/chatbots/PiVoiceSettings.ts
+++ b/src/chatbots/PiVoiceSettings.ts
@@ -1,7 +1,7 @@
 import getMessage from "../i18n";
 import { openSettings } from "../popup/popupopener";
 import { VoiceSelector } from "../tts/VoiceMenu";
-import { SpeechSynthesisVoiceRemote } from "../tts/SpeechModel";
+import { audioProviders, SpeechSynthesisVoiceRemote } from "../tts/SpeechModel";
 import { Chatbot } from "./Chatbot";
 import { UserPreferenceModule } from "../prefs/PreferenceModule";
 
@@ -90,8 +90,7 @@ export class PiVoiceSettings extends VoiceSelector {
     _voices: SpeechSynthesisVoiceRemote[],
     storedVoice: SpeechSynthesisVoiceRemote | null
   ): void {
-    this.overridingVoice = storedVoice;
-    this.ensureSettingsDoor();
+    this.applySelectedVoice(storedVoice);
   }
 
   // No per-row selection to reflect on a door-only surface — but the grid's
@@ -99,7 +98,13 @@ export class PiVoiceSettings extends VoiceSelector {
   protected override applySelectedVoice(
     voice: SpeechSynthesisVoiceRemote | null
   ): void {
-    this.overridingVoice = voice;
+    // A persisted Pi voice is a native choice too. Use the same provider
+    // resolution as playback, rather than treating every stored object as an
+    // override (or mistaking `default`, which is catalog metadata, for one).
+    this.overridingVoice = voice &&
+      audioProviders.retreiveProviderByVoice(voice) === audioProviders.SayPi
+      ? voice
+      : null;
     this.ensureSettingsDoor();
   }
 
@@ -144,9 +149,8 @@ export class PiVoiceSettings extends VoiceSelector {
    * watches, so a React re-render would drop it for good, while a child heals
    * on the same mutation that heals the door.
    *
-   * Pi's own highlighted card is left highlighted: it is a real preference, and
-   * it IS what would speak if the SayPi voice were switched off. It just stops
-   * looking like the answer to "what do I sound like right now".
+   * Pi's own highlighted card remains a real preference. Keep every native
+   * card enabled and normally styled: choosing one now returns playback to Pi.
    */
   private ensureOverrideNotice(): void {
     const grid = this.element;
@@ -155,23 +159,47 @@ export class PiVoiceSettings extends VoiceSelector {
     );
     if (!this.overridingVoice) {
       existing?.remove();
-      grid.classList.remove("saypi-voices-overridden");
       return;
     }
-    grid.classList.add("saypi-voices-overridden");
     const text = getMessage("voiceOverriddenBySayPi", [
       this.overridingVoice.name,
     ]);
     if (existing) {
       // No data-i18n anywhere on it: the text is substituted, and replaceI18n
       // would erase the voice name on the next settings paint.
-      if (existing.textContent !== text) existing.textContent = text;
+      const copy = existing.querySelector(".saypi-voice-override-copy");
+      if (copy && copy.textContent !== text) copy.textContent = text;
       return;
     }
-    const notice = document.createElement("p");
-    notice.className = "saypi-voice-override-notice";
-    notice.textContent = text;
+    const notice = document.createElement("div");
+    // Pi compiles this theme-aware utility on the native voice cards. The
+    // grid itself has no foreground color, so inheriting it yields black
+    // text even in Pi's dark theme.
+    notice.className = "saypi-voice-override-notice text-text-secondary";
+    const copy = document.createElement("span");
+    copy.className = "saypi-voice-override-copy";
+    copy.textContent = text;
+    const change = document.createElement("button");
+    change.type = "button";
+    change.className = "saypi-change-voice";
+    change.textContent = getMessage("voicesChangeVoice");
+    change.addEventListener("click", () => openSettings("voices/pi"));
+    notice.append(copy, change);
     grid.prepend(notice);
+  }
+
+  private async useNativeVoice(): Promise<void> {
+    try {
+      // Pi owns which native card was chosen. Clearing our preference also
+      // changes the audio provider back to Pi and releases the host mute.
+      // Clear stored native ids too, so the converter cannot restore an older
+      // Pi voice over the card the user just selected.
+      await this.userPreferences.unsetVoice(this.chatbot);
+      this.applySelectedVoice(null);
+    } catch (error) {
+      // Keep the notice honest if storage fails: SayPi is still the provider.
+      console.debug("[SayPi] Could not return to Pi's own voice", error);
+    }
   }
 
   /**
@@ -180,6 +208,17 @@ export class PiVoiceSettings extends VoiceSelector {
    * the door's own append never loops.
    */
   private observeSettingsGrid(): void {
+    this.element.addEventListener("click", (event) => {
+      const card = event.target instanceof Element
+        ? event.target.closest("button")
+        : null;
+      // Delegation survives native card replacement. Only direct-child native
+      // cards release the override; both SayPi navigation buttons keep it.
+      if (card?.parentElement === this.element &&
+          !card.classList.contains("saypi-more-voices") && !card.disabled) {
+        void this.useNativeVoice();
+      }
+    }, { capture: true }); // classify before Pi's handler can replace the card
     const observer = new MutationObserver(() => this.ensureSettingsDoor());
     observer.observe(this.element, { childList: true });
   }

--- a/src/chatbots/PiVoiceSettings.ts
+++ b/src/chatbots/PiVoiceSettings.ts
@@ -114,8 +114,8 @@ export class PiVoiceSettings extends VoiceSelector {
     let unavailable = false;
     if (!voice) {
       try {
-        // An unresolved saved remote id still reserves SayPi playback. A null
-        // catalog result must not make this page claim that Pi is speaking.
+        // Keep the saved choice visible even when its metadata cannot resolve.
+        // Authentication decides whether to offer sign-in or recovery later.
         unavailable = await this.userPreferences.hasVoice(this.chatbot);
       } catch (error) {
         console.debug("[SayPi] Could not read Pi's saved voice preference", error);
@@ -189,7 +189,9 @@ export class PiVoiceSettings extends VoiceSelector {
       existing?.remove();
       return;
     }
-    const requiresSignIn = this.ttsRequiresSignIn(this.savedVoiceUnavailable);
+    // Cached remote metadata can still resolve after sign-out, but SayPi TTS
+    // still requires authentication. The notice must reflect that requirement.
+    const requiresSignIn = this.ttsRequiresSignIn(true);
     const text = requiresSignIn
       ? getMessage("signInForTTS")
       : this.savedVoiceUnavailable

--- a/src/styles/voices.scss
+++ b/src/styles/voices.scss
@@ -36,13 +36,25 @@ button.saypi-more-voices {
   grid-column: 1 / -1;
   margin: 0 0 0.25rem;
   font-size: 0.9em;
-  opacity: 0.75;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem 1rem;
 }
-// The glance-level half of the same statement: the host's highlighted card
-// stops claiming to be the voice you hear. Dimmed, never disabled — it is
-// still a real preference, and still what would speak with SayPi's voice off.
-.saypi-voices-overridden > button:not(.saypi-more-voices) {
-  opacity: 0.5;
+button.saypi-change-voice {
+  background: transparent;
+  border: 0;
+  padding: 0.25rem 0;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  cursor: pointer;
+}
+button.saypi-change-voice:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
 }
 // ▶ free-sample preview affordance in the in-page voice menus (design §4).
 // A target of its own, separate from selecting the row. Fully SayPi-styled so

--- a/src/tts/VoiceMenu.ts
+++ b/src/tts/VoiceMenu.ts
@@ -157,11 +157,15 @@ export abstract class VoiceSelector {
         }
         // Re-read through the preference module (its cache is already
         // updated) so we apply a resolved voice object, not a bare id.
-        this.userPreferences.getVoice(this.chatbot).then((voice) => {
-          this.applySelectedVoice(voice ?? null);
-        });
+        void this.refreshSelectedVoice();
       }
     );
+  }
+
+  /** Resolve an external selection; surfaces can guard asynchronous reads. */
+  protected async refreshSelectedVoice(): Promise<void> {
+    const voice = await this.userPreferences.getVoice(this.chatbot);
+    this.applySelectedVoice(voice ?? null);
   }
 
   /**

--- a/src/tts/VoiceMenu.ts
+++ b/src/tts/VoiceMenu.ts
@@ -80,10 +80,11 @@ export abstract class VoiceSelector {
   /**
    * Reflect an externally-changed stored voice on this surface without a
    * repopulate (and therefore without disturbing an open menu).
+   * Async renderers return their completion so the refresh can await it.
    */
   protected abstract applySelectedVoice(
     voice: SpeechSynthesisVoiceRemote | null
-  ): void;
+  ): void | Promise<void>;
 
   /**
    * Gather-then-render: fetch the catalog and the stored voice TOGETHER, then
@@ -165,7 +166,7 @@ export abstract class VoiceSelector {
   /** Resolve an external selection; surfaces can guard asynchronous reads. */
   protected async refreshSelectedVoice(): Promise<void> {
     const voice = await this.userPreferences.getVoice(this.chatbot);
-    this.applySelectedVoice(voice ?? null);
+    await this.applySelectedVoice(voice ?? null);
   }
 
   /**

--- a/test/chatbots/PiVoiceSettings-more-voices-door.spec.ts
+++ b/test/chatbots/PiVoiceSettings-more-voices-door.spec.ts
@@ -366,6 +366,26 @@ describe("PiVoiceSettings — what's actually speaking", () => {
     expect(grid.querySelectorAll(".saypi-voice-override-notice")).toHaveLength(1);
   });
 
+  it("offers sign-in when cached remote details remain available after signing out", async () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.userPreferences.getVoice.mockResolvedValue(voice("Shimmer"));
+    await settings.refreshMenu();
+    expect(notice(grid)?.textContent).toContain("voiceOverriddenBySayPi:Shimmer");
+
+    fakeAuth.authenticated = false;
+    await settings.refreshMenu();
+    expect(notice(grid)?.textContent).toContain("signInForTTS");
+    expect(notice(grid)?.textContent).not.toContain("voiceOverriddenBySayPi");
+    expect(notice(grid)?.querySelector("button")?.textContent).toBe("signIn");
+    expect(settings.userPreferences.unsetVoice).not.toHaveBeenCalled();
+
+    fakeAuth.authenticated = true;
+    await settings.refreshMenu();
+    expect(notice(grid)?.textContent).toContain("voiceOverriddenBySayPi:Shimmer");
+    expect(notice(grid)?.querySelector("button")?.textContent).toBe("voicesChangeVoice");
+  });
+
   it.each(["initial", "external"])("ignores a late %s read after a native choice", async (source) => {
     const grid = buildSettingsGrid();
     const settings = makeSettings(grid);

--- a/test/chatbots/PiVoiceSettings-more-voices-door.spec.ts
+++ b/test/chatbots/PiVoiceSettings-more-voices-door.spec.ts
@@ -13,9 +13,10 @@ vi.mock("../../src/ConfigModule", () => ({
   },
 }));
 
+const fakeAuth = vi.hoisted(() => ({ authenticated: true }));
 vi.mock("../../src/JwtManager", () => ({
   getJwtManagerSync: () => ({
-    isAuthenticated: () => true,
+    isAuthenticated: () => fakeAuth.authenticated,
     getClaims: () => ({ ttsQuotaRemaining: 1000 }),
   }),
 }));
@@ -80,6 +81,7 @@ const door = (grid: HTMLElement) =>
   grid.querySelector<HTMLElement>("button.saypi-more-voices");
 
 beforeEach(() => {
+  fakeAuth.authenticated = true;
   openSettingsMock.mockReset();
   document.body.innerHTML = "";
   EventBus.removeAllListeners();
@@ -327,6 +329,41 @@ describe("PiVoiceSettings — what's actually speaking", () => {
     });
     grid.querySelector<HTMLButtonElement>(":scope > button")!.click();
     await vi.waitFor(() => expect(notice(grid)).toBeNull());
+  });
+
+  it("offers sign-in for an unresolved saved voice while signed out", async () => {
+    fakeAuth.authenticated = false;
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.userPreferences.hasVoice.mockResolvedValue(true);
+    await settings.applySelectedVoice(null);
+    expect(notice(grid)?.textContent).toContain("signInForTTS");
+    expect(notice(grid)?.textContent).not.toContain("voicesSavedUnavailable");
+    const signIn = notice(grid)?.querySelector<HTMLButtonElement>("button");
+    expect(signIn?.textContent).toBe("signIn");
+    signIn!.click();
+    expect(openSettingsMock).toHaveBeenCalledWith("voices/pi");
+    expect(settings.userPreferences.unsetVoice).not.toHaveBeenCalled();
+  });
+
+  it("updates the unresolved notice and action when authentication changes", async () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.userPreferences.hasVoice.mockResolvedValue(true);
+    await settings.refreshMenu();
+    expect(notice(grid)?.textContent).toContain("voicesSavedUnavailable");
+    expect(notice(grid)?.querySelector("button")?.textContent).toBe("voicesChangeVoice");
+
+    fakeAuth.authenticated = false;
+    await settings.refreshMenu();
+    expect(notice(grid)?.textContent).toContain("signInForTTS");
+    expect(notice(grid)?.querySelector("button")?.textContent).toBe("signIn");
+
+    fakeAuth.authenticated = true;
+    await settings.refreshMenu();
+    expect(notice(grid)?.textContent).toContain("voicesSavedUnavailable");
+    expect(notice(grid)?.querySelector("button")?.textContent).toBe("voicesChangeVoice");
+    expect(grid.querySelectorAll(".saypi-voice-override-notice")).toHaveLength(1);
   });
 
   it.each(["initial", "external"])("ignores a late %s read after a native choice", async (source) => {

--- a/test/chatbots/PiVoiceSettings-more-voices-door.spec.ts
+++ b/test/chatbots/PiVoiceSettings-more-voices-door.spec.ts
@@ -36,6 +36,7 @@ vi.mock("../../src/popup/popupopener", () => ({
 
 import { PiVoiceSettings } from "../../src/chatbots/PiVoiceSettings";
 import { PiAIVoice } from "../../src/tts/SpeechModel";
+import EventBus from "../../src/events/EventBus";
 
 /**
  * A faithful fixture of pi.ai's CURRENT Voice settings grid (captured live via
@@ -66,10 +67,12 @@ function makeSettings(grid: HTMLElement): any {
   settings.chatbot = { getID: () => "pi" };
   settings.userPreferences = {
     getVoice: vi.fn(async () => null),
+    hasVoice: vi.fn(async () => false),
     setVoice: vi.fn(async () => {}),
     unsetVoice: vi.fn(async () => {}),
   };
   settings.element = grid;
+  settings.selectionRevision = 0;
   return settings;
 }
 
@@ -79,6 +82,7 @@ const door = (grid: HTMLElement) =>
 beforeEach(() => {
   openSettingsMock.mockReset();
   document.body.innerHTML = "";
+  EventBus.removeAllListeners();
 });
 
 describe("PiVoiceSettings — 'More voices' door on Pi's Voice settings page (#491 follow-up, door-first)", () => {
@@ -133,10 +137,10 @@ describe("PiVoiceSettings — 'More voices' door on Pi's Voice settings page (#4
     expect(openSettingsMock).toHaveBeenCalledWith("voices/pi");
   });
 
-  it("renderMenu (the auth-change path) just re-ensures the door — never draws voice rows", () => {
+  it("refreshMenu (the auth-change path) re-ensures the door without fetching a catalog", async () => {
     const grid = buildSettingsGrid();
     const settings = makeSettings(grid);
-    settings.renderMenu([], null);
+    await settings.refreshMenu();
     expect(door(grid)).not.toBeNull();
     expect(grid.querySelectorAll(".saypi-custom-voice").length).toBe(0);
   });
@@ -209,10 +213,10 @@ describe("PiVoiceSettings — what's actually speaking", () => {
     expect(notice(grid)!.textContent).toContain("Shimmer");
   });
 
-  it("stays out of the way when Pi's own voice is the one speaking", () => {
+  it("stays out of the way when Pi's own voice is the one speaking", async () => {
     const grid = buildSettingsGrid();
     const settings = makeSettings(grid);
-    settings.renderMenu([], null);
+    await settings.applySelectedVoice(null);
     expect(notice(grid)).toBeNull();
     // The door is SayPi's only mark on an un-overridden grid.
     expect(door(grid)).not.toBeNull();
@@ -308,13 +312,52 @@ describe("PiVoiceSettings — what's actually speaking", () => {
     expect(settings.userPreferences.unsetVoice).not.toHaveBeenCalled();
   });
 
-  it("follows a voice chosen elsewhere, without a repopulate", () => {
+  it("keeps an unavailable notice when a saved remote voice cannot resolve", async () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.userPreferences.hasVoice.mockResolvedValue(true);
+    await settings.applySelectedVoice(null);
+    expect(notice(grid)).not.toBeNull();
+    expect(notice(grid)!.textContent).toContain("voicesSavedUnavailable");
+    expect(notice(grid)?.textContent).not.toContain("voiceOverriddenBySayPi");
+    expect(notice(grid)?.querySelector("button")?.textContent).toBe("voicesChangeVoice");
+    settings.observeSettingsGrid();
+    settings.userPreferences.unsetVoice.mockImplementation(async () => {
+      settings.userPreferences.hasVoice.mockResolvedValue(false);
+    });
+    grid.querySelector<HTMLButtonElement>(":scope > button")!.click();
+    await vi.waitFor(() => expect(notice(grid)).toBeNull());
+  });
+
+  it.each(["initial", "external"])("ignores a late %s read after a native choice", async (source) => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    let resolveVoice!: (voice: unknown) => void;
+    const pending = new Promise((resolve) => { resolveVoice = resolve; });
+    settings.userPreferences.getVoice.mockReturnValueOnce(pending);
+    settings.observeSettingsGrid();
+    settings.ensureSettingsDoor();
+    let refresh: Promise<void> | undefined;
+    if (source === "initial") {
+      refresh = settings.refreshOverrideNotice();
+    } else {
+      settings.registerVoicePreferenceChangeHandler();
+      EventBus.emit("userPreferenceChanged", { voicePreferences: { pi: "shimmer" }, voiceChatbotId: "pi" });
+    }
+    await settings.useNativeVoice();
+    resolveVoice(voice("Shimmer"));
+    await pending;
+    await refresh;
+    expect(notice(grid)).toBeNull();
+  });
+
+  it("follows a voice chosen elsewhere, without a repopulate", async () => {
     const grid = buildSettingsGrid();
     const settings = makeSettings(grid);
     settings.renderMenu([], null);
     settings.applySelectedVoice(voice("Marin"));
     expect(notice(grid)!.textContent).toContain("Marin");
-    settings.applySelectedVoice(null);
+    await settings.applySelectedVoice(null);
     expect(notice(grid)).toBeNull();
   });
 

--- a/test/chatbots/PiVoiceSettings-more-voices-door.spec.ts
+++ b/test/chatbots/PiVoiceSettings-more-voices-door.spec.ts
@@ -35,6 +35,7 @@ vi.mock("../../src/popup/popupopener", () => ({
 }));
 
 import { PiVoiceSettings } from "../../src/chatbots/PiVoiceSettings";
+import { PiAIVoice } from "../../src/tts/SpeechModel";
 
 /**
  * A faithful fixture of pi.ai's CURRENT Voice settings grid (captured live via
@@ -206,8 +207,6 @@ describe("PiVoiceSettings — what's actually speaking", () => {
     settings.renderMenu([], voice("Shimmer"));
     expect(notice(grid)).not.toBeNull();
     expect(notice(grid)!.textContent).toContain("Shimmer");
-    // The glance-level half: the native cards stop reading as active.
-    expect(grid.classList.contains("saypi-voices-overridden")).toBe(true);
   });
 
   it("stays out of the way when Pi's own voice is the one speaking", () => {
@@ -215,9 +214,98 @@ describe("PiVoiceSettings — what's actually speaking", () => {
     const settings = makeSettings(grid);
     settings.renderMenu([], null);
     expect(notice(grid)).toBeNull();
-    expect(grid.classList.contains("saypi-voices-overridden")).toBe(false);
     // The door is SayPi's only mark on an un-overridden grid.
     expect(door(grid)).not.toBeNull();
+  });
+
+  it("does not claim a stored native Pi voice is a SayPi override", () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.renderMenu([], new PiAIVoice(4));
+    expect(notice(grid)).toBeNull();
+
+    settings.applySelectedVoice(voice("Shimmer"));
+    settings.applySelectedVoice(new PiAIVoice(2));
+    expect(notice(grid)).toBeNull();
+  });
+
+  it("uses Pi's readable theme color for the current-voice notice", () => {
+    const style = document.createElement("style");
+    style.textContent = ".text-text-secondary { color: rgb(193, 191, 181); }";
+    document.body.appendChild(style);
+    const grid = buildSettingsGrid();
+    document.body.appendChild(grid);
+    makeSettings(grid).renderMenu([], voice("Shimmer"));
+    expect(window.getComputedStyle(notice(grid)!).color).toBe("rgb(193, 191, 181)");
+  });
+
+  it("offers Change voice alongside the voice in use, including after a change", () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.renderMenu([], voice("Shimmer"));
+    settings.applySelectedVoice(voice("Marin"));
+    const change = notice(grid)?.querySelector<HTMLButtonElement>("button");
+    expect(change?.textContent).toBe("voicesChangeVoice");
+    change!.click();
+    expect(openSettingsMock).toHaveBeenCalledWith("voices/pi");
+    expect(settings.userPreferences.unsetVoice).not.toHaveBeenCalled();
+  });
+
+  it("returns to Pi when a native card is clicked, preserving Pi's own click handler", async () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.observeSettingsGrid();
+    settings.renderMenu([], voice("Shimmer"));
+    const native = grid.querySelector<HTMLButtonElement>(":scope > button")!;
+    const selectPiVoice = vi.fn();
+    native.addEventListener("click", selectPiVoice);
+    native.querySelector("span")!.click();
+    await vi.waitFor(() => expect(notice(grid)).toBeNull());
+    expect(settings.userPreferences.unsetVoice).toHaveBeenCalledWith(settings.chatbot);
+    expect(selectPiVoice).toHaveBeenCalledOnce();
+  });
+
+  it("clears a stored native voice too, so it cannot override the newly clicked Pi card", async () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.observeSettingsGrid();
+    settings.renderMenu([], new PiAIVoice(4));
+    grid.querySelector<HTMLButtonElement>(":scope > button")!.click();
+    await vi.waitFor(() => expect(settings.userPreferences.unsetVoice).toHaveBeenCalledOnce());
+  });
+
+  it("returns to Pi even if its selection handler replaces the clicked card", async () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.observeSettingsGrid();
+    settings.renderMenu([], voice("Shimmer"));
+    const native = grid.querySelector<HTMLButtonElement>(":scope > button")!;
+    native.addEventListener("click", () => native.remove());
+    native.click();
+    await vi.waitFor(() => expect(notice(grid)).toBeNull());
+    expect(settings.userPreferences.unsetVoice).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the active SayPi notice if releasing the stored preference fails", async () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.userPreferences.unsetVoice.mockRejectedValue(new Error("Storage unavailable"));
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    settings.observeSettingsGrid();
+    settings.renderMenu([], voice("Shimmer"));
+    grid.querySelector<HTMLButtonElement>(":scope > button")!.click();
+    await vi.waitFor(() => expect(settings.userPreferences.unsetVoice).toHaveBeenCalledOnce());
+    expect(notice(grid)?.textContent).toContain("Shimmer");
+    debug.mockRestore();
+  });
+
+  it("does not relinquish the current voice when opening More voices", () => {
+    const grid = buildSettingsGrid();
+    const settings = makeSettings(grid);
+    settings.observeSettingsGrid();
+    settings.renderMenu([], voice("Shimmer"));
+    door(grid)!.click();
+    expect(settings.userPreferences.unsetVoice).not.toHaveBeenCalled();
   });
 
   it("follows a voice chosen elsewhere, without a repopulate", () => {
@@ -228,7 +316,6 @@ describe("PiVoiceSettings — what's actually speaking", () => {
     expect(notice(grid)!.textContent).toContain("Marin");
     settings.applySelectedVoice(null);
     expect(notice(grid)).toBeNull();
-    expect(grid.classList.contains("saypi-voices-overridden")).toBe(false);
   });
 
   it("is idempotent, and re-appears if Pi's re-render drops it", () => {

--- a/test/tts/VoiceMenuRefresh.spec.ts
+++ b/test/tts/VoiceMenuRefresh.spec.ts
@@ -182,3 +182,26 @@ describe("refreshMenu resolves user pins and forwards them to renderMenu", () =>
     expect(renderSpy.mock.calls[0][2]).toBeNull();
   });
 });
+
+it("waits for an asynchronous selection renderer before completing its refresh", async () => {
+  let finishApply!: () => void;
+  const applying = new Promise<void>((resolve) => { finishApply = resolve; });
+  class AsyncSelector extends TestGrid {
+    protected override applySelectedVoice(): Promise<void> { return applying; }
+    public override refreshSelectedVoice(): Promise<void> { return super.refreshSelectedVoice(); }
+  }
+  const selector = new AsyncSelector({ getID: () => "pi" } as any, {
+    getVoice: vi.fn().mockResolvedValue(null),
+  } as any, document.createElement("div"));
+  let finished = false;
+  const refreshing = selector.refreshSelectedVoice().then(() => { finished = true; });
+  // Yield a task so a refresh that incorrectly ignores `applying` can settle.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  try {
+    expect(finished).toBe(false);
+  } finally {
+    finishApply();
+    await refreshing;
+  }
+  expect(finished).toBe(true);
+});


### PR DESCRIPTION
Pi’s Voice settings could show a barely readable current-voice notice in dark mode, and choosing a Pi card changed Pi’s preference while SayPi kept speaking. The page now makes the active SayPi voice readable and puts **Change voice** beside it. Choosing a native card clears SayPi’s override and returns playback to Pi, while preserving Pi’s own card handler and selection.

The notice uses the same provider identity as playback, so a stored native Pi voice is no longer described as a SayPi override. A saved SayPi voice offers Sign In while signed out, even when cached remote details remain available; an authenticated user sees the temporary-unavailability explanation and Change voice. Native cards keep their normal appearance as an active return path. An explicit native choice also cancels Pi's pending first-install SayPi default, even before an override is stored, so signing in later cannot replace the user's choice with Marin. A revision guard prevents delayed reads from restoring an obsolete notice. The existing preference/provider flow handles audio release. Visible copy is available in all 32 locales, including the reused sign-in keys.

Validation: fail-first DOM coverage reproduced native-provider misclassification, missing theme color/action and missing native return. Further fail-first cases cover Pi replacing the clicked card, unresolved saved voices, signed-out guidance for resolved and unresolved metadata, authentication changes, and delayed initial/external reads after a native choice. The selector contract now explicitly permits an async selection renderer, and a deferred regression proves its base refresh waits for completion. Typecheck passes; Jest passes (2 tests); Vitest passes (240 files, 2,706 tests, 1 existing skipped). Jest used `--watchman=false` because the local sandbox prevented Watchman from changing its own state-directory permissions; the test set is unchanged. Locale messages/placeholders and `git diff --check` pass.

The development-only built extension passes six hermetic Pi settings E2E tests plus the existing Pi chat-decoration check. The tests verify actual background storage, Pi's own native-card handler, Change voice and Sign In destinations, reload persistence, a native choice sealing the pending default, and light/dark contrast of at least 4.5:1. A route-specific fixture preserves the existing mock chat page. Both theme screenshots were visually inspected. Combined release-candidate E2E is tracked in PR #609.

No live-host runs, production builds or release actions were performed for this slice. Merge follows completion of review threads and required checks.

Fixes #606

Authored with Codex.
