### PR TITLE
fix(audio): resume Pi speech when returning to its own voice

### DIFF
--- a/doc/audio-selection-reconciliation.md
+++ b/doc/audio-selection-reconciliation.md
@@ -61,3 +61,37 @@ source changes, unrelated media and shared-page replay/resume.
 
 Store release and attended real-host confirmation remain separate from these
 hermetic checks.
+
+
+## Explicit return to Pi (#624)
+
+“Use Pi’s own voice” is a playback request, not merely removal of a preference.
+`PreferenceModule` marks a local explicit unset, or an actual removal of the
+current host's saved key in `storage.onChanged`, as `nativeVoiceRequested`.
+Startup, auth fallback and writes for other hosts do not carry that intent.
+`AudioSelectionSync` preserves the pending request across a concurrent auth read;
+a newer explicit custom choice cancels it.
+
+The Pi audio owner first waits for an active offscreen stream or preview to stop,
+keeping native players suppressed throughout the wait. Duplicate notifications
+share one pending restore attempt. It then releases native mute bits even if an older runtime left
+them muted, resets output skip/replay state while retaining the call flag, and
+uses the existing `PiAutoRead` control to enable host speech. It resumes only the
+current loaded, unfinished native reply. If Firefox is still bound to its old
+custom player, it binds a retained native reply first. Ended and unrelated media
+are not started. After the asynchronous host control, it rechecks the current
+selection and player so a newer custom choice wins.
+
+Canceled offscreen events are ignored until a new explicit load or reload opens
+playback again; both commands use the same load implementation. This prevents a
+late custom event from stopping restored native speech without discarding the
+next custom voice's lifecycle. It is not a new cross-context generation protocol.
+
+The built-browser regression uses actual Settings selection and native-return
+buttons, starting with a loaded, muted, paused native player. It verifies real
+playback time advances with mute off and positive volume, on the same document,
+with Pi auto-read initially both on and off; selecting custom again suppresses it.
+This proves browser playback eligibility and progression, not an attended audible
+check in a user's installed tab. A rebuilt extension does not replace JavaScript
+already injected in an open page; stale installed runtimes require separate
+update verification before attributing their behavior to current source.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -348,3 +348,9 @@ tests, but it also carries risk that unit tests don't:
 When this suite is red, first reproduce locally with `npm run e2e:build &&
 npm run test:e2e`; if it's green locally but red on CI, suspect timing/flake and
 inspect the uploaded Playwright trace before changing any test.
+
+
+`specs/pi-native-restore.e2e.ts` covers the actual Settings custom→native→custom
+round trip against real media: an inherited muted, paused Pi reply must resume
+without reloading, with auto-read initially on or off. The host control is a
+local DOM contract fixture; no real Pi messages or user credits are consumed.

--- a/e2e/specs/pi-native-restore.e2e.ts
+++ b/e2e/specs/pi-native-restore.e2e.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "../fixtures/extension";
+import { MOCK_VOICE_IDS } from "../support/voice-catalog";
+import { openVoicesRail } from "../support/voices";
+import { resolve } from "node:path";
+
+for (const autoRead of [true, false]) {
+  test(`native return resumes muted, paused Pi without refreshing (auto-read=${autoRead})`, async ({
+    context, serviceWorker, extensionId,
+  }) => {
+    await expect.poll(() => serviceWorker.evaluate(async () =>
+      (await chrome.storage.local.get("saypi_voice_default_pending_hosts")).saypi_voice_default_pending_hosts,
+    )).toEqual(["claude", "pi"]);
+    await serviceWorker.evaluate(async () => {
+      const expiresAt = Date.now() + 3_600_000;
+      const claims = btoa(JSON.stringify({ sub: "native-return-test", exp: expiresAt / 1000 }));
+      await chrome.storage.local.set({
+        jwtToken: `e30.${claims}.hermetic`, tokenExpiresAt: expiresAt,
+        prefs_migration_completed: true, shareData: false,
+        saypi_voice_default_pending_hosts: [], voicePreferences: { pi: "voice4" },
+      });
+    });
+    const pi = await context.newPage();
+    await pi.route("https://pi.ai/api/chat/voice*", route => route.fulfill({
+      path: resolve(import.meta.dirname, "../fixtures/voices/onyx.mp3"), contentType: "audio/mpeg",
+    }));
+    await pi.goto("https://pi.ai/talk");
+    const player = pi.locator("audio#saypi-audio-main");
+    await expect(player).toHaveCount(1);
+    await player.evaluate((audio: HTMLAudioElement) => {
+      audio.src = "https://pi.ai/api/chat/voice?voice=voice4&messageSid=native-return";
+      audio.muted = true; // A player inherited from a previous suppressor/runtime.
+      audio.loop = true;
+      audio.load();
+    });
+    await expect.poll(() => player.evaluate((a: HTMLAudioElement) => a.readyState)).toBe(4);
+    // Model Pi's existing popover contract, including true state and its mirror.
+    await pi.evaluate(enabled => {
+      localStorage.setItem("isVoiceEnabled", String(enabled));
+      const menu = document.createElement("button");
+      menu.setAttribute("aria-label", "Chat options");
+      let item: HTMLButtonElement | null = null;
+      menu.onclick = () => {
+        if (item) { item.remove(); item = null; return; }
+        item = document.createElement("button");
+        item.dataset.testid = "chat-options-auto-read";
+        item.setAttribute("role", "menuitemcheckbox");
+        item.setAttribute("aria-checked", String(enabled));
+        item.onclick = () => {
+          enabled = !enabled;
+          item!.setAttribute("aria-checked", String(enabled));
+          localStorage.setItem("isVoiceEnabled", String(enabled));
+        };
+        document.body.append(item);
+      };
+      document.body.append(menu);
+      document.documentElement.dataset.restoreDocument = "same-page";
+    }, autoRead);
+    const settings = await context.newPage();
+    await openVoicesRail(settings, extensionId);
+    await settings.locator('.voice-host-tab[data-host="pi"]').click();
+    const row = settings.locator(`.voice-row[data-voice-id="${MOCK_VOICE_IDS.onyx}"]`);
+    await row.click();
+    await settings.keyboard.press("Enter");
+    await expect(row).toHaveAttribute("aria-selected", "true");
+    await expect.poll(() => player.evaluate((a: HTMLAudioElement) => a.muted)).toBe(true);
+
+    // Exercise both real settings actions across extension documents. No direct
+    // preference write for the tested round trip, no page reload, no fake play().
+    await settings.locator(".voice-native-return").click();
+    await expect.poll(() => serviceWorker.evaluate(async () =>
+      (await chrome.storage.local.get("voicePreferences")).voicePreferences,
+    )).toEqual({});
+    await expect.poll(() => player.evaluate((a: HTMLAudioElement) =>
+      !a.muted && !a.paused && a.volume > 0 && a.currentTime > 0.15,
+    )).toBe(true);
+    expect(await pi.evaluate(() => localStorage.getItem("isVoiceEnabled"))).toBe("true");
+    await expect(pi.locator("html")).toHaveAttribute("data-restore-document", "same-page");
+    // Returning to custom must silence the same advancing native player again.
+    await row.click(); await settings.keyboard.press("Enter");
+    await expect(row).toHaveAttribute("aria-selected", "true");
+    await expect.poll(() => player.evaluate((a: HTMLAudioElement) => a.muted)).toBe(true);
+  });
+}

