### PR TITLE
fix(vad): delete the unreachable `conservative` preset and lock preset reachability

### DIFF
--- a/bench/vad/README.md
+++ b/bench/vad/README.md
@@ -33,7 +33,8 @@ so it can import the real TypeScript gate.) There are **two corpora**:
 
 ## What it does
 
-For each corpus clip × each preset (`highSensitivity`, `balanced`, `conservative`, `none`):
+For each corpus clip × each preset the extension ships (`highSensitivity`, `balanced`,
+`none`):
 
 1. Resample + frame the audio with vad-web's `Resampler` (512-sample / 32 ms frames).
 2. Run each frame through the **real Silero v5** model → per-frame speech probability.
@@ -85,10 +86,17 @@ reproduction of that fallback path.
 |---|---|---|---|---|
 | highSensitivity | 0% | 17% | 60 ms | 425 ms |
 | balanced | 0% | 0% | 88 ms | 357 ms |
-| conservative | 0% | 0% | 112 ms | 245 ms |
+| ~~conservative~~ (removed, #571) | 0% | 0% | 112 ms | 245 ms |
 | none (v5 default) | 13% | 0% | 91 ms | 589 ms |
 
 (raw and gated are identical on this corpus — see below.)
+
+> **The `conservative` rows below are a historical record, not a reproducible result.**
+> That preset was deleted in #571 — it was tuned but permanently unreachable, and being
+> stricter about *opening* is the wrong axis for the noisy-room symptom that was actually
+> reported (see #572). Re-running the benchmark today sweeps three presets, not four; the
+> `conservative` numbers are kept because they document the shape of the FRR/FAR dial
+> beyond `balanced`, which is still the evidence a future retune starts from.
 
 - **Real speech peaks high — even quiet, even on `highSensitivity`.** Every speech clip,
   including the gain-0.18 quiet variants, peaked **0.89–0.999**. That's a large margin over
@@ -97,8 +105,8 @@ reproduction of that fallback path.
   clean; far-mic/noisy quiet speech could peak lower — exactly what a real corpus would test.)
 - **`highSensitivity` is the only preset that false-accepts** (the pink-ish hiss, which
   opened a segment peaking **0.653**), consistent with #420's concern that the most
-  trigger-happy preset is the riskiest. `balanced`/`conservative` reject it via their
-  stricter threshold + `minSpeechFrames`.
+  trigger-happy preset is the riskiest. `balanced` (and the then-existing `conservative`)
+  reject it via their stricter threshold + `minSpeechFrames`.
 - **The #420 gate neither helped nor hurt on this corpus** (raw FAR == gated FAR, 0 added
   FRR). The gate's drop band is *just above* each preset's opening threshold
   `[threshold, threshold+0.05)`; the seed's negatives are either clearly non-speech (peak ≈
@@ -136,7 +144,7 @@ generated `manifest.json` (with per-clip source/license/attribution) are tracked
 |---|---|---|
 | highSensitivity | 3% | 59% → **56%** |
 | balanced | 8% | 41% → 41% |
