### PR TITLE
fix(pi): match the call button to Pi's native send button

### DIFF
--- a/src/chatbots/Pi.ts
+++ b/src/chatbots/Pi.ts
@@ -180,13 +180,10 @@ class PiAIChatbot extends AbstractChatbot {
   }
 
   getExtraCallButtonClasses(): string[] {
-    return [
-      "fixed",
-      "rounded-full",
-      "bg-cream-550",
-      "enabled:hover:bg-cream-650",
-      "m-2",
-    ];
+    // Colour (incl. hover/tap) is token-driven in pi.scss; Pi's build no longer
+    // ships the `--color-cream-*` tokens, so the old `bg-cream-550` /
+    // `enabled:hover:bg-cream-650` classes were silent no-ops.
+    return ["fixed", "rounded-full", "m-2"];
   }
 
   /**

--- a/src/styles/pi.scss
+++ b/src/styles/pi.scss
@@ -248,6 +248,33 @@ html body.pi {
   #saypi-callButton {
     /* Ensure button stays properly positioned next to both input and textarea */
     align-self: center;
+    /* Match Pi's native send button box (`size-10` = 2.5rem = 40px, all
+       breakpoints). desktop.scss sets a generic 36px width for every host;
+       the extra 4px here is what keeps the two discs the same size side by side. */
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  /* Idle disc: paint it with Pi's own accent tokens rather than call.svg's
+     baked-in SayPi brand green (#418a2f). The native send button beside it is
+     `bg-accent-alt-default hover:bg-accent-alt-hover active:bg-accent-alt-tap`
+     with a `text-base-contrast` glyph, and Pi redefines all of those under
+     `.dark` — so leaning on the tokens keeps the two buttons the same shade in
+     both themes. Scoped to the idle state: `.disabled` keeps the shared cream
+     disc (common.scss) and `.active` keeps its grey hangup disc (below). The
+     receiver glyph is retinted for every state so it always reads as Pi's
+     icon-on-accent colour. */
+  #saypi-callButton:not(.active):not(.disabled) svg path.background {
+    fill: var(--color-accent-alt-default, #038247);
+  }
+  #saypi-callButton:not(.active):not(.disabled):hover svg path.background {
+    fill: var(--color-accent-alt-hover, #077843);
+  }
+  #saypi-callButton:not(.active):not(.disabled):active svg path.background {
+    fill: var(--color-accent-alt-tap, #0a6e40);
+  }
+  #saypi-callButton svg path.phone-receiver {
+    fill: var(--color-base-contrast, #fcfaf7);
   }
 
   /* In-call (active) state: keep the hangup disc clearly visible — its intended
@@ -267,11 +294,11 @@ html body.pi {
   /* Mobile-specific button sizing to match Pi's native buttons */
   @media (max-width: 768px) {
     #saypi-callButton {
-      /* Match Pi's native submit button size (size-9 = 36px = 2.25rem) */
-      min-width: 2.25rem;
-      min-height: 2.25rem;
-      width: 2.25rem;
-      height: 2.25rem;
+      /* Match Pi's native submit button size (size-10 = 40px = 2.5rem) */
+      min-width: 2.5rem;
+      min-height: 2.5rem;
+      width: 2.5rem;
+      height: 2.5rem;
       flex-shrink: 0; /* Prevent button from shrinking in flex container */
     }
 

