### PR TITLE
fix(mobile): stop hiding SayPi's per-message TTS controls on phones

### DIFF
--- a/e2e/specs/mobile-tts-controls.e2e.ts
+++ b/e2e/specs/mobile-tts-controls.e2e.ts
@@ -1,0 +1,209 @@
+import { test, expect } from "../fixtures/extension";
+
+/**
+ * Layer 3 guard for #94 — SayPi's per-message TTS controls must be reachable at a
+ * phone viewport, verified against the REAL built extension CSS
+ * (.output/chrome-mv3-dev via --load-extension).
+ *
+ * #94 was filed in 2024 against a popup menu that no longer exists: `mobile.scss`
+ * hid `.saypi-tts-controls` outright with the justification "on mobile, speech
+ * controls are in a popup menu instead". The emitter for that menu
+ * (`watchForPopupMenu`) was removed in #427 and the `PopupMenu` class itself in
+ * #428, so the rule stopped relocating the controls and simply deleted them on
+ * mobile — the user's original complaint ("I can't reach Read Aloud on my phone")
+ * made worse, not fixed.
+ *
+ * This spec pins the fixed state at the only layer that can see it: the cascade of
+ * the shipped stylesheet, plus real layout and hit-testing. jsdom applies none of
+ * the built CSS and has no layout, so a unit test could not tell `display: none`
+ * from a control that renders but sits off the right edge of a 390px screen —
+ * which is the literal title of #94.
+ *
+ * What it asserts, at a 390×844 (iPhone-class) viewport with `html.mobile-device`:
+ *  1. the controls container renders (not `display: none`);
+ *  2. every injected control is fully inside the viewport horizontally;
+ *  3. every control is the actual hit-test target at its own centre (nothing
+ *     overlays it), at a tap size no smaller than pi.ai's own 32px action buttons;
+ *  4. the page does not scroll horizontally because of them.
+ *
+ * The action bar is populated with eight native-sized (32px) sibling buttons —
+ * 256px of host chrome that a 390px row cannot hold alongside SayPi's ~195px of
+ * controls — so assertions 2 and 4 exercise the overflow case rather than a
+ * comfortably-empty bar. Without the mobile `flex-wrap: wrap` guard the controls
+ * run off the right edge here, which is the symptom #94 was actually filed for.
+ */
+
+const PHONE = { width: 390, height: 844 };
+
+/**
+ * Minimum tap target: 24 CSS px, WCAG 2.2 SC 2.5.8 "Target Size (Minimum)", AA.
+ * Measured on the shipped stylesheet at this viewport: generate-speech 36×31,
+ * pricing link 32×24, telemetry 32×32, cost readout 24 tall. (The generate-speech
+ * button's 31px height is not mobile-specific — it is the same on desktop, one
+ * pixel under pi.ai's own 32px action buttons — so it is left alone here rather
+ * than restyled through a mobile fix.)
+ */
+const MIN_TAP_PX = 24;
+
+test("per-message TTS controls are visible and tappable at a phone viewport (real build)", async ({
+  context,
+}) => {
+  const page = await context.newPage();
+  await page.setViewportSize(PHONE);
+  await page.goto("https://pi.ai/talk", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => document.body.classList.contains("pi"), {
+    timeout: 20_000,
+  });
+
+  await page.evaluate(() => {
+    // Two root flags the shipped CSS keys on, neither of which a headless desktop
+    // Chrome sets for itself:
+    //  - `mobile-device` — UserAgentModule.addDeviceFlags() adds it on a phone; it
+    //    is what scopes the rules under test.
+    //  - `desktop-view` — ImmersionService's *standard* (non-immersive) view, which
+    //    a phone also gets. It matters because desktop.scss loads messages.scss
+    //    inside `html.desktop-view`, and messages.scss is where the controls get
+    //    their layout. Without it the container would be unstyled and this spec
+    //    would pass for the wrong reason.
+    document.documentElement.classList.add("mobile-device", "desktop-view");
+    // pi.ai's theme variables (the mock host doesn't ship them).
+    document.documentElement.style.setProperty("--color-text-secondary", "#655E55");
+    document.body.style.margin = "0";
+
+    // The subtree PiMessageControls actually builds on a decorated message:
+    // AssistantResponse tags the message `chat-message assistant-message`, the
+    // action bar gets `message-action-bar`, and SayPi appends its own
+    // `.saypi-tts-controls` div holding the generate-speech button, the cost
+    // readout (cost + pricing link) and the telemetry button.
+    const message = document.createElement("div");
+    message.className = "chat-message assistant-message";
+
+    const bar = document.createElement("div");
+    bar.className = "message-action-bar";
+
+    // pi.ai's own action buttons (Copy / 👍 / 👎 / …) are `size-8` = 32px and do
+    // not shrink. Eight of them (256px) plus SayPi's controls (~195px) cannot fit
+    // a 390px row, so the bar MUST wrap for our controls to stay on screen.
+    for (let i = 0; i < 8; i++) {
+      const native = document.createElement("button");
+      native.className = "pi-native-action";
+      native.style.cssText = "width:32px;height:32px;flex:none";
+      bar.appendChild(native);
+    }
+
+    const controls = document.createElement("div");
+    controls.className = "saypi-tts-controls pt-4 text-neutral-500 text-sm";
+
+    const regenerate = document.createElement("button");
+    regenerate.type = "button";
+    regenerate.className =
+      "text-center saypi-button tooltip tts-item saypi-regenerate-button";
+    regenerate.setAttribute("aria-label", "Read this message aloud");
+    regenerate.innerHTML =
+      '<svg viewBox="0 0 24 24"><path d="M4 4h16v16H4z"></path></svg>';
+    controls.appendChild(regenerate);
+
+    const costContainer = document.createElement("div");
+    costContainer.className = "saypi-cost-container tts-item";
+    const cost = document.createElement("span");
+    cost.className = "saypi-cost tooltip tooltip-wide";
+    const separator = document.createElement("div");
+    separator.className = "vertical-separator";
+    const price = document.createElement("span");
+    price.className = "price";
+    price.innerHTML =
+      '<span class="value">120</span><span class="currency-label"> credits</span>';
+    cost.appendChild(separator);
+    cost.appendChild(price);
+    const pricingLink = document.createElement("a");
+    pricingLink.className = "saypi-pricing-link tooltip tts-item";
+    pricingLink.href = "https://www.saypi.ai/pricing";
+    pricingLink.appendChild(document.createElement("img"));
+    costContainer.appendChild(cost);
+    costContainer.appendChild(pricingLink);
+    controls.appendChild(costContainer);
+
+    const telemetry = document.createElement("button");
+    telemetry.className = "saypi-telemetry-button";
+    telemetry.innerHTML =
+      '<svg viewBox="0 0 768 768"><path d="M384 96 L384 384"></path></svg>';
+    controls.appendChild(telemetry);
+
+    bar.appendChild(controls);
+    message.appendChild(bar);
+    document.body.insertBefore(message, document.body.firstChild);
+  });
+
+  // 1. The controls render at all.
+  const controls = page.locator(".saypi-tts-controls");
+  await expect(
+    controls,
+    "SayPi's per-message TTS controls must not be hidden on mobile (#94)"
+  ).toBeVisible();
+
+  // 2–3. Every control is on-screen, big enough to tap, and is itself the
+  // hit-test target at its own centre (i.e. nothing is overlaying it).
+  const probe = await page.evaluate(
+    ({ minTap }) => {
+      const selectors = [
+        ".saypi-regenerate-button",
+        ".saypi-cost-container",
+        ".saypi-pricing-link",
+        ".saypi-telemetry-button",
+      ];
+      return {
+        viewportWidth: window.innerWidth,
+        scrollWidth: document.documentElement.scrollWidth,
+        controls: selectors.map((selector) => {
+          const el = document.querySelector(selector) as HTMLElement;
+          const rect = el.getBoundingClientRect();
+          const cx = rect.left + rect.width / 2;
+          const cy = rect.top + rect.height / 2;
+          const hit = document.elementFromPoint(cx, cy);
+          return {
+            selector,
+            display: getComputedStyle(el).display,
+            left: rect.left,
+            right: rect.right,
+            width: rect.width,
+            height: rect.height,
+            // The regenerate/telemetry buttons wrap an <svg>, so the hit-test can
+            // legitimately land on a descendant; the pricing link wraps an <img>.
+            hitsSelf: !!hit && (hit === el || el.contains(hit)),
+            tappable: rect.width >= minTap && rect.height >= minTap,
+          };
+        }),
+      };
+    },
+    { minTap: MIN_TAP_PX }
+  );
+
+  for (const control of probe.controls) {
+    expect(
+      control.display,
+      `${control.selector} must not be display:none on mobile`
+    ).not.toBe("none");
+    expect(
+      control.left,
+      `${control.selector} must not sit off the left edge (left=${control.left})`
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      control.right,
+      `${control.selector} must not overflow the ${probe.viewportWidth}px screen (right=${control.right})`
+    ).toBeLessThanOrEqual(probe.viewportWidth);
+    expect(
+      control.hitsSelf,
+      `${control.selector} must be the hit-test target at its own centre (nothing overlaying it)`
+    ).toBe(true);
+    expect(
+      control.tappable,
+      `${control.selector} must meet the WCAG 2.2 AA ${MIN_TAP_PX}px minimum target size (was ${control.width}×${control.height})`
+    ).toBe(true);
+  }
+
+  // 4. Restoring the controls must not give the page a horizontal scrollbar.
+  expect(
+    probe.scrollWidth,
+    `the action bar must not push the page wider than the ${probe.viewportWidth}px screen`
+  ).toBeLessThanOrEqual(probe.viewportWidth);
+});

