### PR TITLE
Keep the dictation button visible after rapid refocus

### DIFF
--- a/e2e-firefox/README.md
+++ b/e2e-firefox/README.md
@@ -16,7 +16,8 @@ harness's static dev build) **temporary-installs into a real headless Firefox**,
 the background starts, the universal dictation content script
 (`entrypoints/saypi-universal.content.ts`, matches `http://*/*`) injects into a
 plain-HTTP localhost fixture page, and a focused text field gets a visible
-`.saypi-dictation-button`.
+`.saypi-dictation-button`. The smoke also blurs and immediately refocuses the
+field, then verifies visibility after the delayed blur handler has run (#622).
 
 - Manifest rejection, bundle-load errors, content-script injection breakage on
   Gecko, and decoration regressions all fail the smoke.

--- a/e2e-firefox/smoke.mjs
+++ b/e2e-firefox/smoke.mjs
@@ -205,6 +205,18 @@ async function main() {
       );
     }
 
+    // A delayed blur must not hide a field that regained focus (#622).
+    // Check after the 150 ms click grace period, using real browser focus events.
+    await driver.executeScript(
+      "const el = document.getElementById('smoke-input'); el.blur(); el.focus();",
+    );
+    await new Promise((r) => setTimeout(r, 250));
+    state = await driver.executeScript(PROBE_SCRIPT);
+    if (!state.present || state.display === "none" || state.activeElementId !== "smoke-input") {
+      await dumpFailureArtifacts(driver, state);
+      throw new Error(`Rapid refocus hid the dictation button: ${JSON.stringify(state)}`);
+    }
+
     console.log(
       `[e2e-firefox] PASS: .saypi-dictation-button visible on the focused input ` +
         `(probe: ${JSON.stringify(state)})`,

--- a/src/UniversalDictationModule.ts
+++ b/src/UniversalDictationModule.ts
@@ -364,7 +364,8 @@ export class UniversalDictationModule {
 
       // Use setTimeout to delay hiding so click event can fire first
       setTimeout(() => {
-        if (button && !this.currentActiveTarget) {
+        // A quick refocus can happen before this click grace period ends.
+        if (button && !this.currentActiveTarget && document.activeElement !== element) {
           button.style.display = "none";
         }
       }, 150);

--- a/test/UniversalDictationModule-PreFocusedDecoration.spec.ts
+++ b/test/UniversalDictationModule-PreFocusedDecoration.spec.ts
@@ -64,6 +64,7 @@ describe("UniversalDictationModule — decoration of an already-focused field (i
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     module.destroy();
     (UniversalDictationModule as any).instance = undefined;
     document.body.innerHTML = "";
@@ -124,4 +125,34 @@ describe("UniversalDictationModule — decoration of an already-focused field (i
     expect(document.querySelectorAll(".saypi-dictation-button").length).toBe(1);
     expect(buttonDisplay()).toBe("none");
   });
+
+  it("keeps the button visible after a blur followed by rapid refocus (#622)", () => {
+    vi.useFakeTimers();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    module.initialize();
+    input.focus();
+    input.blur();
+    vi.advanceTimersByTime(50);
+    input.focus();
+    expect(buttonDisplay()).toBe("flex");
+
+    vi.advanceTimersByTime(150);
+    expect(document.activeElement).toBe(input);
+    expect(buttonDisplay()).toBe("flex");
+  });
+
+  it("still hides an idle button after the field loses focus", () => {
+    vi.useFakeTimers();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    module.initialize();
+    input.focus();
+    input.blur();
+    vi.advanceTimersByTime(149);
+    expect(buttonDisplay()).toBe("flex");
+    vi.advanceTimersByTime(1);
+    expect(buttonDisplay()).toBe("none");
+  });
+
 });


### PR DESCRIPTION
When an input loses focus and regains it within the 150 ms click grace period, the old blur callback hides its dictation button anyway. The field stays focused, so another focus() call cannot reveal it. The callback now checks the current focused element before hiding the button; ordinary blur and active dictation behavior stay intact.

This was found while investigating #621's Firefox failure. The exact focused-input/hidden-button signature reproduces in both the parent and PR code, although the original CI focus event sequence was not recorded. The Firefox smoke now explicitly exercises blur/refocus and checks visibility after the delay.

Verification: fail-first module regression (1 failed / 5 passed before the fix), all 20 universal-dictation tests pass after; full npm test passes typecheck, Jest 2/2 and Vitest 2774 passed plus 1 existing skipped. Firefox dev build passes. Local Firefox execution is blocked before launch because Selenium Manager cannot download geckodriver through this environment's GitHub network restriction; the strengthened real-Firefox assertion runs in CI. Independent reviewer APPROVE, with 6/6 targeted tests independently run. No real-host voice turns.

Published tree a206c1176b0bdf7f5bbfa14b1cd5774edc1feb89 matches local committed tree exactly. GitHub connector used for publication because shell GitHub transport is unavailable.

Fixes #622.

Implemented and independently reviewed with Codex.