### PR TITLE
Wait for offscreen creation before dispatching messages

### DIFF
--- a/doc/specs/2026-09-05-offscreen-readiness.md
+++ b/doc/specs/2026-09-05-offscreen-readiness.md
@@ -1,0 +1,25 @@
+# Wait for offscreen creation before dispatch
+
+The release candidate's hermetic Opus-upload check exposed a startup race before
+any audio was encoded: the background began creating its offscreen document,
+Chrome reported that the document existed, and a concurrent VAD initialization
+message reached it before its message listener was ready. Chrome rejected the
+message with “Receiving end does not exist”; the call never reached transcription.
+
+The existence query and the creation promise answer different questions. During
+creation, the promise remains the readiness boundary even when `hasDocument()`
+returns true. `setupOffscreenDocument` therefore waits for an ongoing creation
+before treating an existing document as reusable. It checks for creation after
+awaiting the existence query because another caller may begin creation during
+that query. Ready documents still take the existing fast path, and the original
+`finally` clears failed creation so later requests can retry.
+
+Two deterministic tests fail on the unchanged `origin/main` code: a second caller
+arriving after creation begins, and an earlier caller whose existence query
+resolves after another caller begins creation. Both assert that no message is
+dispatched before creation resolves. Further tests retain single creation for
+simultaneous absent-document reads, recovery after failed creation, and reuse of
+an already-ready document. The existing browser upload and lifecycle assertions
+remain unchanged; this change neither adds retries nor extends their timeouts.
+
+Issue: #610. No production host was exercised to reproduce this failure.

--- a/src/offscreen/offscreen_manager.ts
+++ b/src/offscreen/offscreen_manager.ts
@@ -60,8 +60,16 @@ class OffscreenManager {
       throw new Error("Offscreen documents API not available in this browser");
     }
     