--- a/src/styles/messages.scss
+++ b/src/styles/messages.scss
@@ -92,9 +92,12 @@
 // global marker + `:last-of-type` (rather than a per-message class) makes this
 // immune to pi.ai's present-container re-render churn — the latest message is
 // always resolved live.
-// (Mobile: these rules live under html.desktop-view; on mobile the whole
-// .saypi-tts-controls bar is hidden via mobile.scss, so no separate telemetry
-// hide rule is needed there.)
+// (These rules live under html.desktop-view, which is the STANDARD — i.e.
+// non-immersive — view rather than a desktop-only flag, so they apply on phones
+// too. They used to be desktop-only in effect, because mobile.scss hid the whole
+// .saypi-tts-controls bar; that rule was vestigial popup-menu scaffolding and was
+// removed in #94, so the same last-message + recent-telemetry gating is what
+// governs the button on mobile now.)
 .chat-history .assistant-message .saypi-telemetry-button
 {
   display: none;

--- a/src/styles/mobile.scss
+++ b/src/styles/mobile.scss
@@ -132,30 +132,22 @@ html.immersive-view {
     display: none;
   }
 }
-html.mobile-device .chat-message .message-action-bar .saypi-tts-controls,
-html.mobile-device .chat-message .message-hover-menu .saypi-tts-controls {
-  /* on mobile, speech controls are in a popup menu instead */
-  display: none;
-}
-/* styling for the speech controls in the popup menu */
-html.mobile-device .chat-message .message-action-bar .saypi-cost-container,
-html.mobile-device .chat-message .message-hover-menu .saypi-cost-container {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
+/* SayPi's per-message TTS controls used to be hidden here, and the cost readout
+   re-laid-out as a full-width menu row, because on mobile they were relocated into
+   a long-press popup menu. That menu is gone — its emitter (`watchForPopupMenu`)
+   was removed in #427 and the `PopupMenu` class itself in #428 — so both rules had
+   stopped relocating anything and were simply deleting the controls from every
+   phone (#94). They now render inline in the message action bar exactly as they do
+   on desktop, styled by messages.scss.
 
-  .saypi-cost {
-    order: 2;
-    flex-grow: 1;
-    .vertical-separator {
-      display: none;
-    }
-  }
-
-  .saypi-pricing-link {
-    order: 1;
-    margin-left: 10px;
-  }
+   The one thing mobile still needs is an overflow guard. The action bar is a flex
+   row of the host's own buttons plus ours, and on a ~390px screen that row can run
+   past the right edge — the literal symptom #94 was filed for ("the button may
+   appear off the screen"). Allow it to wrap onto a second line instead. This is a
+   no-op whenever the row already fits, and stays scoped to mobile so desktop keeps
+   its single-line bar. */
+html.mobile-device .chat-message .message-action-bar {
+  flex-wrap: wrap;
 }
 
 /* Allow settings button on Firefox Android (popup now opens as a tab) */

--- a/src/styles/mobile.scss
+++ b/src/styles/mobile.scss
@@ -145,8 +145,16 @@ html.immersive-view {
    past the right edge — the literal symptom #94 was filed for ("the button may
    appear off the screen"). Allow it to wrap onto a second line instead. This is a
    no-op whenever the row already fits, and stays scoped to mobile so desktop keeps
-   its single-line bar. */
-html.mobile-device .chat-message .message-action-bar {
+   its single-line bar.
+
+   Scoped to `body.pi` deliberately. `.message-action-bar` is a marker this
+   extension puts on whatever `getActionBarSelector()` finds, on every host — and
+   on Claude that selector is Claude's own native flex container. Only pi.ai
+   actually receives `.saypi-tts-controls` (PiMessageControls.decorateControls is
+   the sole injector), so only pi.ai's bar gains our buttons and can overflow
+   because of them. Writing `flex-wrap` onto the other hosts' native chrome would
+   be changing their layout to fix a problem they do not have. */
+html.mobile-device body.pi .chat-message .message-action-bar {
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## Why

#94 was filed in 2024 against a long-press popup menu that no longer exists. `src/styles/mobile.scss` carried two rules built for it:

```scss
html.mobile-device .chat-message .message-action-bar .saypi-tts-controls,
html.mobile-device .chat-message .message-hover-menu .saypi-tts-controls {
  /* on mobile, speech controls are in a popup menu instead */
  display: none;
}
/* styling for the speech controls in the popup menu */
html.mobile-device .chat-message .message-action-bar .saypi-cost-container, … { … }
```

The menu's emitter `watchForPopupMenu` was removed in #427, and the `PopupMenu` class that actually built the relocated buttons (`ttsControls.addSpeechButton(…, true)` / `addCopyButton(…, true)`) was deleted in #428. So neither rule has relocated anything for months. The first one just deletes SayPi's per-message controls from every phone; the second reshapes the credits readout into a full-width menu row that no menu will ever render. The original complaint — "I can't reach Read Aloud on my phone" — became *more* true, not less.

Classic vestigial structure: CSS still describing a world the code left behind.

## What

- **`src/styles/mobile.scss`** — deleted both rules. The controls now render inline in the message action bar on mobile exactly as they do on desktop, styled by `messages.scss`.
- **`src/styles/mobile.scss`** — added one rule in their place: `html.mobile-device .chat-message .message-action-bar { flex-wrap: wrap }`. Restoring the controls raises the question #94's *title* actually asks — the action bar is a flex row of the host's own buttons plus ours, and on a ~390px screen that row can run past the right edge. Wrapping to a second line is a no-op whenever the row already fits, and it is scoped to mobile so desktop keeps its single-line bar.
- **`src/styles/messages.scss`** — corrected a comment that asserted "on mobile the whole `.saypi-tts-controls` bar is hidden via mobile.scss, so no separate telemetry hide rule is needed there". That stops being true with this change, and it also mis-describes `html.desktop-view`, which is the *standard* (non-immersive) view rather than a desktop-only flag — phones get it too, which is why `messages.scss` applies to them at all.
- **`e2e/specs/mobile-tts-controls.e2e.ts`** — new Layer-3 spec, modelled on the existing `pi-action-buttons.e2e.ts`.

## Scope — narrower than the selector suggests

The selector is host-agnostic, but I traced the element it hides and **`.saypi-tts-controls` is created in exactly one place: `PiMessageControls.decorateControls` in `src/chatbots/pi/PiResponse.ts`.** The base `MessageControls.decorateControls` deliberately only *locates* the host's action bar and tags it `message-action-bar` ("Base: locate the native action bar and record it, but do not inject"), and neither `ClaudeMessageControls` nor `ChatGPTMessageControls` overrides that — ChatGPT drives the host's own native read-aloud control instead. So the observable blast radius of this fix today is **pi.ai**. Claude's `.message-action-bar .saypi-tts-controls` block in `claude.scss` styles an element Claude never gets.

That is the smaller half of the correction. The larger one: **there is no per-message "Read aloud" replay button in the codebase any more, on any host.** `TTSControlsModule.addSpeechButton` / `addCopyButton` lost their only callers when `PopupMenu` was deleted in #428, and nothing else ever calls `createSpeechButton`. So this PR does not restore the button in #94's screenshot — that button is gone. What it restores is what `MessageControls` actually builds today: the **generate-speech button** (`.saypi-regenerate-button`, which is the affordance that makes SayPi speak an unspoken message — the live equivalent of "read this aloud"), the **credits readout** and its pricing link, the **credit-shortfall notice**, and Pi's **telemetry button**. Reintroducing a dedicated replay control would be a feature decision, not a fix, so it is not in here.

## Verification

Fail-first TDD, twice over — the spec was written before the CSS change and both halves were proven load-bearing:

1. Before deleting `display: none` — red on visibility: `locator resolved to <div class="saypi-tts-controls …"> - unexpected value "hidden"`.
2. After the deletion, with the wrap guard temporarily commented out and rebuilt — red on overflow: `.saypi-cost-container must not overflow the 390px screen (right=393.328125)`.

**Layer 3 (headless E2E, real built extension CSS + real layout) — what proves the fix.** `e2e/specs/mobile-tts-controls.e2e.ts` loads the mock pi.ai host at **390×844** with `html.mobile-device` + `html.desktop-view`, injects the exact subtree `PiMessageControls` builds, plus eight native-sized (32px) sibling buttons so the row genuinely cannot fit, and asserts:

- the controls container is visible (not `display: none`);
- every control sits fully within the 390px viewport (`left >= 0`, `right <= 390`);
- every control is the hit-test target at its own centre via `elementFromPoint` — i.e. nothing overlays it;
- every control clears the WCAG 2.2 AA (SC 2.5.8) 24px minimum target size;
- the page gains no horizontal scrollbar (`scrollWidth <= innerWidth`).

Measured at that viewport: generate-speech 36×31, credits readout 119.8×24, pricing link 32×24, telemetry 32×32.

**Counts:** full Layer-3 suite **48/48 passing** (including this new spec and the desktop `pi-action-buttons` / `telemetry-gate` specs, which the mobile-scoped rules must not disturb). `npm test` **2843 Vitest passing** (1 skipped, 247 files) + **2 Jest passing**, plus `tsc --noEmit` clean — unchanged from the `main` baseline, as expected for a CSS-only production change.

No unit/JSDOM test was added: jsdom applies none of the built stylesheet and has no layout, so it could not distinguish `display: none` from a control that renders but sits off the right edge — which is precisely the bug. Layer 3 is the lowest layer that can see this.

### What is NOT verified

- **No real device, and no real host.** Every measurement above is headless Chrome at a phone *viewport*, against a **synthetic** action bar I injected. I have not seen SayPi's controls in pi.ai's real mobile DOM, on a real phone, or under a real touch stack. The eight-button bar is a plausible worst case, not pi.ai's actual bar — the real one may be wider or narrower, and may bring its own wrapping behaviour.
- **Consequently: I am claiming the controls are no longer *removed* on mobile, and that they stay on-screen and hit-testable in a representative narrow layout. I am not claiming they look good on a real phone.** That needs a real-device (or Layer-4 real-host) look, which I cannot do headlessly.
- The `flex-wrap: wrap` guard writes to `.message-action-bar`, which is the **host's own element** (SayPi only tags it). `messages.scss` already sets `display: flex` on it, so this is not a new intrusion, but a host whose bar relies on not wrapping could look different on mobile. Only reachable behind `html.mobile-device`, and today only pi.ai has controls in that bar.
- **Telemetry button now reachable on mobile.** With the bar visible, the existing `body.saypi-recent-telemetry … :last-of-type` gating governs it on phones as it already does on desktop — so after a voice turn the telemetry button appears on the latest Pi message on mobile too. That is consistent with desktop rather than a new decision, but it is a visible change and worth naming.

### Adjacent vestiges found but deliberately left alone

Noted rather than swept, to keep this blast radius to the mobile TTS-control rules:

- `.message-hover-menu` is **set by no code at all** (grep across `src/`, `entrypoints/`, `test/`, `e2e/` finds it only in stylesheets) yet is still paired with `.message-action-bar` in `messages.scss`, `pi.scss`, `claude.scss` and `chatgpt.scss`. This PR drops the two occurrences that were in the rules being deleted; the rest remain.
- `TTSControlsModule.addSpeechButton`, `addCopyButton`, `createSpeechButtonForMenu`, `createCopyButtonForMenu`, `constructTextToSpeechControlForMenu` and `createCostElementForMenu` are all callerless since #428 (`noUnusedLocals` does not flag public class methods). Removing them would also make `MessageControls.getExtraControlClasses`'s Claude/ChatGPT overrides visibly dead — a coherent follow-up sweep, but a different PR.
- `messages.scss` still styles `.assistant-message .popup-menu button.saypi-button svg` for the deleted menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
