### PR TITLE
release: harden submit + retry Edge polls (v1.14.0 learnings, #628)

### DIFF
--- a/doc/release/README.md
+++ b/doc/release/README.md
@@ -17,6 +17,13 @@ auto-update**, and store-submission plumbing is founder-gated.
   copy freely, but **stop at the first mutating/outward gate** and hand off to the founder.
 - The tooling **never loads `.env.production`**, bumps, builds, tags, pushes, or submits
   without the founder. `bump`/`build`/`tag`/`finalize` refuse to run without `--yes`.
+- **When the founder directs a release in-session** ("publish v1.x to the stores"), the
+  division of labour that v1.13.0 and v1.14.0 settled on is: the **founder runs exactly one
+  command — `release:build -- --yes`** (the only step that loads `.env.production`); the
+  agent runs everything else (`bump`, notes, packet, `submit` per store, then `tag` +
+  `finalize` on a **separate** "close out" go-ahead). `submit` reads only the gitignored
+  `.env.publish` (store API keys) so it sits inside the credentials boundary. See
+  "Agent-session gotchas" below for the two traps that cost time on v1.14.0.
 - **Shipped something bad?** The reverse path is
   [`doc/release/incident-response.md`](incident-response.md) — server-side kill-switch
   first, expedited patch second; escalate to the founder immediately.
@@ -134,6 +141,24 @@ Detail + gotchas in `chrome-web-store.md`, `edge-addons.md`, `firefox-amo.md`. K
 to auth-check, then `release:submit -- <store> --yes` to upload + submit via each store's API
 (CWS V2 / Edge v1.1 / AMO `web-ext sign`). Founder-only and irreversible. This is the long-term
 "one-button" path; the manual packet above remains the fallback and for any listing-copy changes.
+
+**Guards on `submit` (v1.14.0 lessons):** it refuses to run off `main` or from a linked
+worktree, re-runs the artifact verification against the target version before uploading,
+and probes the listing URLs. The Edge status poll retries transient network errors and, if
+it still can't confirm, says so explicitly (the operation may have succeeded — poll it before
+re-submitting, or Edge answers `InProgressSubmission`). Issue #628.
+
+### Agent-session gotchas
+- **`!`-prefixed founder commands run in the agent's shell cwd.** If the agent has `cd`'d
+  into a `.worktrees/<task>/` checkout (to build a side PR mid-release), the founder's
+  `! npm run release:submit -- edge --yes` runs there: wrong version, no `.env.publish`. The
+  agent must `cd` back to the repo root before handing over a command; `submit` now also
+  refuses to run from a worktree.
+- **The auto-mode classifier blocks gated commands when they're compound.** A plain
+  `npm run release:submit -- chrome --yes` matches the `Bash(npm run *)` allow rule; the
+  same command piped to `| tail` or chained with `&&` does not, and the classifier then
+  refuses it as store-publishing plumbing. Run gated release commands bare, one per shell
+  call.
 
 ### 6. Finalize ⛔ (founder)
 After all stores are submitted: `node scripts/release.mjs tag <version> --yes` then

--- a/scripts/release-lib.mjs
+++ b/scripts/release-lib.mjs
@@ -734,3 +734,30 @@ export async function probeListingUrls(urls = [], { fetchImpl, attempts = 3, del
   }
   return results;
 }