-    // Check if the document already exists.
-    if (await this.hasDocument()) {
+    const exists = await this.hasDocument();
+    // Chrome can report existence before createDocument resolves and the message
+    // listener is ready. Check after the await: another caller may also have
+    // started creation while this existence query was pending.
+    if (this.creating) {
+      await this.creating;
+      return;
+    }
+
+    if (exists) {
       const now = Date.now();
       if (now - this.lastOffscreenExistsLog > this.offscreenExistsThrottleMs) {
         logger.debug("[OffscreenManager] Reusing existing offscreen document for media coordination.", {
@@ -70,11 +78,6 @@ class OffscreenManager {
         });
         this.lastOffscreenExistsLog = now;
       }
-      return;
-    }
-
-    if (this.creating) {
-      await this.creating;
       return;
     }
 

--- a/test/offscreen/offscreen-manager-readiness.spec.ts
+++ b/test/offscreen/offscreen-manager-readiness.spec.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { browser } from "wxt/browser";
+import { offscreenManager } from "../../src/offscreen/offscreen_manager";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("OffscreenManager — creation readiness", () => {
+  let api: {
+    hasDocument: ReturnType<typeof vi.fn>;
+    createDocument: ReturnType<typeof vi.fn>;
+    Reason: { USER_MEDIA: string; AUDIO_PLAYBACK: string };
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (offscreenManager as any).creating = undefined;
+    (offscreenManager as any).pendingAudioMessages.clear();
+    (offscreenManager as any).portMap.clear();
+    api = {
+      hasDocument: vi.fn().mockResolvedValue(false),
+      createDocument: vi.fn().mockResolvedValue(undefined),
+      Reason: { USER_MEDIA: "USER_MEDIA", AUDIO_PLAYBACK: "AUDIO_PLAYBACK" },
+    };
+    (browser as any).offscreen = api;
+    vi.spyOn(browser.runtime, "sendMessage").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    delete (browser as any).offscreen;
+  });
+
+  it("holds a concurrent VAD request when the document exists but creation is pending", async () => {
+    const creation = deferred<void>();
+    api.createDocument.mockImplementation(() => {
+      api.hasDocument.mockResolvedValue(true);
+      return creation.promise;
+    });
+
+    const arm = offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_USE_SYNTHETIC_AUDIO" }, 42);
+    await vi.advanceTimersByTimeAsync(0);
+    const initialize = offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_INITIALIZE_REQUEST" }, 42);
+    await vi.advanceTimersByTimeAsync(0);
+
+    try {
+      expect(api.createDocument).toHaveBeenCalledTimes(1);
+      expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
+    } finally {
+      creation.resolve();
+      await Promise.all([arm, initialize]);
+    }
+    expect(browser.runtime.sendMessage).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      type: "VAD_USE_SYNTHETIC_AUDIO",
+    }));
+    expect(browser.runtime.sendMessage).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      type: "VAD_INITIALIZE_REQUEST",
+    }));
+  });
+
+  it("also waits when another caller begins creation during the existence check", async () => {
+    const existence = deferred<boolean>();
+    const creation = deferred<void>();
+    api.hasDocument.mockImplementationOnce(() => existence.promise);
+    api.createDocument.mockReturnValue(creation.promise);
+
+    const initialize = offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_INITIALIZE_REQUEST" }, 42);
+    const arm = offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_USE_SYNTHETIC_AUDIO" }, 42);
+    await vi.advanceTimersByTimeAsync(0);
+    existence.resolve(true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    try {
+      expect(api.createDocument).toHaveBeenCalledTimes(1);
+      expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
+    } finally {
+      creation.resolve();
+      await Promise.all([initialize, arm]);
+    }
+    expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates only one document for concurrent callers that both see no document", async () => {
+    const creation = deferred<void>();
+    api.createDocument.mockReturnValue(creation.promise);
+    const first = offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_INITIALIZE_REQUEST" }, 42);
+    const second = offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_INITIALIZE_REQUEST" }, 43);
+    await vi.advanceTimersByTimeAsync(0);
+
+    try {
+      expect(api.createDocument).toHaveBeenCalledTimes(1);
+      expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
+    } finally {
+      creation.resolve();
+      await Promise.all([first, second]);
+    }
+    expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries after failed creation without dispatching the failed callers", async () => {
+    const creation = deferred<void>();
+    api.createDocument.mockReturnValueOnce(creation.promise);
+    const first = offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_INITIALIZE_REQUEST" }, 42);
+    const second = offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_INITIALIZE_REQUEST" }, 43);
+    await vi.advanceTimersByTimeAsync(0);
+    creation.reject(new Error("Creation failed"));
+    await Promise.all([first, second]);
+    expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
+
+    await offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_INITIALIZE_REQUEST" }, 42);
+    expect(api.createDocument).toHaveBeenCalledTimes(2);
+    expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a ready document without creating another", async () => {
+    api.hasDocument.mockResolvedValue(true);
+    await offscreenManager.sendMessageToOffscreenDocument({ type: "VAD_INITIALIZE_REQUEST" }, 42);
+    expect(api.createDocument).not.toHaveBeenCalled();
+    expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Starting a voice call while the offscreen document was still being created could lose its VAD initialization request. Chrome reported that the document existed before `createDocument()` finished, so a second caller dispatched too early and received “Receiving end does not exist.” The call then stalled without an upload.

The manager now awaits an ongoing creation before treating an existing document as ready. It checks after awaiting the existence query, which also covers another caller starting creation during that query. Ready-document reuse and the existing cleanup after failed creation remain intact.

The candidate browser trace identified the exact ordering. Two deterministic regression tests then failed against unchanged `origin/main` before the fix. Five readiness tests now cover those two races, one creation for simultaneous callers, retry after creation failure, and reuse of a ready document. The seven readiness/idle-shutdown tests also passed independent review.

Validation:

- Typecheck, Jest (2 tests), and full Vitest (241 files, 2,696 passed, 1 existing skipped) pass. Jest used `--watchman=false` because local sandbox permissions prevent Watchman's state-directory setup; the test set is unchanged.
- A development-only build passes the unchanged hermetic Opus upload, synthetic STT, service-worker recycle, and offscreen idle-shutdown browser tests (4 passed). The Opus request uploads `audio/webm` and the transcript reaches the prompt.
- `git diff --check` passes. No test timeouts, retries, or assertions were relaxed.

This is a separate review PR for integration into the release candidate. Do not merge during the release-closing review pass. No real-host runs, production builds, or store actions were performed.

Fixes #610

Authored with Codex.
