### PR TITLE
Keep saved voice choices through catalog outages

### DIFF
--- a/src/prefs/PreferenceModule.ts
+++ b/src/prefs/PreferenceModule.ts
@@ -850,19 +850,12 @@ class UserPreferenceModule {
     const chatbotInstance = typeof chatbot === "string" ? undefined : chatbot;
     try {
       return await tts.getVoiceById(voiceIdToFetch, chatbotInstance, chatbotId);
-    } catch (error: any) {
-      if (!getJwtManagerSync().isAuthenticated()) {
-        // While signed out, /voices returns [] (401 shape), so the failed
-        // lookup says nothing about whether the voice still exists on the
-        // user's account. Keep the stored preference so it survives a
-        // sign-out → sign-in cycle (#456).
-        console.info(`Voice with ID ${voiceIdToFetch} unavailable while signed out; keeping stored preference for ${chatbotId}.`);
-        return null;
-      }
-      console.info(`Voice with ID ${voiceIdToFetch} not found for ${chatbotId}. Clearing stored voice preference.`);
-      const updatedPreferences = { ...preferences };
-      delete updatedPreferences[chatbotId];
-      await this.persistVoicePreferences(updatedPreferences);
+    } catch {
+      // A failed request OR a successful catalog omission can be temporary:
+      // disabling a provider hides its voices, including from the by-ID API.
+      // Only explicit set/unset owns the saved choice. Returning null reports
+      // this attempt's unavailability; hasVoice still reports the saved intent.
+      console.info(`Voice with ID ${voiceIdToFetch} unavailable; keeping stored preference for ${chatbotId}.`);
       return null;
     }
   }

--- a/src/tts/README.md
+++ b/src/tts/README.md
@@ -2,6 +2,28 @@
 
 This module provides text-to-speech capabilities for the application.
 