--- a/test/chatbots/Pi-CallButtonNativeParity.spec.ts
+++ b/test/chatbots/Pi-CallButtonNativeParity.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { PiAIChatbot } from "../../src/chatbots/Pi";
+
+/**
+ * Regression guard for the call button matching Pi's native send button.
+ *
+ * Pi's composer send button is `size-10` (40px) painted with Pi's
+ * `--color-accent-alt-*` tokens (#038247 light / #43A774 dark, with hover and
+ * tap shades). The call button had drifted: a 36px disc in SayPi's own brand
+ * green (#418a2f from call.svg), sitting visibly smaller and a different shade
+ * beside the send button. The fix pins the disc's size and fills to Pi's tokens
+ * so it tracks Pi's theme (incl. dark mode) the same way the native button does.
+ *
+ * Visual parity is verified at Layer 4 on real pi.ai; this guards the rules
+ * against silently regressing to the brand green / 36px.
+ */
+const piScss = readFileSync(
+  fileURLToPath(new URL("../../src/styles/pi.scss", import.meta.url)),
+  "utf8"
+);
+
+describe("Pi call button matches the native send button (pi.scss)", () => {
+  it("sizes the call button to Pi's size-10 (2.5rem) on desktop", () => {
+    expect(piScss).toMatch(
+      /#saypi-callButton\s*\{[^}]*width:\s*2\.5rem;[^}]*height:\s*2\.5rem;/
+    );
+  });
+
+  it("does not keep the stale size-9 (2.25rem) mobile sizing", () => {
+    expect(piScss).not.toMatch(/#saypi-callButton\s*\{[^}]*2\.25rem/);
+  });
+
+  it("paints the idle disc with Pi's --color-accent-alt-default token", () => {
+    expect(piScss).toMatch(
+      /#saypi-callButton[^{]*svg path\.background\s*\{[^}]*fill:\s*var\(--color-accent-alt-default/
+    );
+  });
+
+  it("uses Pi's hover and tap accent tokens for the disc", () => {
+    expect(piScss).toMatch(/:hover[^{]*\{[^}]*var\(--color-accent-alt-hover/);
+    expect(piScss).toMatch(/:active[^{]*\{[^}]*var\(--color-accent-alt-tap/);
+  });
+
+  it("colours the receiver glyph with Pi's --color-base-contrast token", () => {
+    expect(piScss).toMatch(
+      /path\.phone-receiver\s*\{[^}]*fill:\s*var\(--color-base-contrast/
+    );
+  });
+});
+
+describe("Pi call button host classes", () => {
+  it("no longer carries the cream Tailwind classes Pi's build has dropped", () => {
+    // Pi's `--color-cream-*` tokens are gone from pi.ai, so bg-cream-550 and
+    // enabled:hover:bg-cream-650 were silent no-ops; hover is now token-driven.
+    const classes = new PiAIChatbot().getExtraCallButtonClasses();
+    expect(classes).not.toContain("bg-cream-550");
+    expect(classes).not.toContain("enabled:hover:bg-cream-650");
+  });
+});


### PR DESCRIPTION
## Why

On pi.ai the SayPi call button sits beside Pi's native send button, and the two had drifted apart: the call button was a 36px disc in SayPi's brand green (#418a2f, baked into `call.svg`) while Pi's send button is now `size-10` (40px) in Pi's `accent-alt` green (#038247). Side by side the call button looked slightly smaller and a slightly different shade.

Measured live on pi.ai/talk before the change:

| | call button | native send |
|---|---|---|
| box | 36×36 | 40×40 |
| disc | `#418a2f` | `#038247` (`--color-accent-alt-default`) |
| hover / tap | none (dead `bg-cream-650` class) | `#077843` / `#0a6e40` |

## What

- **Size**: 2.5rem on desktop and at the mobile breakpoint (was 2.25rem, matching an older `size-9` Pi).
- **Colour**: the idle disc, hover and active states use Pi's `--color-accent-alt-default/hover/tap` tokens; the receiver glyph uses `--color-base-contrast`. Pi redefines all of these under `.dark`, so the button follows Pi's theme exactly like the native button.
- **Untouched states**: `.disabled` keeps the shared cream disc; `.active` keeps the grey hangup disc.
- **Vestigial classes**: Pi's build no longer ships `--color-cream-*`, so `bg-cream-550` / `enabled:hover:bg-cream-650` on the button were silent no-ops and are dropped.

All rules live under `html body.pi` in `pi.scss`; no other host changes.

## Verification

- Fail-first spec `test/chatbots/Pi-CallButtonNativeParity.spec.ts` (6 tests failed before, pass after).
- `npm test` green (tsc + Jest + Vitest); `pi.scss` compiles standalone.
- Live preview of the identical rules injected on pi.ai/talk: both buttons at 40×40 with identical top/bottom edges and the same computed fill `rgb(3,130,71)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hoGbuD6zpRQjc2aZh5tnD