+
+// ── Transient-failure retry (#628) ──────────────────────────────────────────────
+//
+// For IDEMPOTENT calls only (status polls, token exchanges) — never wrap an upload or
+// publish POST in this. Linear backoff: delayMs, 2·delayMs, …; the last error is rethrown.
+
+/**
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {{ attempts?: number, delayMs?: number, sleep?: (ms: number) => Promise<void>, onRetry?: (attempt: number, err: Error) => void }} [opts]
+ * @returns {Promise<T>}
+ */
+export async function retryTransient(fn, { attempts = 3, delayMs = 1000, sleep, onRetry } = {}) {
+  const wait = sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  let lastErr;
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastErr = e;
+      if (i === attempts) break;
+      onRetry?.(i, e);
+      await wait(delayMs * i);
+    }
+  }
+  throw lastErr;
+}

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -34,6 +34,7 @@ import {
   edgePublishPollUrl,
   operationIdFromLocation,
   interpretEdgeOperation,
+  retryTransient,
   AMO_ENV,
   buildAmoMetadata,
   webExtSignArgs,
@@ -94,9 +95,31 @@ export async function chromeSubmit({ zipPath, env = process.env, dryRun = false,
 }
 
 // ── Microsoft Edge Add-ons (API v1.1) ─────────────────────────────────────────────
+// A poll GET is idempotent, so a transient network error (undici "fetch failed", a reset,
+// a 5xx) must be retried rather than reported as a submission failure: on v1.14.0 the
+// publish had already SUCCEEDED on Microsoft's side when the poll's `fetch failed`
+// surfaced as "edge submission failed", inviting a duplicate re-submit (#628).
+const POLL_RETRY_ATTEMPTS = 4;
+const POLL_RETRY_MS = 2000;
 async function pollEdge(url, headers, label, log) {
   for (let i = 0; i < POLL_MAX; i++) {
-    const res = await fetch(url, { headers });
+    let res;
+    try {
+      res = await retryTransient(
+        async () => {
+          const r = await fetch(url, { headers });
+          if (r.status >= 500) throw new Error(`HTTP ${r.status}`);
+          return r;
+        },
+        { attempts: POLL_RETRY_ATTEMPTS, delayMs: POLL_RETRY_MS, sleep, onRetry: (n, err) => log(`  ⚠ ${label} poll attempt ${n} failed (${err.message}) — retrying…`) },
+      );
+    } catch (err) {
+      throw new Error(
+        `Edge ${label} status could NOT be confirmed after ${POLL_RETRY_ATTEMPTS} attempts (${err.message}). ` +
+          `The ${label} operation may still have succeeded — check ${url} (or Partner Center) BEFORE re-running submit, ` +
+          `or a duplicate submission will be refused with InProgressSubmission.`,
+      );
+    }
     const json = await res.json().catch(() => ({}));
     const op = interpretEdgeOperation(json);
     if (op.ok) return;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -273,6 +273,20 @@ function cmdBump({ version, yes }) {
 }
 
 /** Releases are cut from main; tag/finalize refuse to run anywhere else. */
+/**
+ * Refuse to run from a linked git worktree (`.worktrees/<task>/`): the release artifacts,
+ * `.env.publish`, and the bump commit all live in the MAIN checkout, and a worktree's
+ * package.json silently reports the wrong version.
+ */
+function assertMainCheckout(cmd) {
+  const gitDir = git(["rev-parse", "--git-dir"], { allowFail: true });
+  const common = git(["rev-parse", "--git-common-dir"], { allowFail: true });
+  if (gitDir && common && resolvePath(repoRoot, gitDir) !== resolvePath(repoRoot, common)) {
+    bad(`\`${cmd}\` must run from the main checkout, not a linked worktree (${repoRoot}). \`cd\` to the repo root first.`);
+    process.exit(2);
+  }
+}
+
 function assertOnMain(cmd) {
   const branch = git(["rev-parse", "--abbrev-ref", "HEAD"], { allowFail: true });
   if (branch !== "main") {
@@ -499,10 +513,21 @@ async function cmdSubmit({ store, version, yes, dryRun }) {
     bad(`\`submit\` needs a store: ${PUBLISH_STORES.join(" | ")} (e.g. \`npm run release:submit -- chrome --dry-run\`).`);
     process.exit(2);
   }
+  // v1.14.0 lesson: a `!`-prefixed command inherits the agent shell's cwd, which had
+  // drifted into a feature worktree — so `submit edge` ran against the unbumped 1.13.0
+  // tree with no .env.publish. Refuse anything but the main checkout on `main`.
+  assertOnMain(`submit ${store}`);
+  assertMainCheckout(`submit ${store}`);
   loadPublishEnv();
   if (!dryRun) requireYes(`submit ${store}`, { yes });
   const v = version || pkgVersion();
   log(`${C.bold}${dryRun ? "Dry-run" : "Submitting"} ${store} — v${v}${C.reset}`);
+  // Never upload what `build` didn't verify: re-check the artifacts against the target
+  // version (catches a stale dist/ from a previous release as well as the cwd drift above).
+  if (!dryRun && !verifyArtifacts(v)) {
+    bad(`aborting ${store} submission — dist/ artifacts don't verify for v${v} (run \`build\` first).`);
+    process.exit(1);
+  }
   if (await checkListingUrls()) {
     bad(`aborting ${store} ${dryRun ? "dry-run" : "submission"} before upload — listing URLs must answer 200.`);
     process.exit(1);

--- a/test/scripts/release-publish.spec.ts
+++ b/test/scripts/release-publish.spec.ts
@@ -110,6 +110,49 @@ describe("edgeSubmit (Edge v1.1 orchestration)", () => {
     expect(publishCall[1].headers["Content-Type"]).toBeUndefined();
   });
 
+  it("#628: a transient `fetch failed` on the publish poll is retried, not reported as a failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetch = fetchSequence([
+        { status: 202, headers: { location: "op-upload" } },
+        { json: { status: "Succeeded" } },
+        { status: 202, headers: { location: "op-pub" } },
+      ]);
+      // 4th call (first publish poll) is the transient network error; 5th succeeds.
+      fetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+      fetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ status: "Succeeded" }), headers: { get: () => null } });
+      vi.stubGlobal("fetch", fetch);
+      const logs: string[] = [];
+      const p = edgeSubmit({ zipPath: "x.zip", env: EDGE_ENV, dryRun: false, log: (m: string) => logs.push(m) });
+      await vi.runAllTimersAsync();
+      await expect(p).resolves.toMatch(/submitted to certification/i);
+      expect(fetch).toHaveBeenCalledTimes(5);
+      expect(logs.some((l) => /publish poll attempt 1 failed \(fetch failed\)/.test(l))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("#628: when the poll never reaches Edge, the error says the op may have succeeded and names the poll URL", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetch = fetchSequence([
+        { status: 202, headers: { location: "op-upload" } },
+        { json: { status: "Succeeded" } },
+        { status: 202, headers: { location: "op-pub" } },
+      ]);
+      for (let i = 0; i < 4; i++) fetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+      vi.stubGlobal("fetch", fetch);
+      const p = edgeSubmit({ zipPath: "x.zip", env: EDGE_ENV, dryRun: false, log: noop });
+      const assertion = expect(p).rejects.toThrow(/publish status could NOT be confirmed.*may still have succeeded.*op-pub.*InProgressSubmission/s);
+      await vi.runAllTimersAsync();
+      await assertion;
+      expect(fetch).toHaveBeenCalledTimes(3 + 4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("surfaces a Failed operation with its errorCode", async () => {
     const fetch = fetchSequence([
       { status: 202, headers: { location: "op-upload" } },

--- a/test/scripts/release-retry.spec.ts
+++ b/test/scripts/release-retry.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import { retryTransient } from "../../scripts/release-lib.mjs";
+
+// Pins the poll-retry semantics behind #628: an idempotent poll that hits a transient
+// network error must be retried, not surfaced as a submission failure.
+
+const noSleep = async () => {};
+
+describe("retryTransient", () => {
+  it("returns the first successful result without retrying", async () => {
+    const fn = vi.fn(async () => "ok");
+    const sleep = vi.fn(async (_ms: number) => {});
+    await expect(retryTransient(fn, { attempts: 3, delayMs: 10, sleep })).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries a transient failure (fetch failed) and succeeds — the v1.14.0 Edge shape", async () => {
+    let n = 0;
+    const fn = vi.fn(async () => {
+      if (++n === 1) throw new TypeError("fetch failed");
+      return "Succeeded";
+    });
+    const onRetry = vi.fn();
+    await expect(retryTransient(fn, { attempts: 4, delayMs: 5, sleep: noSleep, onRetry })).resolves.toBe("Succeeded");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0][0]).toBe(1);
+    expect((onRetry.mock.calls[0][1] as Error).message).toBe("fetch failed");
+  });
+
+  it("backs off between attempts (delay grows, never before the first)", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("ECONNRESET");
+    });
+    const sleep = vi.fn(async (_ms: number) => {});
+    await expect(retryTransient(fn, { attempts: 3, delayMs: 100, sleep })).rejects.toThrow("ECONNRESET");
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls.map((c) => c[0])).toEqual([100, 200]);
+  });
+
+  it("rethrows the LAST error once attempts are exhausted", async () => {
+    let n = 0;
+    const fn = vi.fn(async () => {
+      throw new Error(`boom ${++n}`);
+    });
+    await expect(retryTransient(fn, { attempts: 2, delayMs: 1, sleep: noSleep })).rejects.toThrow("boom 2");
+  });
+
+  it("does not retry when attempts is 1", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("once");
+    });
+    await expect(retryTransient(fn, { attempts: 1, delayMs: 1, sleep: noSleep })).rejects.toThrow("once");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Why

The founder asked, after shipping v1.14.0, to turn the release's friction into machinery so the next one flows with less hand-holding. Three things cost time; each is now mechanical.

## What

**1. `submit` refuses the wrong tree.** A `!`-prefixed founder command runs in the agent shell's cwd. Mid-release the agent had `cd`'d into a `.worktrees/` checkout to build #627, so `! npm run release:submit -- edge --yes` ran against the unbumped 1.13.0 tree with no `.env.publish`. `submit` now asserts it's on `main` **and** in the main checkout (`--git-dir` vs `--git-common-dir`), and re-runs `verifyArtifacts` against the target version before uploading, so a stale or wrong-version `dist/` can't go out either.

**2. Edge polls retry transient errors (#628).** The Edge publish had *succeeded* when the status poll hit undici's `fetch failed`, and the tool printed `✘ edge submission failed` — inviting a duplicate `--yes` that Edge would have refused with `InProgressSubmission`. Polls are idempotent, so `pollEdge` now wraps each GET in a pure `retryTransient()` (linear backoff, 4 attempts, 5xx also retried). If it still can't reach Edge, the error says the operation may have succeeded and names the poll URL to check first.

**3. Runbook.** `doc/release/README.md` records the founder/agent split that v1.13.0 and v1.14.0 settled on (founder runs only `release:build`; agent does bump/notes/packet/submit, then tag/finalize on a separate go), the new `submit` guards, and two agent-session gotchas: cwd drift, and that the auto-mode classifier blocks gated commands when they're compound (`| tail`, `&&`) even though the bare command is allow-listed.

## Proof

- `test/scripts/release-retry.spec.ts` — 5 tests for `retryTransient` (no retry on success, transient-then-success, backoff cadence, last-error rethrow, attempts=1).
- `test/scripts/release-publish.spec.ts` — 2 new Edge tests under fake timers: a `fetch failed` on the first publish poll is retried and the submit succeeds; four failures produce the "may still have succeeded … InProgressSubmission" message with the op id.
- `npx tsc --noEmit` clean; all four release suites green (81 tests).
- Live smoke: `node scripts/release.mjs submit chrome --dry-run` from this worktree now exits 2 with "must run on main".

Path-guard: touches `scripts/release*`; `founder-approved` applied on the founder's explicit request ("if there are learnings … let's implement them").

Closes #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hoGbuD6zpRQjc2aZh5tnD