### PR TITLE
feat(release): probe every store-listing URL before publish

### DIFF
--- a/doc/release/README.md
+++ b/doc/release/README.md
@@ -81,7 +81,9 @@ needs `.env.production`, which is never copied into a worktree.
 ### 0. Preflight (read-only)
 `node scripts/release.mjs preflight`. Confirms on `main`, tree clean, `HEAD == origin/main`,
 `node`/`npm`/`jq`/`zip` present, `.env.production` exists (existence only), latest `test.yaml`
-green, and prints the version state. Resolve anything blocking first.
+green, **every store-listing URL answers a clean 200** (probed 3× from `stores.json` →
+`listingUrls`; Chrome validates them at publish time and fails with an opaque error
+otherwise — v1.14.0's intermittent 404 on the support URL), and prints the version state. Resolve anything blocking first.
 
 ### 1. Decide the version ⛔
 `node scripts/release.mjs plan`. Derives the version from the **published baseline + the

--- a/doc/release/chrome-web-store.md
+++ b/doc/release/chrome-web-store.md
@@ -26,6 +26,22 @@ Canonical answers live in `doc/WEB_STORE_PERMISSIONS.md`. The tab is sticky but 
 - **Data-usage disclosures** (which data types) + **certifications** (not sold; used only for the single purpose; no creditworthiness use).
 - **Privacy policy URL:** https://saypi.ai/legal/privacy
 
+## Listing URLs are validated at publish time
+
+The `:publish` step (API **and** dashboard) fetches every URL on the listing — homepage,
+support, privacy policy, terms, promo video — and fails the whole submission with an opaque
+`INVALID_ARGUMENT: Your submission does not meet the requirements to be published in the
+store. Check the Developer Dashboard for steps to resolve.` if any of them isn't a clean
+200. The package upload itself succeeds, so the API gives no hint; only the dashboard's
+Store listing tab shows the red flag on the offending field.
+
+**v1.14.0 (2026-09-06):** the support URL `https://www.saypi.ai/docs` was intermittently
+serving a 404, so the first `release:submit -- chrome --yes` was refused. Now guarded:
+`release:preflight` probes each URL in `stores.json` → `listingUrls` three times and
+blocks on any non-200 (redirects count as failures — use the final URL), and
+`release:submit` re-runs the same check before uploading. **Whenever a listing gains a
+new URL on any store, add it to `listingUrls`.**
+
 ## Package & limits
 - `.zip` of the **contents** of `.output/chrome-mv3/` with `manifest.json` at the **root** (package-extension.sh does this).
 - Version bump mandatory (see above). No practical ZIP-size limit for us (the AMO 5 MB non-binary limit is a *Firefox* constraint, not Chrome).

--- a/doc/release/stores.json
+++ b/doc/release/stores.json
@@ -1,6 +1,17 @@
 {
   "_comment": "Single source of truth for store identity + per-store submission facts. Consumed by scripts/release.mjs (renderPacket) and any future browser-driver / publishing-API path. Update when a store changes its flow or when the Edge product ID is captured. Facts verified 2026-06-20 — see references/*.md for sources.",
-  "order": ["chrome", "edge", "firefox"],
+  "order": [
+    "chrome",
+    "edge",
+    "firefox"
+  ],
+  "listingUrls_comment": "Every URL entered on ANY store listing (homepage, support, privacy policy, terms, promo video, …). Chrome validates these at PUBLISH time and rejects with an opaque INVALID_ARGUMENT when one isn't a clean 200 (v1.14.0, 2026-09-06: an intermittent 404 on /docs). `release:preflight` probes each 3× and blocks; `release:submit` re-checks before upload. Use the FINAL url (no redirects), and add new URLs here whenever a listing gains one.",
+  "listingUrls": {
+    "homepage": "https://www.saypi.ai",
+    "support": "https://www.saypi.ai/docs",
+    "privacyPolicy": "https://www.saypi.ai/legal/privacy",
+    "terms": "https://www.saypi.ai/legal/terms"
+  },
   "stores": {
     "chrome": {
       "displayName": "🟢 Chrome Web Store",
@@ -29,7 +40,8 @@
       ],
       "gotchas": [
         "No \"what's new\" field — users do not see the changelog on Chrome.",
-        "Package = the CONTENTS of .output/chrome-mv3 zipped with manifest.json at the root (package-extension.sh already does this)."
+        "Package = the CONTENTS of .output/chrome-mv3 zipped with manifest.json at the root (package-extension.sh already does this).",
+        "The store validates every listing URL (homepage/support/privacy/…) at PUBLISH time; a non-200 fails the publish with the opaque \"Your submission does not meet the requirements to be published in the store\" (v1.14.0). `release:preflight` / `release:submit` probe the URLs in `listingUrls` first."
       ],
       "api": {
         "exists": true,

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -669,3 +669,68 @@ export function webExtSignArgs({ sourceDir, artifactsDir, sourceCode, metadataFi
 }
 
 export const PUBLISH_STORES = ["chrome", "edge", "firefox"];
+
+// ── Listing-URL liveness (lesson from the v1.14.0 wet run) ───────────────────────
+//
+// The Chrome Web Store validates every URL on the listing (homepage, support, privacy
+// policy, terms, promo video, …) at PUBLISH time and refuses the submission with an
+// opaque `INVALID_ARGUMENT: Your submission does not meet the requirements` when one of
+// them doesn't answer 200. v1.14.0 tripped this because the site was *intermittently*
+// serving a 404 for the support route. So: probe every listing URL up front, several
+// times, and treat anything but a clean 200 (redirects included — the store's fetcher
+// is not guaranteed to follow them) as a release blocker.
+
+/** Flatten `stores.json`'s `listingUrls` block into [{ label, url }]. */
+export function listingUrlsFrom(stores = {}) {
+  const block = stores.listingUrls ?? {};
+  return Object.entries(block)
+    .filter(([, url]) => typeof url === "string" && url.length > 0)
+    .map(([label, url]) => ({ label, url }));
+}
+
+/**
+ * Interpret one probe outcome. `redirected`/`finalUrl` come from fetch's Response;
+ * `error` is a thrown network error's message.
+ * @param {{ status?: number, redirected?: boolean, finalUrl?: string, url?: string, error?: string }} [probe]
+ * @returns {{ ok: boolean, detail: string }}
+ */
+export function interpretUrlProbe({ status, redirected = false, finalUrl, url, error } = {}) {
+  if (error) return { ok: false, detail: `network error: ${error}` };
+  if (redirected && finalUrl && finalUrl !== url) {
+    return { ok: false, detail: `redirects to ${finalUrl} — store validators may not follow; use the final URL` };
+  }
+  if (status === 200) return { ok: true, detail: "200" };
+  return { ok: false, detail: `HTTP ${status}` };
+}
+
+/**
+ * Probe each URL `attempts` times (the v1.14.0 failure was intermittent, so a single
+ * 200 proves nothing). A URL passes only if EVERY attempt is a clean 200. Pure w.r.t.
+ * I/O: the caller injects `fetchImpl` (and an optional `sleep`), so tests need no network.
+ */
+/**
+ * @param {Array<{ label: string, url: string }>} urls
+ * @param {{ fetchImpl?: (url: string, init?: any) => Promise<{ status: number, redirected: boolean, url: string }>, attempts?: number, delayMs?: number, sleep?: (ms: number) => Promise<void> }} [opts]
+ * @returns {Promise<Array<{ label: string, url: string, ok: boolean, attempts: number, failures: string[] }>>}
+ */
+export async function probeListingUrls(urls = [], { fetchImpl, attempts = 3, delayMs = 750, sleep } = {}) {
+  if (typeof fetchImpl !== "function") throw new Error("probeListingUrls needs a fetchImpl");
+  const wait = sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const results = [];
+  for (const { label, url } of urls) {
+    const failures = [];
+    for (let i = 0; i < attempts; i++) {
+      if (i > 0) await wait(delayMs);
+      let verdict;
+      try {
+        const res = await fetchImpl(url, { method: "GET", redirect: "follow" });
+        verdict = interpretUrlProbe({ status: res.status, redirected: res.redirected, finalUrl: res.url, url });
+      } catch (e) {
+        verdict = interpretUrlProbe({ url, error: e?.message ?? String(e) });
+      }
+      if (!verdict.ok) failures.push(`attempt ${i + 1}: ${verdict.detail}`);
+    }
+    results.push({ label, url, ok: failures.length === 0, attempts, failures });
+  }
+  return results;
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -37,6 +37,8 @@ import {
   checkSourceEntries,
   chooseReleaseCommit,
   PUBLISH_STORES,
+  listingUrlsFrom,
+  probeListingUrls,
 } from "./release-lib.mjs";
 import { submitToStore } from "./release-publish.mjs";
 
@@ -88,6 +90,32 @@ function loadStores() {
   return JSON.parse(readFileSync(STORES_PATH, "utf8"));
 }
 
+/**
+ * Probe every listing URL from stores.json (homepage/support/privacy/…) several times.
+ * Prints one line per URL; returns the number of failing URLs. Used by preflight
+ * (blocking) and re-run by submit (abort before upload) — see release-lib.mjs.
+ */
+async function checkListingUrls() {
+  const urls = listingUrlsFrom(loadStores());
+  if (!urls.length) {
+    warn(`no listingUrls in stores.json — the store validates them at publish time (add them)`);
+    return 0;
+  }
+  const results = await probeListingUrls(urls, { fetchImpl: globalThis.fetch });
+  let failing = 0;
+  for (const r of results) {
+    if (r.ok) ok(`listing URL ${r.label}: ${r.url} (200 ×${r.attempts})`);
+    else {
+      failing++;
+      bad(`listing URL ${r.label}: ${r.url} — ${r.failures.join("; ")}`);
+    }
+  }
+  if (failing) {
+    bad(`${failing} listing URL(s) unhealthy — the store rejects the publish with an opaque "does not meet the requirements" error. Fix the site (or the URL in the store listing + stores.json) first.`);
+  }
+  return failing;
+}
+
 function gather() {
   const baseline = baselineTag();
   const pkg = pkgVersion();
@@ -99,7 +127,7 @@ function gather() {
 
 // ── Commands ──────────────────────────────────────────────────────────────────────
 
-function cmdPreflight() {
+async function cmdPreflight() {
   log(`${C.bold}Release preflight${C.reset}\n`);
   let problems = 0;
 
@@ -144,6 +172,9 @@ function cmdPreflight() {
   } catch {
     log(`${C.dim}  (gh unavailable — skipped CI status check)${C.reset}`);
   }
+
+  log(`\n${C.bold}Listing URLs${C.reset} ${C.dim}(validated by the stores at publish time)${C.reset}`);
+  problems += await checkListingUrls();
 
   const { baseline, pkg, decision } = gather();
   log(`\n${C.bold}Version state${C.reset}`);
@@ -472,6 +503,10 @@ async function cmdSubmit({ store, version, yes, dryRun }) {
   if (!dryRun) requireYes(`submit ${store}`, { yes });
   const v = version || pkgVersion();
   log(`${C.bold}${dryRun ? "Dry-run" : "Submitting"} ${store} — v${v}${C.reset}`);
+  if (await checkListingUrls()) {
+    bad(`aborting ${store} ${dryRun ? "dry-run" : "submission"} before upload — listing URLs must answer 200.`);
+    process.exit(1);
+  }
   const releaseNotes = existsSync(RELEASE_NOTES_PATH) ? readFileSync(RELEASE_NOTES_PATH, "utf8").trim() : "";
   const approvalNotes =
     "Built with Node >=22 / npm >=10: `npm ci && npm run build:firefox`. Source in source-code.zip " +

--- a/test/scripts/release-listing-urls.spec.ts
+++ b/test/scripts/release-listing-urls.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { listingUrlsFrom, interpretUrlProbe, probeListingUrls } from "../../scripts/release-lib.mjs";
+import stores from "../../doc/release/stores.json";
+
+// Regression net for the v1.14.0 wet run: the Chrome Web Store refused the publish with an
+// opaque INVALID_ARGUMENT because the support URL was intermittently 404ing. These pin the
+// probe semantics that make preflight/submit catch that before any upload.
+
+const resp = (status: number, url: string, redirected = false) =>
+  ({ status, url, redirected }) as unknown as Response;
+
+describe("listingUrlsFrom", () => {
+  it("flattens the stores.json listingUrls block, skipping blanks", () => {
+    expect(listingUrlsFrom({ listingUrls: { homepage: "https://a", support: "", video: undefined } })).toEqual([
+      { label: "homepage", url: "https://a" },
+    ]);
+  });
+  it("returns [] when the block is absent", () => {
+    expect(listingUrlsFrom({})).toEqual([]);
+  });
+  it("the real stores.json carries every URL a store listing uses, all on the final host", () => {
+    const urls = listingUrlsFrom(stores as any);
+    const labels = urls.map((u) => u.label);
+    expect(labels).toEqual(expect.arrayContaining(["homepage", "support", "privacyPolicy", "terms"]));
+    for (const { url } of urls) expect(url).toMatch(/^https:\/\/www\.saypi\.ai(\/|$)/);
+  });
+});
+
+describe("interpretUrlProbe", () => {
+  it("accepts only a clean 200", () => {
+    expect(interpretUrlProbe({ status: 200, url: "https://a" }).ok).toBe(true);
+    expect(interpretUrlProbe({ status: 404, url: "https://a" })).toEqual({ ok: false, detail: "HTTP 404" });
+    expect(interpretUrlProbe({ status: 500, url: "https://a" }).ok).toBe(false);
+  });
+  it("treats a followed redirect as a failure (store validators may not follow)", () => {
+    const v = interpretUrlProbe({ status: 200, redirected: true, finalUrl: "https://www.a/x", url: "https://a/x" });
+    expect(v.ok).toBe(false);
+    expect(v.detail).toContain("redirects to https://www.a/x");
+  });
+  it("reports network errors", () => {
+    expect(interpretUrlProbe({ url: "https://a", error: "ECONNRESET" })).toEqual({
+      ok: false,
+      detail: "network error: ECONNRESET",
+    });
+  });
+});
+
+describe("probeListingUrls", () => {
+  const urls = [{ label: "support", url: "https://www.saypi.ai/docs" }];
+  const noSleep = async () => {};
+
+  it("requires a fetch implementation (no ambient network in tests)", async () => {
+    await expect(probeListingUrls(urls, {} as any)).rejects.toThrow(/fetchImpl/);
+  });
+
+  it("passes a URL only when every attempt is a clean 200", async () => {
+    const fetchImpl = vi.fn(async (u: string) => resp(200, u));
+    const [r] = await probeListingUrls(urls, { fetchImpl, attempts: 3, sleep: noSleep });
+    expect(r).toMatchObject({ label: "support", ok: true, attempts: 3, failures: [] });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails on an INTERMITTENT 404 (the v1.14.0 shape) and names the bad attempt", async () => {
+    let n = 0;
+    const fetchImpl = vi.fn(async (u: string) => resp(++n === 2 ? 404 : 200, u));
+    const [r] = await probeListingUrls(urls, { fetchImpl, attempts: 3, sleep: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.failures).toEqual(["attempt 2: HTTP 404"]);
+  });
+
+  it("captures thrown network errors instead of aborting the whole probe", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ENOTFOUND");
+    });
+    const [r] = await probeListingUrls(urls, { fetchImpl, attempts: 2, sleep: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.failures).toEqual(["attempt 1: network error: ENOTFOUND", "attempt 2: network error: ENOTFOUND"]);
+  });
+
+  it("sleeps between attempts but not before the first", async () => {
+    const sleep = vi.fn(async () => {});
+    await probeListingUrls(urls, { fetchImpl: async (u: string) => resp(200, u), attempts: 3, delayMs: 5, sleep });
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(5);
+  });
+});


### PR DESCRIPTION
## Why

During the v1.14.0 release (2026-09-06) the first `release:submit -- chrome --yes` uploaded the package fine and then failed the publish with:

> `INVALID_ARGUMENT: Your submission does not meet the requirements to be published in the store. Check the Developer Dashboard for steps to resolve.`

The API says nothing more. The dashboard showed the culprit: the Support URL (`https://www.saypi.ai/docs`) was *intermittently* serving a 404, and Google fetches every listing URL at publish time. The founder asked for a check across all of them (support, privacy, terms, video…) so this is caught at preflight instead of after the upload.

## What

- **`doc/release/stores.json`** gains a `listingUrls` block: homepage, support, privacy policy, terms. It's the single place to add a URL when any store listing gains one (a promo video, say). All entries use the final `www` host, since the apex 301s.
- **`release:preflight`** probes each URL **3×** (a single 200 proves nothing for an intermittent fault) and blocks on any non-200. A followed redirect also counts as a failure, because the store's validator isn't guaranteed to follow it.
- **`release:submit`** re-runs the same check and aborts *before* uploading, for every store.
- **`release-lib.mjs`**: `listingUrlsFrom` / `interpretUrlProbe` / `probeListingUrls` are pure, with `fetch` injected so tests never touch the network.
- **Docs**: the runbook's preflight line, a new "Listing URLs are validated at publish time" section in `chrome-web-store.md`, and a Chrome gotcha in `stores.json`.

## Proof

- `test/scripts/release-listing-urls.spec.ts` — 11 tests: flattening, clean-200-only, redirect-as-failure, network errors, the intermittent-404 shape, sleep cadence, and a guard that the real `stores.json` carries the four known URLs on the final host.
- `npx tsc --noEmit` clean; existing `release-lib.spec.ts` (53) still green.
- Live `node scripts/release.mjs preflight` from this branch: all four URLs `200 ×3`.

Path-guard: touches `scripts/release*`; `founder-approved` applied on the founder's explicit in-session request for this check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hoGbuD6zpRQjc2aZh5tnD