+## Resolving a saved voice
+
+A failed catalog request is not evidence that a saved voice was removed. Even
+a successful catalog omission or a by-ID 404 can mean that the API temporarily
+disabled that provider. Preference lookup therefore preserves the saved ID when
+it cannot resolve it (#604); explicit set/unset actions own changes to the choice.
+This also prevents a delayed lookup from overwriting newer choices.
+
+`getVoice` returns null while the voice is unavailable, while `hasVoice` remains
+true because the choice is still saved. Callers must distinguish that state from
+an explicit native-voice/voice-off choice. An unresolved remote choice retains
+SayPi as the selected provider, keeping host audio suppressed; synthesis returns
+a silent placeholder until that voice resolves. Keeping provider ownership
+stable lets recovered speech pass the existing output guard without a new
+provider event. Native Pi IDs resolve locally and remain usable without the API.
+Settings can use the two preference reads to explain unavailability honestly.
+
+A missing ID in a previously cached catalog triggers one host-scoped refresh,
+shared by concurrent lookups. Fresh omissions do not retry within the same
+lookup; later demand may retry. Valid cached choices incur no extra request,
+and there is no background polling or by-ID probe.
+
 ## Handling Failed Utterances
 
 The TTS service can now handle expected failures (like insufficient credits) by returning a `FailedSpeechUtterance` object instead of throwing an error. Here's an example of how to handle this in a UI component:
@@ -47,4 +69,4 @@ To add a new failure reason:
 
 1. Add the reason to the `SpeechFailureReason` enum
 2. Update the TTS service to return the new reason when appropriate
-3. Update UI handlers to display appropriate messages for the new reason 
+3. Update UI handlers to display appropriate messages for the new reason

--- a/src/tts/README.md
+++ b/src/tts/README.md
@@ -12,17 +12,26 @@ This also prevents a delayed lookup from overwriting newer choices.
 
 `getVoice` returns null while the voice is unavailable, while `hasVoice` remains
 true because the choice is still saved. Callers must distinguish that state from
-an explicit native-voice/voice-off choice. An unresolved remote choice retains
-SayPi as the selected provider, keeping host audio suppressed; synthesis returns
-a silent placeholder until that voice resolves. Keeping provider ownership
-stable lets recovered speech pass the existing output guard without a new
-provider event. Native Pi IDs resolve locally and remain usable without the API.
-Settings can use the two preference reads to explain unavailability honestly.
+an explicit native-voice/voice-off choice. While signed in, an unresolved remote
+choice retains SayPi as the selected provider, keeping host audio suppressed;
+synthesis returns a silent placeholder until that voice resolves. Keeping
+provider ownership stable lets recovered speech pass the existing output guard
+without a new provider event. While signed out, a remote choice falls back to
+the host's native provider (Pi or ChatGPT, otherwise none), whether the voice
+resolved or is unavailable, since SayPi cannot synthesize without authentication.
+Auth is checked after the preference reads, including a sign-out during lookup.
+The saved choice survives both states. Native Pi IDs resolve locally and remain
+usable without the API. Settings can use the
+two preference reads to explain unavailability honestly.
 
-A missing ID in a previously cached catalog triggers one host-scoped refresh,
-shared by concurrent lookups. Fresh omissions do not retry within the same
-lookup; later demand may retry. Valid cached choices incur no extra request,
-and there is no background polling or by-ID probe.
+A missing ID can trigger a host-scoped refresh once the last successful catalog
+response is at least 60 seconds old. Concurrent lookups share that refresh, and
+successful empty catalogs observe the same cooldown. This bounds repeated
+lookups from message decoration and speech creation while allowing a disabled
+provider to recover on later demand. Auth/account changes invalidate the cache
+and cooldown immediately. Valid cached choices incur no extra request, and
+there is no background polling or by-ID probe. Failed requests do not populate
+the cache; the next caller may retry them.
 
 ## Handling Failed Utterances
 

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -201,9 +201,22 @@ class SpeechSynthesisModule {
     chatbot?: Chatbot | string,
     chatbotIdOverride?: string
   ): Promise<SpeechSynthesisVoiceRemote> {
-    const voices = await this.getVoices(chatbot, chatbotIdOverride); // populate cache
+    const cacheKey = this.resolveChatbotKey(chatbot, chatbotIdOverride) ?? UNKNOWN_CHATBOT_CACHE_KEY;
+    this.syncVoicesCacheWithAuthState();
+    const cached = this.voicesCache.get(cacheKey);
+    let voices = await this.getVoices(chatbot, chatbotIdOverride);
+    let foundVoice = voices.find((voice) => voice.id === id);
 
-    const foundVoice = voices.find((voice) => voice.id === id);
+    // Providers can disappear temporarily from an otherwise valid catalog.
+    // Retry a cached omission once on demand, sharing any concurrent fetch.
+    // A freshly fetched omission waits for the next lookup rather than looping.
+    if (!foundVoice && cached?.length && voices === cached) {
+      if (this.voicesCache.get(cacheKey) === cached) {
+        this.voicesCache.delete(cacheKey);
+      }
+      voices = await this.getVoices(chatbot, chatbotIdOverride);
+      foundVoice = voices.find((voice) => voice.id === id);
+    }
     if (!foundVoice) {
       throw new Error(`Voice with id ${id} not found`);
     }
@@ -300,8 +313,8 @@ class SpeechSynthesisModule {
     const preferedLang = await this.userPreferences.getLanguage();
     if (!preferedVoice || !getJwtManagerSync().isAuthenticated()) {
       // Degrade to a silent placeholder rather than attempting synthesis when:
-      //  - Voice is off, or the voice was cleared between the provider check and
-      //    here (a race when toggling voice mid-response); or
+      //  - Voice is off, temporarily unavailable, or was cleared between the
+      //    provider check and here (a race when toggling voice mid-response); or
       //  - The user is signed out. SayPi TTS is an authenticated/premium feature,
       //    and a user who selected a voice while signed in, then signed out, still
       //    has that voice persisted — attempting a stream then fails with an
@@ -454,6 +467,12 @@ class SpeechSynthesisModule {
     const voice = await this.userPreferences.getVoice(preferenceScope);
     if (voice) {
       return audioProviders.retreiveProviderByVoice(voice);
+    }
+    // Native Pi IDs resolve locally. An unresolved saved remote choice keeps
+    // SayPi's ownership, suppressing host fallback while createSpeechStream
+    // returns a silent placeholder. Recovery then needs no provider transition.
+    if (await this.userPreferences.hasVoice(preferenceScope)) {
+      return audioProviders.SayPi;
     }
 
     const defaultProvider = audioProviders.getDefaultForChatbot(chatbotId);

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -20,6 +20,7 @@ import { ChatbotIdentifier } from "../chatbots/ChatbotIdentifier";
 import { getJwtManagerSync } from "../JwtManager";
 
 const UNKNOWN_CHATBOT_CACHE_KEY = "__unknown__";
+const VOICE_CATALOG_RETRY_DELAY_MS = 60_000;
 
 function generateUUID(): string {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
@@ -105,7 +106,10 @@ class SpeechSynthesisModule {
     });
   }
 
-  private voicesCache: Map<string, SpeechSynthesisVoiceRemote[]> = new Map();
+  private voicesCache = new Map<string, {
+    voices: SpeechSynthesisVoiceRemote[];
+    fetchedAt: number;
+  }>();
   private voicesLoading: Map<string, Promise<void>> = new Map();
   /** Auth state the caches were populated under — see {@link syncVoicesCacheWithAuthState}. */
   private voicesCacheAuthFingerprint: string | null = null;
@@ -168,8 +172,9 @@ class SpeechSynthesisModule {
     const cacheKey = appId ?? UNKNOWN_CHATBOT_CACHE_KEY;
     this.syncVoicesCacheWithAuthState();
     const cached = this.voicesCache.get(cacheKey);
-    if (cached && cached.length > 0) {
-      return cached;
+    if (cached && (cached.voices.length > 0 ||
+      Date.now() - cached.fetchedAt < VOICE_CATALOG_RETRY_DELAY_MS)) {
+      return cached.voices;
     }
     if (!this.voicesLoading.has(cacheKey)) {
       const fingerprintAtFetchStart = this.voicesCacheAuthFingerprint;
@@ -180,7 +185,7 @@ class SpeechSynthesisModule {
           // flight; caching its result would resurrect the previous auth
           // state's voice list (#456).
           if (this.voicesCacheAuthFingerprint === fingerprintAtFetchStart) {
-            this.voicesCache.set(cacheKey, voices);
+            this.voicesCache.set(cacheKey, { voices, fetchedAt: Date.now() });
           }
         })
         .finally(() => {
@@ -193,7 +198,7 @@ class SpeechSynthesisModule {
       this.voicesLoading.set(cacheKey, loadPromise);
     }
     await this.voicesLoading.get(cacheKey);
-    return this.voicesCache.get(cacheKey) ?? [];
+    return this.voicesCache.get(cacheKey)?.voices ?? [];
   }
 
   async getVoiceById(
@@ -208,9 +213,12 @@ class SpeechSynthesisModule {
     let foundVoice = voices.find((voice) => voice.id === id);
 
     // Providers can disappear temporarily from an otherwise valid catalog.
-    // Retry a cached omission once on demand, sharing any concurrent fetch.
-    // A freshly fetched omission waits for the next lookup rather than looping.
-    if (!foundVoice && cached?.length && voices === cached) {
+    // Retry an omission on demand at most once per minute after a successful
+    // catalog response. Several consumers resolve the same saved ID per reply.
+    // If a concurrent caller already invalidated this entry, join its refresh.
+    if (!foundVoice && cached?.voices.length && voices === cached.voices &&
+      (Date.now() - cached.fetchedAt >= VOICE_CATALOG_RETRY_DELAY_MS ||
+        this.voicesCache.get(cacheKey) !== cached)) {
       if (this.voicesCache.get(cacheKey) === cached) {
         this.voicesCache.delete(cacheKey);
       }
@@ -247,7 +255,7 @@ class SpeechSynthesisModule {
     const appId = chatbotId ?? ChatbotIdentifier.getAppId();
     const cacheKey = appId ?? UNKNOWN_CHATBOT_CACHE_KEY;
     this.syncVoicesCacheWithAuthState(); // stamp: cached under the current auth state
-    this.voicesCache.set(cacheKey, voices);
+    this.voicesCache.set(cacheKey, { voices, fetchedAt: Date.now() });
   }
 
   async createSpeech(
@@ -465,14 +473,20 @@ class SpeechSynthesisModule {
 
     const preferenceScope = chatbot ?? chatbotId;
     const voice = await this.userPreferences.getVoice(preferenceScope);
+    let preferredProvider: AudioProvider = audioProviders.None;
     if (voice) {
-      return audioProviders.retreiveProviderByVoice(voice);
+      preferredProvider = audioProviders.retreiveProviderByVoice(voice);
+    } else if (await this.userPreferences.hasVoice(preferenceScope)) {
+      // An unresolved saved remote choice retains SayPi ownership through an
+      // outage so catalog recovery needs no provider transition.
+      preferredProvider = audioProviders.SayPi;
     }
-    // Native Pi IDs resolve locally. An unresolved saved remote choice keeps
-    // SayPi's ownership, suppressing host fallback while createSpeechStream
-    // returns a silent placeholder. Recovery then needs no provider transition.
-    if (await this.userPreferences.hasVoice(preferenceScope)) {
-      return audioProviders.SayPi;
+    // Resolve auth after the asynchronous preference reads. SayPi cannot
+    // synthesize while signed out, even if the remote voice resolved. Native
+    // Pi voices resolve locally and remain usable without authentication.
+    if (preferredProvider !== audioProviders.None &&
+      (preferredProvider !== audioProviders.SayPi || getJwtManagerSync().isAuthenticated())) {
+      return preferredProvider;
     }
 
     const defaultProvider = audioProviders.getDefaultForChatbot(chatbotId);

--- a/test/prefs/VoicePreferences.spec.ts
+++ b/test/prefs/VoicePreferences.spec.ts
@@ -15,8 +15,8 @@ vi.mock('../../src/tts/SpeechSynthesisModule', () => ({
   SpeechSynthesisModule: { getInstance: () => speechSynthesisMock },
 }));
 
-// getVoice() consults the auth state before treating a failed lookup as a
-// deleted voice (#456).
+// Default adoption consults auth; saved choices survive lookup failure in
+// either auth state (#456, #604).
 const fakeAuth = vi.hoisted(() => ({ authenticated: false }));
 vi.mock('../../src/JwtManager', () => {
   const fakeJwtManager = { isAuthenticated: () => fakeAuth.authenticated };

--- a/test/prefs/VoicePreferences.spec.ts
+++ b/test/prefs/VoicePreferences.spec.ts
@@ -136,6 +136,26 @@ describe('UserPreferenceModule voice scoping', () => {
 // Deleting the stored preference there would silently erase the user's chosen
 // voice across a sign-out → sign-in cycle (#456).
 describe('UserPreferenceModule voice preference across auth changes (#456)', () => {
+  it.each([
+    new TypeError('Failed to fetch'),
+    new Error('Failed to get voices: 503'),
+    new Error('Failed to get voices: 401'),
+    new SyntaxError('Invalid catalog JSON'),
+    new Error('Voice with id shimmer not found'),
+  ])('preserves a signed-in choice when the catalog is unavailable: %s', async (failure) => {
+    store.voicePreferences = { pi: 'shimmer', claude: 'marin' };
+    fakeAuth.authenticated = true;
+    speechSynthesisMock.getVoiceById.mockRejectedValue(failure);
+
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    expect(await prefs.getVoice('pi')).toBeNull();
+    expect(store.voicePreferences).toEqual({ pi: 'shimmer', claude: 'marin' });
+
+    const recoveredVoice = { ...createPiVoice('shimmer', 'Shimmer'), powered_by: 'OpenAI' };
+    speechSynthesisMock.getVoiceById.mockResolvedValue(recoveredVoice);
+    expect(await prefs.getVoice('pi')).toEqual(recoveredVoice);
+  });
+
   it('keeps the stored voice preference when the lookup fails while signed out', async () => {
     store.voicePreferences = { claude: 'custom-voice-abc' };
     fakeAuth.authenticated = false;
@@ -150,18 +170,43 @@ describe('UserPreferenceModule voice preference across auth changes (#456)', () 
     expect(store.voicePreferences).toEqual({ claude: 'custom-voice-abc' });
   });
 
-  it('still clears a genuinely missing voice preference while signed in', async () => {
+  it('keeps an omitted voice so a temporarily disabled provider can return', async () => {
     store.voicePreferences = { claude: 'deleted-voice' };
     fakeAuth.authenticated = true;
-    speechSynthesisMock.getVoiceById.mockRejectedValue(
-      new Error('Voice with id deleted-voice not found')
-    );
+    speechSynthesisMock.getVoiceById.mockRejectedValue(new Error('Voice with id deleted-voice not found'));
 
     const prefs = prefsModule.UserPreferenceModule.getInstance();
     const voice = await prefs.getVoice('claude');
 
     expect(voice).toBeNull();
-    expect(store.voicePreferences).toEqual({});
+    expect(store.voicePreferences).toEqual({ claude: 'deleted-voice' });
+    expect(await prefs.hasVoice('claude')).toBe(true);
+    const availableAgain = { ...createPiVoice('deleted-voice', 'Shimmer'), powered_by: 'OpenAI' };
+    speechSynthesisMock.getVoiceById.mockResolvedValue(availableAgain);
+    expect(await prefs.getVoice('claude')).toEqual(availableAgain);
+  });
+
+  it.each(['pi', 'claude'])('keeps a newer %s choice when an older Pi lookup cannot resolve its voice', async (changedHost) => {
+    store.voicePreferences = { pi: 'deleted-voice', claude: 'marin' };
+    fakeAuth.authenticated = true;
+    let rejectLookup!: (error: Error) => void;
+    let lookupStarted!: () => void;
+    const started = new Promise<void>((resolve) => { lookupStarted = resolve; });
+    speechSynthesisMock.getVoiceById.mockImplementation(() => new Promise((_resolve, reject) => {
+      rejectLookup = reject;
+      lookupStarted();
+    }));
+
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    const lookup = prefs.getVoice('pi');
+    await started;
+    await prefs.setVoice(createPiVoice('voice2', 'Pi 2'), changedHost);
+    rejectLookup(new Error('Voice with id deleted-voice not found'));
+    await lookup;
+
+    expect(store.voicePreferences).toEqual(changedHost === 'pi'
+      ? { pi: 'voice2', claude: 'marin' }
+      : { pi: 'deleted-voice', claude: 'voice2' });
   });
 });
 

--- a/test/tts/SpeechSynthesisModule.spec.ts
+++ b/test/tts/SpeechSynthesisModule.spec.ts
@@ -3,7 +3,7 @@ import type { Mock } from "vitest";
 import { SpeechSynthesisModule } from "../../src/tts/SpeechSynthesisModule";
 import { TextToSpeechService } from "../../src/tts/TextToSpeechService";
 import { AudioStreamManager } from "../../src/tts/AudioStreamManager";
-import { mockVoices } from "../data/Voices";
+import { mockVoices, openAiMockVoices } from "../data/Voices";
 import { UserPreferenceModule } from "../../src/prefs/PreferenceModule";
 import {
   audioProviders,
@@ -11,6 +11,10 @@ import {
   SpeechSynthesisVoiceRemote,
 } from "../../src/tts/SpeechModel";
 import EventBus from "../../src/events/EventBus";
+import { ChatbotIdentifier } from "../../src/chatbots/ChatbotIdentifier";
+import { audioOutputMachine } from "../../src/state-machines/AudioOutputMachine";
+import { shouldMuteHostAudio } from "../../src/audio/hostAudio";
+import { createTestActor } from "../state-machines/support/testActor";
 
 // Controllable stand-in for the JwtManager singleton: the voice cache's
 // validity is keyed off the auth state it reports (#456).
@@ -137,6 +141,45 @@ describe("SpeechSynthesisModule", () => {
 
     expect(voice).toEqual(mockVoice);
     expect(textToSpeechServiceMock.getVoiceById).not.toHaveBeenCalled();
+  });
+
+  it("refreshes a cached omission once so a disabled provider can return", async () => {
+    speechSynthesisModule._cacheVoices(mockVoices, "pi");
+    speechSynthesisModule._cacheVoices(mockVoices, "claude");
+    (textToSpeechServiceMock.getVoices as Mock).mockResolvedValue([
+      ...mockVoices, ...openAiMockVoices,
+    ]);
+
+    const voice = await speechSynthesisModule.getVoiceById("alloy", "pi");
+
+    expect(voice.id).toBe("alloy");
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledExactlyOnceWith(undefined, "pi");
+    expect(await speechSynthesisModule.getVoices("claude")).toEqual(mockVoices);
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a freshly fetched omission in the same lookup", async () => {
+    await expect(speechSynthesisModule.getVoiceById("alloy", "pi"))
+      .rejects.toThrow("Voice with id alloy not found");
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(1);
+
+    // A later demand may retry, once: there is no polling loop when still absent.
+    await expect(speechSynthesisModule.getVoiceById("alloy", "pi"))
+      .rejects.toThrow("Voice with id alloy not found");
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares the refresh when concurrent lookups miss the same cached catalog", async () => {
+    speechSynthesisModule._cacheVoices(mockVoices, "pi");
+    (textToSpeechServiceMock.getVoices as Mock).mockResolvedValue(openAiMockVoices);
+
+    const voices = await Promise.all([
+      speechSynthesisModule.getVoiceById("alloy", "pi"),
+      speechSynthesisModule.getVoiceById("shimmer", "pi"),
+    ]);
+
+    expect(voices.map((voice) => voice.id)).toEqual(["alloy", "shimmer"]);
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(1);
   });
 
   it("should create a speech stream", async () => {
@@ -369,6 +412,7 @@ describe("SpeechSynthesisModule", () => {
 
   it("disables Say Pi provider when no voice preference is set for Claude", async () => {
     (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(null);
+    (userPreferenceModuleMock.hasVoice as Mock).mockResolvedValue(false);
 
     const claudeChatbot = { getID: () => "claude" } as any;
 
@@ -381,6 +425,7 @@ describe("SpeechSynthesisModule", () => {
 
   it("falls back to native providers when no Say Pi voices are selected", async () => {
     (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(null);
+    (userPreferenceModuleMock.hasVoice as Mock).mockResolvedValue(false);
 
     const chatgptChatbot = { getID: () => "chatgpt" } as any;
 
@@ -391,6 +436,67 @@ describe("SpeechSynthesisModule", () => {
     expect(provider).toEqual(
       audioProviders.getDefaultForChatbot("chatgpt")
     );
+  });
+
+  it("keeps SayPi ownership through an outage so recovered speech passes the output guard", async () => {
+    // Drain the constructor's initial provider resolution before simulating startup.
+    await speechSynthesisModule.getActiveAudioProvider("pi");
+    fakeAuth.authenticated = true;
+    (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(null);
+    (userPreferenceModuleMock.hasVoice as Mock).mockResolvedValue(true);
+    const appIdSpy = vi.spyOn(ChatbotIdentifier, "getAppId").mockReturnValue("pi");
+    const actor = createTestActor(audioOutputMachine.provide({
+      actions: { notifySpeechStart: vi.fn() }, // external source parsing is not this seam
+    })).start();
+    let onProvider: (detail: any) => void = () => {};
+
+    try {
+      await new Promise<void>((resolve) => {
+        onProvider = ({ provider }) => {
+          actor.send({ type: "changeProvider", provider });
+          resolve();
+        };
+        EventBus.on("audio:changeProvider", onProvider);
+        speechSynthesisModule.initProvider();
+      });
+      const provider = actor.state.context.provider;
+      expect(provider).toBe(audioProviders.SayPi);
+      expect(shouldMuteHostAudio({
+        providerIsSayPi: provider === audioProviders.SayPi,
+        playbackIsOffscreen: true,
+      })).toBe(true);
+      const chatbot = { getID: () => "pi" } as any;
+      const silent = await speechSynthesisModule.createSpeechStreamOrPlaceholder(provider, chatbot);
+      expect(isPlaceholderUtterance(silent)).toBe(true);
+      expect(silent.provider).toBe(audioProviders.None);
+      expect(audioStreamManagerMock.createStream).not.toHaveBeenCalled();
+      actor.send({ type: "loadstart", source: "https://pi.ai/audio/native.mp3" });
+      expect(actor.state.matches("idle")).toBe(true);
+
+      // Catalog recovery needs no second provider event or machine reset.
+      (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(mockVoices[0]);
+      const recovered = {
+        id: "recovered", lang: "en-US", voice: mockVoices[0],
+        uri: "https://api.saypi.ai/speak/recovered/stream", provider: audioProviders.SayPi,
+      };
+      (audioStreamManagerMock.createStream as Mock).mockResolvedValue(recovered);
+      const utterance = await speechSynthesisModule.createSpeechStreamOrPlaceholder(
+        await speechSynthesisModule.getActiveAudioProvider("pi"), chatbot,
+      );
+      expect(utterance).toBe(recovered);
+      actor.send({ type: "loadstart", source: utterance.uri });
+      expect(actor.state.matches("loading")).toBe(true);
+    } finally {
+      EventBus.off("audio:changeProvider", onProvider);
+      appIdSpy.mockRestore();
+      actor.stop();
+    }
+  });
+
+  it("uses Pi's own provider when the user explicitly clears the saved choice", async () => {
+    (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(null);
+    (userPreferenceModuleMock.hasVoice as Mock).mockResolvedValue(false);
+    expect(await speechSynthesisModule.getActiveAudioProvider('pi')).toBe(audioProviders.Pi);
   });
 
   // The voice list is auth-dependent (401 → [], plus per-user custom voices),

--- a/test/tts/SpeechSynthesisModule.spec.ts
+++ b/test/tts/SpeechSynthesisModule.spec.ts
@@ -8,6 +8,7 @@ import { UserPreferenceModule } from "../../src/prefs/PreferenceModule";
 import {
   audioProviders,
   isPlaceholderUtterance,
+  PiAIVoice,
   SpeechSynthesisVoiceRemote,
 } from "../../src/tts/SpeechModel";
 import EventBus from "../../src/events/EventBus";
@@ -90,6 +91,7 @@ describe("SpeechSynthesisModule", () => {
     // Some tests register menu-style listeners on the shared singleton
     // EventBus; drop them so they can't leak into unrelated tests.
     EventBus.removeAllListeners("saypi:auth:status-changed");
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
@@ -130,8 +132,10 @@ describe("SpeechSynthesisModule", () => {
   });
 
   it("should get voice by ID from the cache if available", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
     const mockVoice = mockVoices[0];
     speechSynthesisModule._cacheVoices([mockVoice], "claude");
+    vi.setSystemTime(Date.now() + 60_000);
 
     const voice = await speechSynthesisModule.getVoiceById(
       mockVoice.id,
@@ -141,11 +145,14 @@ describe("SpeechSynthesisModule", () => {
 
     expect(voice).toEqual(mockVoice);
     expect(textToSpeechServiceMock.getVoiceById).not.toHaveBeenCalled();
+    expect(textToSpeechServiceMock.getVoices).not.toHaveBeenCalled();
   });
 
   it("refreshes a cached omission once so a disabled provider can return", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
     speechSynthesisModule._cacheVoices(mockVoices, "pi");
     speechSynthesisModule._cacheVoices(mockVoices, "claude");
+    vi.setSystemTime(Date.now() + 60_000);
     (textToSpeechServiceMock.getVoices as Mock).mockResolvedValue([
       ...mockVoices, ...openAiMockVoices,
     ]);
@@ -158,19 +165,80 @@ describe("SpeechSynthesisModule", () => {
     expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(1);
   });
 
-  it("does not retry a freshly fetched omission in the same lookup", async () => {
+  it("bounds successful catalog omission retries to once per minute, then recovers on demand", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const fetchedAt = Date.now();
     await expect(speechSynthesisModule.getVoiceById("alloy", "pi"))
       .rejects.toThrow("Voice with id alloy not found");
     expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(1);
 
-    // A later demand may retry, once: there is no polling loop when still absent.
+    // One reply can consult the same saved choice several times.
     await expect(speechSynthesisModule.getVoiceById("alloy", "pi"))
       .rejects.toThrow("Voice with id alloy not found");
+    vi.setSystemTime(fetchedAt + 59_999);
+    await expect(speechSynthesisModule.getVoiceById("alloy", "pi"))
+      .rejects.toThrow("Voice with id alloy not found");
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(fetchedAt + 60_000);
+    (textToSpeechServiceMock.getVoices as Mock).mockResolvedValue(openAiMockVoices);
+    expect((await speechSynthesisModule.getVoiceById("alloy", "pi")).id).toBe("alloy");
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(2);
+  });
+
+  it("also bounds retries when the successful catalog is empty", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const fetchedAt = Date.now();
+    (textToSpeechServiceMock.getVoices as Mock).mockResolvedValue([]);
+    await expect(speechSynthesisModule.getVoiceById("alloy", "pi"))
+      .rejects.toThrow("Voice with id alloy not found");
+    expect(await speechSynthesisModule.getVoices("pi")).toEqual([]);
+    vi.setSystemTime(fetchedAt + 59_999);
+    await expect(speechSynthesisModule.getVoiceById("alloy", "pi"))
+      .rejects.toThrow("Voice with id alloy not found");
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(fetchedAt + 60_000);
+    (textToSpeechServiceMock.getVoices as Mock).mockResolvedValue(openAiMockVoices);
+    expect((await speechSynthesisModule.getVoiceById("alloy", "pi")).id).toBe("alloy");
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps omission retry times independent for each host", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const fetchedAt = Date.now();
+    await expect(speechSynthesisModule.getVoiceById("alloy", "pi")).rejects.toThrow();
+    vi.setSystemTime(fetchedAt + 30_000);
+    await expect(speechSynthesisModule.getVoiceById("alloy", "claude")).rejects.toThrow();
+
+    vi.setSystemTime(fetchedAt + 60_000);
+    (textToSpeechServiceMock.getVoices as Mock).mockResolvedValue(openAiMockVoices);
+    expect((await speechSynthesisModule.getVoiceById("alloy", "pi")).id).toBe("alloy");
+    await expect(speechSynthesisModule.getVoiceById("alloy", "claude")).rejects.toThrow();
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(3);
+
+    vi.setSystemTime(fetchedAt + 90_000);
+    expect((await speechSynthesisModule.getVoiceById("alloy", "claude")).id).toBe("alloy");
+    expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(4);
+  });
+
+  it.each([false, true])("clears an omission cooldown immediately on sign-in or account switch (was authenticated: %s)", async (wasAuthenticated) => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    fakeAuth.authenticated = wasAuthenticated;
+    fakeAuth.userId = wasAuthenticated ? "user-a" : undefined;
+    await expect(speechSynthesisModule.getVoiceById("alloy", "pi")).rejects.toThrow();
+    fakeAuth.authenticated = true;
+    fakeAuth.userId = "user-b";
+    (textToSpeechServiceMock.getVoices as Mock).mockResolvedValue(openAiMockVoices);
+
+    expect((await speechSynthesisModule.getVoiceById("alloy", "pi")).id).toBe("alloy");
     expect(textToSpeechServiceMock.getVoices).toHaveBeenCalledTimes(2);
   });
 
   it("shares the refresh when concurrent lookups miss the same cached catalog", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
     speechSynthesisModule._cacheVoices(mockVoices, "pi");
+    vi.setSystemTime(Date.now() + 60_000);
     (textToSpeechServiceMock.getVoices as Mock).mockResolvedValue(openAiMockVoices);
 
     const voices = await Promise.all([
@@ -352,6 +420,7 @@ describe("SpeechSynthesisModule", () => {
   });
 
   it("keeps native audio for chatbots without a Say Pi voice selection", async () => {
+    fakeAuth.authenticated = true;
     const preferredVoice = mockVoices[0];
     (userPreferenceModuleMock.hasVoice as Mock).mockImplementation(
       async (chatbotArg?: any) => {
@@ -383,6 +452,7 @@ describe("SpeechSynthesisModule", () => {
   });
 
   it("uses per-chatbot Say Pi voices without affecting other chatbots", async () => {
+    fakeAuth.authenticated = true;
     const claudeVoice = { ...mockVoices[0] };
     const chatgptVoice = { ...mockVoices[0], id: "other", name: "Other Voice" };
 
@@ -438,7 +508,80 @@ describe("SpeechSynthesisModule", () => {
     );
   });
 
-  it("keeps SayPi ownership through an outage so recovered speech passes the output guard", async () => {
+  it.each([
+    { state: "unresolved", voice: null }, { state: "resolved", voice: mockVoices[0] },
+  ])("keeps Pi's native audio audible when signed out with a $state saved voice", async ({ voice }) => {
+    await speechSynthesisModule.getActiveAudioProvider("pi");
+    (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(voice);
+    (userPreferenceModuleMock.hasVoice as Mock).mockResolvedValue(true);
+    const appIdSpy = vi.spyOn(ChatbotIdentifier, "getAppId").mockReturnValue("pi");
+    const actor = createTestActor(audioOutputMachine.provide({
+      actions: { notifySpeechStart: vi.fn() },
+    })).start();
+    let onProvider: (detail: any) => void = () => {};
+
+    try {
+      await new Promise<void>((resolve) => {
+        onProvider = ({ provider }) => {
+          actor.send({ type: "changeProvider", provider });
+          resolve();
+        };
+        EventBus.on("audio:changeProvider", onProvider);
+        speechSynthesisModule.initProvider();
+      });
+      const provider = actor.state.context.provider;
+      expect(provider).toBe(audioProviders.Pi);
+      expect(shouldMuteHostAudio({
+        providerIsSayPi: provider === audioProviders.SayPi,
+        playbackIsOffscreen: true,
+      })).toBe(false);
+      const utterance = await speechSynthesisModule.createSpeechStreamOrPlaceholder(
+        provider, { getID: () => "pi" } as any,
+      );
+      expect(isPlaceholderUtterance(utterance)).toBe(true);
+      expect(utterance.provider).toBe(audioProviders.Pi);
+      expect(audioStreamManagerMock.createStream).not.toHaveBeenCalled();
+      actor.send({ type: "loadstart", source: "https://pi.ai/audio/native.mp3" });
+      expect(actor.state.matches("loading")).toBe(true);
+
+      // Signing back in reclaims the saved SayPi choice, even during an outage.
+      fakeAuth.authenticated = true;
+      expect(await speechSynthesisModule.getActiveAudioProvider("pi")).toBe(audioProviders.SayPi);
+    } finally {
+      EventBus.off("audio:changeProvider", onProvider);
+      appIdSpy.mockRestore();
+      actor.stop();
+    }
+  });
+
+  it("uses current auth when a saved remote voice finishes resolving after sign-out", async () => {
+    await speechSynthesisModule.getActiveAudioProvider("pi");
+    fakeAuth.authenticated = true;
+    let resolveVoice!: (voice: SpeechSynthesisVoiceRemote) => void;
+    (userPreferenceModuleMock.getVoice as Mock).mockReturnValueOnce(
+      new Promise<SpeechSynthesisVoiceRemote>((resolve) => { resolveVoice = resolve; }),
+    );
+    const pendingProvider = speechSynthesisModule.getActiveAudioProvider("pi");
+    fakeAuth.authenticated = false;
+    resolveVoice(mockVoices[0]);
+
+    expect(await pendingProvider).toBe(audioProviders.Pi);
+  });
+
+  it("uses a locally resolved Pi voice without authentication", async () => {
+    (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(PiAIVoice.fromVoiceId("voice1"));
+    expect(await speechSynthesisModule.getActiveAudioProvider("pi")).toBe(audioProviders.Pi);
+  });
+
+  it.each([
+    ["chatgpt", audioProviders.ChatGPT], ["claude", audioProviders.None],
+  ])("retains the %s signed-out default for an unresolved saved voice", async (host, expected) => {
+    (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(null);
+    (userPreferenceModuleMock.hasVoice as Mock).mockResolvedValue(true);
+    expect(await speechSynthesisModule.getActiveAudioProvider(host as string)).toBe(expected);
+  });
+
+  it("keeps authenticated SayPi ownership through an outage so recovered speech passes the output guard", async () => {
     // Drain the constructor's initial provider resolution before simulating startup.
     await speechSynthesisModule.getActiveAudioProvider("pi");
     fakeAuth.authenticated = true;


### PR DESCRIPTION
A temporary catalog failure could erase a signed-in user’s saved voice, so opening Voices settings during an outage could permanently change what spoke afterward. This catch also existed in v1.13.0; the defect was reproduced locally, with no evidence of an active user incident.

Saved IDs now survive every unresolved lookup. The API can omit a temporarily disabled provider’s voices, and its by-ID 404 has the same ambiguity, so only an explicit user choice changes or clears the saved preference. `getVoice()` reports current unavailability with null while `hasVoice()` continues to report the saved choice. A delayed failure can no longer overwrite newer choices.

While signed in, an unresolved remote choice retains SayPi provider ownership. Synthesis returns a silent placeholder, host audio stays suppressed, and recovered speech passes the existing output guard without a provider reset. While signed out, both resolved and unresolved remote choices use the host default: native Pi or ChatGPT audio, otherwise no provider. Authentication is checked after the asynchronous preference reads, including sign-out during lookup. The saved ID remains intact. Native Pi IDs resolve locally and remain usable without authentication.

A missing ID can refresh its host’s catalog once the previous successful response is at least 60 seconds old. Concurrent callers share that refresh; successful empty catalogs observe the same cooldown. Signing in, signing out, or switching accounts invalidates the cache immediately. Valid cached voices add no request, and there is no background polling or by-ID probe. Failed requests retain the existing retry behavior: they do not populate the cache, so the next caller may retry. The TTS README documents these distinctions for callers; the companion settings slice explains unavailable and signed-out states.

Verification used Node 22. Fail-first tests reproduced preference deletion and recovery failures before their fixes. The review follow-up separately reproduced six ownership/request-cost failures, then two resolved-voice/sign-out-race failures before fixing them. The final preference, synthesis, service, host-audio and output-machine suites pass all 117 tests. Actual output actors receive provider events and prove native audio is accepted while signed out, while authenticated outage recovery enters loading without a second provider event. Tests also pin cooldown expiry, independent hosts, empty catalogs, concurrent refreshes, auth/account invalidation, and valid cached choices making no requests. Live auth-event handoff in an already-running browser tab is outside this verification.

The complete test chain passes: typecheck, Jest 2/2, and Vitest 2,713 passed with one unchanged skipped test across 240 files. Locally, Watchman could not chmod its state directory within the sandbox, so the same npm-test stages were run with Jest’s `--watchman=false`; no source tests or CI gates were skipped or changed. `git diff --check` is clean. Independent Codex review approved the final diff and independently passed all 117 targeted tests. Combined candidate E2E is handled in the parent release task; this slice made zero real-host runs and read no production environment or secrets.

Fixes #604.

Implemented with Codex. Left open for parent review and merge; no merge performed in this task.