-| conservative | 23% | 29% → 29% |
+| ~~conservative~~ (removed, #571) | 23% | 29% → 29% |
 | none (v5 default) | 50% | 26% → 26% |
 
 (Latency is omitted for real clips — we have no frame-level word boundaries; latency lives
@@ -149,7 +157,8 @@ This is the data the synthetic seed couldn't give, and it changes the picture:
   audio exposes the actual trade-off, and `balanced` sits at its knee.
 - **Music is the worst false-accept source — and `highSensitivity` admits *all* of it.**
   Per negative type on `highSensitivity` (raw): **music 8/8 (100%)**, noise 12/24 (50%),
-  silence 0/2. `balanced` cuts music to 5/8 and noise to 9/24; `conservative` to 3/8 and 7/24. Since
+  silence 0/2. `balanced` cuts music to 5/8 and noise to 9/24 (the removed `conservative`
+  cut them to 3/8 and 7/24). Since
   generic web pages frequently have **background music/video playing**, binding the
   trigger-happiest preset to them is the worst possible match — exactly #420's gap-#3 concern,
   now measured.
@@ -179,11 +188,17 @@ dedicated chat sites `balanced`. The data says that's backwards for the noisy co
 `highSensitivity` → `balanced`. **Leave chat sites at `balanced`** — they're the core product
 and the quietest context (a focused voice conversation), so there's no data-backed reason to
 make them *more* trigger-happy, and changing them carries more risk than reward. Net: `balanced`
-everywhere; `highSensitivity` becomes a reserved preset (like `conservative`).
+everywhere by default; `highSensitivity` is no longer any context's default, and is now
+reached only by the explicit quiet/whisper-mode opt-in (#437).
 
 Still-open refinements (not blockers): a **noise/SNR-adaptive** or **mobile-vs-desktop** axis
 (the corpus isn't device-labelled, so that needs its own data), and broadening the corpus with
-café/keyboard ambient and non-English speech.
+café/keyboard ambient and non-English speech. Note that the adaptive axis no longer has a
+preset waiting in the wings — #571 deleted `conservative` rather than leave tuned-but-dead
+configuration in the file, so wiring an adaptive split means re-deriving its thresholds from
+data in the same change. It should also reckon with #572: this harness's FRR only counts
+clips that produced *no* segment, so it is blind to a segment that opens correctly and then
+terminates mid-utterance — the symptom a stricter-opening preset would make worse.
 
 ## Files
 

--- a/bench/vad/run.ts
+++ b/bench/vad/run.ts
@@ -20,7 +20,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 //   npm run bench:vad -- corpus-real
 const corpusName = process.argv[2] && !process.argv[2].startsWith("-") ? process.argv[2] : "corpus";
 const corpusDir = resolve(here, corpusName);
-const PRESETS = ["highSensitivity", "balanced", "conservative", "none"];
+// The sweep is the set of presets the extension actually ships (#571 removed
+// `conservative`); `runClip` looks each name up in the real VAD_CONFIGS, so a name
+// that no longer exists there would silently benchmark as "no overrides".
+const PRESETS = ["highSensitivity", "balanced", "none"];
 
 const fmtPct = (x: number | null) => (x === null ? "  —  " : `${(x * 100).toFixed(0)}%`.padStart(5));
 const fmtMs = (x: number | null) => (x === null ? "  —  " : `${Math.round(x)}ms`.padStart(6));

--- a/src/vad/VADConfigs.ts
+++ b/src/vad/VADConfigs.ts
@@ -14,19 +14,29 @@ import type { RealTimeVADOptions } from "@ricky0123/vad-web";
  * false-accept risk; a VAD-quality benchmark to re-tune these numbers is #420 item 3.
  *
  * Wiring status (which presets a code path actually selects) — see `selectVADPreset`:
- *  - `balanced`: the preset every context uses today (#420 item 4). The VAD-quality
+ *  - `balanced`: the preset every context uses by default (#420 item 4). The VAD-quality
  *    benchmark (bench/vad/README.md) put it at the knee of the false-reject/false-accept
  *    trade-off, so it is the host-agnostic default.
- *  - `highSensitivity`: previously bound to dictation/generic pages, but the benchmark
- *    showed it false-accepts ~59% of real non-speech there (100% of music) for only a
- *    marginal false-reject edge — so it is now **reserved, unselected** (the gap-#3 fix).
- *  - `conservative`: a valid noisy-environment preset that **no code path selects yet**.
- *    Kept (not deleted) because #420 item 4 plans to wire it to a noise/SNR estimate.
+ *  - `highSensitivity`: selected only when the user turns on quiet/whisper mode (#437).
+ *    It was previously bound to dictation/generic pages too, but the benchmark showed it
+ *    false-accepts ~59% of real non-speech there (100% of music) for only a marginal
+ *    false-reject edge, so it is no longer any context's default (the gap-#3 fix).
  *  - `none`: the no-override fallback `initializeVAD` resolves to when no (or an
  *    unknown) preset is requested — it inherits the library's v5 defaults verbatim.
- * (Both `highSensitivity` and `conservative` stay locked by test so they can't rot.)
+ *
+ * Every tuned preset above is reachable, and `test/vad/VADConfigs.spec.ts` locks that
+ * as an invariant. A preset no context can select is dead configuration that still
+ * reads as an available option to whoever tunes this file next — #571 removed one such
+ * (`conservative`, tuned for noisy rooms and wired to nothing for months). If you add a
+ * preset, wire it in the same change.
+ *
+ * When you do, treat **opening** and **closing** as opposed axes rather than one
+ * sensitivity dial: raising `positiveSpeechThreshold` makes the VAD harder to trigger on
+ * background noise, whereas *lowering* `negativeSpeechThreshold` and lengthening
+ * `redemptionFrames` is what stops it cutting a sentence short mid-utterance (#572). A
+ * single preset that is stricter about opening is strictly worse for chopping.
  */
-export type VADPreset = "highSensitivity" | "balanced" | "conservative" | "none";
+export type VADPreset = "highSensitivity" | "balanced" | "none";
 
 /**
  * Parameter presets for different use-cases.
@@ -55,16 +65,6 @@ export const VAD_CONFIGS: Record<VADPreset, Partial<RealTimeVADOptions>> = {
     redemptionFrames: 10, //          320 ms tail (vs v5 768 ms)
     minSpeechFrames: 3, //            96 ms min (vs v5 288 ms)
     preSpeechPadFrames: 2, //         64 ms pre-roll (vs v5 96 ms)
-    submitUserSpeechOnPause: false,
-  },
-  conservative: {
-    model: "v5",
-    // Noisy environments – lower sensitivity (reserved; not yet selected — see header).
-    positiveSpeechThreshold: 0.6, //  vs v5 default 0.5 — needs clearer speech to open
-    negativeSpeechThreshold: 0.45, // vs v5 default 0.35
-    redemptionFrames: 8, //           256 ms tail (vs v5 768 ms)
-    minSpeechFrames: 4, //            128 ms min (vs v5 288 ms)
-    preSpeechPadFrames: 1, //         32 ms pre-roll (vs v5 96 ms)
     submitUserSpeechOnPause: false,
   },
   none: {

--- a/test/vad/VADConfigs.spec.ts
+++ b/test/vad/VADConfigs.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { VAD_CONFIGS, selectVADPreset, type VADPreset } from "../../src/vad/VADConfigs";
+import {
+  VAD_CONFIGS,
+  selectVADPreset,
+  type VADPreset,
+  type VADSelectionContext,
+} from "../../src/vad/VADConfigs";
 
 /**
  * #420 item 2 — Lock the VAD preset values. They were hand-tuned in one commit (PR
@@ -34,32 +39,17 @@ describe("#420 VAD_CONFIGS preset values are locked", () => {
     });
   });
 
-  it("conservative matches the committed tuning", () => {
-    expect(VAD_CONFIGS.conservative).toEqual({
-      model: "v5",
-      positiveSpeechThreshold: 0.6,
-      negativeSpeechThreshold: 0.45,
-      redemptionFrames: 8,
-      minSpeechFrames: 4,
-      preSpeechPadFrames: 1,
-      submitUserSpeechOnPause: false,
-    });
-  });
-
   it("'none' inherits all library defaults (empty override)", () => {
     expect(VAD_CONFIGS.none).toEqual({});
   });
 });
 
 describe("#420 VAD_CONFIGS preset ordering invariants", () => {
-  const tuned: VADPreset[] = ["highSensitivity", "balanced", "conservative"];
+  const tuned = (Object.keys(VAD_CONFIGS) as VADPreset[]).filter((p) => p !== "none");
 
-  it("positive speech threshold rises from highSensitivity → balanced → conservative", () => {
+  it("positive speech threshold rises from highSensitivity → balanced", () => {
     expect(VAD_CONFIGS.highSensitivity.positiveSpeechThreshold!).toBeLessThan(
       VAD_CONFIGS.balanced.positiveSpeechThreshold!
-    );
-    expect(VAD_CONFIGS.balanced.positiveSpeechThreshold!).toBeLessThan(
-      VAD_CONFIGS.conservative.positiveSpeechThreshold!
     );
   });
 
@@ -82,10 +72,10 @@ describe("#420 VAD_CONFIGS preset ordering invariants", () => {
     // The aggressive presets deliberately favour NOT clipping short/quiet phrases:
     // a longer redemption window and a lower minimum-speech-frames bar.
     expect(VAD_CONFIGS.highSensitivity.redemptionFrames!).toBeGreaterThan(
-      VAD_CONFIGS.conservative.redemptionFrames!
+      VAD_CONFIGS.balanced.redemptionFrames!
     );
     expect(VAD_CONFIGS.highSensitivity.minSpeechFrames!).toBeLessThan(
-      VAD_CONFIGS.conservative.minSpeechFrames!
+      VAD_CONFIGS.balanced.minSpeechFrames!
     );
   });
 });
@@ -95,10 +85,10 @@ describe("#420 VAD_CONFIGS preset ordering invariants", () => {
  * showed `highSensitivity` (previously bound to generic / universal-dictation pages, the
  * noisiest context) false-accepts 59% of real non-speech there — 100% of music — for only
  * a marginal false-reject edge concentrated in one short word. So the noisiest context no
- * longer gets the trigger-happiest preset (the issue's gap #3): every context now uses
- * `balanced` (the measured knee), and `highSensitivity` joins `conservative` as a reserved,
- * unselected preset. This locks that decision; a future noise/SNR- or device-adaptive split
- * would re-diverge them.
+ * longer gets the trigger-happiest preset (the issue's gap #3): every context now defaults
+ * to `balanced` (the measured knee), and `highSensitivity` is reached only by an explicit
+ * quiet-mode opt-in (#437). This locks that decision; a future noise/SNR- or device-adaptive
+ * split would re-diverge them.
  */
 describe("#420 selectVADPreset (host→preset mapping)", () => {
   it("uses balanced for dictation / generic pages (was highSensitivity — the gap-#3 fix)", () => {
@@ -124,5 +114,30 @@ describe("#437 selectVADPreset quiet/whisper mode", () => {
   it("falls back to the normal mapping when quiet mode is off or unset", () => {
     expect(selectVADPreset({ isDictation: false, quietMode: false })).toBe("balanced");
     expect(selectVADPreset({ isDictation: true })).toBe("balanced");
+  });
+});
+
+/**
+ * #571 — reachability invariant. A tuned, tested preset that no code path can ever
+ * select reads as an available option to anyone tuning the VAD, but is dead
+ * configuration: `conservative` sat in `VAD_CONFIGS` for months, locked by the tests
+ * above, while `selectVADPreset` could only ever return `balanced` or
+ * `highSensitivity`. This pins the invariant so the next unreachable preset fails CI
+ * on the commit that adds it, instead of lingering as plausible-looking dead tuning.
+ *
+ * `none` is excluded on purpose: it is not a *selection*, it is the no-override
+ * fallback `initializeVAD` resolves to when no (or an unknown) preset is requested.
+ */
+describe("#571 every tuned preset is reachable through selectVADPreset", () => {
+  /** The complete input space of the selector: two booleans, quietMode also absent. */
+  const everyContext: VADSelectionContext[] = [true, false].flatMap((isDictation) =>
+    [undefined, true, false].map((quietMode) => ({ isDictation, quietMode }))
+  );
+
+  it("the reachable set is exactly the tuned presets (no dead tuning, no phantom name)", () => {
+    const reachable = new Set(everyContext.map(selectVADPreset));
+    const tuned = (Object.keys(VAD_CONFIGS) as VADPreset[]).filter((p) => p !== "none");
+
+    expect([...reachable].sort()).toEqual([...tuned].sort());
   });
 });


### PR DESCRIPTION
## Why

`src/vad/VADConfigs.ts` shipped three tuned VAD presets, but `selectVADPreset` is total and has exactly two outcomes:

```ts
if (context.quietMode) return "highSensitivity";
return "balanced";
```

Nothing else produces a preset — `AudioInputMachine` is the only caller, and both the offscreen (`vad_handler.ts`) and onscreen (`OnscreenVADClient.ts`) clients only consume what it hands them. So `conservative` was **permanently unreachable**, while the file header described it as "a valid noisy-environment preset" and `test/vad/VADConfigs.spec.ts` pinned its exact thresholds. Tuned, tested, documented, and dead: the worst kind of dead code, because it reads as an available option to whoever tunes this file next.

**Deleted rather than wired**, on the evidence in #571's correction comment. The founder's noisy-room report was *"it did not hear me, sentence got chopped"* — premature segment **termination**, not failure to open. In `@ricky0123/vad-web` a segment closes once `redemptionCounter >= redemptionFrames`, and that counter advances on frames scoring *below* `negativeSpeechThreshold`. `conservative` had both the highest negative threshold (0.45) and the shortest tail (8 frames / 256 ms), making it the **worst** of the three presets for chopping. Opening (`positiveSpeechThreshold`) and closing (`negativeSpeechThreshold` + `redemptionFrames`) are opposed axes; one "noisy environment" preset cannot serve both. The closing half is tracked separately as #572.

## What

- **`src/vad/VADConfigs.ts`** — removed `conservative` from the `VADPreset` union and from `VAD_CONFIGS`. Rewrote the header's "wiring status" so it describes the presets that exist: `balanced` (every context's default), `highSensitivity` (reached only by the quiet/whisper-mode opt-in, #437 — the old header still called it "reserved, unselected", which stopped being true when #437 shipped), and the `none` fallback. Dropped the promise that #420 item 4 would wire `conservative` up. Added a note that opening and closing are opposed axes, so the next person to reach for "a stricter preset" sees why that is not the chopping fix.
- **`test/vad/VADConfigs.spec.ts`** — new `#571` invariant: enumerate the selector's *entire* input space (`isDictation` × `quietMode` including absent) and assert the reachable set equals the tuned presets in `VAD_CONFIGS` exactly. Both directions, so it also catches a phantom name. Removed the `conservative` lock test; the ordering invariants now derive their preset list from `VAD_CONFIGS` keys instead of hard-coding it, so they can't go stale the same way.
- **`bench/vad/run.ts`** — dropped `conservative` from the sweep. This one matters beyond tidiness: `runClip` looks the name up as `(VAD_CONFIGS as any)[preset] ?? {}`, so a stale name would have silently benchmarked as "no overrides" (i.e. a duplicate `none` row) rather than erroring. `bench/` is outside `tsconfig.json`'s `include`, so `tsc` would not have caught it.
- **`bench/vad/README.md`** — kept the historical `conservative` measurements (they document the shape of the FRR/FAR dial beyond `balanced`, which is the evidence a future retune starts from) but struck them through and flagged them as a record of a preset that no longer exists and no longer reproduces. Also corrected the stale "`highSensitivity` becomes a reserved preset (like `conservative`)" conclusion, and noted on the still-open noise/SNR-adaptive refinement that it no longer has a preset waiting in the wings, plus the #572 blindness in this harness's FRR metric.

## Verification

Fail-first TDD: the reachability test was added **before** the deletion and failed for exactly the right reason —

```
AssertionError: expected [ 'balanced', 'highSensitivity' ] to deeply equal [ 'balanced', 'conservative', …(1) ]
```

— then passed after removing the preset.

- **Layer 0 (`tsc --noEmit`)**: clean. This is what proves the deletion is complete on the typed surface: `VADPreset` is a string-literal union used at every call site, so any remaining reference to `"conservative"` in `src/`, `entrypoints/`, `test/` or `scripts/` would be a type error.
- **Layers 1–2 (`npm test`)**: **2843 Vitest passing** (1 skipped, 247 files) + **2 Jest passing** — identical to the `main` baseline. Net test count is unchanged because one lock test was removed and one invariant test added.
- **Not run:** `npm run bench:vad`. It needs the ONNX model and (for the real corpus) a ~2.4 GB fetch, and this change removes a row from the sweep rather than altering how any surviving row is measured. The README's numbers for `highSensitivity` / `balanced` / `none` are untouched.
- **No runtime behaviour change.** Every user was already on `balanced` or `highSensitivity`; no code path could reach the deleted preset, so no user's VAD tuning moves.

Not deliberately changed: `doc/vad/silero-vad-v5-optimization-guide.md` still shows a generic `conservativeConfig` example. That doc is third-party Silero reference material about the library's option space, not a description of SayPi's shipped presets, and it is already flagged in `doc/codebase-caution-map.md` §10 for a separate correction (its millisecond math is v4-era). Folding that into this PR would mix an unrelated fix into the blast radius. `doc/codebase-caution-map.md` itself needed no edit — it references the lock test, never the preset by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
