### PR TITLE
fix(audio): also reject a partial Opus encode, not just a silent one (#630)

### DIFF
--- a/src/audio/AudioEncoder.ts
+++ b/src/audio/AudioEncoder.ts
@@ -2,7 +2,7 @@ import { encodeWAV, decodePcm16Wav } from "./WavEncoder";
 import {
   isOpusUploadSupported,
   encodeToOpusWebM,
-  OpusEmptyOutputError,
+  OpusIncompleteOutputError,
 } from "./OpusEncoder";
 import { logger } from "../LoggingModule";
 
@@ -65,10 +65,10 @@ export async function transcodeForUpload(audioBlob: Blob): Promise<Blob> {
     if (!samples || samples.length === 0) return audioBlob;
     return await encodeToOpusWebM(samples);
   } catch (e) {
-    // The empty-output case (#630) already warned with the sample count and
-    // browser, so don't report the same occurrence twice.
-    if (e instanceof OpusEmptyOutputError) {
-      logger.debug("[AudioEncoder] Opus produced no audio; uploading WAV", e);
+    // The incomplete-output case (#630) already warned with the sample count,
+    // chunk count and browser, so don't report the same occurrence twice.
+    if (e instanceof OpusIncompleteOutputError) {
+      logger.debug("[AudioEncoder] Opus stream incomplete; uploading WAV", e);
     } else {
       logger.warn(
         "[AudioEncoder] Opus transcode failed; uploading 16-bit PCM WAV",

--- a/src/audio/OpusEncoder.ts
+++ b/src/audio/OpusEncoder.ts
@@ -35,17 +35,20 @@ const OPUS_CONFIG: AudioEncoderConfig = {
 let opusSupportPromise: Promise<boolean> | undefined;
 
 /**
- * Thrown when an encode finished without a single Opus chunk reaching the muxer.
+ * Thrown when an encode did not deliver a complete Opus stream to the muxer —
+ * either no chunk arrived at all, or one was dropped part-way through.
  *
- * The muxer will happily finalize a valid-but-audio-less WebM in that case, and
- * the server can only answer it with `invalid_audio` — so every transcription
- * from an affected install fails (#630, seen on Firefox 154). Callers treat this
- * like any other encode failure and upload the PCM WAV instead.
+ * The muxer finalizes whatever it was given, so neither case fails on its own:
+ * no chunks yields a valid-but-audio-less WebM the server can only answer with
+ * `invalid_audio` (#630, seen on Firefox 154), and a dropped chunk yields a
+ * truncated file that decodes to a partial transcript — a wrong answer, billed
+ * the same as a right one. Callers treat this like any other encode failure and
+ * upload the PCM WAV instead.
  */
-export class OpusEmptyOutputError extends Error {
+export class OpusIncompleteOutputError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message);
-    this.name = "OpusEmptyOutputError";
+    this.name = "OpusIncompleteOutputError";
     if (options && "cause" in options) {
       (this as { cause?: unknown }).cause = options.cause;
     }
@@ -83,9 +86,9 @@ async function probeOpusSupport(): Promise<boolean> {
 /**
  * Encode 16 kHz mono Float32 PCM samples to a WebM/Opus Blob.
  *
- * @throws if WebCodecs Opus is unavailable, encoding fails, or the encode
- *   produced no audio chunks (#630) — callers fall back to PCM WAV rather than
- *   uploading a file the server cannot decode.
+ * @throws if WebCodecs Opus is unavailable, encoding fails, or the encode did
+ *   not deliver a complete stream (#630) — callers fall back to PCM WAV rather
+ *   than uploading a file the server cannot decode, or can decode wrongly.
  */
 export async function encodeToOpusWebM(audioData: Float32Array): Promise<Blob> {
   if (!(await isOpusUploadSupported())) {
@@ -105,8 +108,9 @@ export async function encodeToOpusWebM(audioData: Float32Array): Promise<Blob> {
   // An encoder that emits nothing still yields a well-formed, empty container,
   // so success is measured by chunks actually muxed — not by flush() resolving.
   let chunksMuxed = 0;
-  // The browser owns the `output` callback: anything thrown inside it is
-  // swallowed and would otherwise vanish. Keep the first one for diagnosis.
+  // The browser owns the `output` callback, so anything thrown inside it is
+  // swallowed per invocation and would otherwise vanish. Keep the first one:
+  // it is both the diagnosis and the signal that this stream lost a chunk.
   let outputError: unknown;
 
   await new Promise<void>((resolve, reject) => {
@@ -160,12 +164,15 @@ export async function encodeToOpusWebM(audioData: Float32Array): Promise<Blob> {
     }
   });
 
-  if (chunksMuxed === 0) {
+  // Reject on a dropped chunk too, not just on silence: finalizing a stream
+  // that lost a chunk uploads a truncated file, which transcribes to something
+  // plausible and wrong. `chunks` in the log tells the two apart.
+  if (chunksMuxed === 0 || outputError !== undefined) {
     logger.warn(
-      "[OpusEncoder] Opus encode produced no audio chunks; uploading WAV instead",
+      "[OpusEncoder] Opus encode did not produce a complete stream; uploading WAV instead",
       {
         samples: audioData.length,
-        chunks: 0,
+        chunks: chunksMuxed,
         cause: outputError,
         userAgent:
           typeof navigator === "undefined" ? undefined : navigator.userAgent,
@@ -179,8 +186,12 @@ export async function encodeToOpusWebM(audioData: Float32Array): Promise<Blob> {
         : outputError !== undefined
           ? `: ${String(outputError)}`
           : "";
-    throw new OpusEmptyOutputError(
-      `Opus encode produced no audio chunks for ${audioData.length} samples${reason}`,
+    const what =
+      chunksMuxed === 0
+        ? "produced no audio chunks"
+        : `dropped a chunk after muxing ${chunksMuxed}`;
+    throw new OpusIncompleteOutputError(
+      `Opus encode ${what} for ${audioData.length} samples${reason}`,
       { cause: outputError }
     );
   }

--- a/test/audio/OpusEncoder-incompleteOutput.spec.ts
+++ b/test/audio/OpusEncoder-incompleteOutput.spec.ts
@@ -1,15 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 /**
- * Guard against a WebM/Opus upload that carries no audio (#630).
+ * Guard against a WebM/Opus upload the server cannot correctly decode (#630).
  *
  * One Firefox 154 install shipped 47 consecutive uploads whose container had a
  * valid EBML header and no audio blocks at all — every transcription from it
  * failed. `encodeToOpusWebM` awaited `flush()` and finalized the muxer without
- * ever checking that a chunk had reached it, so an encoder that emitted nothing
- * still produced a well-formed, empty file. These tests pin the two ways that
- * happens: `output` never fires, and `output` fires but the muxer throws inside
- * it (a throw the browser swallows, since it owns the callback).
+ * ever checking what had reached it, so an encoder that emitted nothing still
+ * produced a well-formed, empty file.
+ *
+ * These tests pin the three ways a stream can arrive incomplete: `output` never
+ * fires; `output` fires but the muxer throws inside it (a throw the browser
+ * swallows, since it owns the callback); and `output` fires twice, the first
+ * chunk muxing and the second throwing — which finalizes a truncated file that
+ * transcribes to a plausible wrong answer rather than failing outright.
  */
 describe("OpusEncoder — incomplete-output guard (#630)", () => {
   const g = globalThis as any;

--- a/test/audio/OpusEncoder-incompleteOutput.spec.ts
+++ b/test/audio/OpusEncoder-incompleteOutput.spec.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
  * happens: `output` never fires, and `output` fires but the muxer throws inside
  * it (a throw the browser swallows, since it owns the callback).
  */
-describe("OpusEncoder — empty-output guard (#630)", () => {
+describe("OpusEncoder — incomplete-output guard (#630)", () => {
   const g = globalThis as any;
   const originalAudioEncoder = g.AudioEncoder;
   const originalAudioData = g.AudioData;
@@ -58,12 +58,12 @@ describe("OpusEncoder — empty-output guard (#630)", () => {
     stubEncoder(() => {
       /* flush resolves without ever invoking output — the Firefox 154 signature */
     });
-    const { encodeToOpusWebM, OpusEmptyOutputError } = await import(
+    const { encodeToOpusWebM, OpusIncompleteOutputError } = await import(
       "../../src/audio/OpusEncoder"
     );
 
     const samples = new Float32Array(1600); // 100ms @ 16 kHz
-    await expect(encodeToOpusWebM(samples)).rejects.toBeInstanceOf(OpusEmptyOutputError);
+    await expect(encodeToOpusWebM(samples)).rejects.toBeInstanceOf(OpusIncompleteOutputError);
   });
 
   it("reports the input sample count so the affected installs are visible in logs", async () => {
@@ -76,7 +76,7 @@ describe("OpusEncoder — empty-output guard (#630)", () => {
 
     expect(warn).toHaveBeenCalledTimes(1);
     const [message, detail] = warn.mock.calls[0];
-    expect(String(message)).toMatch(/no audio/i);
+    expect(String(message)).toMatch(/complete stream/i);
     expect(detail).toMatchObject({ samples: 4321, chunks: 0 });
   });
 
@@ -105,5 +105,113 @@ describe("OpusEncoder — empty-output guard (#630)", () => {
     const { encodeToOpusWebM } = await import("../../src/audio/OpusEncoder");
 
     await expect(encodeToOpusWebM(new Float32Array(1600))).rejects.toThrow(/detached buffer/);
+  });
+
+  it("rejects a partial encode where one chunk muxed and the next threw", async () => {
+    // The swallow is per-invocation: an encoder can deliver chunk 1 fine and
+    // throw on chunk 2. Finalizing then yields a TRUNCATED file that decodes
+    // to a partial transcript — a wrong answer is worse than no answer, and
+    // the user is billed for it either way.
+    stubEncoder((output) => {
+      const meta = { decoderConfig: { description: new Uint8Array([1, 2, 3]) } };
+      const bytes = new Uint8Array([1, 2, 3, 4]);
+      output(
+        new g.EncodedAudioChunk({
+          type: "key",
+          timestamp: 0,
+          duration: 20000,
+          byteLength: bytes.byteLength,
+          copyTo(dest: Uint8Array) {
+            dest.set(bytes);
+          },
+        }),
+        meta
+      );
+      try {
+        output(
+          new g.EncodedAudioChunk({
+            type: "delta",
+            timestamp: 20000,
+            duration: 20000,
+            byteLength: 4,
+            copyTo() {
+              throw new Error("detached buffer");
+            },
+          }),
+          meta
+        );
+      } catch {
+        /* swallowed, exactly as the browser does */
+      }
+    });
+    const { encodeToOpusWebM } = await import("../../src/audio/OpusEncoder");
+
+    await expect(encodeToOpusWebM(new Float32Array(1600))).rejects.toThrow(/detached buffer/);
+  });
+
+  it("reports how many chunks did land, so partial and total failures are distinguishable", async () => {
+    stubEncoder((output) => {
+      const bytes = new Uint8Array([1, 2, 3, 4]);
+      const meta = { decoderConfig: { description: new Uint8Array([1, 2, 3]) } };
+      output(
+        new g.EncodedAudioChunk({
+          type: "key",
+          timestamp: 0,
+          duration: 20000,
+          byteLength: bytes.byteLength,
+          copyTo(dest: Uint8Array) {
+            dest.set(bytes);
+          },
+        }),
+        meta
+      );
+      try {
+        output(
+          new g.EncodedAudioChunk({
+            type: "delta",
+            timestamp: 20000,
+            duration: 20000,
+            byteLength: 4,
+            copyTo() {
+              throw new Error("detached buffer");
+            },
+          }),
+          meta
+        );
+      } catch {
+        /* swallowed */
+      }
+    });
+    const { encodeToOpusWebM } = await import("../../src/audio/OpusEncoder");
+    const { logger } = await import("../../src/LoggingModule");
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    await expect(encodeToOpusWebM(new Float32Array(1600))).rejects.toThrow();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][1]).toMatchObject({ samples: 1600, chunks: 1 });
+  });
+
+  it("closes the codec resources before rejecting", async () => {
+    const closed: string[] = [];
+    g.AudioEncoder = class {
+      static isConfigSupported = vi.fn().mockResolvedValue({ supported: true });
+      constructor(_init: unknown) {}
+      configure() {}
+      encode() {}
+      async flush() {}
+      close() {
+        closed.push("encoder");
+      }
+    };
+    g.AudioData = class {
+      close() {
+        closed.push("frame");
+      }
+    };
+    const { encodeToOpusWebM } = await import("../../src/audio/OpusEncoder");
+
+    await expect(encodeToOpusWebM(new Float32Array(1600))).rejects.toThrow();
+    expect(closed).toEqual(expect.arrayContaining(["encoder", "frame"]));
   });
 });

--- a/test/audio/transcodeForUpload.spec.ts
+++ b/test/audio/transcodeForUpload.spec.ts
@@ -16,7 +16,7 @@ import {
 import {
   isOpusUploadSupported,
   encodeToOpusWebM,
-  OpusEmptyOutputError,
+  OpusIncompleteOutputError,
 } from "../../src/audio/OpusEncoder";
 import { logger } from "../../src/LoggingModule";
 
@@ -83,7 +83,7 @@ describe("transcodeForUpload — WAV→Opus at the network boundary (#414)", () 
   it("uploads the WAV when the encoder emitted no audio, without re-reporting it (#630)", async () => {
     vi.mocked(isOpusUploadSupported).mockResolvedValue(true);
     vi.mocked(encodeToOpusWebM).mockRejectedValue(
-      new OpusEmptyOutputError("Opus encode produced no audio chunks for 1600 samples")
+      new OpusIncompleteOutputError("Opus encode produced no audio chunks for 1600 samples")
     );
     const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
 


### PR DESCRIPTION
Follow-up to #632, which fixed the reported failure (a Firefox install uploading an entirely audio-less WebM). Review of that PR found the adjacent half, and I merged #632 before this part had actually landed — my mistake, so it ships here instead.

## Why

The guard that merged measures success as "at least one chunk reached the muxer". The browser owns the `output` callback and swallows anything thrown inside it **per invocation**, so an encoder can deliver chunk 1 cleanly and lose chunk 2. In that case the counter sits at 1, the guard never fires, and `muxer.finalize()` produces a *truncated* WebM.

That uploads as an ordinary success. The server decodes what it was given and returns a partial transcript, so the user sees something plausible and wrong, and is billed for it exactly as if it were right. It is a worse outcome than the empty file the first guard catches, because the empty file at least fails loudly.

## What

- The guard now fires on `chunksMuxed === 0 || outputError !== undefined`, so a dropped chunk falls back to the PCM WAV upload just like silence does.
- The warning reports the real chunk count instead of a hardcoded zero, so a partial failure is distinguishable from a total one in a client log — for an affected install that line is the only signal we get.
- `OpusEmptyOutputError` becomes `OpusIncompleteOutputError`, since "empty" no longer describes what it means.

## Verification

Fail-first: with the guard reverted to `chunksMuxed === 0`, the two new behavioural tests fail and the four existing ones pass; with it restored, all six pass. Confirmed by running it both ways rather than by inspection.

- a partial encode (chunk 1 muxes, chunk 2's `copyTo` throws, the test swallowing it exactly as a browser does) rejects instead of resolving with a Blob;
- the log carries `chunks: 1`, distinguishing partial from total;
- the codec resources are closed before the rejection, which the merged tests relied on by construction rather than asserting.

`npm test`: type-check clean, Jest green, Vitest **2850 passed / 1 skipped** (2847 on `main`).

Layers 3 and 4 add nothing: this is a pure encoder-output condition that JSDOM reproduces deterministically, and no real host can be made to drop a chunk on demand.

Relates to #630 (already closed by #632).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