--- a/src/audio/AudioModule.js
+++ b/src/audio/AudioModule.js
@@ -20,6 +20,7 @@ import { audioProviders } from "../tts/SpeechModel.ts";
 import { SpeechSynthesisModule } from "../tts/SpeechSynthesisModule.ts";
 import { isVoiceSampleUrl } from "../tts/SpeechSourceParsers.ts";
 import { PiNativeAudioGuard, audioSource, isPiNativeSpeechSource } from "./PiNativeAudioGuard.ts";
+import { piAutoRead } from "../chatbots/pi/PiAutoRead.ts";
 import { AudioSelectionSync } from "./AudioSelectionSync.ts";
 
 const INITIAL_PLAYBACK_BUFFER_TIMEOUT_MS = 5000;
@@ -208,14 +209,26 @@ export default class AudioModule {
       this.selectionSync = new AudioSelectionSync({
         hostId: chatbot.getID(),
         resolve: () => SpeechSynthesisModule.getInstance().getActiveAudioSelection(chatbot),
-        apply: (selection) => this.applyAudioSelection(selection),
+        apply: (selection, intent) => this.applyAudioSelection(selection, intent),
         onError: (error) => logger.error("[AudioModule] Could not reconcile voice selection", error),
       });
     }
     await this.selectionSync.start();
   }
 
