### PR TITLE
Reconcile running playback when the selected voice or sign-in state changes

### DIFF
--- a/doc/audio-selection-reconciliation.md
+++ b/doc/audio-selection-reconciliation.md
@@ -1,0 +1,41 @@
+# Keeping playback aligned with the selected voice
+
+A voice selected in extension settings reaches an already-open host through
+`chrome.storage.onChanged`. That path updates `PreferenceModule` and emits
+`userPreferenceChanged`; the former process-local `audio:changeProvider` event
+never reached the host. Reply synthesis already read fresh preferences, so Pi
+could keep its native output while SayPi synthesized the newly selected voice.
+Authentication changes exposed the same missing handoff (#617).
+
+`AudioSelectionSync` belongs to the running `AudioModule`. It attaches before
+reading the saved selection, then refreshes on voice-preference and auth events.
+`SpeechSynthesisModule.getActiveAudioSelection` applies the same effective-provider
+policy used by synthesis and returns the matching voice with it. Only the latest
+asynchronous resolution can update the output actor, voice converter, and host
+mute ownership. A failed resolution leaves the last known selection intact.
+
+The resolver preserves saved preferences through sign-out and catalog outages.
+Pi falls back to native playback while signed out; hosts without a usable native
+fallback use no provider. An unresolved saved remote choice retains SayPi
+ownership when authenticated, with no stale voice matcher. Playback reconciliation
+does not write preferences or change authentication.
+
+Chrome/Edge silence the host player because SayPi output runs offscreen.
+Firefox/Safari share the page player, so they stop an incompatible current source
+without muting that shared player. Returning to native also stops an old custom
+stream offscreen. Canned voice samples remain allowed while a selection resolves. Reapplying an
+unchanged selection preserves intentional replays of replies in an older voice.
+Offscreen lifecycle forwarding is registered before awaiting the voice catalog,
+so playback events cannot disappear during a slow startup lookup.
+
+The fail-first regression net uses the real output actor and AudioModule's apply
+and mute methods for startup, storage-shaped events, auth transitions, stale
+reads, unavailable voices, failed reads, shared-page playback, preview continuity,
+and startup forwarding. The built-extension browser test additionally changes
+real extension storage from a separate document while native media advances,
+then covers SPA navigation, reload, and return to native playback. It does not
+claim an audible real-host sign-out/sign-in or Firefox browser confirmation.
+
+Audio-element insertion/replacement is a distinct lifecycle boundary; this change
+does not claim to cover every simultaneously present native player. Store release
+and attended real-host confirmation are separate from the hermetic checks.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -221,6 +221,13 @@ to Pi from an unresolved saved voice. The test
 attaches light/dark screenshots; it measures contrast from the built extension
 CSS and representative host-theme utilities rather than keeping pixel baselines.
 
+`specs/pi-audio-ownership.e2e.ts` keeps real native media playing on the mock Pi
+conversation while a separate extension document changes the saved voice. It
+checks immediate host muting, SPA navigation, saved ownership after reload, and
+native playback after clearing the override. The test waits for fresh-install
+seeding before representing an existing user, so a late onboarding writer cannot
+silently adopt a default during the return-to-Pi assertion.
+
 ## The dual-env gotcha (read this before editing launch/build config)
 
 There are **two separate environment channels** and they reach different layers.

--- a/e2e/specs/pi-audio-ownership.e2e.ts
+++ b/e2e/specs/pi-audio-ownership.e2e.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "../fixtures/extension";
+import { MOCK_VOICE_IDS } from "../support/voice-catalog";
+import { resolve } from "node:path";
+
+test("an open Pi conversation follows a voice selected in another extension document", async ({
+  context, serviceWorker, extensionId,
+}) => {
+  // Wait for the fresh-install writer before seeding an existing user.
+  await expect.poll(() => serviceWorker.evaluate(async () =>
+    (await chrome.storage.local.get("saypi_voice_default_pending_hosts")).saypi_voice_default_pending_hosts,
+  )).toEqual(["claude", "pi"]);
+  await serviceWorker.evaluate(async () => {
+    const expiresAt = Date.now() + 3_600_000;
+    const claims = btoa(JSON.stringify({ sub: "ownership-test", exp: expiresAt / 1000 }));
+    await chrome.storage.local.set({
+      jwtToken: `e30.${claims}.hermetic`, tokenExpiresAt: expiresAt,
+      prefs_migration_completed: true, shareData: false,
+      saypi_voice_default_pending_hosts: [], voicePreferences: { pi: "voice4" },
+    });
+  });
+  const pi = await context.newPage();
+  await pi.route("https://pi.ai/api/chat/voice*", route => route.fulfill({
+    path: resolve(import.meta.dirname, "../fixtures/voices/onyx.mp3"), contentType: "audio/mpeg",
+  }));
+  await pi.goto("https://pi.ai/talk");
+  const player = pi.locator("audio#saypi-audio-main");
+  await expect(player).toHaveCount(1);
+  await expect.poll(() => player.evaluate((audio: HTMLAudioElement) => audio.muted)).toBe(false);
+  await player.evaluate(async (audio: HTMLAudioElement) => {
+    audio.src = "https://pi.ai/api/chat/voice?voice=voice4&messageSid=ownership-test";
+    audio.loop = true;
+    await audio.play();
+  });
+  await expect.poll(() => player.evaluate((audio: HTMLAudioElement) => audio.currentTime)).toBeGreaterThan(0.15);
+
+  // A distinct extension document is crucial: calling setVoice inside Pi would
+  // deliver the old process-local provider event and conceal the storage gap.
+  const settings = await context.newPage();
+  await settings.goto(`chrome-extension://${extensionId}/settings.html`);
+  await settings.evaluate((id) => chrome.storage.local.set({ voicePreferences: { pi: id } }), MOCK_VOICE_IDS.onyx);
+  await expect.poll(() => player.evaluate((audio: HTMLAudioElement) => audio.muted)).toBe(true);
+  // Real native playback can continue to advance, but it must be inaudible.
+  // This catches a mute attached only to the next loadstart instead of ownership.
+  expect(await player.evaluate((audio: HTMLAudioElement) => audio.paused)).toBe(false);
+
+  // A resumed SPA route retains the live actor. A full reload separately proves
+  // that a choice made before audio startup is picked up too.
+  await pi.evaluate(() => history.pushState({}, "", "/talk/existing-conversation"));
+  await expect.poll(() => player.evaluate((audio: HTMLAudioElement) => audio.muted)).toBe(true);
+  await pi.reload();
+  await expect.poll(() => player.evaluate((audio: HTMLAudioElement) => audio.muted)).toBe(true);
+
+  await settings.evaluate(() => chrome.storage.local.set({ voicePreferences: {} }));
+  await expect.poll(() => player.evaluate((audio: HTMLAudioElement) => audio.muted)).toBe(false);
+  await player.evaluate(async (audio: HTMLAudioElement) => {
+    audio.src = "https://pi.ai/api/chat/voice?voice=voice4&messageSid=ownership-test";
+    await audio.play();
+  });
+  await expect.poll(() => player.evaluate((audio: HTMLAudioElement) => audio.currentTime)).toBeGreaterThan(0.15);
+  expect(await player.evaluate((audio: HTMLAudioElement) => audio.muted)).toBe(false);
+});

--- a/e2e/specs/settings-opens-in-tab.e2e.ts
+++ b/e2e/specs/settings-opens-in-tab.e2e.ts
@@ -23,12 +23,14 @@ test.describe("settings tab flow", () => {
     const trigger = await context.newPage();
     await trigger.goto(`chrome-extension://${extensionId}/permissions.html`);
 
-    const pagePromise = context.waitForEvent("page");
+    const settingsUrl = `chrome-extension://${extensionId}/settings.html`;
     await trigger.evaluate(() =>
       chrome.runtime.sendMessage({ action: "openPopup" }),
     );
-    const settingsPage = await pagePromise;
-    await settingsPage.waitForURL(/settings\.html/);
+    // Installation can open onboarding concurrently. Match the requested tab
+    // instead of assuming the next page event belongs to this message.
+    await expect.poll(() => context.pages().filter(page => page.url() === settingsUrl).length).toBe(1);
+    const settingsPage = context.pages().find(page => page.url() === settingsUrl)!;
 
     // The page must live in a normal (tabbed) window — no popup-type window
     // may have been created anywhere in the browser.

--- a/src/audio/AudioControlsModule.ts
+++ b/src/audio/AudioControlsModule.ts
@@ -1,14 +1,4 @@
 import EventBus from "../events/EventBus";
-import { logger } from "../LoggingModule";
-import {
-  AIVoice,
-  AudioProvider,
-  audioProviders,
-  ChangeVoiceEvent,
-  MatchableVoice,
-  SpeechSynthesisVoiceRemote,
-  VoiceFactory,
-} from "../tts/SpeechModel";
 import { ChatbotIdentifier } from "../chatbots/ChatbotIdentifier";
 import { getAudioOutputToggle } from "../chatbots/AudioOutputToggle";
 
@@ -87,38 +77,4 @@ export default class AudioControlsModule {
     return svgPath === activePath;
   }
 
-  notifyAudioProviderSelection(provider: AudioProvider): void {
-    logger.debug(`Speech provided by ${provider.name}`);
-    EventBus.emit("audio:changeProvider", { provider });
-  }
-
-  notifyAudioVoiceSelection(voice: AIVoice | SpeechSynthesisVoiceRemote): void {
-    logger.debug(`Using ${voice.name} voice for speech`);
-    const matchableVoice =
-      voice instanceof AIVoice
-        ? voice
-        : VoiceFactory.matchableFromVoiceRemote(voice);
-    const event = new ChangeVoiceEvent(matchableVoice);
-    EventBus.emit(
-      "audio:changeVoice",
-      event as { voice: MatchableVoice | null }
-    );
-    this.notifyAudioProviderSelection(
-      audioProviders.retreiveProviderByVoice(voice)
-    );
-  }
-
-  notifyAudioVoiceDeselection(): void {
-    logger.debug("Using default voice for speech");
-    EventBus.emit("audio:changeVoice", { voice: null });
-    const chatbotId = ChatbotIdentifier.identifyChatbot();
-    const defaultProvider = chatbotId
-      ? audioProviders.getDefaultForChatbot(chatbotId)
-      : audioProviders.getDefault();
-    const provider =
-      defaultProvider === audioProviders.SayPi
-        ? audioProviders.None
-        : defaultProvider;
-    this.notifyAudioProviderSelection(provider);
-  }
 }

--- a/src/audio/AudioModule.js
+++ b/src/audio/AudioModule.js
@@ -17,6 +17,9 @@ import { BrowserCompatibilityModule } from "../compat/BrowserCompatibilityModule
 import { createAudioRemovalObserverCallback } from "./audioElementRemoval.ts";
 import { findHostAudioElement, shouldMuteHostAudio } from "./hostAudio.ts";
 import { audioProviders } from "../tts/SpeechModel.ts";
+import { SpeechSynthesisModule } from "../tts/SpeechSynthesisModule.ts";
+import { isVoiceSampleUrl } from "../tts/SpeechSourceParsers.ts";
+import { AudioSelectionSync } from "./AudioSelectionSync.ts";
 
 const INITIAL_PLAYBACK_BUFFER_TIMEOUT_MS = 5000;
 
@@ -28,7 +31,7 @@ export default class AudioModule {
 
     this.AUDIO_ELEMENT_ID = "saypi-audio-main";
     this.audioElement = null;
-    /** Are WE the voice? Set from audio:changeProvider; decides the host's mute. */
+    /** Are WE the voice? Reconciled from current preferences and auth. */
     this.providerIsSayPi = false;
     this.mutationObserver = null;
     this.swapObserver = null;
@@ -45,7 +48,7 @@ export default class AudioModule {
     
     if (this.needsAudioOutput) {
       // Dynamically import and initialize audio output machine only when needed
-      this.initializeAudioOutputMachine();
+      this.audioOutputReady = this.initializeAudioOutputMachine();
     }
 
     this.audioInputActor = createActor(audioInputMachine);
@@ -90,6 +93,7 @@ export default class AudioModule {
 
   async start() {
     try {
+      await this.audioOutputReady;
       // Initialize offscreen bridge and check if supported
       this.useOffscreenAudio = await this.offscreenBridge.isSupported();
 
@@ -125,17 +129,15 @@ export default class AudioModule {
       // (offscreen or in-page)
       this.registerAudioCommands(
         this.audioInputActor,
-        this.audioOutputActor,
-        this.voiceConverter
+        this.audioOutputActor
       );
       
-      // Initialize voice converter
-      this.initializeVoiceConverter();
 
       // Register EventBus listeners for offscreen audio events and forward them to audio actors
       if (this.audioOutputActor) {
         this.registerOffscreenAudioEvents(this.audioOutputActor);
       }
+      await this.initializeAudioSelection();
     } catch (error) {
       logger.error("[AudioModule] Error during start:", error);
       // Fallback to in-page audio if there was an error with offscreen initialization
@@ -152,8 +154,7 @@ export default class AudioModule {
       }
       this.audioInputActor.start();
       this.voiceConverter.start();
-      this.registerAudioCommands(this.audioInputActor, this.audioOutputActor, this.voiceConverter);
-      this.initializeVoiceConverter();
+      this.registerAudioCommands(this.audioInputActor, this.audioOutputActor);
       
       // Ensure audio element swapping is monitored in fallback mode
       this.listenForAudioElementSwap();
@@ -163,6 +164,7 @@ export default class AudioModule {
       if (this.audioOutputActor) {
         this.registerOffscreenAudioEvents(this.audioOutputActor);
       }
+      await this.initializeAudioSelection();
     }
   }
 
@@ -198,18 +200,49 @@ export default class AudioModule {
     }
   }
 
-  initializeVoiceConverter() {
-    const prefs = UserPreferenceModule.getInstance();
-    ChatbotService.getChatbot().then((chatbot) => {
-      prefs.getVoice(chatbot).then((voice) => {
-        if (voice) {
-          logger.debug("Preferred voice is", voice);
-          this.voiceConverter.send({ type: "changeVoice", voice });
-        } else {
-          logger.debug("Default voice is preferred");
-        }
+  async initializeAudioSelection() {
+    if (!this.needsAudioOutput) return;
+    if (!this.selectionSync) {
+      const chatbot = await ChatbotService.getChatbot();
+      this.selectionSync = new AudioSelectionSync({
+        hostId: chatbot.getID(),
+        resolve: () => SpeechSynthesisModule.getInstance().getActiveAudioSelection(chatbot),
+        apply: (selection) => this.applyAudioSelection(selection),
+        onError: (error) => logger.error("[AudioModule] Could not reconcile voice selection", error),
       });
-    });
+    }
+    await this.selectionSync.start();
+  }
+
+  applyAudioSelection({ provider, voice }) {
+    this.audioOutputActor?.send({ type: "changeVoice", voice });
+    this.audioOutputActor?.send({ type: "changeProvider", provider });
+    this.voiceConverter.send({ type: "changeVoice", voice });
+    this.providerIsSayPi = provider === audioProviders.SayPi;
+    this.applyHostAudioMute();
+
+    // Auth refreshes and other hosts' storage writes can resolve the same
+    // selection again. Preserve intentional historical replays in that case.
+    const previous = this.appliedSelection;
+    this.appliedSelection = { provider, voice };
+    if (previous?.provider === provider && (previous.voice?.id ?? null) === (voice?.id ?? null)) return;
+
+    const offscreenSource = this.lastAudioUrl;
+    if (this.useOffscreenAudio && offscreenSource && !isVoiceSampleUrl(offscreenSource) &&
+        (!provider.matches(offscreenSource) || (voice && !voice.matchesSource(offscreenSource)))) {
+      this.lastAudioUrl = null;
+      this.offscreenBridge.stopAudio().catch((error) => {
+        logger.error("[AudioModule] Could not stop the previous voice", error);
+      });
+    }
+
+    // Firefox/Safari share the page player with SayPi. Muting would silence
+    // our speech too, but an already-playing native source must still stop.
+    const source = this.audioElement?.currentSrc || this.audioElement?.src;
+    if (!this.useOffscreenAudio && source && !isVoiceSampleUrl(source) &&
+        (!provider.matches(source) || (voice && !voice.matchesSource(source)))) {
+      this.stopOnscreenAudio();
+    }
   }
 
   async initializeSlowResponseHandler() {
@@ -479,6 +512,7 @@ export default class AudioModule {
       "audio:load",
       async (detail) => {
         logger.debug("audio:load", detail, this.useOffscreenAudio ? "offscreen" : "in-page");
+        this.lastAudioUrl = detail.url;
         if (this.useOffscreenAudio) {
           // Use offscreen bridge if available - now use loadAudio instead of playAudio
           await this.offscreenBridge.loadAudio(detail.url, true);
@@ -516,7 +550,7 @@ export default class AudioModule {
   }
 
   /* These events are used to control/pass requests to the audio module from other modules */
-  registerAudioCommands(inputActor, outputActor, voiceConverter) {
+  registerAudioCommands(inputActor, outputActor) {
     // audio input (recording) commands
     EventBus.on("audio:setupRecording", function (e) {
       inputActor.send({ type: "acquire" });
@@ -555,23 +589,6 @@ export default class AudioModule {
     });
 
     // audio output (playback) commands
-    EventBus.on("audio:changeProvider", (detail) => {
-      if (outputActor) {
-        outputActor.send({ type: "changeProvider", ...detail });
-      }
-      // Whether the host may be heard is decided by who is speaking, so it is
-      // settled here rather than at each playback event (#602). Matched by
-      // identity against the SayPi provider — `matches(source)` answers a
-      // different question (does this URL belong to it).
-      this.providerIsSayPi = detail?.provider === audioProviders.SayPi;
-      this.applyHostAudioMute();
-    });
-    EventBus.on("audio:changeVoice", (detail) => {
-      if (outputActor) {
-        outputActor.send({ type: "changeVoice", ...detail });
-      }
-      voiceConverter.send({ type: "changeVoice", ...detail });
-    });
     EventBus.on("audio:skipNext", (e) => {
       logger.debug("Skipping next audio");
       if (outputActor) {

--- a/src/audio/AudioSelectionSync.ts
+++ b/src/audio/AudioSelectionSync.ts
@@ -1,0 +1,49 @@
+import EventBus from "../events/EventBus";
+import type { AudioProvider, MatchableVoice } from "../tts/SpeechModel";
+
+export type AudioSelection = {
+  provider: AudioProvider;
+  voice: (MatchableVoice & { id: string }) | null;
+};
+
+/** The playback owner reads current state; events only tell it to read again. */
+export class AudioSelectionSync {
+  private revision = 0;
+  private started = false;
+
+  constructor(private readonly deps: {
+    hostId: string;
+    resolve: () => Promise<AudioSelection>;
+    apply: (selection: AudioSelection) => void;
+    onError: (error: unknown) => void;
+  }) {}
+
+  start(): Promise<void> {
+    if (!this.started) {
+      this.started = true;
+      EventBus.on("userPreferenceChanged", (detail: {
+        voicePreferences?: unknown;
+        voiceId?: unknown;
+        voiceChatbotId?: string;
+      } | undefined) => {
+        if (!detail || (detail.voicePreferences === undefined && detail.voiceId === undefined)) return;
+        if (detail.voiceChatbotId && detail.voiceChatbotId !== this.deps.hostId) return;
+        void this.refresh();
+      });
+      EventBus.on("saypi:auth:status-changed", () => { void this.refresh(); });
+    }
+    // A provider notification sent before audio was ready cannot be replayed.
+    // Resolve the saved choice after attaching, including on startup retries.
+    return this.refresh();
+  }
+
+  private async refresh(): Promise<void> {
+    const revision = ++this.revision;
+    try {
+      const selection = await this.deps.resolve();
+      if (revision === this.revision) this.deps.apply(selection);
+    } catch (error) {
+      if (revision === this.revision) this.deps.onError(error);
+    }
+  }
+}

--- a/src/prefs/PreferenceModule.ts
+++ b/src/prefs/PreferenceModule.ts
@@ -1,6 +1,5 @@
 import { config } from "../ConfigModule";
 import { SpeechSynthesisModule } from "../tts/SpeechSynthesisModule";
-import AudioControlsModule from "../audio/AudioControlsModule";
 import EventBus from "../events/EventBus";
 import {
   audioProviders,
@@ -953,9 +952,6 @@ class UserPreferenceModule {
       voicePreferences: updatedPreferences,
       voiceChatbotId: chatbotId,
     });
-
-    const audioControls = new AudioControlsModule();
-    audioControls.notifyAudioVoiceSelection(voice);
   }
 
   public async unsetVoice(chatbot?: Chatbot | string): Promise<void> {
@@ -974,8 +970,6 @@ class UserPreferenceModule {
         voicePreferences: preferences,
         voiceChatbotId: chatbotId,
       });
-      const audioControls = new AudioControlsModule();
-      audioControls.notifyAudioVoiceDeselection();
       return;
     }
 
@@ -989,9 +983,6 @@ class UserPreferenceModule {
       voicePreferences: updatedPreferences,
       voiceChatbotId: chatbotId,
     });
-
-    const audioControls = new AudioControlsModule();
-    audioControls.notifyAudioVoiceDeselection();
   }
   
   // Allow Interruptions (now local, was sync)

--- a/src/tts/SpeechModel.ts
+++ b/src/tts/SpeechModel.ts
@@ -86,7 +86,7 @@ const audioProviders = {
         // unrecognised powered_by must NOT crash voice selection the way
         // "OpenAI" did before this fix (#215/#92): treat any future API-added
         // provider as SayPi-served and warn, rather than throwing into the
-        // synchronous setVoice / notifyAudioVoiceSelection call paths.
+        // voice preference and playback reconciliation paths.
         console.warn(
           `Unrecognised TTS provider "${powered_by}"; treating as SayPi-served.`
         );
@@ -300,7 +300,7 @@ interface MatchableVoice {
 class VoiceFactory {
   static matchableFromVoiceRemote(
     v: SpeechSynthesisVoiceRemote
-  ): MatchableVoice {
+  ): AIVoice {
     const provider = audioProviders.retrieveProviderByEngine(v.powered_by);
     switch (provider) {
       case audioProviders.SayPi:

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -1,6 +1,6 @@
 import { UserPreferenceModule } from "../prefs/PreferenceModule";
 import { config } from "../ConfigModule";
-import AudioControlsModule from "../audio/AudioControlsModule";
+import type { AudioSelection } from "../audio/AudioSelectionSync";
 import { AudioStreamManager } from "./AudioStreamManager";
 import { TextToSpeechService } from "./TextToSpeechService";
 import EventBus from "../events/EventBus";
@@ -96,14 +96,6 @@ class SpeechSynthesisModule {
     this.audioStreamManager = audioStreamManager;
     this.userPreferences = userPreferenceModule;
     this.registerEventListeners();
-    this.initProvider();
-  }
-
-  initProvider(): void {
-    const audioControls = new AudioControlsModule();
-    this.getActiveAudioProvider().then((provider) => {
-      audioControls.notifyAudioProviderSelection(provider);
-    });
   }
 
   private voicesCache = new Map<string, {
@@ -461,14 +453,18 @@ class SpeechSynthesisModule {
    * @returns {Promise<AudioProvider>}
    */
   async getActiveAudioProvider(chatbot?: Chatbot | string): Promise<AudioProvider> {
+    return (await this.getActiveAudioSelection(chatbot)).provider;
+  }
+
+  async getActiveAudioSelection(chatbot?: Chatbot | string): Promise<AudioSelection> {
     const chatbotId = this.resolveChatbotKey(chatbot);
 
     if (!chatbotId) {
-      return audioProviders.None;
+      return { provider: audioProviders.None, voice: null };
     }
 
     if (chatbotId === "web") {
-      return audioProviders.None;
+      return { provider: audioProviders.None, voice: null };
     }
 
     const preferenceScope = chatbot ?? chatbotId;
@@ -486,15 +482,18 @@ class SpeechSynthesisModule {
     // Pi voices resolve locally and remain usable without authentication.
     if (preferredProvider !== audioProviders.None &&
       (preferredProvider !== audioProviders.SayPi || getJwtManagerSync().isAuthenticated())) {
-      return preferredProvider;
+      return {
+        provider: preferredProvider,
+        voice: voice ? VoiceFactory.matchableFromVoiceRemote(voice) : null,
+      };
     }
 
     const defaultProvider = audioProviders.getDefaultForChatbot(chatbotId);
     if (defaultProvider === audioProviders.SayPi) {
-      return audioProviders.None;
+      return { provider: audioProviders.None, voice: null };
     }
 
-    return defaultProvider;
+    return { provider: defaultProvider, voice: null };
   }
 
   private isStreamOpen(utteranceId: string): boolean {

--- a/test/audio/AudioSelectionSync.spec.ts
+++ b/test/audio/AudioSelectionSync.spec.ts
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AudioSelectionSync, type AudioSelection } from "../../src/audio/AudioSelectionSync";
+import EventBus from "../../src/events/EventBus";
+import { audioProviders, VoiceFactory } from "../../src/tts/SpeechModel";
+import { openAiMockVoices } from "../data/Voices";
+import { audioOutputMachine } from "../../src/state-machines/AudioOutputMachine";
+import { createTestActor, type TestActor } from "../state-machines/support/testActor";
+import AudioModule from "../../src/audio/AudioModule.js";
+
+// Keep the real output actor, bus and AudioModule apply/mute methods. The input
+// and converter imports otherwise bootstrap unrelated recording/UI singletons.
+vi.mock("../../src/state-machines/AudioInputMachine", () => ({ audioInputMachine: {} }));
+vi.mock("../../src/state-machines/VoiceConverter", () => ({ voiceConverterMachine: {} }));
+vi.mock("../../src/state-machines/AudioRetryMachine", () => ({ machine: {} }));
+vi.mock("../../src/chatbots/ChatbotService", () => ({ ChatbotService: {} }));
+vi.mock("../../src/compat/BrowserCompatibilityModule", () => ({ BrowserCompatibilityModule: { getInstance: () => ({ checkTTSCompatibility() {} }) } }));
+vi.mock("../../src/audio/OffscreenAudioBridge.js", () => ({ default: {} }));
+vi.mock("../../src/prefs/PreferenceModule", () => ({ UserPreferenceModule: {} }));
+vi.mock("../../src/tts/SpeechSynthesisModule", () => ({ SpeechSynthesisModule: {} }));
+vi.mock("../../src/ConfigModule", () => ({ config: { apiServerUrl: "https://api.saypi.ai" } }));
+
+const shimmer = VoiceFactory.matchableFromVoiceRemote(openAiMockVoices.find(v => v.id === "shimmer")!);
+const custom = { provider: audioProviders.SayPi, voice: shimmer };
+const native = { provider: audioProviders.Pi, voice: null };
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(r => { resolve = r; });
+  return { promise, resolve };
+}
+
+describe("reconciling the running audio selection", () => {
+  let actor: TestActor;
+  let audio: any;
+  let selection: AudioSelection;
+  let sync: AudioSelectionSync;
+  let resolve: ReturnType<typeof vi.fn>;
+  let onError: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    EventBus.removeAllListeners();
+    document.body.innerHTML = "<audio></audio>";
+    actor = createTestActor(audioOutputMachine.provide({ actions: { notifySpeechStart: () => {} } })).start();
+    audio = Object.create(AudioModule.prototype);
+    Object.assign(audio, { audioElement: document.querySelector("audio"), audioOutputActor: actor,
+      voiceConverter: { send: vi.fn() }, providerIsSayPi: false, useOffscreenAudio: true });
+    selection = native;
+    resolve = vi.fn(async () => selection);
+    onError = vi.fn();
+    sync = new AudioSelectionSync({ hostId: "pi", resolve: () => resolve(),
+      apply: value => audio.applyAudioSelection(value), onError });
+  });
+
+  afterEach(() => { actor.stop(); EventBus.removeAllListeners(); vi.restoreAllMocks(); });
+
+  it("reads a saved custom choice when playback starts after the settings event", async () => {
+    selection = custom;
+    EventBus.emit("userPreferenceChanged", { voicePreferences: { pi: "shimmer" } });
+    await sync.start();
+    expect(actor.state.context.provider).toBe(audioProviders.SayPi);
+    expect(actor.state.context.voice.matchesId("shimmer")).toBe(true);
+    expect(audio.audioElement.muted).toBe(true);
+  });
+
+  it("switches an open Pi tab to custom and back through storage-shaped events", async () => {
+    await sync.start();
+    selection = custom;
+    EventBus.emit("userPreferenceChanged", { voicePreferences: { pi: "shimmer" }, voiceChatbotId: "pi" });
+    await vi.waitFor(() => expect(audio.audioElement.muted).toBe(true));
+    expect(actor.state.context.voice.matchesId("shimmer")).toBe(true);
+    selection = native;
+    EventBus.emit("userPreferenceChanged", { voicePreferences: {}, voiceId: null, voiceChatbotId: "pi" });
+    await vi.waitFor(() => expect(audio.audioElement.muted).toBe(false));
+    expect(actor.state.context.provider).toBe(audioProviders.Pi);
+    expect(actor.state.context.voice).toBeNull();
+    actor.send({ type: "loadstart", source: "https://pi.ai/api/chat/voice?voice=voice4" });
+    expect(actor.state.matches("loading")).toBe(true);
+  });
+
+  it("reconciles sign-out and sign-in with the saved choice unchanged", async () => {
+    selection = custom;
+    await sync.start();
+    selection = native; // effective resolver's signed-out Pi fallback
+    EventBus.emit("saypi:auth:status-changed", false);
+    await vi.waitFor(() => expect(audio.audioElement.muted).toBe(false));
+    expect(actor.state.context.voice).toBeNull();
+    selection = custom;
+    EventBus.emit("saypi:auth:status-changed", true);
+    await vi.waitFor(() => expect(audio.audioElement.muted).toBe(true));
+    expect(actor.state.context.provider).toBe(audioProviders.SayPi);
+  });
+
+  it("rejects a slow startup read overtaken by a newer explicit choice", async () => {
+    const old = deferred<AudioSelection>();
+    resolve.mockReturnValueOnce(old.promise);
+    const starting = sync.start();
+    selection = custom;
+    EventBus.emit("userPreferenceChanged", { voiceId: "shimmer", voiceChatbotId: "pi" });
+    await vi.waitFor(() => expect(audio.audioElement.muted).toBe(true));
+    old.resolve(native);
+    await starting;
+    expect(audio.audioElement.muted).toBe(true);
+    expect(actor.state.context.voice.matchesId("shimmer")).toBe(true);
+  });
+
+  it("rejects a pre-sign-out read that resolves after sign-out", async () => {
+    await sync.start();
+    const old = deferred<AudioSelection>();
+    resolve.mockReturnValueOnce(old.promise);
+    EventBus.emit("userPreferenceChanged", { voiceId: "shimmer" });
+    EventBus.emit("saypi:auth:status-changed", false);
+    await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(3));
+    old.resolve(custom);
+    await Promise.resolve();
+    expect(audio.audioElement.muted).toBe(false);
+    expect(actor.state.context.provider).toBe(audioProviders.Pi);
+  });
+
+  it("ignores another host's explicit selection and non-voice preferences", async () => {
+    await sync.start();
+    selection = custom;
+    EventBus.emit("userPreferenceChanged", { voiceId: "shimmer", voiceChatbotId: "claude" });
+    EventBus.emit("userPreferenceChanged", { quietMode: true });
+    await Promise.resolve();
+    expect(audio.audioElement.muted).toBe(false);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains ownership but clears stale voice matching when a saved voice is unavailable", async () => {
+    selection = custom;
+    await sync.start();
+    selection = { provider: audioProviders.SayPi, voice: null };
+    EventBus.emit("saypi:auth:status-changed", true);
+    await vi.waitFor(() => expect(actor.state.context.voice).toBeNull());
+    expect(audio.audioElement.muted).toBe(true);
+  });
+
+  it("preserves the last known ownership on a failed read and can recover", async () => {
+    selection = custom;
+    await sync.start();
+    resolve.mockRejectedValueOnce(new Error("storage unavailable"));
+    EventBus.emit("saypi:auth:status-changed", true);
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(audio.audioElement.muted).toBe(true);
+    selection = native;
+    EventBus.emit("userPreferenceChanged", { voiceId: null });
+    await vi.waitFor(() => expect(audio.audioElement.muted).toBe(false));
+  });
+
+  it("stops a mismatched shared-page source without muting Firefox's custom player", async () => {
+    audio.useOffscreenAudio = false;
+    audio.audioElement.src = "https://pi.ai/api/chat/voice?voice=voice4";
+    const pause = vi.spyOn(audio.audioElement, "pause").mockImplementation(() => {});
+    selection = custom;
+    await sync.start();
+    expect(audio.audioElement.muted).toBe(false);
+    expect(pause).toHaveBeenCalledTimes(1);
+    audio.audioElement.src = "https://api.saypi.ai/speak/test/stream?voice_id=shimmer";
+    await sync.start();
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(actor.state.context.voice.matchesId("shimmer")).toBe(true);
+  });
+
+  it.each([true, false])("preserves a voice preview while selection resolves (offscreen=%s)", async (offscreen) => {
+    audio.useOffscreenAudio = offscreen;
+    audio.offscreenBridge = { stopAudio: vi.fn().mockResolvedValue(undefined) };
+    const pause = vi.spyOn(audio.audioElement, "pause").mockImplementation(() => {});
+    const pending = deferred<AudioSelection>();
+    resolve.mockReturnValueOnce(pending.promise);
+    const starting = sync.start();
+    const sample = "https://api.saypi.ai/voices/shimmer/sample";
+    audio.lastAudioUrl = sample;
+    audio.audioElement.src = sample;
+    actor.send({ type: "preview", source: sample });
+    actor.send({ type: "loadstart", source: sample });
+    pending.resolve(custom);
+    await starting;
+    await sync.start();
+    expect(audio.offscreenBridge.stopAudio).not.toHaveBeenCalled();
+    expect(pause).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])("preserves a historical reply on unchanged reconciliation (offscreen=%s)", async (offscreen) => {
+    audio.useOffscreenAudio = offscreen;
+    audio.offscreenBridge = { stopAudio: vi.fn().mockResolvedValue(undefined) };
+    const pause = vi.spyOn(audio.audioElement, "pause").mockImplementation(() => {});
+    selection = custom;
+    await sync.start();
+    const historical = "https://api.saypi.ai/speak/old/stream?voice_id=onyx";
+    audio.lastAudioUrl = historical;
+    audio.audioElement.src = historical;
+    actor.send({ type: "replaying" });
+    actor.send({ type: "loadstart", source: historical });
+    // Catalog resolution builds a new matchable object for the same voice.
+    selection = { provider: audioProviders.SayPi,
+      voice: VoiceFactory.matchableFromVoiceRemote(openAiMockVoices.find(v => v.id === "shimmer")!) };
+    EventBus.emit("userPreferenceChanged", { voicePreferences: { pi: "shimmer", claude: "alloy" } });
+    await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(2));
+    expect(audio.offscreenBridge.stopAudio).not.toHaveBeenCalled();
+    expect(pause).not.toHaveBeenCalled();
+  });
+
+  it("forwards playback events before a slow startup voice lookup finishes", async () => {
+    const pending = deferred<void>();
+    Object.assign(audio, {
+      offscreenBridge: { isSupported: async () => true, initialize: async () => {} },
+      audioInputActor: { start() {} }, voiceConverter: { start() {}, send() {} },
+      initialiseOnscreenAudio() {}, listenForAudioElementSwap() {}, registerAudioCommands() {},
+      initializeAudioSelection: () => pending.promise,
+    });
+    const forwarding = vi.spyOn(audio, "registerOffscreenAudioEvents");
+    const starting = audio.start();
+    await vi.waitFor(() => expect(forwarding).toHaveBeenCalledTimes(1));
+    pending.resolve();
+    await starting;
+  });
+
+  it("stops the active custom output when returning to Pi's native voice", async () => {
+    audio.offscreenBridge = { loadAudio: vi.fn().mockResolvedValue(undefined), stopAudio: vi.fn().mockResolvedValue(undefined) };
+    audio.registerOfflineAudioCommands();
+    selection = custom;
+    await sync.start();
+    EventBus.emit("audio:load", { url: "https://api.saypi.ai/speak/test/stream?voice_id=shimmer" });
+    selection = native;
+    EventBus.emit("userPreferenceChanged", { voiceId: null });
+    await vi.waitFor(() => expect(audio.audioElement.muted).toBe(false));
+    expect(audio.offscreenBridge.stopAudio).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/audio/audioElementRemoval.spec.ts
+++ b/test/audio/audioElementRemoval.spec.ts
@@ -220,7 +220,7 @@ describe("AudioModule removal-observer wiring", () => {
     expect(source).toMatch(/applyHostAudioMute\(\)\s*\{/);
     expect(source).toMatch(/shouldMuteHostAudio\(\{/);
     const onProviderChange = source.match(
-      /EventBus\.on\("audio:changeProvider"[\s\S]*?\n {4}\}\);/
+      /applyAudioSelection\(\{ provider, voice \}\)\s*\{[\s\S]*?\n {2}\}/
     )?.[0];
     expect(onProviderChange).toMatch(/providerIsSayPi = /);
     expect(onProviderChange).toMatch(/this\.applyHostAudioMute\(\)/);

--- a/test/tts/SpeechSynthesisModule.spec.ts
+++ b/test/tts/SpeechSynthesisModule.spec.ts
@@ -15,6 +15,7 @@ import EventBus from "../../src/events/EventBus";
 import { ChatbotIdentifier } from "../../src/chatbots/ChatbotIdentifier";
 import { audioOutputMachine } from "../../src/state-machines/AudioOutputMachine";
 import { shouldMuteHostAudio } from "../../src/audio/hostAudio";
+import { AudioSelectionSync } from "../../src/audio/AudioSelectionSync";
 import { createTestActor } from "../state-machines/support/testActor";
 
 // Controllable stand-in for the JwtManager singleton: the voice cache's
@@ -91,6 +92,7 @@ describe("SpeechSynthesisModule", () => {
     // Some tests register menu-style listeners on the shared singleton
     // EventBus; drop them so they can't leak into unrelated tests.
     EventBus.removeAllListeners("saypi:auth:status-changed");
+    EventBus.removeAllListeners("userPreferenceChanged");
     vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.clearAllMocks();
@@ -100,10 +102,16 @@ describe("SpeechSynthesisModule", () => {
     expect(speechSynthesisModule).toBeInstanceOf(SpeechSynthesisModule);
   });
 
-  it("should initialize the provider", () => {
-    const initProviderSpy = vi.spyOn(speechSynthesisModule, "initProvider");
-    speechSynthesisModule.initProvider();
-    expect(initProviderSpy).toHaveBeenCalled();
+  it("does not publish playback ownership from a TTS constructor", async () => {
+    const changed = vi.fn();
+    EventBus.on("audio:changeProvider", changed);
+    try {
+      const tts = new SpeechSynthesisModule(textToSpeechServiceMock, audioStreamManagerMock, userPreferenceModuleMock);
+      await tts.getActiveAudioProvider("pi");
+      expect(changed).not.toHaveBeenCalled();
+    } finally {
+      EventBus.off("audio:changeProvider", changed);
+    }
   });
 
   it("should get voices from the cache if available", async () => {
@@ -518,17 +526,17 @@ describe("SpeechSynthesisModule", () => {
     const actor = createTestActor(audioOutputMachine.provide({
       actions: { notifySpeechStart: vi.fn() },
     })).start();
-    let onProvider: (detail: any) => void = () => {};
 
     try {
-      await new Promise<void>((resolve) => {
-        onProvider = ({ provider }) => {
+      await new AudioSelectionSync({
+        hostId: "pi",
+        resolve: () => speechSynthesisModule.getActiveAudioSelection("pi"),
+        apply: ({ provider, voice }) => {
           actor.send({ type: "changeProvider", provider });
-          resolve();
-        };
-        EventBus.on("audio:changeProvider", onProvider);
-        speechSynthesisModule.initProvider();
-      });
+          actor.send({ type: "changeVoice", voice });
+        },
+        onError: error => { throw error; },
+      }).start();
       const provider = actor.state.context.provider;
       expect(provider).toBe(audioProviders.Pi);
       expect(shouldMuteHostAudio({
@@ -548,7 +556,6 @@ describe("SpeechSynthesisModule", () => {
       fakeAuth.authenticated = true;
       expect(await speechSynthesisModule.getActiveAudioProvider("pi")).toBe(audioProviders.SayPi);
     } finally {
-      EventBus.off("audio:changeProvider", onProvider);
       appIdSpy.mockRestore();
       actor.stop();
     }
@@ -582,8 +589,6 @@ describe("SpeechSynthesisModule", () => {
   });
 
   it("keeps authenticated SayPi ownership through an outage so recovered speech passes the output guard", async () => {
-    // Drain the constructor's initial provider resolution before simulating startup.
-    await speechSynthesisModule.getActiveAudioProvider("pi");
     fakeAuth.authenticated = true;
     (userPreferenceModuleMock.getVoice as Mock).mockResolvedValue(null);
     (userPreferenceModuleMock.hasVoice as Mock).mockResolvedValue(true);
@@ -591,17 +596,17 @@ describe("SpeechSynthesisModule", () => {
     const actor = createTestActor(audioOutputMachine.provide({
       actions: { notifySpeechStart: vi.fn() }, // external source parsing is not this seam
     })).start();
-    let onProvider: (detail: any) => void = () => {};
 
     try {
-      await new Promise<void>((resolve) => {
-        onProvider = ({ provider }) => {
+      await new AudioSelectionSync({
+        hostId: "pi",
+        resolve: () => speechSynthesisModule.getActiveAudioSelection("pi"),
+        apply: ({ provider, voice }) => {
           actor.send({ type: "changeProvider", provider });
-          resolve();
-        };
-        EventBus.on("audio:changeProvider", onProvider);
-        speechSynthesisModule.initProvider();
-      });
+          actor.send({ type: "changeVoice", voice });
+        },
+        onError: error => { throw error; },
+      }).start();
       const provider = actor.state.context.provider;
       expect(provider).toBe(audioProviders.SayPi);
       expect(shouldMuteHostAudio({
@@ -630,7 +635,6 @@ describe("SpeechSynthesisModule", () => {
       actor.send({ type: "loadstart", source: utterance.uri });
       expect(actor.state.matches("loading")).toBe(true);
     } finally {
-      EventBus.off("audio:changeProvider", onProvider);
       appIdSpy.mockRestore();
       actor.stop();
     }
@@ -694,6 +698,7 @@ describe("SpeechSynthesisModule", () => {
 
     // Mirror bootstrap order: menu listener first, module constructed second.
     EventBus.removeAllListeners("saypi:auth:status-changed");
+    EventBus.removeAllListeners("userPreferenceChanged");
     let voicesSeenByMenu: Promise<SpeechSynthesisVoiceRemote[]> | undefined;
     EventBus.on("saypi:auth:status-changed", () => {
       voicesSeenByMenu = lateModule.getVoices(undefined, "claude");


### PR DESCRIPTION
Selecting a custom voice in extension settings updated storage and reply synthesis, but an already-open host kept its old playback provider. Pi could therefore keep native speech audible while SayPi synthesized the newly selected voice. Startup timing and sign-in transitions exposed the same missing handoff.

The running AudioModule now resolves one effective provider/voice pair after attaching its listeners and whenever voice preferences or auth status change. A revision guard prevents a slow earlier lookup from overriding a newer choice. Actor acceptance, voice conversion, native muting, and stopping incompatible current speech follow that same selection. Saved preferences and the existing signed-out/catalog-outage policy are preserved. Voice previews and historical replays survive unchanged reconciliation, and slow catalog lookup no longer delays offscreen lifecycle forwarding. The obsolete constructor and local-only selection writers are removed.

Validation: fail-first runtime tests use the real output actor and AudioModule apply/mute methods; the built-extension browser regression changes actual extension storage from a second document while native media advances, then checks SPA navigation, reload and return to native. Type-check, Jest (2 tests) and Vitest (2772 passed, 1 existing skipped) pass. Full browser suite previously passed 45/45; final rerun includes a test-only correction for an independently reproduced baseline race that confused the onboarding tab with settings. Two independent reviewer agents approve after their playback findings were fixed. Exact final browser/CI results will be recorded in the review comment.

Addresses #617. Direct insertion and simultaneous native players are the next separate lifecycle slice. No real-host voice turn, Firefox browser confirmation or store release is claimed here; real-host spend is zero. Auth/JWT, manifest, permissions and release machinery are unchanged.

Implemented by Codex (GPT-6 Astra), with independent Codex reviewer agents. This was not executed in Claude Code.