### PR TITLE
capture: redact secrets and PII in the DOM recorder (#552)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -47,8 +47,10 @@ regexes = [
 # here. Scope: ONLY the generic-api-key rule, ONLY these fixture paths. Every
 # specific rule (jwt, openai-api-key, aws-*, github-*, private-key, ...) still
 # applies to these files, so a real captured token still fails the scan.
-# Belt-and-braces: the DOM capture recorder is to redact tokens/PII at capture
-# time (doc/secret-scanning.md, "Fixture hygiene").
+# These files are pre-#552 manual page-saves. The DOM capture recorder now
+# redacts tokens/PII at capture time (doc/secret-scanning.md, "Fixture
+# hygiene"), so this allowlist covers history, not new captures — it can shrink
+# as these files are re-captured or retired.
 [[allowlists]]
 description = "generic-api-key keyword+entropy false positives in recorded third-party DOM fixtures (public experiment/gate ids)"
 targetRules = ["generic-api-key"]

--- a/doc/autonomous-dev-loop.md
+++ b/doc/autonomous-dev-loop.md
@@ -338,6 +338,52 @@ snapshot.
 Refresh deliberately when a host redesigns — a stale fixture is a signal to
 re-capture, not a contract violation.
 
+### Redaction (on by default) — what it does and does not promise
+
+Captures come from pages the founder is signed into, so the recorder redacts as
+it copies (#552). Every point where host content is copied — the resting
+snapshot, attribute values, element text, and mutation `value`/`added`/`removed`
+payloads — runs through it, and the record is stamped `"redaction": {"enabled":
+true}`.
+
+What it replaces, with stable and obviously-fake markers:
+
+| Class | Marker |
+| --- | --- |
+| JWTs (`eyJ…`) | the `alg:none` placeholder from the #541 scrub |
+| `Bearer` / `Basic` / `Token` credentials | `Bearer REDACTED` |
+| Email addresses | `redacted@example.com` |
+| UUIDs (message/device/conversation ids) | `00000000-0000-4000-8000-0000000000NN`, numbered per distinct source id so the fixture keeps its "these two refer to the same thing" topology |
+| `user-…` / `org-…` / `session-…` account ids | `user-REDACTED`, `org-REDACTED`, … |
+| `?access_token=…`-style credential query params | `access_token=REDACTED` |
+| Long random-looking runs (32+ chars, mixed classes, entropy ≥ 4.2; or 32+ hex) | `REDACTED-SECRET` |
+| Any attribute whose *name* says credential (`data-auth-token`, `api-key`, …) | `REDACTED` |
+| The value of an `<input>`/`<textarea>` whose `type` or naming says credential | `REDACTED` |
+
+**What it does NOT catch — read this before committing a capture.** It is a
+heuristic safety net, not a guarantee:
+
+- **Conversation content is not redacted, by design.** Message text *is* the
+  fixture; scrubbing it would leave nothing to test against. Capture from a
+  throwaway thread, and read what you are about to commit.
+- **Names, addresses, phone numbers and other free-text PII** in page copy pass
+  through untouched.
+- **Short or low-entropy secrets** (an 8-character code, a numeric OTP sitting in
+  a `<div>`) look exactly like ordinary content and survive.
+- **Novel credential shapes** — a host-specific opaque cookie value under a name
+  none of the keyword lists know — survive.
+- The long-secret rule trades recall for fidelity: the entropy floor is set to
+  preserve long host selectors, so a *low*-entropy token can slip through.
+
+So: capture-time redaction plus `gitleaks` (`doc/secret-scanning.md`) plus a read
+of the diff. None of the three is sufficient alone.
+
+**Opting out.** `window.__domCapture.start(sel, { redact: false })` records
+verbatim, for debugging a suspected redaction false positive. The record is
+stamped `"redaction": {"enabled": false}` with a `warning`, and `start()` returns
+a banner saying so. **An unredacted record must never be committed** — read it,
+learn what you needed, throw it away.
+
 ## Reloading and driving the mic without the founder (DEV-only hooks)
 
 Two of the loop's recurring founder asks now have in-extension, DEV-only escape

--- a/doc/secret-scanning.md
+++ b/doc/secret-scanning.md
@@ -72,16 +72,26 @@ Consequences:
    vendor API keys, `private-key`, …) still applies to the fixtures, so a
    future capture embedding a real token still fails.
 
-### Fixture hygiene (capture-time redaction — follow-up)
+### Fixture hygiene (capture-time redaction)
 
-The durable fix for fixture noise is upstream of the scanner: the DOM
-capture recorder (`scripts/dom-capture/`) should **redact at capture time**
-— strip or placeholder session tokens, cookies, JWTs, email addresses, and
-account/org/device identifiers before a fixture is ever written to disk (the
-#541 review recommendation). Until that lands, treat any newly recorded
-fixture as suspect: run the local scan before committing it, and scrub with
-the #541 placeholder convention (`REDACTED` scalars, the `alg:none`
-placeholder JWT) rather than adding allowlist entries.
+The durable fix for fixture noise sits upstream of the scanner: the DOM
+capture recorder (`scripts/dom-capture/recorder.js`) **redacts at capture
+time** (#552), replacing JWTs, `Bearer` credentials, email addresses,
+UUIDs, `user-`/`org-`/`session-` ids, credential-shaped query parameters and
+long high-entropy runs with the #541 placeholder convention (`REDACTED`
+scalars, the `alg:none` placeholder JWT) before a record is ever written to
+disk. It is on by default; the record carries `"redaction": {"enabled": true}`
+to prove it. The table of classes and markers is in
+`doc/autonomous-dev-loop.md` → "Capturing real-host DOM".
+
+**It is a safety net, not a guarantee.** It is keyword- and shape-driven, so
+conversation content (deliberately), free-text PII, short/low-entropy secrets
+and novel credential shapes still pass through. A newly recorded fixture is
+therefore still reviewed, not trusted: run the local scan before committing
+it, read the diff, and scrub anything the recorder missed with the same
+placeholder convention rather than adding an allowlist entry. A record stamped
+`"redaction": {"enabled": false}` (the `start(sel, { redact: false })` debug
+opt-out) must never be committed at all.
 
 ## Running locally
 

--- a/scripts/dom-capture/recorder.js
+++ b/scripts/dom-capture/recorder.js
@@ -3,21 +3,265 @@
  * See doc/autonomous-dev-loop.md → "Capturing real-host DOM".
  *
  * Injected verbatim into a host page via the Claude-in-Chrome javascript_tool.
- * Installs window.__domCapture with start(rootSelector?) / stop(). Records BOTH a
- * resting snapshot AND the live MutationObserver stream, so dynamic, event-driven
- * DOM changes are captured — not just a still frame. The host DOM is a moving
- * target, not an API contract: re-run this to refresh fixtures when a host changes.
+ * Installs window.__domCapture with start(rootSelector?, options?) / stop().
+ * Records BOTH a resting snapshot AND the live MutationObserver stream, so
+ * dynamic, event-driven DOM changes are captured — not just a still frame. The
+ * host DOM is a moving target, not an API contract: re-run this to refresh
+ * fixtures when a host changes.
+ *
+ * Captures are taken from pages the founder is signed into, so every point where
+ * host content is copied runs through capture-time redaction (issue #552). It is
+ * ON by default; `start(sel, { redact: false })` opts out and the resulting
+ * record is stamped `redaction.enabled === false` — such a record must NEVER be
+ * committed.
  *
  * Self-contained (no imports) so it can be eval'd in the page, and exercised
- * directly in jsdom by test/scripts/dom-capture-recorder.spec.ts.
+ * directly in jsdom by test/scripts/dom-capture-recorder.spec.ts and
+ * test/scripts/dom-capture-redaction.spec.ts.
  */
 (function installDomRecorder(global) {
   const MAX_TEXT = 200;
 
+  // ==========================================================================
+  // Capture-time redaction (#552)
+  //
+  // A heuristic safety net, not a guarantee. It replaces credential- and
+  // identity-shaped substrings with stable, obviously-fake markers so a fixture
+  // keeps its shape (same HTML structure, same distinct-identifier topology)
+  // while carrying nothing that authenticates or identifies anyone.
+  // ==========================================================================
+
+  // The exact placeholder minted by the PR #541 fixture scrub, so redacted
+  // captures reuse a token the secret scanner already knows is fake:
+  //   header {"alg":"none"} / payload {"sub":"REDACTED","note":"scrubbed-fixture"}
+  const PLACEHOLDER_JWT =
+    "eyJhbGciOiJub25lIn0.eyJzdWIiOiJSRURBQ1RFRCIsIm5vdGUiOiJzY3J1YmJlZC1maXh0dXJlIn0.SCRUBBED";
+  const PLACEHOLDER_EMAIL = "redacted@example.com";
+  const PLACEHOLDER_SECRET = "REDACTED-SECRET";
+  const PLACEHOLDER_VALUE = "REDACTED";
+
+  // Sentinel used to park a replacement so a later, broader rule cannot re-match
+  // a marker this same pass just inserted. U+0001 never occurs in host DOM text
+  // and is not in any of the character classes below.
+  const HOLD = String.fromCharCode(1);
+
+  // Three-part (or unsigned two-part) base64url JWTs. `eyJ` is base64url for '{"'.
+  const JWT_RE = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]*)?/g;
+  // Authorization-header shapes: `Bearer <opaque>`, `Basic <base64>`.
+  const AUTH_SCHEME_RE = /\b(Bearer|Basic|Token)\s+[A-Za-z0-9._~+/=-]{8,}/gi;
+  const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}/g;
+  const UUID_RE =
+    /\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/g;
+  // Account/tenant/device ids: a known prefix plus a long opaque tail. The 16-char
+  // floor is deliberate — a shorter one mangles ordinary hyphenated identifiers
+  // such as "new-user-days-past-days" (a real casualty of the #541 manual scrub).
+  const ACCOUNT_ID_RE =
+    /\b(user|org|acct|account|customer|cust|team|workspace|device|session)([-_])([A-Za-z0-9]{16,})\b/gi;
+  // `?access_token=…` / `&api_key=…` style query parameters.
+  const CREDENTIAL_PARAM_RE =
+    /\b([A-Za-z0-9_-]*(?:token|secret|password|passwd|apikey|api_key|auth|session|signature)[A-Za-z0-9_-]*)=([A-Za-z0-9._~+/%-]{6,})/gi;
+  // Fallback: long opaque runs. Filtered by isLikelySecretRun() below.
+  const LONG_SECRET_RE = /[A-Za-z0-9_-]{32,}/g;
+
+  // Attribute/field names that mean "this value is a credential", matched on
+  // word segments so "spinner" does not look like a PIN and "user" does not look
+  // like a password.
+  const CREDENTIAL_WORDS = [
+    "password", "passwd", "pwd", "passphrase", "secret", "token", "jwt",
+    "apikey", "auth", "authorization", "credential", "credentials", "otp",
+    "totp", "mfa", "cvv", "cvc", "ssn", "pin", "session", "sessionid", "sid",
+    "csrf", "nonce", "signature", "bearer",
+  ];
+  const CREDENTIAL_JOINED_RE =
+    /(password|passphrase|apikey|accesstoken|refreshtoken|idtoken|authtoken|sessiontoken|secretkey|privatekey|clientsecret|cardnumber|securitycode)/;
+
+  function looksCredentialish(name) {
+    if (!name) return false;
+    // Split on separators AND camelCase humps, so "csrfToken" and "data-csrf-token"
+    // classify alike. Whole-word matching is what keeps "spinner" from looking
+    // like a PIN and "username" from looking like a password.
+    const parts = String(name)
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean);
+    for (const part of parts) {
+      if (CREDENTIAL_WORDS.indexOf(part) !== -1) return true;
+    }
+    return CREDENTIAL_JOINED_RE.test(parts.join(""));
+  }
+
+  const FIELD_HINT_ATTRS = [
+    "name", "id", "autocomplete", "placeholder", "aria-label", "data-testid",
+  ];
+
+  /** True for an <input>/<textarea> whose type or naming says "credential". */
+  function isCredentialField(el) {
+    if (!el || !el.tagName) return false;
+    const tag = el.tagName.toLowerCase();
+    if (tag !== "input" && tag !== "textarea") return false;
+    const type = ((el.getAttribute && el.getAttribute("type")) || "").toLowerCase();
+    if (type === "password") return true;
+    for (const attr of FIELD_HINT_ATTRS) {
+      const value = el.getAttribute ? el.getAttribute(attr) : null;
+      if (value && looksCredentialish(value)) return true;
+    }
+    return false;
+  }
+
+  function shannonEntropy(text) {
+    const counts = Object.create(null);
+    for (let i = 0; i < text.length; i++) {
+      const ch = text[i];
+      counts[ch] = (counts[ch] || 0) + 1;
+    }
+    let bits = 0;
+    for (const ch in counts) {
+      const p = counts[ch] / text.length;
+      bits -= p * (Math.log(p) / Math.LN2);
+    }
+    return bits;
+  }
+
+  /**
+   * Does a long opaque run look random rather than like content?
+   *
+   * Long lowercase hex is taken as a digest/session id outright. Otherwise the
+   * run must use all three character classes AND clear an entropy floor of 4.2
+   * bits/char. That floor is measured, not guessed: real 32+ char tokens score
+   * 4.6–5.4 ("AbCd1234EfGh5678IjKl9012MnOp3456" = 4.63, an sk-proj key = 5.35),
+   * while the long mixed-case host identifiers a capture must preserve score
+   * 3.7–4.0 ("ProseMirror-focused-composer-Wrapper2" = 3.71,
+   * "data-messageAuthorRoleAssistantV2Container" = 4.00). A lower floor mangles
+   * host selectors, which is the failure mode that makes a fixture lie.
+   */
+  const SECRET_ENTROPY_FLOOR = 4.2;
+
+  function isLikelySecretRun(run) {
+    if (run.length < 32) return false;
+    if (/^[0-9a-fA-F]{32,}$/.test(run)) return true;
+    if (!/[a-z]/.test(run) || !/[A-Z]/.test(run) || !/[0-9]/.test(run)) return false;
+    return shannonEntropy(run) >= SECRET_ENTROPY_FLOOR;
+  }
+
+  /**
+   * Build a redactor with its own alias table. Identifier-shaped values (UUIDs,
+   * account ids) get *numbered* fake markers so a capture keeps the distinctness
+   * that makes it useful as a fixture — two different message UUIDs stay two
+   * different (fake) UUIDs. Credential-shaped values collapse to one marker,
+   * because a fixture never needs to tell two secrets apart.
+   */
+  function createRedactor(options) {
+    const enabled = !options || options.redact !== false;
+    const aliases = new Map();
+    const counters = Object.create(null);
+    // Markers this redactor has already minted. Re-redacting an output must be a
+    // no-op, so an alias-shaped input is passed straight through rather than
+    // being handed a second alias.
+    const minted = new Set();
+
+    function alias(kind, value, make) {
+      if (minted.has(value)) return value;
+      const key = kind + String.fromCharCode(0) + value;
+      if (aliases.has(key)) return aliases.get(key);
+      const index = counters[kind] || 0;
+      counters[kind] = index + 1;
+      const marker = make(index);
+      aliases.set(key, marker);
+      minted.add(marker);
+      return marker;
+    }
+
+    /** Redact a scalar of host content. */
+    function text(value) {
+      if (!enabled || typeof value !== "string" || value === "") return value;
+      const held = [];
+      const hold = (marker) => {
+        held.push(marker);
+        return HOLD + (held.length - 1) + HOLD;
+      };
+
+      let out = value;
+      out = out.replace(JWT_RE, () => hold(PLACEHOLDER_JWT));
+      out = out.replace(AUTH_SCHEME_RE, (_m, scheme) => hold(scheme + " " + PLACEHOLDER_VALUE));
+      out = out.replace(EMAIL_RE, () => hold(PLACEHOLDER_EMAIL));
+      out = out.replace(UUID_RE, (m) =>
+        hold(
+          alias(
+            "uuid",
+            m.toLowerCase(),
+            (n) => "00000000-0000-4000-8000-" + String(n).padStart(12, "0"),
+          ),
+        ),
+      );
+      out = out.replace(ACCOUNT_ID_RE, (_m, prefix, sep, tail) =>
+        hold(
+          alias(
+            "account:" + prefix.toLowerCase(),
+            tail,
+            (n) => prefix + sep + PLACEHOLDER_VALUE + (n ? String(n) : ""),
+          ),
+        ),
+      );
+      out = out.replace(CREDENTIAL_PARAM_RE, (_m, key) => hold(key + "=" + PLACEHOLDER_VALUE));
+      out = out.replace(LONG_SECRET_RE, (m) =>
+        isLikelySecretRun(m) ? hold(PLACEHOLDER_SECRET) : m,
+      );
+
+      const restore = new RegExp(HOLD + "(\\d+)" + HOLD, "g");
+      return out.replace(restore, (_m, i) => held[Number(i)]);
+    }
+
+    /** Redact one attribute value, using the owning element for field context. */
+    function attribute(el, name, value) {
+      if (!enabled) return value;
+      if (looksCredentialish(name)) return PLACEHOLDER_VALUE;
+      if (name && name.toLowerCase() === "value" && isCredentialField(el)) {
+        return PLACEHOLDER_VALUE;
+      }
+      return text(value);
+    }
+
+    /**
+     * Serialize an element for the resting snapshot. Works on a clone so live
+     * credential fields can be emptied before serialization without touching the
+     * host page; the resulting HTML then goes through text() like any scalar.
+     */
+    function snapshot(root) {
+      if (!enabled) return root.outerHTML;
+      const clone = root.cloneNode(true);
+      const elements = [clone];
+      if (clone.querySelectorAll) {
+        for (const el of Array.from(clone.querySelectorAll("*"))) elements.push(el);
+      }
+      for (const el of elements) {
+        if (!el.attributes) continue;
+        const credentialField = isCredentialField(el);
+        for (const attr of Array.from(el.attributes)) {
+          if (looksCredentialish(attr.name)) {
+            el.setAttribute(attr.name, PLACEHOLDER_VALUE);
+          } else if (credentialField && attr.name.toLowerCase() === "value") {
+            el.setAttribute(attr.name, PLACEHOLDER_VALUE);
+          }
+        }
+        if (credentialField && el.tagName.toLowerCase() === "textarea") {
+          el.textContent = PLACEHOLDER_VALUE;
+        }
+      }
+      return text(clone.outerHTML);
+    }
+
+    return { enabled, text, attribute, snapshot };
+  }
+
+  // The redactor in force between start() and stop(). summarizeNode() is also
+  // callable standalone (tests, ad-hoc probing), so there is always one active.
+  let redactor = createRedactor();
+
   function summarizeNode(node) {
     if (!node) return null;
     if (node.nodeType === 3 /* TEXT_NODE */) {
-      const text = (node.textContent || "").trim();
+      const text = redactor.text((node.textContent || "").trim());
       return text ? { type: "text", text: text.slice(0, MAX_TEXT) } : null;
     }
     if (node.nodeType !== 1 /* ELEMENT_NODE */) {
@@ -27,14 +271,16 @@
     const attrs = {};
     for (const attr of Array.from(el.attributes || [])) {
       // Skip class/id — surfaced separately as first-class fields.
-      if (attr.name !== "class" && attr.name !== "id") attrs[attr.name] = attr.value;
+      if (attr.name !== "class" && attr.name !== "id") {
+        attrs[attr.name] = redactor.attribute(el, attr.name, attr.value);
+      }
     }
     // SVG elements expose an SVGAnimatedString (not a string) for className;
     // we drop their classes rather than serialize that object.
     const className = typeof el.className === "string" ? el.className : "";
     const classes = className ? className.split(/\s+/).filter(Boolean) : undefined;
     const result = { type: "element", tag: el.tagName.toLowerCase() };
-    if (el.id) result.id = el.id;
+    if (el.id) result.id = redactor.text(el.id);
     if (classes && classes.length) result.classes = classes;
     if (Object.keys(attrs).length) result.attrs = attrs;
     return result;
@@ -44,11 +290,15 @@
     const base = { at: now, type: mutation.type, target: summarizeNode(mutation.target) };
     if (mutation.type === "attributes") {
       base.attributeName = mutation.attributeName;
-      base.value = mutation.target.getAttribute
+      const raw = mutation.target.getAttribute
         ? mutation.target.getAttribute(mutation.attributeName)
         : undefined;
+      base.value =
+        typeof raw === "string"
+          ? redactor.attribute(mutation.target, mutation.attributeName, raw)
+          : raw;
     } else if (mutation.type === "characterData") {
-      base.value = (mutation.target.textContent || "").slice(0, MAX_TEXT);
+      base.value = redactor.text(mutation.target.textContent || "").slice(0, MAX_TEXT);
     } else if (mutation.type === "childList") {
       base.added = Array.from(mutation.addedNodes).map(summarizeNode).filter(Boolean);
       base.removed = Array.from(mutation.removedNodes).map(summarizeNode).filter(Boolean);
@@ -59,9 +309,18 @@
   const api = {
     summarizeNode,
     buildMutationRecord,
+    createRedactor,
+    looksCredentialish,
+    isCredentialField,
     _observer: null,
     _record: null,
-    start(rootSelector) {
+    /**
+     * @param {string} [rootSelector] tight selector for the subtree to record.
+     * @param {{redact?: boolean}} [options] `{ redact: false }` disables
+     *   capture-time redaction. Debug-only: the record is stamped
+     *   `redaction.enabled === false` and must never be committed.
+     */
+    start(rootSelector, options) {
       // Re-runnable: drop any prior session so a second start() doesn't leak an
       // observer firing into an orphaned record.
       if (this._observer) {
@@ -71,13 +330,21 @@
       }
       const root = rootSelector ? global.document.querySelector(rootSelector) : global.document.body;
       if (!root) throw new Error(`dom-recorder: root not found: ${rootSelector}`);
+      redactor = createRedactor(options);
       const startedAt = Date.now();
       this._record = {
-        host: global.location ? global.location.host : "(unknown)",
-        url: global.location ? global.location.href : "(unknown)",
+        host: global.location ? redactor.text(global.location.host) : "(unknown)",
+        url: global.location ? redactor.text(global.location.href) : "(unknown)",
         rootSelector: rootSelector || "body",
         startedAt,
-        restingSnapshot: root.outerHTML,
+        redaction: redactor.enabled
+          ? { enabled: true }
+          : {
+              enabled: false,
+              warning:
+                "UNREDACTED CAPTURE — may contain live tokens, emails and account ids. Do not commit.",
+            },
+        restingSnapshot: redactor.snapshot(root),
         mutations: [],
       };
       const record = this._record;
@@ -86,7 +353,9 @@
         for (const m of mutations) record.mutations.push(buildMutationRecord(m, now));
       });
       this._observer.observe(root, { subtree: true, childList: true, attributes: true, characterData: true });
-      return `recording "${record.rootSelector}" on ${record.host}`;
+      return `recording "${record.rootSelector}" on ${record.host}${
+        redactor.enabled ? "" : " (REDACTION DISABLED — do not commit)"
+      }`;
     },
     stop() {
       if (!this._record && !this._observer) {

--- a/test/fixtures/host-dom/README.md
+++ b/test/fixtures/host-dom/README.md
@@ -10,6 +10,13 @@ Layout: `host-dom/<host>/<YYYY-MM-DD>/<scenario>.json`
 Each file records a resting snapshot **and** the live mutation stream around an
 interaction — capturing dynamic behavior, not just a still frame.
 
+Captures are **redacted at capture time** (#552): tokens, emails, UUIDs and
+account ids are replaced with stable fake markers before the record is written,
+and each file carries `"redaction": {"enabled": true}` to say so. That is a
+heuristic safety net, not a guarantee — conversation text is preserved on
+purpose, and short or novel secrets can survive — so still read a capture before
+committing it (`doc/secret-scanning.md` → "Fixture hygiene").
+
 **These are not API contracts.** Host DOM drifts over time. A fixture that no
 longer matches a host is a signal to re-capture deliberately (re-run the
 recorder), not evidence of a regression in our code. Keep older dated captures

--- a/test/scripts/dom-capture-redaction.spec.ts
+++ b/test/scripts/dom-capture-redaction.spec.ts
@@ -1,0 +1,286 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect, beforeEach } from "vitest";
+
+const recorderSrc = readFileSync(
+  resolve(__dirname, "../../scripts/dom-capture/recorder.js"),
+  "utf8",
+);
+
+function loadRecorder(): any {
+  new Function(recorderSrc)();
+  return (window as any).__domCapture;
+}
+
+/** A fresh redactor per case, so alias counters don't leak between tests. */
+function redactor(options?: { redact?: boolean }) {
+  return loadRecorder().createRedactor(options);
+}
+
+const PLACEHOLDER_JWT =
+  "eyJhbGciOiJub25lIn0.eyJzdWIiOiJSRURBQ1RFRCIsIm5vdGUiOiJzY3J1YmJlZC1maXh0dXJlIn0.SCRUBBED";
+
+// ---------------------------------------------------------------------------
+// Secret-SHAPED inputs are BUILT here, never written as literals.
+//
+// A committed high-entropy string is itself a secret-scanner finding — a
+// redaction test whose fixtures trip `gitleaks generic-api-key` would become
+// the very thing the redactor exists to prevent, and the honest fix is to stop
+// committing the string, not to widen the scanner. These builders are
+// deterministic, so every case is still reproducible, and each one names the
+// shape it is standing in for.
+// ---------------------------------------------------------------------------
+
+const BASE62 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const HEX = "0123456789abcdef";
+
+/** A deterministic opaque run — what a real token looks like, minus the literal. */
+function opaqueToken(length: number, seed = 7, alphabet = BASE62): string {
+  let out = "";
+  let x = seed >>> 0;
+  for (let i = 0; i < length; i++) {
+    x = (Math.imul(x, 1103515245) + 12345) >>> 0;
+    out += alphabet[(x >>> 16) % alphabet.length];
+  }
+  return out;
+}
+
+const base64url = (json: string) =>
+  Buffer.from(json, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+/** A structurally real HS256 JWT: base64url header . payload . opaque signature. */
+const REAL_SHAPED_JWT = [
+  base64url('{"alg":"HS256","typ":"JWT"}'),
+  base64url('{"sub":"1234567890","name":"Jane Doe"}'),
+  opaqueToken(43, 5),
+].join(".");
+
+/** OpenAI project-key shape: a known prefix plus an opaque tail. */
+const OPENAI_SHAPED_KEY = "sk-" + "proj-" + opaqueToken(38, 13);
+/** A 32-char mixed-case token, the shortest run the redactor treats as a secret. */
+const MIXED_TOKEN = opaqueToken(32, 7);
+/** A 40-char lowercase-hex digest — the sha1/sha256 session-id shape. */
+const HEX_DIGEST = opaqueToken(40, 17, HEX);
+/** An opaque bearer credential (not a JWT). */
+const OPAQUE_BEARER = opaqueToken(24, 3);
+/** Account-id tails: long enough to clear the redactor's 16-char floor. */
+const USER_ID_TAIL = opaqueToken(24, 11);
+const ORG_ID_TAIL = opaqueToken(24, 29);
+
+describe("dom recorder redaction — things it must catch", () => {
+  it("replaces a JWT with the scrubbed-fixture placeholder", () => {
+    const out = redactor().text(`{"accessToken":"${REAL_SHAPED_JWT}"}`);
+    expect(out).not.toContain(REAL_SHAPED_JWT);
+    expect(out).toBe(`{"accessToken":"${PLACEHOLDER_JWT}"}`);
+  });
+
+  it("redacts an opaque Bearer token but keeps the scheme", () => {
+    expect(redactor().text(`Authorization: Bearer ${OPAQUE_BEARER}`)).toBe(
+      "Authorization: Bearer REDACTED",
+    );
+  });
+
+  it("redacts a Bearer JWT as a JWT (the specific rule wins over the generic one)", () => {
+    expect(redactor().text(`Bearer ${REAL_SHAPED_JWT}`)).toBe(`Bearer ${PLACEHOLDER_JWT}`);
+  });
+
+  it("replaces email addresses with a fake but well-formed address", () => {
+    expect(redactor().text('"email","ross.cadogan@gmail.com","plan"')).toBe(
+      '"email","redacted@example.com","plan"',
+    );
+  });
+
+  it("replaces long random-looking secrets", () => {
+    const r = redactor();
+    expect(r.text(`key=${MIXED_TOKEN}`)).toContain("REDACTED");
+    expect(r.text(OPENAI_SHAPED_KEY)).toBe("REDACTED-SECRET");
+  });
+
+  it("replaces long hex digests (sha-shaped session ids)", () => {
+    expect(redactor().text(`sid=${HEX_DIGEST}`)).toBe("sid=REDACTED-SECRET");
+  });
+
+  it("redacts credential-shaped URL query parameters", () => {
+    expect(
+      redactor().text("https://host/cb?access_token=short1&state=xyz"),
+    ).toBe("https://host/cb?access_token=REDACTED&state=xyz");
+  });
+
+  it("redacts account/org identifiers using the #541 placeholder convention", () => {
+    const r = redactor();
+    expect(r.text(`"id","user-${USER_ID_TAIL}"`)).toBe('"id","user-REDACTED"');
+    expect(r.text(`"org","org-${ORG_ID_TAIL}"`)).toBe('"org","org-REDACTED"');
+  });
+
+  it("gives distinct UUIDs distinct fake UUIDs, and repeats the same one stably", () => {
+    const r = redactor();
+    const a = "3f2b1c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d";
+    const b = "aaaabbbb-cccc-4ddd-8eee-ffff00001111";
+    expect(r.text(a)).toBe("00000000-0000-4000-8000-000000000000");
+    expect(r.text(b)).toBe("00000000-0000-4000-8000-000000000001");
+    // Stable within a capture: the same source UUID always maps to the same alias,
+    // so a fixture keeps its "these two nodes reference the same thing" topology.
+    expect(r.text(`${a} and ${b} and ${a}`)).toBe(
+      "00000000-0000-4000-8000-000000000000 and " +
+        "00000000-0000-4000-8000-000000000001 and " +
+        "00000000-0000-4000-8000-000000000000",
+    );
+  });
+
+  it("is idempotent — redacting an already-redacted string changes nothing", () => {
+    const r = redactor();
+    const once = r.text(`${REAL_SHAPED_JWT} ross@example.org 3f2b1c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d`);
+    expect(r.text(once)).toBe(once);
+  });
+});
+
+describe("dom recorder redaction — things it must NOT mangle", () => {
+  it("leaves ordinary prose alone", () => {
+    const prose =
+      "Sure — I can help with that. Let's start by listing the three options, " +
+      "then we can talk through the tradeoffs of each one.";
+    expect(redactor().text(prose)).toBe(prose);
+  });
+
+  it("leaves long host selectors and identifiers alone", () => {
+    const r = redactor();
+    // Measured entropy 3.7-4.0: below the secret floor, so these survive intact.
+    for (const id of [
+      "data-messageAuthorRoleAssistantV2Container",
+      "ProseMirror-focused-composer-Wrapper2",
+      "reactRouterDataRouterHydrationV3Element",
+      "this-is-a-fairly-long-hyphenated-slug-for-a-post",
+      "SOME_VERY_LONG_UPPERCASE_CONSTANT_NAME_HERE",
+    ]) {
+      expect(r.text(id)).toBe(id);
+    }
+  });
+
+  it("does not mangle hyphenated names that merely start with an id prefix", () => {
+    // The #541 manual scrub corrupted this exact class of string.
+    const r = redactor();
+    expect(r.text("new-user-days-past-days")).toBe("new-user-days-past-days");
+    expect(r.text("user-message-bubble")).toBe("user-message-bubble");
+    expect(r.text("account-settings")).toBe("account-settings");
+  });
+
+  it("leaves short ids, numbers and timestamps alone", () => {
+    const r = redactor();
+    expect(r.text("conversation-turn-12")).toBe("conversation-turn-12");
+    expect(r.text("2026-09-06T12:34:56.789Z")).toBe("2026-09-06T12:34:56.789Z");
+  });
+
+  it("passes through non-strings and empty strings untouched", () => {
+    const r = redactor();
+    expect(r.text("")).toBe("");
+    expect(r.text(undefined)).toBeUndefined();
+    expect(r.text(null)).toBeNull();
+  });
+});
+
+describe("dom recorder redaction — credential-shaped fields", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("classifies credential field names without over-matching", () => {
+    const rec = loadRecorder();
+    for (const name of ["password", "api-key", "user_token", "data-session-id", "otp", "csrfToken"]) {
+      expect(rec.looksCredentialish(name), name).toBe(true);
+    }
+    for (const name of ["username", "spinner", "data-testid", "placeholder", "aria-label", "pinned"]) {
+      expect(rec.looksCredentialish(name), name).toBe(false);
+    }
+  });
+
+  it("redacts the value of a type=password input regardless of shape", () => {
+    const rec = loadRecorder();
+    document.body.innerHTML = `<input type="password" value="hunter2">`;
+    const input = document.querySelector("input")!;
+    const r = rec.createRedactor();
+    expect(rec.isCredentialField(input)).toBe(true);
+    expect(r.attribute(input, "value", "hunter2")).toBe("REDACTED");
+  });
+
+  it("redacts the value of an input whose name suggests a credential", () => {
+    const rec = loadRecorder();
+    document.body.innerHTML = `<input type="text" name="apiKey" value="short">`;
+    const input = document.querySelector("input")!;
+    expect(rec.createRedactor().attribute(input, "value", "short")).toBe("REDACTED");
+  });
+
+  it("leaves an ordinary text input's value alone", () => {
+    const rec = loadRecorder();
+    document.body.innerHTML = `<input type="text" name="search" value="pasta recipes">`;
+    const input = document.querySelector("input")!;
+    expect(rec.createRedactor().attribute(input, "value", "pasta recipes")).toBe("pasta recipes");
+  });
+
+  it("redacts any attribute whose NAME says credential, on any element", () => {
+    const rec = loadRecorder();
+    document.body.innerHTML = `<div data-auth-token="abc"></div>`;
+    const div = document.querySelector("div")!;
+    expect(rec.createRedactor().attribute(div, "data-auth-token", "abc")).toBe("REDACTED");
+  });
+});
+
+describe("dom recorder redaction — fixture integrity", () => {
+  it("keeps the snapshot's HTML structure intact while scrubbing its content", () => {
+    const rec = loadRecorder();
+    document.body.innerHTML = `
+      <div id="root" data-conversation-id="3f2b1c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d">
+        <p class="msg">Signed in as ross.cadogan@gmail.com</p>
+        <input type="password" name="pw" value="hunter2">
+        <input type="text" name="search" value="pasta recipes">
+        <a href="/c/3f2b1c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d">thread</a>
+      </div>`;
+    const root = document.querySelector("#root")!;
+    const html = rec.createRedactor().snapshot(root);
+
+    // Structure preserved: same tags, same count, still parseable.
+    const reparsed = document.createElement("div");
+    reparsed.innerHTML = html;
+    expect(reparsed.querySelectorAll("*").length).toBe(root.querySelectorAll("*").length + 1);
+    expect(reparsed.querySelector("p.msg")).toBeTruthy();
+    expect(reparsed.querySelector('input[name="search"]')!.getAttribute("value")).toBe(
+      "pasta recipes",
+    );
+
+    // Content scrubbed.
+    expect(html).not.toContain("ross.cadogan@gmail.com");
+    expect(html).toContain("redacted@example.com");
+    expect(html).not.toContain("hunter2");
+    expect(html).not.toContain("3f2b1c4d");
+    // The same source UUID aliases identically in the attribute and the href,
+    // so the fixture still shows they referenced one another.
+    expect(html.match(/00000000-0000-4000-8000-000000000000/g)!.length).toBe(2);
+
+    // The live page is untouched — snapshot() works on a clone.
+    expect(document.querySelector('input[type="password"]')!.getAttribute("value")).toBe("hunter2");
+  });
+});
+
+describe("dom recorder redaction — the opt-out", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `<div id="root"><span>ross@example.com</span></div>`;
+  });
+
+  it("is on by default and stamps the record", () => {
+    const rec = loadRecorder();
+    rec.start("#root");
+    const record = rec.stop();
+    expect(record.redaction).toEqual({ enabled: true });
+    expect(record.restingSnapshot).toContain("redacted@example.com");
+    expect(record.restingSnapshot).not.toContain("ross@example.com");
+  });
+
+  it("start(sel, { redact: false }) passes content through but marks the record do-not-commit", () => {
+    const rec = loadRecorder();
+    const banner = rec.start("#root", { redact: false });
+    const record = rec.stop();
+    expect(banner).toContain("REDACTION DISABLED");
+    expect(record.redaction.enabled).toBe(false);
+    expect(record.redaction.warning).toMatch(/Do not commit/i);
+    expect(record.restingSnapshot).toContain("ross@example.com");
+  });
+});


### PR DESCRIPTION
## Why

`scripts/dom-capture/recorder.js` is aimed at real host pages the founder is signed into, and it copies what it finds verbatim — element text, attribute values, input values, and every mutation payload. That has already cost us twice: PR #541 had to scrub live session tokens, an email address, and account/org/device ids out of three committed ChatGPT fixtures, and #547 needed a rule-scoped `gitleaks` allowlist to keep the tree's secret-scan baseline clean.

Scrubbing after the fact is the wrong end of the pipe. The capture itself should never mint an artifact that has to be scrubbed.

## What

Capture-time redaction, **on by default**, applied at every point the recorder copies host content: the resting snapshot, attribute values, element text, and mutation `value` / `added` / `removed` payloads. It is self-contained (no imports) because the file is eval'd into the host page.

Replacement, not deletion — stable, obviously-fake markers so the fixture keeps its shape:

| Class | Marker |
| --- | --- |
| JWTs (`eyJ…`) | the exact `alg:none` placeholder minted by the #541 scrub (already gitleaks-allowlisted, so redacted captures don't trip the scan) |
| `Bearer` / `Basic` / `Token` credentials | `Bearer REDACTED` (scheme preserved) |
| Email addresses | `redacted@example.com` |
| UUIDs | `00000000-0000-4000-8000-0000000000NN` |
| `user-…` / `org-…` / `session-…` account ids | `user-REDACTED`, `org-REDACTED`, … |
| `?access_token=…`-style credential query params | `access_token=REDACTED` |
| Long random-looking runs (32+ chars, all three character classes, entropy ≥ 4.2; or 32+ hex) | `REDACTED-SECRET` |
| Any attribute whose *name* says credential (`data-auth-token`, `api-key`, `csrfToken`, …) | `REDACTED` |
| The `value` of an `<input>`/`<textarea>` whose `type` or naming says credential | `REDACTED` |

Two design calls worth flagging:

**Identifier-shaped values get *numbered* aliases, credential-shaped ones collapse to a single marker.** Two distinct message UUIDs become two distinct fake UUIDs, and the same source UUID always maps to the same alias within a capture — so a fixture keeps its "these two nodes reference the same thing" topology, which is exactly what makes it useful. A fixture never needs to tell two secrets apart, so secrets share one marker.

**The entropy floor is measured, not guessed.** Real 32+ char tokens score 4.6–5.4 bits/char (`AbCd1234EfGh5678IjKl9012MnOp3456` = 4.63, an `sk-proj-…` key = 5.35); the long mixed-case host identifiers a capture must preserve score 3.7–4.0 (`ProseMirror-focused-composer-Wrapper2` = 3.71, `data-messageAuthorRoleAssistantV2Container` = 4.00). A floor of 3.5 would have mangled host selectors — the failure mode that makes a fixture *lie*. The 16-char floor on account-id tails exists for the same reason: the manual #541 scrub used a looser pattern and turned `new-user-days-past-days` into `new-user-REDACTED-past-days`, which is now a pinned regression case.

**The tests build every secret-shaped input at runtime rather than committing a literal.** The first push of this branch failed `gitleaks` on its own fixture (`generic-api-key`, entropy 4.63) — a true positive: I had committed a secret-shaped string so the redactor would have something to redact. A redaction test whose fixtures trip the secret scanner has become the thing the redactor exists to prevent, and the fix is to stop committing the string, not to widen the scanner (an allowlist there would trade a permanent hole for a test convenience, and gate-weakening is founder-gated here). So the spec now derives its JWT from `base64url` of benign JSON plus a deterministic opaque signature, and its tokens/digests/account-id tails from a seeded generator — same inputs to the redactor, no scannable secret in the file. Each builder is named for the shape it stands in for, so the cases stay legible. Verified with the pinned gitleaks 8.30.1 in **both** CI modes (tree scan and the `base..head` commit-range scan); the branch was amended rather than fixed forward, because the PR-mode scan reads every commit in the range.

Opt-out: `start(sel, { redact: false })`. The record is stamped `"redaction": {"enabled": false}` with a `warning`, `start()` returns a banner saying so, and the docs say plainly that such a record is never committed.

Docs updated: `doc/autonomous-dev-loop.md` (the capture recipe now carries the guarantee *and* its limits), `doc/secret-scanning.md` ("Fixture hygiene" moves from future-tense follow-up to landed), `test/fixtures/host-dom/README.md`, and the `.gitleaks.toml` comment (the `doc/dom/**` allowlist now covers history, not new captures).

### What this deliberately does NOT catch

A heuristic redactor is a safety net, not a guarantee, and the PR should say so as clearly as the code does:

- **Conversation content is not redacted, by design.** Message text *is* the fixture; scrubbing it would leave nothing to test against. Capture from a throwaway thread and read what you commit.
- **Free-text PII** — names, addresses, phone numbers in page copy — passes through untouched.
- **Short or low-entropy secrets**: an 8-character code or a numeric OTP sitting in a `<div>` is indistinguishable from ordinary content.
- **Novel credential shapes** — a host-specific opaque value under a name none of the keyword lists know — survive.
- The long-secret rule trades recall for fidelity: the entropy floor is set to preserve host selectors, so a *low*-entropy token can slip through.
- **`document.cookie`, `localStorage` and JS heap state are not captured at all**, so they are also not a redaction concern here.

Capture-time redaction, `gitleaks`, and a human read of the diff are three imperfect filters. None is sufficient alone, and the docs now say that in both places a capture author will look.

## Verification

- `npm test` green: **2866 Vitest passing, 1 skipped, 248 files** (baseline on `main` was 2843 — 23 new); Jest 2/2; `tsc --noEmit` clean.
- New `test/scripts/dom-capture-redaction.spec.ts` (23 cases) exercises the redaction function directly:
  - **Must catch** — realistic HS256 JWT, opaque `Bearer` token, `Bearer <JWT>` (specific rule beats generic), email, `sk-proj-…` key, 32-char mixed token, 40-char hex digest, `?access_token=`, `user-…`/`org-…` ids, UUID aliasing (distinct → distinct, repeat → stable), and idempotency (redacting an already-redacted string is a no-op).
  - **Must NOT mangle** — ordinary prose, five long host selectors/identifiers pinned by their measured entropy, `new-user-days-past-days` (the #541 casualty), `user-message-bubble`, short ids, ISO timestamps, and non-string/empty inputs.
  - **Fixture integrity** — a snapshot with a password field, an ordinary search field, an email in text, and a UUID in both an attribute and an `href`: asserts the re-parsed HTML has the same element count, the ordinary field's value survives, the secrets are gone, the shared UUID aliases identically in both places, and the **live page is untouched** (snapshot works on a clone).
  - **Opt-out** — default stamps `{enabled: true}` and redacts; `{ redact: false }` passes content through, stamps `{enabled: false}` with a do-not-commit warning, and returns a banner.
- `gitleaks 8.30.1` clean on the branch: `gitleaks git . --log-opts "--no-merges origin/main..HEAD"` → *no leaks found*, and the tree scan reports nothing outside the local gitignored `.env`. CI's `gitleaks` check is green.
- The existing `test/scripts/dom-capture-recorder.spec.ts` (5 cases) still passes unmodified — the redaction layer is transparent to the recorder's existing contract.

**Not verified:** no fresh real-host capture was taken (that would spend a Layer-4 run and leave a real conversation behind, and the redaction is exercised hermetically in jsdom against the same code path the page eval's). The issue's acceptance criterion "a fresh capture of an authenticated page contains only redacted placeholders" is therefore proven by unit test, not by a live capture; the next real capture is the confirmation. The #547 `.gitleaks.toml` fixture allowlist is **not** narrowed in this PR — the files it covers are pre-#552 manual page-saves, so narrowing it would break the clean-baseline invariant until they are re-captured or retired; the comment now says that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