-  applyAudioSelection({ provider, voice }) {
+  applyAudioSelection({ provider, voice }, { nativeVoiceRequested = false } = {}) {
+    // Keep a pending return alive through duplicate storage/auth notifications,
+    // but let a newer voice choice cancel it before releasing any native mute.
+    const previous = this.appliedSelection;
+    const changed = previous?.provider !== provider || (previous.voice?.id ?? null) !== (voice?.id ?? null);
+    if (changed) {
+      this.nativeRestoreRequest = null;
+      this.nativeRestoreHold = false;
+    }
+    const restoreNative = nativeVoiceRequested && provider === audioProviders.Pi && ChatbotIdentifier.isChatbotType("pi");
+    const offscreenSource = this.lastAudioUrl;
+    if (restoreNative && this.useOffscreenAudio && offscreenSource) this.nativeRestoreHold = true;
+    this.appliedSelection = { provider, voice };
     this.audioOutputActor?.send({ type: "changeVoice", voice });
     this.audioOutputActor?.send({ type: "changeProvider", provider });
     this.voiceConverter.send({ type: "changeVoice", voice });
@@ -224,25 +237,79 @@ export default class AudioModule {
 
     // Auth refreshes and other hosts' storage writes can resolve the same
     // selection again. Preserve intentional historical replays in that case.
-    const previous = this.appliedSelection;
-    this.appliedSelection = { provider, voice };
-    if (previous?.provider === provider && (previous.voice?.id ?? null) === (voice?.id ?? null)) return;
-
-    const offscreenSource = this.lastAudioUrl;
-    if (this.useOffscreenAudio && offscreenSource && !isVoiceSampleUrl(offscreenSource) &&
-        (!provider.matches(offscreenSource) || (voice && !voice.matchesSource(offscreenSource)))) {
+    let previousPlaybackStopped;
+    if (this.useOffscreenAudio && offscreenSource && (nativeVoiceRequested ||
+        (changed && !isVoiceSampleUrl(offscreenSource) &&
+          (!provider.matches(offscreenSource) || (voice && !voice.matchesSource(offscreenSource)))))) {
       this.lastAudioUrl = null;
-      this.offscreenBridge.stopAudio().catch((error) => {
+      this.offscreenPlaybackCancelled = true;
+      previousPlaybackStopped = this.offscreenBridge.stopAudio().catch((error) => {
         logger.error("[AudioModule] Could not stop the previous voice", error);
+        return false;
+      }).then(stopped => {
+        // The bridge reports transport failures as false, not just rejection.
+        // Retain the source so a later explicit return retries the stop first.
+        if (stopped === false && this.nativeRestoreHold && !this.lastAudioUrl) this.lastAudioUrl = offscreenSource;
+        return stopped;
       });
     }
 
     // Firefox/Safari share the page player with SayPi. Muting would silence
     // our speech too, but an already-playing native source must still stop.
     const source = this.audioElement?.currentSrc || this.audioElement?.src;
-    if (!this.useOffscreenAudio && source && !isVoiceSampleUrl(source) &&
-        (!provider.matches(source) || (voice && !voice.matchesSource(source)))) {
+    if (!this.useOffscreenAudio && source &&
+        ((nativeVoiceRequested && !isPiNativeSpeechSource(source)) ||
+        (changed && !isVoiceSampleUrl(source) &&
+          (!provider.matches(source) || (voice && !voice.matchesSource(source)))))) {
       this.stopOnscreenAudio();
+    }
+
+    if (restoreNative && !this.nativeRestoreRequest) {
+      // A user request is stronger than passive auth/startup reconciliation:
+      // release inherited mutes, skip/replay state and canceled custom events.
+      this.offscreenPlaybackCancelled = true;
+      this.audioOutputActor?.send({ type: "restoreNative" });
+      const request = {};
+      this.nativeRestoreRequest = request;
+      void this.restorePiNativePlayback(request, previousPlaybackStopped).catch(error => {
+        logger.error("[AudioModule] Could not resume Pi's native speech", error);
+      }).finally(() => {
+        if (this.nativeRestoreRequest === request) this.nativeRestoreRequest = null;
+      });
+    }
+  }
+
+  async restorePiNativePlayback(request, previousPlaybackStopped) {
+    if (previousPlaybackStopped && await previousPlaybackStopped === false) return;
+    const isCurrent = () => this.nativeRestoreRequest === request && this.appliedSelection?.provider === audioProviders.Pi;
+    if (!isCurrent()) return;
+    // A muted native player may already be running. Release it only after the
+    // custom stream has stopped, including capture events during that wait.
+    this.nativeRestoreHold = false;
+    this.piNativeAudioGuard.restoreNative([...document.querySelectorAll("audio")]);
+    // Reuse Pi's read-before-write control without call-start's skipNext policy.
+    await piAutoRead.setAudioOutputEnabled(true);
+    // The menu can mount asynchronously. A newer custom choice must win, and
+    // Pi may have replaced or started the player while enabling auto-read.
+    if (!isCurrent()) return;
+    const canResume = candidate => candidate?.isConnected &&
+      isPiNativeSpeechSource(audioSource(candidate)) && !candidate.ended && candidate.readyState >= 1;
+    let audio = this.audioElement;
+    if (!canResume(audio)) {
+      // Shared-page custom playback can keep the module bound while Pi inserts
+      // its next native player. Reuse that retained reply instead of waiting for
+      // another insertion or a page refresh. Never resume every coexisting player.
+      audio = [...document.querySelectorAll("audio")].reverse().find(canResume);
+    }
+    if (!audio) return;
+    if (audio !== this.audioElement) this.swapAudioElement(audio);
+    audio.muted = false;
+    const actor = this.audioOutputActor;
+    actor?.send({ type: "loadstart", source: audioSource(audio) });
+    actor?.send({ type: "loadedmetadata" });
+    if (audio.paused) await audio.play();
+    if (isCurrent() && audio === this.audioElement && !audio.paused) {
+      actor?.send({ type: "play", source: audioSource(audio) });
     }
   }
 
@@ -331,7 +398,7 @@ export default class AudioModule {
     if (ChatbotIdentifier.isChatbotType("pi")) {
       this.piNativeAudioGuard ??= new PiNativeAudioGuard();
       this.piNativeAudioGuard.reconcile([...document.querySelectorAll("audio")], {
-        customVoice: this.providerIsSayPi, offscreen: this.useOffscreenAudio, tracked: this.audioElement,
+        customVoice: this.providerIsSayPi || this.nativeRestoreHold, offscreen: this.useOffscreenAudio, tracked: this.audioElement,
         sharedOutput: this.isSharedPlayback(this.audioElement) ? this.audioElement : null,
       });
       return;
@@ -461,7 +528,7 @@ export default class AudioModule {
   }
 
   shouldIgnoreHostPlayback(audio) {
-    return this.providerIsSayPi && ChatbotIdentifier.isChatbotType("pi") &&
+    return (this.providerIsSayPi || this.nativeRestoreHold) && ChatbotIdentifier.isChatbotType("pi") &&
       isPiNativeSpeechSource(audioSource(audio)) && !this.isSharedPlayback(audio);
   }
 
@@ -521,15 +588,8 @@ export default class AudioModule {
       "audio:load",
       async (detail) => {
         logger.debug("audio:load", detail, this.useOffscreenAudio ? "offscreen" : "in-page");
-        this.lastAudioUrl = detail.url;
-        if (this.useOffscreenAudio) {
-          // Use offscreen bridge if available - now use loadAudio instead of playAudio
-          await this.offscreenBridge.loadAudio(detail.url, true);
-        } else {
-          // Fallback to in-page audio
-          const audio = this.findAudioElement(document) || new Audio();
-          this.loadAudio(audio, detail.url);
-        }
+        const audio = this.useOffscreenAudio ? this.audioElement : this.findAudioElement(document) || new Audio();
+        await this.loadAudio(audio, detail.url);
       },
       this
     );
@@ -541,7 +601,7 @@ export default class AudioModule {
           : this.lastAudioUrl;
           
         if (url) {
-          await this.offscreenBridge.loadAudio(url, reloadAudioRequest?.playImmediately !== false);
+          await this.loadAudio(this.audioElement, url, reloadAudioRequest?.playImmediately !== false);
         }
       } else {
         // For in-page audio
@@ -689,6 +749,7 @@ export default class AudioModule {
     if (url) {
       // Store the last URL for potential cache busting on reload
       this.lastAudioUrl = url;
+      this.offscreenPlaybackCancelled = false;
 
       this.cancelPendingPlayback();
 
@@ -1047,6 +1108,7 @@ export default class AudioModule {
     // Register listeners for standard events
     standardEvents.forEach((event) => {
       EventBus.on(`audio:offscreen:${event}`, (detail) => {
+        if (this.offscreenPlaybackCancelled) return;
         logger.debug(`[AudioModule] Forwarding offscreen event to audio output actor: ${event}`);
         outputActor.send({ type: event });
       }, this);
@@ -1055,6 +1117,7 @@ export default class AudioModule {
     // Register listeners for sourced events  
     sourcedEvents.forEach((event) => {
       EventBus.on(`audio:offscreen:${event}`, (detail) => {
+        if (this.offscreenPlaybackCancelled) return;
         logger.debug(`[AudioModule] Forwarding offscreen sourced event to audio output actor: ${event}`, detail);
         const eventDetail = { source: detail?.source || 'offscreen' };
         outputActor.send({ type: event, ...eventDetail });
@@ -1063,6 +1126,7 @@ export default class AudioModule {
     
     // Handle special case for 'playing' event which maps to 'play' 
     EventBus.on("audio:offscreen:playing", (detail) => {
+      if (this.offscreenPlaybackCancelled) return;
       logger.debug("[AudioModule] Forwarding offscreen 'playing' event as 'play' to audio output actor", detail);
       const eventDetail = { source: detail?.source || 'offscreen' };
       outputActor.send({ type: "play", ...eventDetail });

--- a/src/audio/AudioSelectionSync.ts
+++ b/src/audio/AudioSelectionSync.ts
@@ -10,11 +10,12 @@ export type AudioSelection = {
 export class AudioSelectionSync {
   private revision = 0;
   private started = false;
+  private nativeVoiceRequested = false;
 
   constructor(private readonly deps: {
     hostId: string;
     resolve: () => Promise<AudioSelection>;
-    apply: (selection: AudioSelection) => void;
+    apply: (selection: AudioSelection, intent: { nativeVoiceRequested: boolean }) => void;
     onError: (error: unknown) => void;
   }) {}
 
@@ -25,9 +26,12 @@ export class AudioSelectionSync {
         voicePreferences?: unknown;
         voiceId?: unknown;
         voiceChatbotId?: string;
+        nativeVoiceRequested?: boolean;
       } | undefined) => {
         if (!detail || (detail.voicePreferences === undefined && detail.voiceId === undefined)) return;
         if (detail.voiceChatbotId && detail.voiceChatbotId !== this.deps.hostId) return;
+        if (detail.nativeVoiceRequested) this.nativeVoiceRequested = true;
+        else if (detail.voiceId != null) this.nativeVoiceRequested = false;
         void this.refresh();
       });
       EventBus.on("saypi:auth:status-changed", () => { void this.refresh(); });
@@ -41,7 +45,11 @@ export class AudioSelectionSync {
     const revision = ++this.revision;
     try {
       const selection = await this.deps.resolve();
-      if (revision === this.revision) this.deps.apply(selection);
+      if (revision === this.revision) {
+        const nativeVoiceRequested = this.nativeVoiceRequested;
+        this.nativeVoiceRequested = false;
+        this.deps.apply(selection, { nativeVoiceRequested });
+      }
     } catch (error) {
       if (revision === this.revision) this.deps.onError(error);
     }

--- a/src/audio/PiNativeAudioGuard.ts
+++ b/src/audio/PiNativeAudioGuard.ts
@@ -16,6 +16,16 @@ export function audioSource(audio: HTMLAudioElement): string {
 export class PiNativeAudioGuard {
   private originalMute = new Map<HTMLAudioElement, boolean>();
 
+  /** An explicit native choice supersedes a stale mute inherited at startup. */
+  restoreNative(elements: HTMLAudioElement[]): void {
+    for (const audio of elements) {
+      if (audio.isConnected && isPiNativeSpeechSource(audioSource(audio))) {
+        this.originalMute.delete(audio);
+        audio.muted = false;
+      }
+    }
+  }
+
   reconcile(elements: HTMLAudioElement[], state: {
     customVoice: boolean;
     offscreen: boolean;

--- a/src/prefs/PreferenceModule.ts
+++ b/src/prefs/PreferenceModule.ts
@@ -454,6 +454,10 @@ class UserPreferenceModule {
                       voicePreferences: sanitized,
                       voiceId: voiceChatbotId ? sanitized[voiceChatbotId] ?? null : null,
                       voiceChatbotId: voiceChatbotId ?? null,
+                      // Only removing THIS host's saved choice is a native-return
+                      // request; startup, auth and other-host writes are passive.
+                      nativeVoiceRequested: Boolean(voiceChatbotId &&
+                        changes[key].oldValue?.[voiceChatbotId] && !sanitized[voiceChatbotId]),
                     };
                     break;
                   case "enableTTS": 
@@ -969,6 +973,7 @@ class UserPreferenceModule {
         audioProvider: audioProviders.getDefaultForChatbot(chatbotId),
         voicePreferences: preferences,
         voiceChatbotId: chatbotId,
+        nativeVoiceRequested: true,
       });
       return;
     }
@@ -982,6 +987,7 @@ class UserPreferenceModule {
       audioProvider: audioProviders.getDefaultForChatbot(chatbotId),
       voicePreferences: updatedPreferences,
       voiceChatbotId: chatbotId,
+        nativeVoiceRequested: true,
     });
   }
   

--- a/src/state-machines/AudioOutputMachine.ts
+++ b/src/state-machines/AudioOutputMachine.ts
@@ -44,6 +44,7 @@ type AudioOutputEvent =
   | { type: "canplaythrough" }
   | { type: "seeked" }
   | { type: "emptied" }
+  | { type: "restoreNative" }
   | ChangeProviderEvent
   | ChangeVoiceEvent
   | ReplayingAudioEvent
@@ -167,6 +168,10 @@ export const audioOutputMachine = setup({
   id: "audioOutput",
   initial: "idle",
   on: {
+    restoreNative: {
+      target: ".idle",
+      actions: ["clearSkip", "clearReplaying"],
+    },
     changeProvider: {
       actions: "setProvider",
     },

--- a/test/audio/AudioSelectionSync.spec.ts
+++ b/test/audio/AudioSelectionSync.spec.ts
@@ -48,10 +48,30 @@ describe("reconciling the running audio selection", () => {
     resolve = vi.fn(async () => selection);
     onError = vi.fn();
     sync = new AudioSelectionSync({ hostId: "pi", resolve: () => resolve(),
-      apply: value => audio.applyAudioSelection(value), onError });
+      apply: (value, intent) => audio.applyAudioSelection(value, intent), onError });
   });
 
   afterEach(() => { actor.stop(); EventBus.removeAllListeners(); vi.restoreAllMocks(); });
+
+  it("delivers an explicit native request through a concurrent auth refresh", async () => {
+    const apply = vi.spyOn(audio, "applyAudioSelection");
+    await sync.start(); apply.mockClear();
+    EventBus.emit("userPreferenceChanged", { voiceId: null, voiceChatbotId: "pi", nativeVoiceRequested: true });
+    EventBus.emit("saypi:auth:status-changed", true);
+    await vi.waitFor(() => expect(apply).toHaveBeenCalledWith(native, { nativeVoiceRequested: true }));
+  });
+
+  it("a newer custom choice cancels an outstanding explicit native request", async () => {
+    await sync.start();
+    const apply = vi.spyOn(audio, "applyAudioSelection");
+    const old = deferred<AudioSelection>(); resolve.mockReturnValueOnce(old.promise);
+    EventBus.emit("userPreferenceChanged", { voiceId: null, voiceChatbotId: "pi", nativeVoiceRequested: true });
+    selection = custom;
+    EventBus.emit("userPreferenceChanged", { voiceId: "shimmer", voiceChatbotId: "pi" });
+    await vi.waitFor(() => expect(apply).toHaveBeenCalledWith(custom, { nativeVoiceRequested: false }));
+    old.resolve(native); await Promise.resolve();
+    expect(actor.state.context.provider).toBe(audioProviders.SayPi);
+  });
 
   it("reads a saved custom choice when playback starts after the settings event", async () => {
     selection = custom;

--- a/test/audio/audioElementRemoval.spec.ts
+++ b/test/audio/audioElementRemoval.spec.ts
@@ -220,7 +220,7 @@ describe("AudioModule removal-observer wiring", () => {
     expect(source).toMatch(/applyHostAudioMute\(\)\s*\{/);
     expect(source).toMatch(/shouldMuteHostAudio\(\{/);
     const onProviderChange = source.match(
-      /applyAudioSelection\(\{ provider, voice \}\)\s*\{[\s\S]*?\n {2}\}/
+      /applyAudioSelection\(\{ provider, voice \}, \{ nativeVoiceRequested = false \} = \{\}\)\s*\{[\s\S]*?\n {2}\}/
     )?.[0];
     expect(onProviderChange).toMatch(/providerIsSayPi = /);
     expect(onProviderChange).toMatch(/this\.applyHostAudioMute\(\)/);

--- a/test/audio/piNativePlayerLifecycle.spec.ts
+++ b/test/audio/piNativePlayerLifecycle.spec.ts
@@ -5,6 +5,7 @@ import { audioProviders } from "../../src/tts/SpeechModel";
 import { audioOutputMachine } from "../../src/state-machines/AudioOutputMachine";
 import { createTestActor, type TestActor } from "../state-machines/support/testActor";
 import { isPiNativeSpeechSource } from "../../src/audio/PiNativeAudioGuard";
+import { piAutoRead } from "../../src/chatbots/pi/PiAutoRead";
 import AudioModule from "../../src/audio/AudioModule.js";
 
 // Keep the real output actor, bus and AudioModule apply/mute methods. The input
@@ -55,6 +56,194 @@ describe("Pi native player lifecycle", () => {
     if (audio.onHostAudioPlayback) for (const type of ["loadstart", "play", "playing"])
       document.removeEventListener(type, audio.onHostAudioPlayback, true);
     actor.stop(); EventBus.removeAllListeners(); vi.restoreAllMocks();
+  });
+
+  it.each([true, false])("explicit native return restores a previously muted, paused player (offscreen=%s)", async offscreen => {
+    audio.useOffscreenAudio = offscreen;
+    audio.applyAudioSelection({ provider: audioProviders.SayPi, voice: null });
+    const native = player(); native.muted = true;
+    let paused = true;
+    Object.defineProperties(native, {
+      paused: { get: () => paused }, readyState: { value: 4 },
+      currentSrc: { value: nativeSource },
+    });
+    native.play = vi.fn(async () => { paused = false; native.dispatchEvent(new Event("play")); });
+    document.body.append(native);
+    await vi.waitFor(() => expect(audio.audioElement).toBe(native));
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockResolvedValue(undefined);
+    actor.send({ type: "callStarted" });
+    actor.send({ type: "skipNext" });
+    audio.lastAudioUrl = "https://api.saypi.ai/speak/live/stream?voice_id=shimmer";
+    audio.registerOffscreenAudioEvents(actor);
+
+    audio.applyAudioSelection({ provider: audioProviders.Pi, voice: null }, { nativeVoiceRequested: true });
+    await vi.waitFor(() => expect(native.play).toHaveBeenCalledTimes(1));
+    expect(native.muted).toBe(false); expect(native.paused).toBe(false);
+    expect(piAutoRead.setAudioOutputEnabled).toHaveBeenCalledWith(true);
+    expect(actor.state.context.skip).toBe(false);
+    expect(actor.state.context.callActive).toBe(true);
+    expect(actor.state.matches({ loaded: "playing" })).toBe(true);
+    vi.mocked(native.pause).mockClear();
+    for (const event of ["pause", "emptied", "play"]) EventBus.emit(`audio:offscreen:${event}`, {
+      source: "https://api.saypi.ai/speak/live/stream?voice_id=shimmer",
+    });
+    expect(native.pause).not.toHaveBeenCalled();
+    expect(actor.state.matches({ loaded: "playing" })).toBe(true);
+  });
+
+  it("restores existing native audio while Firefox is still bound to its custom player", async () => {
+    audio.useOffscreenAudio = false;
+    audio.playWhenBuffered = vi.fn().mockResolvedValue(undefined);
+    audio.registerOfflineAudioCommands();
+    audio.applyAudioSelection({ provider: audioProviders.SayPi, voice: null });
+    EventBus.emit("audio:load", { url: "https://api.saypi.ai/speak/live/stream?voice_id=shimmer" });
+    const shared = audio.audioElement;
+    const native = player();
+    let paused = false;
+    Object.defineProperties(native, { paused: { get: () => paused }, readyState: { value: 4 } });
+    native.pause = vi.fn(() => { paused = true; });
+    native.play = vi.fn(async () => { paused = false; native.dispatchEvent(new Event("play")); });
+    document.body.append(native);
+    await vi.waitFor(() => expect(native.pause).toHaveBeenCalled());
+    expect(audio.audioElement).toBe(shared);
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockResolvedValue(undefined);
+    audio.applyAudioSelection({ provider: audioProviders.Pi, voice: null }, { nativeVoiceRequested: true });
+    await vi.waitFor(() => expect(audio.audioElement).toBe(native));
+    expect(native.paused).toBe(false); expect(native.muted).toBe(false);
+    expect(actor.state.matches({ loaded: "playing" })).toBe(true);
+  });
+
+  it.each(["audio:load", "audio:reload"])("accepts new offscreen playback after native return via %s", async command => {
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockResolvedValue(undefined);
+    audio.offscreenBridge.loadAudio = vi.fn().mockResolvedValue(undefined);
+    audio.registerOfflineAudioCommands(); audio.registerOffscreenAudioEvents(actor);
+    audio.applyAudioSelection({ provider: audioProviders.Pi, voice: null }, { nativeVoiceRequested: true });
+    audio.applyAudioSelection({ provider: audioProviders.SayPi, voice: null });
+    const source = "https://api.saypi.ai/speak/new/stream?voice_id=shimmer";
+    if (command === "audio:reload") audio.lastAudioUrl = source;
+    EventBus.emit(command, { url: source });
+    await vi.waitFor(() => expect(audio.offscreenBridge.loadAudio).toHaveBeenCalled());
+    EventBus.emit("audio:offscreen:loadstart", { source });
+    EventBus.emit("audio:offscreen:loadedmetadata", {});
+    EventBus.emit("audio:offscreen:play", { source });
+    expect(actor.state.matches({ loaded: "playing" })).toBe(true);
+  });
+
+  it("stops an active offscreen preview before resuming native speech", async () => {
+    let stopped!: () => void;
+    audio.offscreenBridge.stopAudio.mockImplementation(() => new Promise<void>(r => { stopped = r; }));
+    audio.offscreenBridge.loadAudio = vi.fn().mockResolvedValue(undefined);
+    audio.registerOfflineAudioCommands(); audio.registerOffscreenAudioEvents(actor);
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockResolvedValue(undefined);
+    const native = audio.audioElement;
+    Object.defineProperty(native, "readyState", { value: 4 });
+    const source = "https://api.saypi.ai/voices/shimmer/sample";
+    actor.send({ type: "preview", source });
+    EventBus.emit("audio:offscreen:loadstart", { source });
+    EventBus.emit("audio:offscreen:loadedmetadata", {});
+    EventBus.emit("audio:offscreen:play", { source });
+    audio.applyAudioSelection({ provider: audioProviders.Pi, voice: null }, { nativeVoiceRequested: true });
+    expect(audio.offscreenBridge.stopAudio).toHaveBeenCalledTimes(1);
+    await Promise.resolve(); expect(native.play).not.toHaveBeenCalled();
+    stopped(); await vi.waitFor(() => expect(native.play).toHaveBeenCalledTimes(1));
+  });
+
+  it("holds an already-playing native reply silent until offscreen stop finishes", async () => {
+    let stopped!: () => void;
+    audio.offscreenBridge.stopAudio.mockReturnValue(new Promise<void>(r => { stopped = r; }));
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockResolvedValue(undefined);
+    const native = audio.audioElement;
+    Object.defineProperties(native, { readyState: { value: 4 }, paused: { value: false } });
+    audio.lastAudioUrl = "https://api.saypi.ai/voices/shimmer/sample";
+    audio.applyAudioSelection({ provider: audioProviders.Pi, voice: null }, { nativeVoiceRequested: true });
+    expect(native.muted).toBe(true);
+    native.dispatchEvent(new Event("play"));
+    expect(native.muted).toBe(true);
+    expect(piAutoRead.setAudioOutputEnabled).not.toHaveBeenCalled();
+    stopped(); await vi.waitFor(() => expect(native.muted).toBe(false));
+    expect(native.play).not.toHaveBeenCalled();
+    expect(actor.state.matches({ loaded: "playing" })).toBe(true);
+  });
+
+  it.each([false, "reject"])("retries a failed offscreen stop before releasing native mute (%s)", async failure => {
+    if (failure === false) audio.offscreenBridge.stopAudio.mockResolvedValueOnce(false);
+    else audio.offscreenBridge.stopAudio.mockRejectedValueOnce(new Error("stop failed"));
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockResolvedValue(undefined);
+    const native = audio.audioElement;
+    Object.defineProperties(native, { readyState: { value: 4 }, paused: { value: false } });
+    audio.lastAudioUrl = "https://api.saypi.ai/voices/shimmer/sample";
+    const selection = { provider: audioProviders.Pi, voice: null };
+    audio.applyAudioSelection(selection, { nativeVoiceRequested: true });
+    await vi.waitFor(() => expect(audio.nativeRestoreRequest).toBeNull());
+    expect(native.muted).toBe(true);
+    let stopped!: () => void;
+    audio.offscreenBridge.stopAudio.mockReturnValue(new Promise<void>(r => { stopped = r; }));
+    audio.applyAudioSelection(selection, { nativeVoiceRequested: true });
+    expect(audio.offscreenBridge.stopAudio).toHaveBeenCalledTimes(2);
+    expect(native.muted).toBe(true);
+    stopped(); await vi.waitFor(() => expect(native.muted).toBe(false));
+  });
+
+  it.each(["ended", "unloaded"])("restores a retained reply when the tracked native player is %s", async state => {
+    const tracked = audio.audioElement;
+    const retained = player();
+    Object.defineProperty(retained, "readyState", { value: 4 });
+    document.body.append(retained);
+    await Promise.resolve();
+    audio.swapAudioElement(tracked);
+    Object.defineProperties(tracked, { readyState: { value: state === "ended" ? 4 : 0 }, ended: { value: state === "ended" } });
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockResolvedValue(undefined);
+    audio.applyAudioSelection({ provider: audioProviders.Pi, voice: null }, { nativeVoiceRequested: true });
+    await vi.waitFor(() => expect(retained.play).toHaveBeenCalledTimes(1));
+    expect(tracked.play).not.toHaveBeenCalled(); expect(audio.audioElement).toBe(retained);
+  });
+
+  it.each(["ended", "unrelated"])("does not start an %s player on explicit native return", async state => {
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockResolvedValue(undefined);
+    const native = audio.audioElement;
+    Object.defineProperties(native, { readyState: { value: 4 }, ended: { value: state === "ended" } });
+    if (state === "unrelated") native.src = "https://pi.ai/attachments/music.mp3";
+    audio.applyAudioSelection({ provider: audioProviders.Pi, voice: null }, { nativeVoiceRequested: true });
+    await Promise.resolve(); await Promise.resolve();
+    expect(native.play).not.toHaveBeenCalled();
+  });
+
+  it("uses Pi's replacement started while enabling auto-read without playing it twice", async () => {
+    const old = audio.audioElement;
+    const next = player();
+    Object.defineProperties(next, { readyState: { value: 4 }, paused: { value: false } });
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockImplementation(async () => {
+      document.body.append(next);
+      audio.swapAudioElement(next);
+    });
+    audio.applyAudioSelection({ provider: audioProviders.Pi, voice: null }, { nativeVoiceRequested: true });
+    await Promise.resolve(); await Promise.resolve();
+    expect(next.muted).toBe(false); expect(next.play).not.toHaveBeenCalled(); expect(old.play).not.toHaveBeenCalled();
+    expect(actor.state.matches({ loaded: "playing" })).toBe(true);
+  });
+
+  it("coalesces local and storage notifications for the same native request", async () => {
+    let enabled!: () => void;
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockReturnValue(new Promise<void>(r => { enabled = r; }));
+    const native = audio.audioElement;
+    Object.defineProperty(native, "readyState", { value: 4 });
+    const selection = { provider: audioProviders.Pi, voice: null };
+    audio.applyAudioSelection(selection, { nativeVoiceRequested: true });
+    audio.applyAudioSelection(selection, { nativeVoiceRequested: true });
+    expect(piAutoRead.setAudioOutputEnabled).toHaveBeenCalledTimes(1);
+    enabled(); await vi.waitFor(() => expect(native.play).toHaveBeenCalledTimes(1));
+  });
+
+  it("a new custom choice cancels native restoration while auto-read opens", async () => {
+    let enabled!: () => void;
+    vi.spyOn(piAutoRead, "setAudioOutputEnabled").mockReturnValue(new Promise(r => { enabled = r; }));
+    const native = audio.audioElement;
+    Object.defineProperty(native, "readyState", { value: 4 });
+    audio.applyAudioSelection({ provider: audioProviders.Pi, voice: null }, { nativeVoiceRequested: true });
+    expect(piAutoRead.setAudioOutputEnabled).toHaveBeenCalled();
+    audio.applyAudioSelection({ provider: audioProviders.SayPi, voice: null });
+    enabled(); await Promise.resolve(); await Promise.resolve();
+    expect(native.play).not.toHaveBeenCalled(); expect(native.muted).toBe(true);
   });
 
   it.each([false, true])("binds directly/nested inserted native audio (nested=%s)", async nested => {
@@ -184,7 +373,7 @@ describe("Pi native player lifecycle", () => {
     EventBus.emit("audio:load", { url: nativeSource });
     audio.applyAudioSelection({ provider: audioProviders.SayPi, voice: null });
     const native = audio.audioElement;
-    native.pause.mockClear();
+    vi.mocked(native.pause).mockClear();
     Object.defineProperty(native, "paused", { configurable: true, value: false });
     native.dispatchEvent(new Event("play"));
     expect(native.pause).toHaveBeenCalled();

--- a/test/prefs/VoicePreferences.spec.ts
+++ b/test/prefs/VoicePreferences.spec.ts
@@ -327,3 +327,38 @@ describe('UserPreferenceModule new-install default voice (Marin, 2026-07-05)', (
     expect(store[VOICE_DEFAULT_PENDING_KEY]).toEqual(['pi']); // drained by the off
   });
 });
+
+
+describe('explicit native return intent', () => {
+  it.each([
+    [{ pi: 'shimmer', claude: 'alloy' }, { claude: 'alloy' }, true],
+    [{ claude: 'alloy' }, {}, false],
+    [undefined, {}, false],
+    [{ pi: 'shimmer' }, { pi: 'alloy' }, false],
+  ])('marks only this host removal (%j → %j)', async (oldValue, newValue, expected) => {
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const { ChatbotIdentifier } = await import('../../src/chatbots/ChatbotIdentifier');
+    vi.spyOn(ChatbotIdentifier, 'getAppId').mockReturnValue('pi');
+    const { default: EventBus } = await import('../../src/events/EventBus');
+    const events: any[] = [];
+    EventBus.on('userPreferenceChanged', (detail: unknown) => events.push(detail));
+    let listener: any;
+    (globalThis as any).chrome.storage.onChanged = { addListener: (fn: any) => { listener = fn; } };
+    (prefs as any).registerMessageListeners();
+    listener({ voicePreferences: { oldValue, newValue } }, 'local');
+    expect(events.at(-1)).toMatchObject({ nativeVoiceRequested: expected, voiceChatbotId: 'pi' });
+    EventBus.removeAllListeners();
+  });
+
+  it('keeps an explicit local native request even when no override is stored', async () => {
+    const prefs = prefsModule.UserPreferenceModule.getInstance();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const { default: EventBus } = await import('../../src/events/EventBus');
+    const events: any[] = [];
+    EventBus.on('userPreferenceChanged', (detail: unknown) => events.push(detail));
+    await prefs.unsetVoice('pi');
+    expect(events.at(-1)).toMatchObject({ nativeVoiceRequested: true, voiceChatbotId: 'pi', voiceId: null });
+    EventBus.removeAllListeners();
+  });
+});


### PR DESCRIPTION
Selecting “Use Pi’s own voice” removed the custom preference but could leave Pi’s current player muted and paused. The explicit return now carries playback intent through storage and auth reconciliation, waits for custom audio to stop, clears inherited native mutes and skip/replay state, enables Pi auto-read, and resumes a loaded unfinished native reply on the same page. Passive startup/auth refresh remains passive, and a newer custom choice cancels restoration.

The change also handles retained Firefox/Safari native players, coexisting players, duplicate notifications, active previews, late canceled offscreen events, and stop failures that resolve false or reject. Both load and reload reopen the same offscreen event path.

Validation: fail-first Settings round-trip regressions failed on main with auto-read initially on and off, then passed with real media time advancing, mute off, positive volume, and no page reload. Final local typecheck, Jest (2 tests), Vitest (2,819 passed; one existing skip), and all 47 Chrome E2E tests pass. Two independent Codex reviewers approved after adversarial review and fail-first corrections. Firefox development build and smoke pass in CI. Local smoke could not download geckodriver because shell access to GitHub is unavailable; the CI smoke executed successfully. The full local unit suite was also rerun successfully with Node 22 explicitly pinned.

Installed-runtime limitation: read-only inspection found an old open Pi tab with a muted, paused native player and auto-read already enabled. Its console behavior suggests stale injected JavaScript despite a newer build on disk. Installed Settings access was security-blocked, and no alternate access was attempted. Hermetic tests prove this source fix; attended installed-tab confirmation and store release remain separate. Zero real-host voice runs.

Fixes #624

Implemented and independently reviewed with OpenAI Codex (Astra).