### PR TITLE
settings: keep the Voices tab in step with the current session (#227)

### DIFF
--- a/entrypoints/settings/index.ts
+++ b/entrypoints/settings/index.ts
@@ -10,6 +10,10 @@ import { DictationTab } from "./tabs/dictation";
 import { VoicesTab, setInitialVoicesHost } from "./tabs/voices";
 import { AboutTab } from "./tabs/about";
 import { replaceI18n } from "./shared/i18n";
+import {
+  installSettingsAuthSync,
+  onSettingsAuthChange,
+} from "./shared/auth-sync";
 import type { TabController } from "./shared/types";
 import {
   SETTINGS_DEEP_LINK_KEY,
@@ -52,6 +56,23 @@ class SettingsApp {
 
   async init(): Promise<void> {
     console.info("[Settings] Bootstrap starting");
+
+    // Before anything renders: a sign-in, sign-out or account switch that
+    // happens while this page is open has to reach the tabs, and a broadcast
+    // that lands mid-bootstrap must not fall on the floor (#227). The header
+    // has always re-rendered on these signals; until this, nothing reconciled
+    // the page's own JwtManager, so the Voices tab went on reading the
+    // previous session until the user reloaded the tab.
+    installSettingsAuthSync();
+    onSettingsAuthChange(() => {
+      // The quota panel is auth-scoped too, and it is the OTHER half of "don't
+      // keep showing the previous account". Re-run the status subscription's
+      // own entry point (it re-checks auth with the background and either
+      // hides the bars or refetches them) rather than teaching this file how
+      // quota works. Absent until status-subscription.js has loaded, which is
+      // why it is resolved at call time.
+      void (window as any).refreshQuotaStatus?.();
+    });
 
     const headerRoot = document.querySelector<HTMLElement>('.settings-header');
     if (!headerRoot) {

--- a/entrypoints/settings/shared/auth-sync.ts
+++ b/entrypoints/settings/shared/auth-sync.ts
@@ -71,12 +71,14 @@ const AUTH_EVENT = "saypi:auth:status-changed";
 let toldSignedOut = false;
 
 /**
- * The `(authenticated, token)` pair the last reconciliation settled on.
+ * The SESSION the last reconciliation settled on: `authenticated:userId`.
  *
- * Both signals can describe the same change — the background broadcasts AND
- * writes storage — and it re-broadcasts on every service-worker wake. Without
- * this, one sign-in would repaint the Voices tab (and re-fetch its catalog)
- * two or three times.
+ * Identity, not the raw token, and for two reasons. Both signals can describe
+ * the same change — the background broadcasts AND writes storage — and it
+ * re-broadcasts on every service-worker wake, so without this one sign-in
+ * would repaint the Voices tab (and re-fetch its catalog) two or three times.
+ * And the background swaps the token every ~15 minutes on a routine refresh,
+ * which is a new token but the same session: nothing the tabs need to redraw.
  */
 let lastSignature: string | null = null;
 
@@ -126,9 +128,25 @@ async function storedToken(): Promise<string | null> {
   }
 }
 
+/**
+ * WHO the stored token belongs to — the only part of it a settings tab cares
+ * about. Falls back to the raw token when the claims cannot be read, which
+ * errs towards treating an opaque change as a new session.
+ */
+function identityOf(token: string | null): string {
+  if (!token) return "";
+  try {
+    const payload = token.split(".")[1];
+    const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    return String(JSON.parse(json).userId ?? token);
+  } catch {
+    return token;
+  }
+}
+
 async function reconcileNow(isAuthenticated: boolean): Promise<void> {
-  const signature = `${isAuthenticated}:${(await storedToken()) ?? ""}`;
-  if (signature === lastSignature) return;
+  const signature = `${isAuthenticated}:${identityOf(await storedToken())}`;
+  const sessionChanged = signature !== lastSignature;
   lastSignature = signature;
 
   if (isAuthenticated) {
@@ -136,7 +154,17 @@ async function reconcileNow(isAuthenticated: boolean): Promise<void> {
     // and handleAuthStatusUpdate emits the event itself once the singleton has
     // loaded the new token.
     toldSignedOut = false;
-    await handleAuthStatusUpdate(true);
+    if (sessionChanged) {
+      await handleAuthStatusUpdate(true);
+      return;
+    }
+    // Same session, new token — the background's routine ~15-minute refresh.
+    // The page's singleton still has to pick it up, or the token it holds
+    // expires under an open settings page and every consumer starts reading a
+    // signed-in user as signed out. But nothing about the SESSION changed, so
+    // the tabs are not told: an announcement here would silently re-fetch the
+    // voice catalog and repaint the rail every quarter of an hour.
+    await getJwtManagerSync().loadFromStorage();
     return;
   }
 
@@ -144,7 +172,7 @@ async function reconcileNow(isAuthenticated: boolean): Promise<void> {
   // false), which would clear() the singleton and with it the background's
   // refresh alarm and stored recovery credentials.
   toldSignedOut = true;
-  EventBus.emit(AUTH_EVENT, false);
+  if (sessionChanged) EventBus.emit(AUTH_EVENT, false);
 }
 
 function reconcile(isAuthenticated: boolean): Promise<void> {
@@ -163,7 +191,7 @@ function reconcile(isAuthenticated: boolean): Promise<void> {
  */
 async function seed(): Promise<void> {
   const token = await storedToken();
-  lastSignature = `${!!token}:${token ?? ""}`;
+  lastSignature = `${!!token}:${identityOf(token)}`;
 }
 
 /**

--- a/entrypoints/settings/shared/auth-sync.ts
+++ b/entrypoints/settings/shared/auth-sync.ts
@@ -1,0 +1,220 @@
+import { browser } from "wxt/browser";
+import EventBus from "../../../src/events/EventBus";
+import { handleAuthStatusUpdate } from "../../../src/AuthStatusSync";
+import { getJwtManagerSync } from "../../../src/JwtManager";
+
+/**
+ * Keeps the settings page's own view of authentication in step with the rest
+ * of the extension — without letting a settings tab mutate extension-wide
+ * credential state that the background service worker owns (#227).
+ *
+ * ## Why the page needs this at all
+ *
+ * `src/popup/auth.js` already re-renders the HEADER on the two signals the
+ * background produces — the `AUTH_STATUS_CHANGED` runtime message and a
+ * `jwtToken` change in `chrome.storage.local` — but it only updates a
+ * module-local flag. Nothing reconciles the settings page's own `JwtManager`
+ * singleton, which loaded from storage once at page load and has no storage
+ * listener of its own. So a sign-in, sign-out or account switch elsewhere
+ * flipped the header while every consumer of the singleton went on reading the
+ * previous session, until the user reloaded the tab.
+ *
+ * ## Why this is NOT the content script's reconciler
+ *
+ * `handleAuthStatusUpdate` in `src/AuthStatusSync.ts` reconciles a CONTENT
+ * SCRIPT, and its signed-out branch calls `JwtManager.clear()`. `clear()`
+ * calls `clearRefreshAlarm()`, whose `browser.alarms.clear()` is a no-op in a
+ * content script (no alarms API — hence the try/catch there) but is very much
+ * NOT a no-op here: the settings page is an extension page, `alarms` is in the
+ * manifest, and alarms are extension-wide. Clearing `saypi-jwt-refresh` from
+ * this tab would delete the schedule the BACKGROUND owns.
+ *
+ * That matters because a signed-out broadcast does not always mean a real
+ * sign-out. `pollAuthCookie` force-refreshes on every service-worker wake, and
+ * a dead website cookie sends `JwtManager.refresh()` down its silent-401
+ * branch: it nulls `jwtToken` in storage while deliberately preserving
+ * `authCookieValue` / `oauthRefreshToken` as the way back in, and the
+ * background broadcasts `false` off that write (see the long rationale at the
+ * top of `src/AuthStatusSync.ts` and PR #457). A failed refresh likewise
+ * schedules its own backoff RETRY on that same alarm (`JwtManager.refresh()`'s
+ * catch block). Letting a settings tab clear it would turn a transient 401
+ * into a session that never recovers — silent, and invisible in every test
+ * that does not mock the alarms API.
+ *
+ * So the sign-out path here records the signed-out state in SETTINGS-SCOPED
+ * state and emits the same EventBus event, leaving the singleton's in-memory
+ * token — and the background's alarm and recovery credentials — alone.
+ * Consumers read {@link isSettingsAuthenticated} instead of
+ * `getJwtManagerSync().isAuthenticated()`, so a token the page has been told
+ * is dead can never make a tab render or fetch as the previous user.
+ *
+ * The becoming-authenticated path DOES reuse `handleAuthStatusUpdate(true)`:
+ * its authenticated branch is only `loadFromStorage()` plus the EventBus emit.
+ * Storage already holds the new token, and the refresh it reschedules matches
+ * what the background scheduled anyway.
+ *
+ * ## Ordering is load-bearing
+ *
+ * Reconciliation completes BEFORE `saypi:auth:status-changed` is emitted:
+ * listeners — and anything they synchronously call during their re-render —
+ * read auth state straight through, so the state has to be right by the time
+ * they run (#456).
+ */
+
+const AUTH_EVENT = "saypi:auth:status-changed";
+
+/**
+ * The background told this page it is signed out, and we deliberately did not
+ * drop the singleton's in-memory token (see above). Settings-scoped: it
+ * describes what THIS page has been told, never what the extension holds.
+ */
+let toldSignedOut = false;
+
+/**
+ * The `(authenticated, token)` pair the last reconciliation settled on.
+ *
+ * Both signals can describe the same change — the background broadcasts AND
+ * writes storage — and it re-broadcasts on every service-worker wake. Without
+ * this, one sign-in would repaint the Voices tab (and re-fetch its catalog)
+ * two or three times.
+ */
+let lastSignature: string | null = null;
+
+/** Reconciliations run one at a time: each one reads storage and awaits. */
+let queue: Promise<void> = Promise.resolve();
+
+let uninstall: (() => void) | null = null;
+
+/**
+ * Is the settings page authenticated, as far as this page has been told?
+ *
+ * Read this rather than `getJwtManagerSync().isAuthenticated()` anywhere on
+ * the settings page: after a signed-out broadcast the singleton knowingly
+ * still holds a live token (it is not this page's to clear), and the whole
+ * point of the settings-scoped state is that no tab renders or fetches as the
+ * previous user on the strength of it.
+ */
+export function isSettingsAuthenticated(): boolean {
+  return !toldSignedOut && getJwtManagerSync().isAuthenticated();
+}
+
+/**
+ * Subscribe to settings-page auth changes. The callback runs after the page's
+ * auth state has been reconciled, so it may read {@link isSettingsAuthenticated}
+ * (and the JwtManager singleton, on the authenticated path) synchronously.
+ */
+export function onSettingsAuthChange(
+  fn: (isAuthenticated: boolean) => void
+): () => void {
+  EventBus.on(AUTH_EVENT, fn);
+  return () => {
+    EventBus.off(AUTH_EVENT, fn);
+  };
+}
+
+/** Resolves once every reconciliation queued so far has run. */
+export function settingsAuthSyncSettled(): Promise<void> {
+  return queue.then(() => {});
+}
+
+async function storedToken(): Promise<string | null> {
+  try {
+    const { jwtToken } = await browser.storage.local.get(["jwtToken"]);
+    return typeof jwtToken === "string" && jwtToken ? jwtToken : null;
+  } catch {
+    return null;
+  }
+}
+
+async function reconcileNow(isAuthenticated: boolean): Promise<void> {
+  const signature = `${isAuthenticated}:${(await storedToken()) ?? ""}`;
+  if (signature === lastSignature) return;
+  lastSignature = signature;
+
+  if (isAuthenticated) {
+    // Order matters: the flag is settings-scoped state that listeners read,
+    // and handleAuthStatusUpdate emits the event itself once the singleton has
+    // loaded the new token.
+    toldSignedOut = false;
+    await handleAuthStatusUpdate(true);
+    return;
+  }
+
+  // Signed out: record it HERE and announce it — never handleAuthStatusUpdate(
+  // false), which would clear() the singleton and with it the background's
+  // refresh alarm and stored recovery credentials.
+  toldSignedOut = true;
+  EventBus.emit(AUTH_EVENT, false);
+}
+
+function reconcile(isAuthenticated: boolean): Promise<void> {
+  queue = queue
+    .then(() => reconcileNow(isAuthenticated))
+    .catch((error) => {
+      console.warn("[Settings] Auth reconciliation failed", error);
+    });
+  return queue;
+}
+
+/**
+ * Seed the signature from what the page already holds, so the background's
+ * routine re-broadcast of an unchanged state on its next wake does not read as
+ * a change.
+ */
+async function seed(): Promise<void> {
+  const token = await storedToken();
+  lastSignature = `${!!token}:${token ?? ""}`;
+}
+
+/**
+ * Start listening. Install this before the tabs render — a broadcast that
+ * lands during bootstrap should still reach them.
+ *
+ * @returns a function that stops listening (idempotent).
+ */
+export function installSettingsAuthSync(): () => void {
+  if (uninstall) return uninstall;
+
+  const onMessage = (message: any): void => {
+    if (message?.type === "AUTH_STATUS_CHANGED") {
+      void reconcile(!!message.isAuthenticated);
+    }
+    // Deliberately returns undefined: this listener answers nothing, and
+    // returning true would hold the background's message channel open.
+  };
+
+  const onStorageChanged = (
+    changes: Record<string, { oldValue?: unknown; newValue?: unknown }>,
+    areaName: string
+  ): void => {
+    if (areaName !== "local") return;
+    const change = changes?.jwtToken;
+    // A VALUE change, not just a presence flip: swapping one account's token
+    // for another's keeps presence identical, and that is still a new session
+    // whose catalog and quota this page must re-read.
+    if (!change || change.oldValue === change.newValue) return;
+    void reconcile(!!change.newValue);
+  };
+
+  browser.runtime.onMessage.addListener(onMessage);
+  browser.storage.onChanged.addListener(onStorageChanged);
+  queue = queue.then(seed).catch(() => {});
+
+  uninstall = () => {
+    browser.runtime.onMessage.removeListener(onMessage);
+    browser.storage.onChanged.removeListener(onStorageChanged);
+    uninstall = null;
+  };
+  return uninstall;
+}
+
+/**
+ * Visible only for testing: drop the listeners and the module-scoped state so
+ * one spec's session cannot leak into the next.
+ */
+export function resetSettingsAuthSyncForTests(): void {
+  uninstall?.();
+  toldSignedOut = false;
+  lastSignature = null;
+  queue = Promise.resolve();
+}

--- a/entrypoints/settings/shared/auth-sync.ts
+++ b/entrypoints/settings/shared/auth-sync.ts
@@ -46,9 +46,16 @@ import { getJwtManagerSync } from "../../../src/JwtManager";
  * token, the background's alarm and the stored recovery credentials alone.
  * Consumers read {@link isSettingsAuthenticated} instead of
  * `getJwtManagerSync().isAuthenticated()`, so a token the page has been told
- * is dead does not make a tab render as the previous user — including the TTS
- * module's voice-cache fingerprint, which the studio's deps point at this
- * state for the same reason (`SpeechSynthesisModule.setAuthStateReader`).
+ * is dead does not make a tab render as the previous user — nor FETCH as one:
+ * the studio's deps point the TTS module at this state
+ * (`SpeechSynthesisModule.setAuthStateReader`), which both keys its voice
+ * cache and stops the catalog request going out at all. That last part is not
+ * optional. `callApi` builds its `Authorization` header from a JwtManager —
+ * this page's on the direct path, the background's on the proxied one — and
+ * never from this state, so a request issued while the page is told signed out
+ * can still leave carrying the previous account's credentials. The only place
+ * the page can honestly stop it is before the request is made, which is what
+ * the quota panel already does (ask the background, return before any fetch).
  *
  * ## What this page DOES do to the alarm, and why that is the safe half
  *

--- a/entrypoints/settings/shared/auth-sync.ts
+++ b/entrypoints/settings/shared/auth-sync.ts
@@ -71,14 +71,17 @@ const AUTH_EVENT = "saypi:auth:status-changed";
 let toldSignedOut = false;
 
 /**
- * The SESSION the last reconciliation settled on: `authenticated:userId`.
+ * The SESSION the last reconciliation settled on — `user:<id>`, or
+ * `signed-out`, which has no identity to carry.
  *
- * Identity, not the raw token, and for two reasons. Both signals can describe
- * the same change — the background broadcasts AND writes storage — and it
- * re-broadcasts on every service-worker wake, so without this one sign-in
- * would repaint the Voices tab (and re-fetch its catalog) two or three times.
- * And the background swaps the token every ~15 minutes on a routine refresh,
- * which is a new token but the same session: nothing the tabs need to redraw.
+ * Identity rather than the raw token, and for three reasons. Both signals can
+ * describe the same change — the background broadcasts AND writes storage —
+ * and it re-broadcasts on every service-worker wake, so without this one
+ * sign-in would repaint the Voices tab (and re-fetch its catalog) two or three
+ * times. The background swaps the token every ~15 minutes on a routine
+ * refresh, which is a new token but the same session. And a sign-out arrives
+ * as up to two events (the broadcast, then the storage wipe), which is one
+ * sign-out however it is spelled.
  */
 let lastSignature: string | null = null;
 
@@ -128,24 +131,30 @@ async function storedToken(): Promise<string | null> {
   }
 }
 
+const SIGNED_OUT = "signed-out";
+
 /**
- * WHO the stored token belongs to — the only part of it a settings tab cares
- * about. Falls back to the raw token when the claims cannot be read, which
- * errs towards treating an opaque change as a new session.
+ * WHICH SESSION the stored token belongs to — the only part of it a settings
+ * tab cares about. Falls back to the raw token when the claims cannot be read,
+ * which errs towards treating an opaque change as a new session.
  */
-function identityOf(token: string | null): string {
-  if (!token) return "";
+function sessionOf(token: string | null): string {
+  if (!token) return SIGNED_OUT;
   try {
     const payload = token.split(".")[1];
     const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
-    return String(JSON.parse(json).userId ?? token);
+    return `user:${JSON.parse(json).userId ?? token}`;
   } catch {
-    return token;
+    return `user:${token}`;
   }
 }
 
 async function reconcileNow(isAuthenticated: boolean): Promise<void> {
-  const signature = `${isAuthenticated}:${identityOf(await storedToken())}`;
+  // Signed out carries no identity: the broadcast and the storage wipe that
+  // follows it are one sign-out, whichever order they land in.
+  const signature = isAuthenticated
+    ? sessionOf(await storedToken())
+    : SIGNED_OUT;
   const sessionChanged = signature !== lastSignature;
   lastSignature = signature;
 
@@ -190,8 +199,7 @@ function reconcile(isAuthenticated: boolean): Promise<void> {
  * a change.
  */
 async function seed(): Promise<void> {
-  const token = await storedToken();
-  lastSignature = `${!!token}:${identityOf(token)}`;
+  lastSignature = sessionOf(await storedToken());
 }
 
 /**

--- a/entrypoints/settings/shared/auth-sync.ts
+++ b/entrypoints/settings/shared/auth-sync.ts
@@ -43,15 +43,28 @@ import { getJwtManagerSync } from "../../../src/JwtManager";
  *
  * So the sign-out path here records the signed-out state in SETTINGS-SCOPED
  * state and emits the same EventBus event, leaving the singleton's in-memory
- * token — and the background's alarm and recovery credentials — alone.
+ * token, the background's alarm and the stored recovery credentials alone.
  * Consumers read {@link isSettingsAuthenticated} instead of
  * `getJwtManagerSync().isAuthenticated()`, so a token the page has been told
- * is dead can never make a tab render or fetch as the previous user.
+ * is dead does not make a tab render as the previous user — including the TTS
+ * module's voice-cache fingerprint, which the studio's deps point at this
+ * state for the same reason (`SpeechSynthesisModule.setAuthStateReader`).
  *
- * The becoming-authenticated path DOES reuse `handleAuthStatusUpdate(true)`:
- * its authenticated branch is only `loadFromStorage()` plus the EventBus emit.
- * Storage already holds the new token, and the refresh it reschedules matches
- * what the background scheduled anyway.
+ * ## What this page DOES do to the alarm, and why that is the safe half
+ *
+ * The invariant is "never clear the alarm without re-creating it", not "never
+ * touch it". The becoming-authenticated path reuses
+ * `handleAuthStatusUpdate(true)`, whose branch is `loadFromStorage()` plus the
+ * EventBus emit — and `loadFromStorage()` calls `scheduleRefresh()`, which
+ * clears the alarm and immediately re-creates it from the same stored
+ * `tokenExpiresAt` the background computed from. So the schedule survives;
+ * only the bare `clear()` of the sign-out branch destroys it. (This is not new
+ * behaviour: the singleton's constructor runs the same `loadFromStorage()` on
+ * every settings-page load.) Two honest edges come with it: `scheduleRefresh`
+ * is invoked un-awaited, so closing the tab inside its millisecond-wide gap
+ * leaves no alarm until the background's next wake; and a token already within
+ * a minute of expiry sends it down `performRefresh()` instead, so the page can
+ * refresh a token the background was about to refresh itself.
  *
  * ## Ordering is load-bearing
  *
@@ -71,7 +84,7 @@ const AUTH_EVENT = "saypi:auth:status-changed";
 let toldSignedOut = false;
 
 /**
- * The SESSION the last reconciliation settled on — `user:<id>`, or
+ * The SESSION the last reconciliation settled on — `user:<id>/<plan>`, or
  * `signed-out`, which has no identity to carry.
  *
  * Identity rather than the raw token, and for three reasons. Both signals can
@@ -82,6 +95,12 @@ let toldSignedOut = false;
  * refresh, which is a new token but the same session. And a sign-out arrives
  * as up to two events (the broadcast, then the storage wipe), which is one
  * sign-out however it is spelled.
+ *
+ * The plan rides along because an upgrade is a change this page must show —
+ * the quota panel's entitlement copy and bars are drawn from it — and it moves
+ * only when the user's plan actually changes. The quota NUMBERS deliberately
+ * do not: they fall with every transcription, so keying on them would put the
+ * 15-minute repaint back and then some.
  */
 let lastSignature: string | null = null;
 
@@ -107,6 +126,10 @@ export function isSettingsAuthenticated(): boolean {
  * Subscribe to settings-page auth changes. The callback runs after the page's
  * auth state has been reconciled, so it may read {@link isSettingsAuthenticated}
  * (and the JwtManager singleton, on the authenticated path) synchronously.
+ *
+ * The `isAuthenticated` argument is ADVISORY — it is what the background said,
+ * which can briefly run ahead of the storage write it describes. Read
+ * {@link isSettingsAuthenticated} for the state to render from.
  */
 export function onSettingsAuthChange(
   fn: (isAuthenticated: boolean) => void
@@ -117,7 +140,10 @@ export function onSettingsAuthChange(
   };
 }
 
-/** Resolves once every reconciliation queued so far has run. */
+/**
+ * Visible only for testing: resolves once every reconciliation queued so far
+ * has run. Production never needs to wait — the listeners are fire-and-forget.
+ */
 export function settingsAuthSyncSettled(): Promise<void> {
   return queue.then(() => {});
 }
@@ -135,15 +161,23 @@ const SIGNED_OUT = "signed-out";
 
 /**
  * WHICH SESSION the stored token belongs to — the only part of it a settings
- * tab cares about. Falls back to the raw token when the claims cannot be read,
- * which errs towards treating an opaque change as a new session.
+ * tab cares about.
+ *
+ * Decoded here rather than through `JwtManager.getClaims()` because the
+ * question is about the token in STORAGE, not the one the singleton is holding
+ * — comparing the two is the entire point. Falls back to the raw token when
+ * the claims cannot be read, which errs towards treating an opaque change as a
+ * new session.
  */
 function sessionOf(token: string | null): string {
   if (!token) return SIGNED_OUT;
   try {
     const payload = token.split(".")[1];
-    const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
-    return `user:${JSON.parse(json).userId ?? token}`;
+    const claims = JSON.parse(
+      atob(payload.replace(/-/g, "+").replace(/_/g, "/"))
+    );
+    // `||`, not `??`: an empty id is as unusable as a missing one.
+    return `user:${claims.userId || token}/${claims.planId ?? ""}`;
   } catch {
     return `user:${token}`;
   }

--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -259,6 +259,12 @@ function auditionThrough(
 // carry an explicit chatbot id — the no-arg default resolves to "web" here.
 function defaultDeps(): VoiceStudioDeps {
   const speech = SpeechSynthesisModule.getInstance();
+  // The TTS module keys its voice cache on who is signed in, and on this page
+  // the JwtManager singleton is not that answer: a sign-out broadcast leaves
+  // its token in place on purpose (#227). Hand the module the settings-scoped
+  // truth, or the rail re-reads the catalog and is served the previous
+  // account's list straight back out of the cache.
+  speech.setAuthStateReader(isSettingsAuthenticated);
   const prefs = UserPreferenceModule.getInstance();
   const storage = defaultLocalStorage();
   return {

--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -2,7 +2,10 @@ import getMessage from "../../../../src/i18n";
 import { audioProviders, SpeechSynthesisVoiceRemote } from "../../../../src/tts/SpeechModel";
 import { SpeechSynthesisModule } from "../../../../src/tts/SpeechSynthesisModule";
 import { UserPreferenceModule } from "../../../../src/prefs/PreferenceModule";
-import { getJwtManagerSync } from "../../../../src/JwtManager";
+import {
+  isSettingsAuthenticated,
+  onSettingsAuthChange,
+} from "../../shared/auth-sync";
 import {
   HostPinOverlay,
   loadHostOverlay,
@@ -115,6 +118,22 @@ export interface VoiceStudioDeps {
   unsetVoice?(host: VoiceHostId): Promise<void>;
   hasVoice?(host: VoiceHostId): Promise<boolean>;
   onVoiceChange?(fn: () => void): () => void;
+  /**
+   * Subscribe to a change of SESSION — sign-in, sign-out, or one account
+   * replaced by another. Distinct from `onVoiceChange`, which reports a
+   * changed preference within one session: this one invalidates the catalog
+   * itself, because a different account can be offered a different voice list.
+   *
+   * Optional, like the other subscriptions: a studio wired without it simply
+   * never hears about auth (which is what most unit tests want).
+   */
+  onAuthChange?(fn: () => void): () => void;
+  /**
+   * Is the page authenticated? Read through the settings-scoped state
+   * (`shared/auth-sync.ts`), never straight off the JwtManager singleton — a
+   * sign-out broadcast deliberately leaves that singleton's in-memory token
+   * alone (#227), and the rail must not render or fetch as the previous user.
+   */
   isAuthenticated(): boolean;
   /**
    * Play the voice's free canned sample clip (design §4), replacing whatever
@@ -256,7 +275,8 @@ function defaultDeps(): VoiceStudioDeps {
       chrome.storage.onChanged.addListener(listener);
       return () => chrome.storage.onChanged.removeListener(listener);
     },
-    isAuthenticated: () => getJwtManagerSync().isAuthenticated(),
+    isAuthenticated: () => isSettingsAuthenticated(),
+    onAuthChange: (fn) => onSettingsAuthChange(fn),
     // A single audition IS a one-item sequence — same queue, same beat, same
     // cancellation — so both entry points are this one call.
     playPreview: (voice, onState, gain = 1) => {
@@ -338,6 +358,17 @@ export class VoicesController {
   private auditionState: AuditionState = IDLE_AUDITION;
   private cache = new Map<VoiceHostId, HostStudioData>();
   private loading = new Map<VoiceHostId, Promise<HostStudioData>>();
+  /**
+   * Which SESSION the cached catalogs belong to.
+   *
+   * Bumped whenever the caches are thrown away wholesale (an auth change).
+   * A fetch issued for the previous session can still be in flight when that
+   * happens, and it resolves into `ensureData` — which would otherwise write
+   * the old account's catalog over the new one's and un-register the new
+   * fetch. The render token can't cover this: it guards the PAINT, and the
+   * cache write happens before it.
+   */
+  private dataEpoch = 0;
 
   // --- the rail's own state -------------------------------------------------
 
@@ -352,6 +383,7 @@ export class VoicesController {
   private optionsOpen = false;
   private destroyed = false;
   private unsubscribeVoice: (() => void) | null = null;
+  private unsubscribeAuth: (() => void) | null = null;
   /**
    * Which voice focus is on, carried ACROSS repaints. `useVoice` rebuilds the
    * body from scratch, and landing the reader back at the top of a 22-row rail
@@ -534,6 +566,7 @@ export class VoicesController {
       this.deps.onHeard?.((voiceId) => this.onVoiceHeard(voiceId)) ?? null;
     await this.render();
     this.unsubscribeVoice = this.deps.onVoiceChange?.(this.onVoiceChange) ?? null;
+    this.unsubscribeAuth = this.deps.onAuthChange?.(this.onAuthChange) ?? null;
     window.addEventListener("focus", this.onVoiceChange);
   }
 
@@ -583,6 +616,28 @@ export class VoicesController {
 
   private readonly onVoiceChange = (): void => {
     void this.refreshCurrentVoice();
+  };
+
+  /**
+   * The session changed under the open page (#227) — signed in, signed out, or
+   * one account swapped for another.
+   *
+   * Unlike a voice-preference change, this invalidates the CATALOG: the voice
+   * list is fetched per account, so what is cached here was fetched for a
+   * session that is over. Drop it and re-render rather than repainting the
+   * previous user's rail with the new user's copy around it — that is the
+   * "don't retain the previous account's catalog" half of the fix; the copy
+   * half falls out of `deps.isAuthenticated()` now reading the settings-scoped
+   * state.
+   */
+  private readonly onAuthChange = (): void => {
+    if (this.destroyed) return;
+    this.dataEpoch++;
+    this.cache.clear();
+    this.loading.clear();
+    // A choice read still in flight was started for the previous session.
+    this.currentReadToken++;
+    void this.render();
   };
 
   /** Refresh the choice, keeping the expensive catalog and sample cache. */
@@ -690,6 +745,8 @@ export class VoicesController {
     this.currentReadToken++;
     this.unsubscribeVoice?.();
     this.unsubscribeVoice = null;
+    this.unsubscribeAuth?.();
+    this.unsubscribeAuth = null;
     window.removeEventListener("focus", this.onVoiceChange);
     this.wantsRailFocus = false;
     document.removeEventListener("visibilitychange", this.onVisibilityChange);
@@ -784,12 +841,18 @@ export class VoicesController {
   private async ensureData(host: VoiceHostId): Promise<HostStudioData> {
     const cached = this.cache.get(host);
     if (cached) return cached;
+    const epoch = this.dataEpoch;
     let inFlight = this.loading.get(host);
     if (!inFlight) {
       inFlight = this.fetchHost(host);
       this.loading.set(host, inFlight);
     }
     const data = await inFlight;
+    // The session changed while this was in flight: the answer describes an
+    // account that is no longer signed in. Hand it back to a caller whose
+    // render token will drop it, but keep it out of the cache — and leave the
+    // replacement fetch registered.
+    if (epoch !== this.dataEpoch) return data;
     this.loading.delete(host);
     this.cache.set(host, data);
     return data;

--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -259,11 +259,12 @@ function auditionThrough(
 // carry an explicit chatbot id — the no-arg default resolves to "web" here.
 function defaultDeps(): VoiceStudioDeps {
   const speech = SpeechSynthesisModule.getInstance();
-  // The TTS module keys its voice cache on who is signed in, and on this page
-  // the JwtManager singleton is not that answer: a sign-out broadcast leaves
-  // its token in place on purpose (#227). Hand the module the settings-scoped
-  // truth, or the rail re-reads the catalog and is served the previous
-  // account's list straight back out of the cache.
+  // The TTS module keys its voice cache on who is signed in — and decides
+  // whether to fetch a catalog at all — and on this page the JwtManager
+  // singleton is not that answer: a sign-out broadcast leaves its token in
+  // place on purpose (#227). Hand the module the settings-scoped truth, or the
+  // rail re-reads the catalog: served the previous account's list out of the
+  // cache, or fetched fresh on that account's still-live bearer.
   speech.setAuthStateReader(isSettingsAuthenticated);
   const prefs = UserPreferenceModule.getInstance();
   const storage = defaultLocalStorage();

--- a/src/popup/status-subscription.js
+++ b/src/popup/status-subscription.js
@@ -578,6 +578,11 @@ if (document.readyState === 'loading') {
 
 // Export functions to global scope for use in other scripts
 window.updateUnauthenticatedDisplay = updateUnauthenticatedDisplay;
+// Re-run the whole status read after the session changes under an open
+// settings page (#227). getQuotaStatus() re-checks auth with the background
+// and then either hides the bars (signed out) or refetches the numbers, so a
+// new account never inherits the previous one's quota display.
+window.refreshQuotaStatus = initializeStatusSubscription;
 window.updateQuotaDisplayForAuthState = async function() {
   await checkAuthenticationStatus();
   if (!isUserAuthenticated) {

--- a/src/popup/status-subscription.js
+++ b/src/popup/status-subscription.js
@@ -197,7 +197,15 @@ function updateQuotaProgress(status, type = 'tts') {
   }
 
   const quotaProgress = document.querySelector(`.quota-progress.${type}`);
-  
+  // The quota bars live in the General tab, and tabs are mounted lazily — a
+  // deep link straight into Voices ("More voices…") never builds them. Reading
+  // the status is still worth doing (it is what tells the header the truth),
+  // but there is nothing here to paint it into (#227).
+  if (!quotaProgress) {
+    quotaStatuses[type] = status;
+    return;
+  }
+
   const progressLabel = quotaProgress.querySelector(
     `#premium-status .progress-label .label`
   );
@@ -582,6 +590,12 @@ window.updateUnauthenticatedDisplay = updateUnauthenticatedDisplay;
 // settings page (#227). getQuotaStatus() re-checks auth with the background
 // and then either hides the bars (signed out) or refetches the numbers, so a
 // new account never inherits the previous one's quota display.
+//
+// Deliberately NOT folded into updateQuotaDisplayForAuthState below, which
+// only shows or hides what is already painted. That one runs on every General
+// tab load; making it refetch would put an API call on a path that already has
+// fresh numbers. This one runs when the session changed, which is exactly when
+// the numbers are stale.
 window.refreshQuotaStatus = initializeStatusSubscription;
 window.updateQuotaDisplayForAuthState = async function() {
   await checkAuthenticationStatus();

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -115,7 +115,9 @@ class SpeechSynthesisModule {
    * settings page deliberately keeps a token it has been told is dead and
    * tracks the truth beside it (entrypoints/settings/shared/auth-sync.ts,
    * #227). Without this hook the fingerprint below would stay `user:A` after a
-   * sign-out and go on serving the previous account's voice list.
+   * sign-out and go on serving the previous account's voice list — and
+   * {@link getVoices} would go on FETCHING it, carrying that account's still-
+   * live bearer out of a page that has been told the session is over.
    *
    * Per-instance, not static: each extension context has its own module
    * instance, so the settings page sets this without any reach into the
@@ -145,6 +147,32 @@ class SpeechSynthesisModule {
       return "anonymous";
     }
     return `user:${jwtManager.getClaims()?.userId ?? "authenticated"}`;
+  }
+
+  /**
+   * Has this context told us, explicitly, that it is signed out?
+   *
+   * Only a context that injected {@link setAuthStateReader} can answer yes —
+   * and injecting one is an assertion that the JwtManager singleton here is
+   * NOT the truth. On the settings page it is not: a sign-out broadcast
+   * deliberately leaves the singleton's token in place so that a settings tab
+   * cannot destroy the extension-wide refresh alarm (#227). That token is
+   * still live, and `callApi` — directly, or via the background proxy — builds
+   * its `Authorization` header from a manager, never from this reader. So
+   * without this check the catalog fetch below would leave the page carrying
+   * the previous account's credentials and come back with their voice list,
+   * under a UI that has already said "sign in for TTS". The quota panel avoids
+   * exactly this by asking the background and returning before any fetch.
+   *
+   * Deliberately NOT applied when no reader was injected. There the singleton
+   * IS the truth, but "the singleton says no token" is a CLIENT-side expiry
+   * judgement about a stateless bearer — the server is the honest arbiter of
+   * what an anonymous caller may see, and this repo verifies no server
+   * behaviour that would let the client answer for it. Content scripts keep
+   * asking, exactly as before.
+   */
+  private toldSignedOut(): boolean {
+    return this.authStateReader !== null && !this.authStateReader();
   }
 
   /**
@@ -191,6 +219,13 @@ class SpeechSynthesisModule {
     const appId = this.resolveChatbotKey(chatbot, chatbotIdOverride);
     const cacheKey = appId ?? UNKNOWN_CHATBOT_CACHE_KEY;
     this.syncVoicesCacheWithAuthState();
+    // Nothing to ask for, and asking would cost more than an empty list — see
+    // toldSignedOut(). Placed after the fingerprint sync so the caches are
+    // still dropped on the way through, and before the cache read so a stale
+    // entry cannot answer either.
+    if (this.toldSignedOut()) {
+      return [];
+    }
     const cached = this.voicesCache.get(cacheKey);
     if (cached && (cached.voices.length > 0 ||
       Date.now() - cached.fetchedAt < VOICE_CATALOG_RETRY_DELAY_MS)) {

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -105,6 +105,31 @@ class SpeechSynthesisModule {
   private voicesLoading: Map<string, Promise<void>> = new Map();
   /** Auth state the caches were populated under — see {@link syncVoicesCacheWithAuthState}. */
   private voicesCacheAuthFingerprint: string | null = null;
+  /**
+   * Where "am I signed in?" comes from, when the JwtManager singleton is not
+   * the honest answer.
+   *
+   * A content script's singleton IS the honest answer — its reconciler clears
+   * the stale token on sign-out. An extension page's is not: clearing there
+   * would destroy the extension-wide refresh alarm the background owns, so the
+   * settings page deliberately keeps a token it has been told is dead and
+   * tracks the truth beside it (entrypoints/settings/shared/auth-sync.ts,
+   * #227). Without this hook the fingerprint below would stay `user:A` after a
+   * sign-out and go on serving the previous account's voice list.
+   *
+   * Per-instance, not static: each extension context has its own module
+   * instance, so the settings page sets this without any reach into the
+   * content scripts'.
+   */
+  private authStateReader: (() => boolean) | null = null;
+
+  /**
+   * Teach this module where auth truth lives in this context. Idempotent;
+   * called by the settings page's studio deps.
+   */
+  public setAuthStateReader(read: () => boolean): void {
+    this.authStateReader = read;
+  }
 
   /**
    * The voice list is auth-dependent: signed-out requests 401 → [], and each
@@ -113,7 +138,10 @@ class SpeechSynthesisModule {
    */
   private currentAuthFingerprint(): string {
     const jwtManager = getJwtManagerSync();
-    if (!jwtManager.isAuthenticated()) {
+    const authenticated = this.authStateReader
+      ? this.authStateReader()
+      : jwtManager.isAuthenticated();
+    if (!authenticated) {
       return "anonymous";
     }
     return `user:${jwtManager.getClaims()?.userId ?? "authenticated"}`;

--- a/src/tts/SpeechSynthesisModule.ts
+++ b/src/tts/SpeechSynthesisModule.ts
@@ -150,29 +150,44 @@ class SpeechSynthesisModule {
   }
 
   /**
-   * Has this context told us, explicitly, that it is signed out?
+   * Would a request from here carry a credential this context has already
+   * disowned?
    *
-   * Only a context that injected {@link setAuthStateReader} can answer yes —
-   * and injecting one is an assertion that the JwtManager singleton here is
-   * NOT the truth. On the settings page it is not: a sign-out broadcast
-   * deliberately leaves the singleton's token in place so that a settings tab
-   * cannot destroy the extension-wide refresh alarm (#227). That token is
-   * still live, and `callApi` — directly, or via the background proxy — builds
-   * its `Authorization` header from a manager, never from this reader. So
-   * without this check the catalog fetch below would leave the page carrying
-   * the previous account's credentials and come back with their voice list,
-   * under a UI that has already said "sign in for TTS". The quota panel avoids
-   * exactly this by asking the background and returning before any fetch.
+   * Three things have to be true at once, and the conjunction is the point.
    *
-   * Deliberately NOT applied when no reader was injected. There the singleton
-   * IS the truth, but "the singleton says no token" is a CLIENT-side expiry
-   * judgement about a stateless bearer — the server is the honest arbiter of
-   * what an anonymous caller may see, and this repo verifies no server
-   * behaviour that would let the client answer for it. Content scripts keep
-   * asking, exactly as before.
+   * 1. A reader was injected — {@link setAuthStateReader} — which is an
+   *    assertion that the JwtManager singleton is NOT the truth in this
+   *    context. Only the settings page says that today.
+   * 2. That reader says signed out.
+   * 3. The manager would nonetheless still attach an `Authorization` header.
+   *
+   * On the settings page all three hold after a sign-out broadcast, by design:
+   * the page records the sign-out in its own state and deliberately does NOT
+   * clear the singleton, because `clear()` would destroy the extension-wide
+   * refresh alarm the background owns (#227). `callApi` builds its header from
+   * a manager — this page's on the direct path, the background's on the
+   * proxied one — and never from the reader, so the catalog fetch would leave
+   * carrying the previous account's bearer and come back with their voice
+   * list, under a UI that has already said "sign in for TTS". The quota panel
+   * avoids exactly this by asking the background and returning before any
+   * fetch.
+   *
+   * Condition 3 is what keeps this narrow, and it is load-bearing. A page that
+   * was NEVER signed in holds nothing to leak, and suppressing its request
+   * would only deny an anonymous visitor whatever catalog the server is
+   * willing to serve one — a judgement that belongs to the server, not to a
+   * client reading a stateless bearer's client-side expiry. (Layer 3 proves
+   * this is not hypothetical: the mock API serves `/voices` to an
+   * unauthenticated caller, and the E2E settings page never signs in.)
+   * Condition 1 keeps content scripts on exactly their previous behaviour,
+   * where the singleton IS the truth and the server is still the arbiter.
    */
-  private toldSignedOut(): boolean {
-    return this.authStateReader !== null && !this.authStateReader();
+  private wouldCarryStaleCredentials(): boolean {
+    return (
+      this.authStateReader !== null &&
+      !this.authStateReader() &&
+      getJwtManagerSync().getAuthHeader() !== null
+    );
   }
 
   /**
@@ -219,11 +234,11 @@ class SpeechSynthesisModule {
     const appId = this.resolveChatbotKey(chatbot, chatbotIdOverride);
     const cacheKey = appId ?? UNKNOWN_CHATBOT_CACHE_KEY;
     this.syncVoicesCacheWithAuthState();
-    // Nothing to ask for, and asking would cost more than an empty list — see
-    // toldSignedOut(). Placed after the fingerprint sync so the caches are
-    // still dropped on the way through, and before the cache read so a stale
-    // entry cannot answer either.
-    if (this.toldSignedOut()) {
+    // The request would authenticate itself against this context's own
+    // judgement — see wouldCarryStaleCredentials(). Placed after the
+    // fingerprint sync so the caches are still dropped on the way through, and
+    // before the cache read so a stale entry cannot answer either.
+    if (this.wouldCarryStaleCredentials()) {
       return [];
     }
     const cached = this.voicesCache.get(cacheKey);

--- a/test/settings/shared/auth-sync.spec.ts
+++ b/test/settings/shared/auth-sync.spec.ts
@@ -240,6 +240,13 @@ describe("settings-page auth reconciliation (#227)", () => {
     // the singleton already held it.
     expect(getJwtManagerSync().getAuthHeader()).toBe(`Bearer ${token}`);
     expect(seen).toEqual([{ header: `Bearer ${token}`, settings: true }]);
+    // The invariant that actually protects the background's schedule: this
+    // path DOES clear the alarm (loadFromStorage → scheduleRefresh), and must
+    // always put it back. Only the sign-out branch's bare clear() is banned.
+    expect(alarms.create).toHaveBeenCalledWith(
+      JWT_REFRESH_ALARM,
+      expect.anything()
+    );
   });
 
   it("picks up a sign-in seen only as a storage write (no broadcast reached the page)", async () => {
@@ -359,6 +366,29 @@ describe("settings-page auth reconciliation (#227)", () => {
     expect(seen).toEqual([]);
   });
 
+  it("collapses a broadcast and its storage write that arrive back to back", async () => {
+    // The background does both for one sign-in, and neither ordering is
+    // guaranteed. Here they land before the first reconciliation has even
+    // finished its storage read — the case every other test in this file
+    // skips, because they await in between. (The signature check-and-set is
+    // what makes this safe, not the queue: the queue is there so two
+    // reconciliations can never interleave INSIDE loadFromStorage.)
+    installSettingsAuthSync();
+    await settingsAuthSyncSettled();
+    const seen: boolean[] = [];
+    EventBus.on("saypi:auth:status-changed", (auth: boolean) => seen.push(auth));
+
+    const token = makeJwt({ userId: "user-a" });
+    seedStorage({ jwtToken: token, tokenExpiresAt: Date.now() + 15 * 60_000 });
+    const { onMessage, onStorage } = capturedListeners();
+    onMessage({ type: "AUTH_STATUS_CHANGED", isAuthenticated: true });
+    onStorage({ jwtToken: { oldValue: undefined, newValue: token } }, "local");
+    await settingsAuthSyncSettled();
+
+    expect(isSettingsAuthenticated()).toBe(true);
+    expect(seen).toEqual([true]);
+  });
+
   it("stops listening once uninstalled", async () => {
     const uninstall = installSettingsAuthSync();
     await settingsAuthSyncSettled();
@@ -366,6 +396,27 @@ describe("settings-page auth reconciliation (#227)", () => {
 
     expect(browser.runtime.onMessage.removeListener).toHaveBeenCalled();
     expect(browser.storage.onChanged.removeListener).toHaveBeenCalled();
+  });
+
+  it("stops serving the previous account's catalog after a sign-out (AC 3)", async () => {
+    // The page deliberately keeps the singleton's token on sign-out, so the
+    // TTS module's auth fingerprint would otherwise stay `user:A` and go on
+    // serving user A's cached voice list — including their custom voices —
+    // under a "sign in for TTS" label. The settings page hands the module its
+    // own view of auth instead.
+    speechSynthesisModule.setAuthStateReader(() => isSettingsAuthenticated());
+    await openSettingsSignedInAs("user-a");
+    const userAVoices = [mockVoices[0]];
+    textToSpeechServiceMock.getVoices = vi.fn(() => Promise.resolve(userAVoices));
+    expect(await speechSynthesisModule.getVoices(undefined, "claude")).toEqual(
+      userAVoices
+    );
+
+    // Signed out, a /voices request comes back empty (mapped from 401).
+    textToSpeechServiceMock.getVoices = vi.fn(() => Promise.resolve([]));
+    await broadcastAuthStatus(false);
+
+    expect(await speechSynthesisModule.getVoices(undefined, "claude")).toEqual([]);
   });
 
   it("flips the open Voices tab from signed in to signed out, with no reload (AC 1)", async () => {

--- a/test/settings/shared/auth-sync.spec.ts
+++ b/test/settings/shared/auth-sync.spec.ts
@@ -312,6 +312,29 @@ describe("settings-page auth reconciliation (#227)", () => {
     expect(seen).toEqual([]);
   });
 
+  it("keeps the page's token current across a routine refresh without repainting the tabs", async () => {
+    const tokenA = await openSettingsSignedInAs("user-a");
+    const seen: boolean[] = [];
+    EventBus.on("saypi:auth:status-changed", (auth: boolean) => seen.push(auth));
+
+    // The background refreshes ~every 15 minutes: a new token for the SAME
+    // session. The page's singleton has to pick it up (the one it holds is
+    // about to expire under an open settings page, and an expired token reads
+    // as signed out to every consumer)...
+    const refreshed = makeJwt({ userId: "user-a", iat: 2 });
+    seedStorage({
+      jwtToken: refreshed,
+      tokenExpiresAt: Date.now() + 15 * 60_000,
+    });
+    await storageChanged(tokenA, refreshed);
+
+    expect(getJwtManagerSync().getAuthHeader()).toBe(`Bearer ${refreshed}`);
+    expect(isSettingsAuthenticated()).toBe(true);
+    // ...but nothing about the session changed, so the tabs are not asked to
+    // re-fetch a catalog and repaint a rail every quarter of an hour.
+    expect(seen).toEqual([]);
+  });
+
   it("stops listening once uninstalled", async () => {
     const uninstall = installSettingsAuthSync();
     await settingsAuthSyncSettled();

--- a/test/settings/shared/auth-sync.spec.ts
+++ b/test/settings/shared/auth-sync.spec.ts
@@ -12,7 +12,8 @@ import {
 import EventBus from "../../../src/events/EventBus";
 import { getJwtManagerSync } from "../../../src/JwtManager";
 import { SpeechSynthesisModule } from "../../../src/tts/SpeechSynthesisModule";
-import type { TextToSpeechService } from "../../../src/tts/TextToSpeechService";
+import { TextToSpeechService } from "../../../src/tts/TextToSpeechService";
+import { callApi } from "../../../src/ApiClient";
 import type { AudioStreamManager } from "../../../src/tts/AudioStreamManager";
 import type { UserPreferenceModule } from "../../../src/prefs/PreferenceModule";
 import { mockVoices } from "../../data/Voices";
@@ -49,6 +50,25 @@ vi.mock("../../../src/ConfigModule", () => ({
     apiServerUrl: "https://api.saypi.ai",
   },
 }));
+
+/**
+ * `callApi` is the REQUEST LAYER — the one place that attaches
+ * `Authorization` (directly, or by handing the request to the background
+ * proxy that attaches it). Spying here rather than on the TTS service is the
+ * whole point of the outbound-request test below: it can distinguish "the
+ * page decided not to ask" from "the page asked and the server said no".
+ */
+vi.mock("../../../src/ApiClient", () => ({
+  callApi: vi.fn(),
+}));
+const callApiMock = vi.mocked(callApi);
+
+/** A `/voices` response as the API returns one. */
+const voicesResponse = (voices: unknown[]) =>
+  new Response(JSON.stringify(voices), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
 
 const b64url = (obj: object) =>
   Buffer.from(JSON.stringify(obj))
@@ -412,11 +432,61 @@ describe("settings-page auth reconciliation (#227)", () => {
       userAVoices
     );
 
-    // Signed out, a /voices request comes back empty (mapped from 401).
-    textToSpeechServiceMock.getVoices = vi.fn(() => Promise.resolve([]));
+    // A signed-out page must not serve user A's list back out of the cache.
+    // The service stub is re-armed with A's voices ON PURPOSE: if the module
+    // asked for them it would get them, so an empty result here can only mean
+    // the cache was dropped AND the fetch was not made. (What the SERVER would
+    // answer an unauthenticated caller is not something this repo verifies —
+    // the outbound-request test below is what pins the client's behaviour.)
+    textToSpeechServiceMock.getVoices = vi.fn(() => Promise.resolve(userAVoices));
     await broadcastAuthStatus(false);
 
     expect(await speechSynthesisModule.getVoices(undefined, "claude")).toEqual([]);
+    expect(textToSpeechServiceMock.getVoices).not.toHaveBeenCalled();
+  });
+
+  it("sends NO outbound request from a page that has been told it is signed out (AC 3)", async () => {
+    // The gap the rendering half does not close. `isSettingsAuthenticated()`
+    // gates what the tab DRAWS and which cache entry it reads, but the fetch
+    // underneath ran on a different authority: SpeechSynthesisModule.getVoices
+    // -> TextToSpeechService.getVoices -> callApi, and callApi's Authorization
+    // header comes from the JwtManager singleton this design deliberately
+    // never clears (or, on the proxied path, from the background's own).
+    //
+    // So a sign-out — which now clears the catalog cache and re-renders, where
+    // before the tab simply froze until reload — used to put a real request on
+    // the wire for a page that had just been told the session was over.
+    //
+    // Everything below the module is production code; only callApi is a spy,
+    // because it is the request layer and the assertion is about the request.
+    const service = new TextToSpeechService("https://api.saypi.ai");
+    const speech = new SpeechSynthesisModule(
+      service,
+      {} as unknown as AudioStreamManager,
+      {} as unknown as UserPreferenceModule
+    );
+    speech.setAuthStateReader(() => isSettingsAuthenticated());
+
+    await openSettingsSignedInAs("user-a");
+    const userAVoices = [{ id: "voice-a", name: "A" }];
+    // A fresh Response per call — a body can only be read once.
+    callApiMock.mockImplementation(async () => voicesResponse(userAVoices));
+
+    // Control: signed in, the page really does fetch.
+    expect(await speech.getVoices(undefined, "claude")).toEqual(userAVoices);
+    expect(callApiMock).toHaveBeenCalledTimes(1);
+
+    await broadcastAuthStatus(false);
+    callApiMock.mockClear();
+
+    const voices = await speech.getVoices(undefined, "claude");
+
+    // The assertion this test exists for: nothing left the page.
+    expect(callApiMock).not.toHaveBeenCalled();
+    // And this is why that matters — the singleton is still holding user A's
+    // live bearer, on purpose (#227), so a request here would have carried it.
+    expect(getJwtManagerSync().getAuthHeader()).toMatch(/^Bearer /);
+    expect(voices).toEqual([]);
   });
 
   it("flips the open Voices tab from signed in to signed out, with no reload (AC 1)", async () => {

--- a/test/settings/shared/auth-sync.spec.ts
+++ b/test/settings/shared/auth-sync.spec.ts
@@ -1,7 +1,14 @@
 import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { h } from "preact";
+import { cleanup, render } from "@testing-library/preact";
 import { browser } from "wxt/browser";
+import { VoicesPanel } from "../../../entrypoints/settings/tabs/voices/VoicesPanel";
+import {
+  VoicesController,
+  type VoiceStudioDeps,
+} from "../../../entrypoints/settings/tabs/voices/voices-controller";
 import EventBus from "../../../src/events/EventBus";
 import { getJwtManagerSync } from "../../../src/JwtManager";
 import { SpeechSynthesisModule } from "../../../src/tts/SpeechSynthesisModule";
@@ -12,6 +19,7 @@ import { mockVoices } from "../../data/Voices";
 import {
   installSettingsAuthSync,
   isSettingsAuthenticated,
+  onSettingsAuthChange,
   resetSettingsAuthSyncForTests,
   settingsAuthSyncSettled,
 } from "../../../entrypoints/settings/shared/auth-sync";
@@ -358,6 +366,43 @@ describe("settings-page auth reconciliation (#227)", () => {
 
     expect(browser.runtime.onMessage.removeListener).toHaveBeenCalled();
     expect(browser.storage.onChanged.removeListener).toHaveBeenCalled();
+  });
+
+  it("flips the open Voices tab from signed in to signed out, with no reload (AC 1)", async () => {
+    // The whole chain, end to end: a real background sign-out broadcast, the
+    // real reconciler, and a real VoicesController reading the real
+    // settings-scoped state through the real subscription. Only the studio's
+    // network-bound deps are stubbed.
+    await openSettingsSignedInAs("user-a");
+    const { container } = render(h(VoicesPanel, {}));
+    const studio = new VoicesController(container as HTMLElement, {
+      getVoices: async () => [mockVoices[0] as any],
+      getVoice: async () => mockVoices[0] as any,
+      setVoice: async () => {},
+      hasVoice: async () => true,
+      loadPins: async () => null,
+      setPinned: async () => {},
+      playPreview: () => {},
+      // The two under test, wired exactly as defaultDeps() wires them.
+      isAuthenticated: () => isSettingsAuthenticated(),
+      onAuthChange: (fn: () => void) => onSettingsAuthChange(fn),
+    } as unknown as VoiceStudioDeps);
+    await studio.init();
+    const scope = () =>
+      (container as HTMLElement).querySelector(".voice-current-host")
+        ?.textContent;
+    expect(scope()).toBe("voicesSpeaksWith");
+
+    try {
+      await broadcastAuthStatus(false);
+      // The controller re-renders asynchronously (it re-reads the catalog).
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(scope()).toBe("signInForTTS");
+    } finally {
+      studio.destroy();
+      cleanup();
+    }
   });
 
   it("keeps the Voices tab off the JwtManager singleton", () => {

--- a/test/settings/shared/auth-sync.spec.ts
+++ b/test/settings/shared/auth-sync.spec.ts
@@ -1,0 +1,340 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { browser } from "wxt/browser";
+import EventBus from "../../../src/events/EventBus";
+import { getJwtManagerSync } from "../../../src/JwtManager";
+import { SpeechSynthesisModule } from "../../../src/tts/SpeechSynthesisModule";
+import type { TextToSpeechService } from "../../../src/tts/TextToSpeechService";
+import type { AudioStreamManager } from "../../../src/tts/AudioStreamManager";
+import type { UserPreferenceModule } from "../../../src/prefs/PreferenceModule";
+import { mockVoices } from "../../data/Voices";
+import {
+  installSettingsAuthSync,
+  isSettingsAuthenticated,
+  resetSettingsAuthSyncForTests,
+  settingsAuthSyncSettled,
+} from "../../../entrypoints/settings/shared/auth-sync";
+
+/**
+ * The settings page is an EXTENSION PAGE, not a content script, and #227's
+ * remaining seam is that nothing there reconciles the page's own JwtManager
+ * with a background auth broadcast: the header flips, the Voices tab does not.
+ *
+ * Like test/AuthStatusSync.spec.ts, this spec drives the REAL JwtManager
+ * singleton (only chrome/wxt storage is mocked, via test/vitest.setup.js) —
+ * the whole point is what the singleton holds after a broadcast, so a truthful
+ * stand-in would hide the bug.
+ *
+ * Unlike a content script, this context HAS browser.alarms, so the spec
+ * installs an alarms mock. That is the regression these tests exist to make
+ * visible: JwtManager.clear() clears the extension-wide JWT_REFRESH_ALARM the
+ * background service worker owns, and a signed-out broadcast does not always
+ * mean a real sign-out.
+ *
+ * authServerUrl is deliberately absent from the config mock: every JwtManager
+ * refresh path bails out without it, keeping the spec fully offline.
+ */
+vi.mock("../../../src/ConfigModule", () => ({
+  config: {
+    appServerUrl: "https://app.example.com",
+    apiServerUrl: "https://api.saypi.ai",
+  },
+}));
+
+const b64url = (obj: object) =>
+  Buffer.from(JSON.stringify(obj))
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+/** A structurally valid (unsigned) JWT whose claims getClaims() can parse. */
+const makeJwt = (claims: object) =>
+  `${b64url({ alg: "HS256", typ: "JWT" })}.${b64url(claims)}.sig`;
+
+const storageState = () => (browser.storage.local as any)._getState();
+const seedStorage = (state: Record<string, unknown>) =>
+  (browser.storage.local as any)._setState(state);
+
+/** The extension-wide alarm the background owns — JwtManager's own name. */
+const JWT_REFRESH_ALARM = "saypi-jwt-refresh";
+
+const alarms = {
+  create: vi.fn(async () => {}),
+  clear: vi.fn(async () => true),
+  get: vi.fn(async () => undefined),
+  getAll: vi.fn(async () => []),
+  onAlarm: { addListener: vi.fn(), removeListener: vi.fn() },
+};
+
+type Listeners = {
+  onMessage: (message: any) => void;
+  onStorage: (
+    changes: Record<string, { oldValue?: unknown; newValue?: unknown }>,
+    areaName: string
+  ) => void;
+};
+
+/**
+ * The listeners the reconciler installed — captured the way production
+ * delivers to them, so the tests exercise the real subscription wiring rather
+ * than an internal entry point.
+ */
+function capturedListeners(): Listeners {
+  const messageCalls = (browser.runtime.onMessage.addListener as any).mock.calls;
+  const storageCalls = (browser.storage.onChanged.addListener as any).mock.calls;
+  return {
+    onMessage: messageCalls[messageCalls.length - 1][0],
+    onStorage: storageCalls[storageCalls.length - 1][0],
+  };
+}
+
+/** The background's AUTH_STATUS_CHANGED broadcast, as tabs.sendMessage delivers it. */
+async function broadcastAuthStatus(isAuthenticated: boolean): Promise<void> {
+  capturedListeners().onMessage({
+    type: "AUTH_STATUS_CHANGED",
+    isAuthenticated,
+    timestamp: Date.now(),
+  });
+  await settingsAuthSyncSettled();
+}
+
+/** A chrome.storage.local change event for the JWT, as the background produces it. */
+async function storageChanged(
+  oldValue: unknown,
+  newValue: unknown
+): Promise<void> {
+  capturedListeners().onStorage(
+    { jwtToken: { oldValue, newValue } },
+    "local"
+  );
+  await settingsAuthSyncSettled();
+}
+
+describe("settings-page auth reconciliation (#227)", () => {
+  let speechSynthesisModule: SpeechSynthesisModule;
+  let textToSpeechServiceMock: TextToSpeechService;
+
+  beforeEach(() => {
+    seedStorage({});
+    // The settings page is an extension page: the alarms API is present here.
+    (globalThis as any).chrome.alarms = alarms;
+    alarms.create.mockClear();
+    alarms.clear.mockClear();
+
+    textToSpeechServiceMock = {
+      getVoiceById: vi.fn(() => Promise.resolve(mockVoices[0])),
+      getVoices: vi.fn(() => Promise.resolve(mockVoices)),
+      createSpeech: vi.fn(),
+      addTextToSpeechStream: vi.fn(),
+    } as unknown as TextToSpeechService;
+
+    speechSynthesisModule = new SpeechSynthesisModule(
+      textToSpeechServiceMock,
+      {
+        createStream: vi.fn(),
+        addSpeechToStream: vi.fn(),
+        endStream: vi.fn(),
+        isOpen: vi.fn().mockReturnValue(false),
+      } as unknown as AudioStreamManager,
+      {
+        hasVoice: vi.fn().mockResolvedValue(true),
+        getVoice: vi.fn().mockResolvedValue(mockVoices[0]),
+        getLanguage: vi.fn().mockResolvedValue("en-US"),
+      } as unknown as UserPreferenceModule
+    );
+  });
+
+  afterEach(async () => {
+    resetSettingsAuthSyncForTests();
+    EventBus.removeAllListeners("saypi:auth:status-changed");
+    // Fully reset the shared JwtManager singleton so one test's credentials
+    // can't leak into the next.
+    await getJwtManagerSync().clear();
+    seedStorage({});
+    delete (globalThis as any).chrome.alarms;
+    vi.clearAllMocks();
+  });
+
+  /** A signed-in settings page: token in storage, singleton loaded from it. */
+  async function openSettingsSignedInAs(
+    userId: string,
+    extra: Record<string, unknown> = {}
+  ): Promise<string> {
+    const token = makeJwt({ userId });
+    seedStorage({
+      jwtToken: token,
+      tokenExpiresAt: Date.now() + 15 * 60_000,
+      ...extra,
+    });
+    await getJwtManagerSync().loadFromStorage();
+    installSettingsAuthSync();
+    await settingsAuthSyncSettled();
+    return token;
+  }
+
+  it("flips the page to signed out WITHOUT clearing the extension-wide refresh alarm", async () => {
+    await openSettingsSignedInAs("user-a", { oauthRefreshToken: "refresh-456" });
+    expect(isSettingsAuthenticated()).toBe(true); // sanity
+    alarms.clear.mockClear();
+
+    // A signed-out broadcast does NOT always mean a real sign-out: the
+    // background emits one on a transient 401 while deliberately preserving
+    // the credentials (and the backoff retry alarm) it needs to recover.
+    await broadcastAuthStatus(false);
+
+    // The page's own view of auth flips...
+    expect(isSettingsAuthenticated()).toBe(false);
+    // ...without touching the alarm the background service worker owns...
+    expect(alarms.clear).not.toHaveBeenCalledWith(JWT_REFRESH_ALARM);
+    expect(alarms.clear).not.toHaveBeenCalled();
+    // ...or the stored recovery credential...
+    expect(storageState().oauthRefreshToken).toBe("refresh-456");
+    // ...and deliberately without calling JwtManager.clear(): a settings tab
+    // must not wipe extension-wide credential state (see auth-sync.ts).
+    expect(getJwtManagerSync().isAuthenticated()).toBe(true);
+  });
+
+  it("tells the page it is signed out only after the settings-scoped state has flipped", async () => {
+    await openSettingsSignedInAs("user-a");
+    const seen: boolean[] = [];
+    EventBus.on("saypi:auth:status-changed", () => {
+      // Listeners read auth state synchronously during their re-render (#456).
+      seen.push(isSettingsAuthenticated());
+    });
+
+    await broadcastAuthStatus(false);
+
+    expect(seen).toEqual([false]);
+  });
+
+  it("loads the new token into the JWT manager BEFORE announcing the sign-in", async () => {
+    installSettingsAuthSync();
+    await settingsAuthSyncSettled();
+    expect(isSettingsAuthenticated()).toBe(false); // sanity: signed out
+
+    const seen: Array<{ header: string | null; settings: boolean }> = [];
+    EventBus.on("saypi:auth:status-changed", () => {
+      seen.push({
+        header: getJwtManagerSync().getAuthHeader(),
+        settings: isSettingsAuthenticated(),
+      });
+    });
+
+    // Sign-in as the background produces it: token lands in storage, then the
+    // AUTH_STATUS_CHANGED broadcast.
+    const token = makeJwt({ userId: "user-a" });
+    seedStorage({ jwtToken: token, tokenExpiresAt: Date.now() + 15 * 60_000 });
+    await broadcastAuthStatus(true);
+
+    // A later API call carries the new token, and the announcement came after
+    // the singleton already held it.
+    expect(getJwtManagerSync().getAuthHeader()).toBe(`Bearer ${token}`);
+    expect(seen).toEqual([{ header: `Bearer ${token}`, settings: true }]);
+  });
+
+  it("picks up a sign-in seen only as a storage write (no broadcast reached the page)", async () => {
+    installSettingsAuthSync();
+    await settingsAuthSyncSettled();
+
+    const token = makeJwt({ userId: "user-a" });
+    seedStorage({ jwtToken: token, tokenExpiresAt: Date.now() + 15 * 60_000 });
+    await storageChanged(undefined, token);
+
+    expect(isSettingsAuthenticated()).toBe(true);
+    expect(getJwtManagerSync().getAuthHeader()).toBe(`Bearer ${token}`);
+  });
+
+  it("treats an account replacement (token value changes, presence does not) as a new session", async () => {
+    const tokenA = await openSettingsSignedInAs("user-a");
+
+    // User A's catalog, cached under user A's auth fingerprint.
+    const userAVoices = [mockVoices[0]];
+    textToSpeechServiceMock.getVoices = vi.fn(() =>
+      Promise.resolve(userAVoices)
+    );
+    expect(await speechSynthesisModule.getVoices(undefined, "claude")).toEqual(
+      userAVoices
+    );
+
+    // The page re-reads the catalog when it hears the change.
+    const userBVoices = [
+      { ...mockVoices[0], id: "user-b-voice", name: "User B's Voice" },
+    ];
+    let catalogSeenByTab: Promise<unknown> | undefined;
+    EventBus.on("saypi:auth:status-changed", () => {
+      catalogSeenByTab = speechSynthesisModule.getVoices(undefined, "claude");
+    });
+
+    // The background swaps the token in place — no presence flip, so the
+    // header's "did presence change?" test would ignore this entirely.
+    const tokenB = makeJwt({ userId: "user-b" });
+    seedStorage({
+      jwtToken: tokenB,
+      tokenExpiresAt: Date.now() + 15 * 60_000,
+    });
+    textToSpeechServiceMock.getVoices = vi.fn(() =>
+      Promise.resolve(userBVoices)
+    );
+    await storageChanged(tokenA, tokenB);
+
+    expect(isSettingsAuthenticated()).toBe(true);
+    expect(getJwtManagerSync().getAuthHeader()).toBe(`Bearer ${tokenB}`);
+    expect(getJwtManagerSync().getClaims()?.userId).toBe("user-b");
+    // The re-read got user B's catalog, not user A's cache.
+    expect(await catalogSeenByTab).toEqual(userBVoices);
+    expect(await speechSynthesisModule.getVoices(undefined, "claude")).toEqual(
+      userBVoices
+    );
+  });
+
+  it("ignores a storage write that did not change the token", async () => {
+    const tokenA = await openSettingsSignedInAs("user-a");
+    const seen: boolean[] = [];
+    EventBus.on("saypi:auth:status-changed", (auth: boolean) => seen.push(auth));
+
+    await storageChanged(tokenA, tokenA);
+
+    expect(seen).toEqual([]);
+  });
+
+  it("does not re-announce a broadcast that says nothing new", async () => {
+    await openSettingsSignedInAs("user-a");
+    const seen: boolean[] = [];
+    EventBus.on("saypi:auth:status-changed", (auth: boolean) => seen.push(auth));
+
+    // The background broadcasts on every service-worker wake; a repeat of the
+    // state the page already holds must not churn the tabs that listen.
+    await broadcastAuthStatus(true);
+    await broadcastAuthStatus(true);
+
+    expect(seen).toEqual([]);
+  });
+
+  it("stops listening once uninstalled", async () => {
+    const uninstall = installSettingsAuthSync();
+    await settingsAuthSyncSettled();
+    uninstall();
+
+    expect(browser.runtime.onMessage.removeListener).toHaveBeenCalled();
+    expect(browser.storage.onChanged.removeListener).toHaveBeenCalled();
+  });
+
+  it("keeps the Voices tab off the JwtManager singleton", () => {
+    // The whole point of the settings-scoped state: a stale in-memory token
+    // must not be able to make the Voices tab render or fetch as the previous
+    // user. A direct getJwtManagerSync() read there would bypass it.
+    const source = readFileSync(
+      fileURLToPath(
+        new URL(
+          "../../../entrypoints/settings/tabs/voices/voices-controller.ts",
+          import.meta.url
+        )
+      ),
+      "utf8"
+    );
+    expect(source).not.toMatch(/getJwtManagerSync/);
+    expect(source).toMatch(/isSettingsAuthenticated/);
+  });
+});

--- a/test/settings/shared/auth-sync.spec.ts
+++ b/test/settings/shared/auth-sync.spec.ts
@@ -489,6 +489,33 @@ describe("settings-page auth reconciliation (#227)", () => {
     expect(voices).toEqual([]);
   });
 
+  it("still asks when the page holds no credential to leak (never signed in)", async () => {
+    // The narrow half of the guard above, and the one Layer 3 caught: a
+    // settings page that was never signed in has nothing stale in hand, so
+    // there is no reason to answer for the server about what an anonymous
+    // caller may see. Suppressing here would only empty the rail for a
+    // signed-out visitor — which is exactly what the E2E harness is (its mock
+    // API serves /voices without auth, and nothing ever signs in).
+    const service = new TextToSpeechService("https://api.saypi.ai");
+    const speech = new SpeechSynthesisModule(
+      service,
+      {} as unknown as AudioStreamManager,
+      {} as unknown as UserPreferenceModule
+    );
+    speech.setAuthStateReader(() => isSettingsAuthenticated());
+
+    installSettingsAuthSync();
+    await settingsAuthSyncSettled();
+    expect(isSettingsAuthenticated()).toBe(false); // sanity: signed out...
+    expect(getJwtManagerSync().getAuthHeader()).toBeNull(); // ...and empty-handed
+
+    const anonymousCatalog = [{ id: "voice-free", name: "Free" }];
+    callApiMock.mockImplementation(async () => voicesResponse(anonymousCatalog));
+
+    expect(await speech.getVoices(undefined, "claude")).toEqual(anonymousCatalog);
+    expect(callApiMock).toHaveBeenCalledTimes(1);
+  });
+
   it("flips the open Voices tab from signed in to signed out, with no reload (AC 1)", async () => {
     // The whole chain, end to end: a real background sign-out broadcast, the
     // real reconciler, and a real VoicesController reading the real

--- a/test/settings/shared/auth-sync.spec.ts
+++ b/test/settings/shared/auth-sync.spec.ts
@@ -312,6 +312,22 @@ describe("settings-page auth reconciliation (#227)", () => {
     expect(seen).toEqual([]);
   });
 
+  it("announces one sign-out however many events spell it", async () => {
+    const tokenA = await openSettingsSignedInAs("user-a");
+    const seen: boolean[] = [];
+    EventBus.on("saypi:auth:status-changed", (auth: boolean) => seen.push(auth));
+
+    // The broadcast can reach the page before the storage wipe it describes,
+    // so the page sees "signed out, token still there" and then "signed out,
+    // token gone". Two events, one sign-out.
+    await broadcastAuthStatus(false);
+    seedStorage({});
+    await storageChanged(tokenA, undefined);
+
+    expect(isSettingsAuthenticated()).toBe(false);
+    expect(seen).toEqual([false]);
+  });
+
   it("keeps the page's token current across a routine refresh without repainting the tabs", async () => {
     const tokenA = await openSettingsSignedInAs("user-a");
     const seen: boolean[] = [];

--- a/test/settings/tabs/voices-controller.spec.tsx
+++ b/test/settings/tabs/voices-controller.spec.tsx
@@ -3645,3 +3645,141 @@ describe("adversarial release current choice", () => {
     expect(rowOf(container, "shimmer")?.getAttribute("aria-selected")).toBe("true");
   });
 });
+
+describe("VoicesController — the session can change under an open page (#227)", () => {
+  /** Mount a studio whose auth dep and auth subscription the test drives. */
+  async function mountWithAuth(
+    cfg: Parameters<typeof makeDeps>[0] & { authenticated?: boolean } = {}
+  ) {
+    let fire: (() => void) | undefined;
+    let unsubscribed = false;
+    let authenticated = cfg.authenticated ?? true;
+    const deps = makeDeps({
+      ...cfg,
+      overrides: {
+        isAuthenticated: vi.fn(() => authenticated),
+        onAuthChange: (fn: () => void) => {
+          fire = fn;
+          return () => {
+            unsubscribed = true;
+          };
+        },
+        ...cfg.overrides,
+      },
+    });
+    const mounted = await mount(deps);
+    return {
+      ...mounted,
+      /** The settings page's reconciler has settled and announced the change. */
+      async announce(nowAuthenticated: boolean) {
+        authenticated = nowAuthenticated;
+        fire?.();
+        await flushAsync();
+      },
+      wasUnsubscribed: () => unsubscribed,
+    };
+  }
+
+  it("re-renders on a sign-out that happened elsewhere, with no reload and no gesture", async () => {
+    const { container, announce } = await mountWithAuth({
+      pi: [mkVoice("marin")],
+      piCurrent: mkVoice("marin"),
+    });
+    expect(q(container, ".voice-current-host")?.textContent).toBe(
+      "voicesSpeaksWith"
+    );
+
+    await announce(false);
+
+    // Nobody clicked anything and nobody reloaded the tab.
+    expect(q(container, ".voice-current-host")?.textContent).toBe(
+      "signInForTTS"
+    );
+  });
+
+  it("re-reads the catalog rather than repainting the previous session's", async () => {
+    const piVoices = [mkVoice("marin")];
+    const { container, deps, announce } = await mountWithAuth({
+      pi: piVoices,
+      piCurrent: mkVoice("marin"),
+    });
+    expect(deps.getVoices).toHaveBeenCalledTimes(1);
+
+    // The new session is offered a different list — the catalog is fetched per
+    // account, so what was cached belongs to a session that is over.
+    piVoices.splice(0, piVoices.length, mkVoice("ash"));
+    await announce(true);
+
+    expect(deps.getVoices).toHaveBeenCalledTimes(2);
+    expect(rowIds(container)).toEqual(["ash"]);
+    expect(rowOf(container, "marin")).toBeNull();
+  });
+
+  it("re-renders on a sign-in that happened elsewhere", async () => {
+    const { container, announce } = await mountWithAuth({
+      authenticated: false,
+      pi: [mkVoice("marin")],
+      piCurrent: mkVoice("marin"),
+    });
+    expect(q(container, ".voice-current-host")?.textContent).toBe(
+      "signInForTTS"
+    );
+
+    await announce(true);
+
+    expect(q(container, ".voice-current-host")?.textContent).toBe(
+      "voicesSpeaksWith"
+    );
+  });
+
+  it("never lets the previous session's in-flight catalog land in the cache", async () => {
+    // A catalog fetch issued for the old session can still be in flight when
+    // the next one starts. Its answer belongs to an account that is no longer
+    // signed in, and the render token only guards the PAINT — a cache write
+    // happens before it, and would resurface on the next revisit.
+    let pending: ((voices: SpeechSynthesisVoiceRemote[]) => void) | undefined;
+    let nextVoices: SpeechSynthesisVoiceRemote[] | "pending" = [mkVoice("marin")];
+    const { container, announce } = await mountWithAuth({
+      claude: [mkVoice("nova")],
+      overrides: {
+        getVoices: vi.fn((host: string) => {
+          if (host === "claude") return Promise.resolve([mkVoice("nova")]);
+          if (nextVoices === "pending") {
+            return new Promise<SpeechSynthesisVoiceRemote[]>((resolve) => {
+              pending = resolve;
+            });
+          }
+          return Promise.resolve(nextVoices);
+        }),
+      },
+    });
+    expect(rowIds(container)).toEqual(["marin"]);
+
+    // Session 2's fetch never settles...
+    nextVoices = "pending";
+    await announce(true);
+    // ...before session 3 replaces it and settles first.
+    nextVoices = [mkVoice("ash")];
+    await announce(true);
+    expect(rowIds(container)).toEqual(["ash"]);
+
+    // The abandoned fetch finally answers, for a session two changes ago.
+    pending?.([mkVoice("marin")]);
+    await flushAsync();
+
+    // Leave and come back: the revisit reads the cache.
+    hostTab(container, "claude")!.click();
+    await flushAsync();
+    hostTab(container, "pi")!.click();
+    await flushAsync();
+    expect(rowIds(container)).toEqual(["ash"]);
+  });
+
+  it("stops listening for auth when the studio is destroyed", async () => {
+    const { controller, wasUnsubscribed } = await mountWithAuth({
+      pi: [mkVoice("marin")],
+    });
+    controller.destroy();
+    expect(wasUnsubscribed()).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #227

## Why

The settings **header** has re-rendered on auth changes for a while: `src/popup/auth.js` listens for the background's `AUTH_STATUS_CHANGED` broadcast and for a `jwtToken` write in `chrome.storage.local`. But it only updates a module-local flag of its own. Nothing on the settings page ever reconciled the page's **own** `JwtManager` singleton, which loads from storage once at page load and has no storage listener.

The Voices tab read auth straight off that singleton (`isAuthenticated: () => getJwtManagerSync().isAuthenticated()`), and its only re-render triggers were a voice-preference change and a `window` focus — with a render that short-circuits when `renderedAuthenticated` already matches. So after a sign-in, sign-out or account switch elsewhere, the header flipped and Voices did not: sign in from the settings page and the header greets you by name while the Voices tab still says "sign in for TTS", until you reload the tab. That is the residual seam in #227 (the 2025 header failure is already fixed); the founder's 2026-09-05 comment on the issue is the scope this PR implements.

## What

**New: `entrypoints/settings/shared/auth-sync.ts`** — a settings-scoped reconciler installed from `entrypoints/settings/index.ts` before anything renders. It listens to the same two signals the header already uses, and reacts to a **presence flip or a value change** (a value change with no presence flip is an account switch, which the header's `hadToken !== hasToken` test ignores entirely). It exposes `isSettingsAuthenticated()` and `onSettingsAuthChange()`.

It separates *reconciling* from *announcing*, which matters more than it first looks. The page's `JwtManager` picks up **every** new token, because it must: the one it holds otherwise expires under an open settings page and every consumer starts reading a signed-in user as signed out. But only a change of **session** reaches the tabs. The dedupe signature is the session — `user:<id>`, or `signed-out`, which has no identity to carry — not the raw token, so: the background's routine ~15-minute refresh does not silently re-fetch the voice catalog and repaint the rail every quarter of an hour; the two signals that describe one change (the background both broadcasts *and* writes storage, in either order) collapse into one announcement; and its re-broadcast on every service-worker wake is correctly seen as nothing new.

**The explicit decision NOT to reuse the content-script sign-out path.** The obvious move is to call `handleAuthStatusUpdate()` from `src/AuthStatusSync.ts` for both directions. Its **authenticated** branch is safe here and is reused verbatim — it is only `loadFromStorage()` plus the EventBus emit, run against a storage that already holds the new token, and the refresh it reschedules matches what the background scheduled anyway. Its **signed-out** branch is not safe here:

- it calls `JwtManager.clear()`, which calls `clearRefreshAlarm()` → `browser.alarms.clear('saypi-jwt-refresh')`;
- in a **content script** that is a harmless no-op (no alarms API — hence the try/catch in `JwtManager`), but the settings page is an **extension page**: `alarms` is in the manifest, and alarms are **extension-wide**. Clearing it from a settings tab deletes the schedule the **background service worker** owns;
- and a signed-out broadcast does **not** always mean a real sign-out. a dead website cookie sends `JwtManager.refresh()` down its silent-401 branch (reached via `cookies.onChanged`, and via `pollAuthCookie` where its interval actually survives — on MV3 the worker is usually evicted first, per `doc/codebase-caution-map.md`), which nulls `jwtToken` in storage while deliberately preserving `authCookieValue`/`oauthRefreshToken` as the way back in (see the rationale comment at the top of `AuthStatusSync.ts`, and PR #457). A failed refresh separately schedules its own **backoff retry** on that same alarm (`src/JwtManager.ts:529` in `refresh()`'s catch, and `:727` in `refreshWithOAuth()`'s).

So a settings tab calling `clear()` would turn a transient 401 into a session that never recovers — silent, and invisible to every test that does not mock the alarms API. The sign-out path here therefore records signed-out in settings-scoped state and emits the same EventBus event, leaving the singleton's in-memory token, the alarm and the stored credentials alone. Consumers read `isSettingsAuthenticated()` instead of the singleton, so a token the page has been *told* is dead can never make a tab render or fetch as the previous user. `src/JwtManager.ts` and `src/auth/` are untouched (founder-gated; `path-guard` clean).

**Ordering is load-bearing and asserted.** Reconciliation completes before `saypi:auth:status-changed` is emitted, because listeners read auth state synchronously while re-rendering (#456).

**Voices wiring.** `VoiceStudioDeps` gains `onAuthChange` alongside `onVoiceChange`; `defaultDeps()` takes `isAuthenticated` from `isSettingsAuthenticated()`. On a session change the studio drops its cached catalogs and re-renders rather than repainting the previous account's rail — the voice list is fetched per account, so a swap invalidates it. Dropping the caches opened a race the render token cannot cover (`ensureData` writes the cache *before* the paint-time token check, so a slow fetch from the previous session could overwrite the new one and un-register its replacement), so `ensureData` now stamps each fetch with a session epoch and refuses to file an answer belonging to a session that is over.

**Quota.** `src/popup/status-subscription.js` exposes its existing entry point as `window.refreshQuotaStatus`, and the settings bootstrap re-runs it on the same event — it re-checks auth with the background and then either hides the bars (signed out) or refetches the numbers, so a new account never inherits the previous one's quota display. That is the "quota presentation" half of the issue's AC 3.

`getJwtManagerSync().isAuthenticated()` had exactly one reader across `entrypoints/settings/` and `src/popup/` (the Voices controller), so nothing else needed bringing along.

## Verification

Fail-first TDD throughout. `npm test` (type-check → Jest → Vitest) is fully green.

| | before | after |
|---|---|---|
| Vitest | 2843 passed, 1 skipped (247 files) | **2862 passed, 1 skipped (248 files)** |
| Jest | 2 passed | 2 passed |
| `tsc --noEmit` | clean | clean |

**New: `test/settings/shared/auth-sync.spec.ts` (14 tests).** Like `test/AuthStatusSync.spec.ts` it drives the **real** `JwtManager` singleton (only storage is mocked) — a truthful stand-in would hide the bug. Unlike that spec it **installs an alarms mock**, because that is the whole point: the regression is invisible without one. Each test pins:

- *sign-out broadcast with the page open* → `isSettingsAuthenticated()` flips to false, `alarms.clear` is **never called**, the stored `oauthRefreshToken` survives, and the singleton is deliberately left authenticated. **Proved fail-first**: swapping the sign-out branch for `handleAuthStatusUpdate(false)` fails this test on `expected "spy" to not be called with arguments: [ 'saypi-jwt-refresh' ]`.
- *sign-out ordering* → the event's listeners already see `isSettingsAuthenticated() === false`.
- *sign-in broadcast* → the singleton holds the new token (so a later API call carries it) **and** the event was emitted after that: the listener observes `getAuthHeader() === "Bearer <new token>"` from inside the emit.
- *sign-in seen only as a storage write* (no broadcast reached the page).
- *account replacement* — `jwtToken` value changes, presence does not → treated as a change, `getClaims().userId` is user B's, and a catalog re-read triggered from the event returns **user B's** voices, not user A's cache (driven through a real `SpeechSynthesisModule`, whose auth fingerprint is what drops the stale list).
- *routine token refresh* (new token, same `userId`) → the singleton holds the refreshed token and the page still reads as authenticated, but **no** event is emitted. Proved fail-first against the raw-token signature the first commit used (`expected [ true ] to deeply equal []`).
- *a sign-out spelled as two events* (broadcast first, storage wipe second) → announced once, not twice.
- *no-op storage write* and *repeat broadcast* → no churn; *uninstall* → listeners removed.
- **the whole chain, joined** (the issue's AC 1): a settings page open on a signed-in session + a real background sign-out broadcast + the real reconciler + a real `VoicesController` reading the real settings-scoped state through the real subscription (only the studio's network-bound deps stubbed) → the rail's copy flips from `voicesSpeaksWith` to `signInForTTS` with no reload. Proved fail-first by removing the `onAuthChange` subscription. This is what a broken `defaultDeps` wiring would have slipped past, since both halves pass independently.
- a wiring guard that `voices-controller.ts` contains no `getJwtManagerSync` reference.

**Extended: `test/settings/tabs/voices-controller.spec.tsx` (+5).** Re-renders on a sign-out and on a sign-in that happened elsewhere, with **no reload and no gesture**; re-reads the catalog instead of repainting the previous session's; unsubscribes on `destroy()`; and never lets a previous session's in-flight catalog land in the cache. **Proved fail-first**: all four subscription tests fail without the `onAuthChange` wiring, and the race test fails without the epoch guard (`expected [ 'marin' ] to deeply equal [ 'ash' ]`).

`test/AuthStatusSync.spec.ts` is untouched and green; the existing Voices specs (211 of them, including the one that flips auth via `onShown()`) are unmodified and green.

One delivery-path note worth recording: the background broadcasts via `browser.tabs.sendMessage`, which MDN documents as reaching extension pages in the tab but which Chrome's docs describe only in terms of content scripts. The fix does not depend on the answer — the `storage.onChanged` listener fires in every extension context, and every sign-in/sign-out/switch writes `jwtToken` (the background's own auth listener is driven off that same write) — so the two listeners are belt and braces rather than a single point of failure.

### What I could not verify

- **An attended real OAuth round trip.** #227's AC asks for one, and it is not something an agent session can perform: it needs a human at `https://www.saypi.ai/auth/login` completing SSO. Layer 4 (CDP) drives an already-seeded profile; it cannot do the sign-in leg. This wants a founder spot-check: open settings → Voices, sign in from the header, and confirm the rail's copy flips without a reload.
- **Real `browser.alarms` behaviour.** The alarm-preservation guarantee is proved against a mock. The claim it rests on — that `chrome.alarms` on an extension page shares one namespace with the service worker — is documented Chrome behaviour and is why the guard exists, but this PR does not re-prove it in a real browser.
- **Whether the `/voices` catalog actually differs per account** on the server today. The account-replacement test proves the client re-reads and does not serve the previous account's cache; it cannot prove the server returns something different.

### Review round (adversarial reviewer, `REQUEST CHANGES` → addressed)

An independent reviewer found two claims stronger than the code supported. Both are now fixed rather than softened:

- **The voice cache was still keyed on the singleton.** `SpeechSynthesisModule.currentAuthFingerprint()` read `getJwtManagerSync()` directly, so on a sign-out it stayed `user:A` and the rail's re-read was handed user A's cached list — custom voices and all — under a "sign in for TTS" label. The module now takes a **per-instance** auth reader (`setAuthStateReader`), which the studio's deps point at `isSettingsAuthenticated`. Per-instance because each extension context has its own module instance, so the settings page sets it without reaching into the content scripts'. New fail-first test (AC 3, sign-out direction).
- **The alarm story was half-told.** The real invariant is *never clear without re-creating*, not *never touch it*: `loadFromStorage()` → `scheduleRefresh()` does clear and immediately re-create the schedule from the same stored expiry the background used (and already does so on every settings page load, before this PR). Only the sign-out branch's bare `clear()` destroys it. The module doc now says that, with its two honest edges (`scheduleRefresh` is un-awaited, so a tab closed inside its millisecond gap leaves no alarm; a token within a minute of expiry takes `performRefresh()` instead), and the test assertion moved onto the authenticated path — `expect(alarms.create).toHaveBeenCalledWith(JWT_REFRESH_ALARM, …)`.

Also from the review: `planId` joins the session signature (a plan upgrade is a change this page must show; quota *numbers* stay out, since they fall with every transcription); `updateQuotaProgress` null-guards the quota DOM, which a deep link straight into Voices never builds (lazy tabs — this was a latent throw the new refresh would have made recur); the auth event's payload is documented as advisory, since the broadcast can run ahead of the storage write it describes; and a test now drives both listeners *before* the queue drains.

Two findings declined, with reasons: fencing an in-flight `saveChoice` against an auth change (cosmetic — the voice preference is local, not account-scoped, and the reviewer agreed), and dropping the source-text guard that keeps `voices-controller.ts` off `getJwtManagerSync` (coarse, but it guards a future call site that the behavioural test would only catch if it happened to affect rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
