### PR TITLE
docs(e2e): one table for every Layer-3 spec, with a guard against drift (#551)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -61,10 +61,43 @@ step is a browsable report, not an empty directory (#463). `workers: 1` /
 `fullyParallel: false` — the harness binds mock servers and a fake-mic device
 per run, so the specs run serially.
 
+## Specs
+
+Every file in `e2e/specs/`. "Gate" is the merge posture: **Required** specs run in
+the `npm run test:e2e` suite that the e2e workflow gates merges on; **On-demand**
+specs are matched only by their own config and never run in CI.
+
+| Spec | What it proves | Gate |
+| --- | --- | --- |
+| `chat-adjacent-dictation.e2e.ts` | `hey.pi.ai` — where pi.ai bounces logged-out visitors — gets *universal dictation*, not the chat call button: the real manifest decides which script injects, and the dictation button lands on a real field (#559) | Required |
+| `decoration.e2e.ts` | The bundled content script detects Pi on the mock page and injects `#saypi-callButton`. Doubles as the GA-less bootstrap guard (telemetry must fail soft, #292) and proves the `__SAYPI_BUILD_STAMP__` Vite define really replaced the token in a real build (#312) | Required |
+| `dictation-stt.e2e.ts` | The full voice-input path against the local mocks: fake mic → `getUserMedia` → offscreen Silero-v5 VAD → `onSpeechEnd` → SW POSTs `/transcribe` → transcript drafted into `#saypi-prompt` | Required |
+| `mock-isolation.e2e.ts` | The per-test mock reset holds: a fresh test observes **zero** `/transcribe` state, so no spec's hit-count assertion can be satisfied by an earlier spec's traffic (#462) | Required |
+| `offscreen-shutdown.e2e.ts` | An idle offscreen auto-shutdown closes the document but keeps the live content-script port, so the next `VAD_SPEECH_END` stays routable (#308) | Required |
+| `onboarding.e2e.ts` | The welcome page works fully offline: local artwork and Poppins load with the context offline and zero external requests, the environment radio writes `quietMode` to storage, the microphone test runs, and the narrow viewport doesn't overflow | Required |
+| `opus-upload.e2e.ts` | A synthetic voice turn uploads **WebM/Opus** when this Chromium supports WebCodecs Opus encoding, and falls back to 16-bit PCM WAV when it doesn't — either way a transcript must land, so the encode can never break the upload (#414 / #417) | Required |
+| `pi-action-buttons.e2e.ts` | Against the **real built CSS**: SayPi's redundant copy button is hidden now that pi.ai ships its own, and the telemetry button is visually seamless with pi.ai's native action-bar buttons (size, radius, padding, colour, icon size) | Required |
+| `pi-audio-ownership.e2e.ts` | An open Pi conversation follows a voice chosen in a *different* extension document: host muting, simultaneous native players, SPA navigation, ownership surviving a reload, and native playback resuming when the override is cleared | Required |
+| `pi-call-button.e2e.ts` | Against the **real built CSS**: the call button carries no vertical margin (so it doesn't inflate Pi's composer by 16px) and the active-call button keeps its visible grey disc while disabled | Required |
+| `pi-native-restore.e2e.ts` | The Settings custom→native→custom round trip against real media: an inherited muted, paused Pi reply resumes without a page reload, with auto-read initially on *and* off | Required |
+| `pi-voice-settings.e2e.ts` | The real content script on Pi's mock settings route: a stored SayPi voice reads correctly in light and dark, "Change voice" opens the catalog without committing, and a native Pi card runs Pi's own handler *and* clears the SayPi override in real `chrome.storage.local` | Required |
+| `settings-layout.e2e.ts` | Settings layout stability: the header stays anchored across tab switches with real (non-overlay) scrollbars — the ~7px shunt of #582/#583 — and no tab overflows horizontally at 390/735/736px, including the longer `de` and `el` catalogs | Required |
+| `settings-opens-in-tab.e2e.ts` | The `openPopup` runtime message opens settings as a normal browser **tab** (not a popup window), dedupes to the already-open tab, and `options_ui` is registered in the manifest | Required |
+| `settings.e2e.ts` | The Preact settings page bootstraps for real: the header mounts, every tab panel renders content on selection, the Voices rail draws every voice the mock catalog serves, and nothing throws a `pageerror` | Required |
+| `settings.visual.ts` | Pixel baselines per settings tab via `toHaveScreenshot`, auth/quota/status regions masked. Platform-specific committed baselines — a local pre-flight tool, deliberately **not** a cross-platform CI check | On-demand |
+| `sw-recycle.e2e.ts` | An idle MV3 service-worker recycle (forced via CDP `Target.closeTarget`) raises **no** "VAD service disconnected" alarm and voice input self-heals on the next call (#307) | Required |
+| `synthetic-audio-stt.e2e.ts` | The **in-extension** synthetic audio source drives the whole pipeline with no microphone: `saypi:dev-feed-speech` → offscreen latch → WAV decoded to a `MediaStream` → VAD → mock STT → transcript. This is the spec to copy for a mic-less voice turn (`doc/synthetic-voice-turn.md`) | Required |
+| `telemetry-gate.e2e.ts` | Against the **real built CSS**: the telemetry button stays hidden on the most-recent message until that voice turn actually recorded metrics (gated on `body.saypi-recent-telemetry`), so a greeting never shows it | Required |
+| `tooltip-contrast.e2e.ts` | Against the **real built CSS**: `.saypi-tooltip` renders as an opaque dark pill on the claude.ai mock host, which defines no `--black` — the undefined-`var()`-computes-to-`transparent` bug | Required |
+| `voices-rail.e2e.ts` | What the Voices audition room *does*: DOM focus landing on the rail, `Space` alone sounding a voice (asserted on the heard counter), the arming rule in both directions, rows ordered by measured pitch on a shared reference line, wrapping at 320px, inflated-copy locales, and `Play all` walking the queue | Required |
+| `voices-release.e2e.ts` | The release-candidate voice journey under **normal** autoplay policy: a saved native choice survives reopening, keyboard preview doesn't commit, `Enter` commits only its host, switch-back compares without committing, and an open studio refreshes an external choice | Required |
+
 ## Settings page (Preact migration)
 
 The settings UI (`entrypoints/settings/**`) was migrated from imperative HTML
-strings to Preact components. Two specs cover it — they load the real
+strings to Preact components. Six specs cover it (`settings`, `settings-layout`,
+`settings-opens-in-tab`, `voices-rail`, `voices-release`, and the on-demand
+`settings.visual`) — they load the real
 `settings.html` over `chrome-extension://<id>/…`, so the *full* bootstrap runs
 with the extension runtime live (`browser.runtime.getURL`, chunk loading, the
 Preact mounts, and the imperative controllers that wire them by id). That's the
@@ -72,36 +105,15 @@ thing a static file server can't show and unit tests can't reach: a page that
 mounts but renders wrong (e.g. the PR4f header that lost a CSS utility) or a
 panel left empty by a chunk/import break.
 
-- **`specs/settings.e2e.ts` — REQUIRED (in the CI gate).** Asserts the header
-  mounts, every tab panel renders content on selection, and there are **no
-  uncaught page errors**. Robust and deterministic: it keys on DOM presence, not
-  pixels, and treats network 404s (the hermetic env has no auth/status backend)
-  as expected — only `pageerror` (a thrown mount/controller) fails it. It seeds
-  `chrome.storage.local` with a consent decision so the General tab renders its
-  steady state rather than the first-run consent gate (whose hero overlays the
-  sidebar). On the Voices tab it goes one step further than "has children" —
-  the mock API now serves a catalog, so it asserts the rail drew every voice in
-  it. That panel's content is network-bound, and a dead fetch used to render an
-  empty state that a child count happily accepted.
+Those specs are inventoried in the table above; two things about them don't fit
+in a table cell:
 
-- **`specs/voices-rail.e2e.ts` — REQUIRED (in the CI gate).** What the Voices
-  rail *does*, as opposed to whether it mounted: DOM focus landing on the rail
-  when the tab is activated (and `Space` alone then sounding a voice, asserted
-  on the **heard counter**, which only moves past a real playback threshold),
-  the arming rule in both directions, the pitch ordering and the shared
-  reference line measured off laid-out boxes, the twins staying apart at rest,
-  and `Play all` walking the queue. All of it needs a real browser: jsdom has no
-  layout, no `decodeAudioData` and no media element, so the rail's ~2650 unit
-  tests stop exactly where this starts. **It cannot prove sticky autoplay
-  activation** — `launch-args.ts` passes `--autoplay-policy=no-user-gesture-required`
-  to every Layer-3 Chrome, so chained playback is licensed here regardless; see
-  the header comment in the spec.
-
-- **`specs/voices-release.e2e.ts` — REQUIRED (in the CI gate).** Covers saved
-  choice, native return, cross-document refresh, narrow-layout labels, and real
-  media progress during preview/comparison/Play all. It opts out of the harness’s
-  autoplay bypass and first requires a gestureless ordinary-page negative control
-  to fail, so its positive sequence result establishes normal-policy behavior.
+- **`voices-rail.e2e.ts` cannot prove sticky autoplay activation.**
+  `launch-args.ts` passes `--autoplay-policy=no-user-gesture-required` to every
+  Layer-3 Chrome, so chained playback is licensed there regardless. See the
+  spec's header comment. `voices-release.e2e.ts` is the one that opts *out* of
+  that bypass, and first requires a gestureless ordinary-page negative control
+  to fail, so its positive result establishes normal-policy behaviour.
 
 - **`specs/settings.visual.ts` — ON-DEMAND (NOT in the CI gate).** Pixel
   baselines per tab via `toHaveScreenshot`, with auth/quota/status regions
@@ -141,33 +153,7 @@ panel left empty by a chunk/import break.
         │    --use-file-for-fake-audio-capture=<speech-16k-mono.wav>
         │    --headless=new
         ▼
-  Specs
-     decoration.e2e.ts   page.goto(https://pi.ai/talk) -> #saypi-callButton appears
-     dictation-stt.e2e.ts fake mic (WAV) -> getUserMedia -> offscreen Silero-v5 VAD
-                          -> onSpeechEnd -> SW POSTs /transcribe (mock echoes a
-                          transcript) -> draft written into #saypi-prompt.value
-     mock-isolation.e2e.ts a fresh test observes ZERO mock /transcribe state —
-                          guards the per-test reset the context fixture performs,
-                          so no spec's hits/content-type assertion can be
-                          satisfied by another spec's traffic (#462)
-     chat-adjacent-dictation.e2e.ts page.goto(https://hey.pi.ai/) -> the CHAT
-                          script's `https://pi.ai/*` doesn't match, so only the
-                          universal script injects -> .saypi-dictation-button
-                          appears and #saypi-callButton does NOT (#559)
-     tooltip-contrast.e2e.ts page.goto(https://claude.ai/new) -> body.claude ->
-                          the real built CSS renders .saypi-tooltip as an opaque
-                          dark pill (guards the host-CSS-var contrast bug)
-     sw-recycle.e2e.ts    force an idle MV3 service-worker recycle (CDP
-                          Target.closeTarget) -> assert NO "VAD disconnected"
-                          alarm + voice input self-heals on next call (#307)
-     offscreen-shutdown.e2e.ts force the offscreen idle auto-shutdown -> assert
-                          the document closes but the live content-script port
-                          survives (so VAD_SPEECH_END stays routable) (#308)
-     voices-rail.e2e.ts   settings.html -> Voices -> the mock /voices catalog +
-                          its three real MP3s -> the rail takes DOM focus, Space
-                          sounds a voice (heard counter moves), arrows stay
-                          silent until armed, the prints share one reference
-                          line and ascend by measured pitch, Play all walks
+  Specs (e2e/specs/*.e2e.ts — every one inventoried in "Specs" above)
 ```
 
 The pivotal trick is **`--host-resolver-rules`**: the extension is built with the
@@ -209,26 +195,7 @@ instead of silently calling the real internet.
 | `support/voices.ts` | drive-the-rail helpers: `openVoicesRail` (waits out catalog → prints → pitch re-sort, never sleeps) and a MutationObserver-backed **play log**, which is how a spec proves a voice did *not* sound |
 | `support/lifecycle.ts` | MV3 lifecycle drivers (`evictServiceWorker`, `reacquireServiceWorker`, `isWorkerDead`, `triggerOffscreenShutdown`, `hasOffscreenDocument`, `getConnectedTabCount`) — see the section below |
 | `support/lifecycle-targets.ts` | pure CDP-target predicates (`isExtensionServiceWorkerTarget`, `pickExtensionServiceWorkerTarget`); unit-tested in the **required** gate (`test/e2e/lifecycle-targets.spec.ts`) |
-| `specs/*.e2e.ts` | the tests |
-
-`specs/pi-voice-settings.e2e.ts` exercises the actual content script on Pi's
-mock settings route: a stored SayPi voice appears in a readable notice in both
-themes, Change voice opens the candidate catalog without changing the stored
-choice, and a native Pi card both runs Pi's own selection handler and clears the
-SayPi override in real `chrome.storage.local`. It also covers a native id arriving
-through a storage change, without treating it as a SayPi override, and returning
-to Pi from an unresolved saved voice. The test
-attaches light/dark screenshots; it measures contrast from the built extension
-CSS and representative host-theme utilities rather than keeping pixel baselines.
-
-`specs/pi-audio-ownership.e2e.ts` keeps real native media playing on the mock Pi
-conversation while a separate extension document changes the saved voice. It
-checks immediate host muting, direct/nested insertion of simultaneous native
-players, SPA navigation, saved ownership after reload, and native playback after
-clearing the override. All three native media clocks advance while muted, then
-resume audible playback together when native ownership returns. The test waits for fresh-install
-seeding before representing an existing user, so a late onboarding writer cannot
-silently adopt a default during the return-to-Pi assertion.
+| `specs/*.e2e.ts`, `specs/*.visual.ts` | the tests — see [Specs](#specs) for the full inventory |
 
 ## The dual-env gotcha (read this before editing launch/build config)
 
@@ -349,8 +316,3 @@ When this suite is red, first reproduce locally with `npm run e2e:build &&
 npm run test:e2e`; if it's green locally but red on CI, suspect timing/flake and
 inspect the uploaded Playwright trace before changing any test.
 
-
-`specs/pi-native-restore.e2e.ts` covers the actual Settings custom→native→custom
-round trip against real media: an inherited muted, paused Pi reply must resume
-without reloading, with auto-read initially on or off. The host control is a
-local DOM contract fixture; no real Pi messages or user credits are consumed.

--- a/test/e2e/readme-spec-inventory.spec.ts
+++ b/test/e2e/readme-spec-inventory.spec.ts
@@ -1,0 +1,89 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+/**
+ * AGENTS.md tells every reader to read `e2e/README.md` before running or
+ * extending the Layer-3 harness, so its spec inventory has to actually account
+ * for the suite. It drifted once already (#551: 7 of 12 specs documented, 5
+ * invisible), and drift is silent — adding a spec is a normal, green change.
+ *
+ * This is the cheapest thing that can notice: a file-vs-table diff, no browser
+ * and no Playwright. It fails when a spec has no row, when a row names a file
+ * that no longer exists, and when a row's required-vs-on-demand posture is
+ * missing — the posture the issue explicitly asked to keep explicit.
+ */
+
+const E2E_DIR = resolve(__dirname, "../../e2e");
+const SPECS_DIR = resolve(E2E_DIR, "specs");
+const README = resolve(E2E_DIR, "README.md");
+
+/** Gate labels the table is allowed to use; anything else is a typo or a fudge. */
+const GATES = ["Required", "On-demand"] as const;
+
+function specFileNames(): string[] {
+  return readdirSync(SPECS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+/** The "## Specs" section's markdown table, as {spec, gate} rows. */
+function inventoryRows(): { spec: string; gate: string }[] {
+  const readme = readFileSync(README, "utf8");
+  const afterHeading = readme.split(/^## Specs\s*$/m)[1];
+  expect(afterHeading, "e2e/README.md has no '## Specs' section").toBeDefined();
+  const section = afterHeading.split(/^## /m)[0];
+
+  return section
+    .split("\n")
+    .filter((line) => line.startsWith("|") && !/^\|\s*-+/.test(line))
+    .map((line) => line.split("|").slice(1, -1).map((cell) => cell.trim()))
+    .filter((cells) => cells.length === 3 && /^`.+\.ts`$/.test(cells[0]))
+    .map((cells) => ({ spec: cells[0].replace(/`/g, ""), gate: cells[2] }));
+}
+
+describe("e2e/README.md spec inventory (#551)", () => {
+  it("has a row for every file in e2e/specs/", () => {
+    const documented = inventoryRows().map((row) => row.spec);
+    const undocumented = specFileNames().filter((file) => !documented.includes(file));
+    expect(
+      undocumented,
+      "these specs exist but have no row in the '## Specs' table of e2e/README.md — " +
+        "add one (one-line purpose + Required/On-demand)",
+    ).toEqual([]);
+  });
+
+  it("has no row for a spec that no longer exists", () => {
+    const files = specFileNames();
+    const stale = inventoryRows()
+      .map((row) => row.spec)
+      .filter((spec) => !files.includes(spec));
+    expect(
+      stale,
+      "the '## Specs' table of e2e/README.md documents specs that are not in e2e/specs/ — " +
+        "remove the rows",
+    ).toEqual([]);
+  });
+
+  it("states an explicit CI posture for every row", () => {
+    for (const row of inventoryRows()) {
+      expect(GATES, `${row.spec} has an unrecognised Gate value "${row.gate}"`).toContain(
+        row.gate,
+      );
+    }
+  });
+
+  it("keeps settings.visual.ts documented as on-demand, not in the CI gate", () => {
+    // playwright.config.ts matches **/*.e2e.ts; the visual baselines have their
+    // own config precisely so the required gate never runs them.
+    const visual = inventoryRows().find((row) => row.spec === "settings.visual.ts");
+    expect(visual?.gate).toBe("On-demand");
+  });
+
+  it("marks every *.e2e.ts spec as required (they all match the gate's testMatch)", () => {
+    for (const row of inventoryRows().filter((r) => r.spec.endsWith(".e2e.ts"))) {
+      expect(row.gate, `${row.spec} matches playwright.config.ts testMatch`).toBe("Required");
+    }
+  });
+});


### PR DESCRIPTION
## Why

`AGENTS.md` tells every reader to read `e2e/README.md` before running or extending the Layer-3 harness. That instruction only pays off if the README actually accounts for the suite — and it had quietly stopped doing so.

The inventory was spread across three places that each drifted independently: an ASCII block inside the architecture diagram, per-spec bullets in the settings section, and three loose paragraphs bolted onto the end of the file. Between them they covered **15 of the 22 files** in `e2e/specs/`. (The issue was filed at 7-of-12; the suite has grown since, and so has the gap.) Undocumented: `onboarding`, `opus-upload`, `pi-action-buttons`, `pi-call-button`, `settings-layout`, `settings-opens-in-tab`, `synthetic-audio-stt`, `telemetry-gate` — the last of which is the spec `doc/synthetic-voice-turn.md` and `CLAUDE.md` both tell readers to copy.

## What

**One table, in a new `## Specs` section.** Every file in `e2e/specs/`, a one-line purpose lifted from each spec's own header comment (I read the specs), and an explicit **Gate** column — `Required` (matched by `playwright.config.ts`'s `**/*.e2e.ts`, so it runs in the e2e workflow that gates merges) or `On-demand` (`settings.visual.ts`, matched only by `playwright.visual.config.ts`). That keeps the required-vs-on-demand posture explicit, per the issue's second acceptance criterion.

**This is an inventory fix, not a rewrite.** Everything that carries real knowledge stays untouched: the architecture diagram and the `--host-resolver-rules` explanation, the `Files` table, the dual-env gotcha, fixture/STT-contract refresh, the four MV3-lifecycle facts behind the #307/#308 nets, and the local-vs-CI risk split. What was removed is only inventory that the table now says better — the ASCII spec list inside the diagram (now a one-line pointer), the three REQUIRED settings bullets, and the trailing `pi-voice-settings` / `pi-audio-ownership` / `pi-native-restore` paragraphs. Two things that genuinely don't fit a table cell were kept as prose right under the table: why `voices-rail` **cannot** prove sticky autoplay activation (and that `voices-release` is the spec that opts out of the bypass), and how to run/regenerate the platform-specific visual baselines.

**A guard, so it can't drift silently again.** `test/e2e/readme-spec-inventory.spec.ts` — alongside the harness's other unit tests (`launch-args`, `lifecycle-targets`, `manifest-guard`, `transcribe-response`) — diffs the directory against the table in **both** directions and checks each row declares a recognised gate. It reads a directory and a markdown table: no browser, no Playwright, ~6ms in the required gate. Drift is silent precisely because adding a spec is a normal, green change; this is the cheapest thing that notices.

## Verification

- `npm test` green: **2852 Vitest passing, 1 skipped, 249 files** (baseline 2843 — 5 new here, the rest landed on `main` in the interim); Jest 2/2; `tsc --noEmit` clean.
- The guard's 5 cases pin: (1) every spec file has a row, (2) no row names a deleted file, (3) every row's Gate is one of `Required`/`On-demand`, (4) `settings.visual.ts` is specifically documented as on-demand, (5) every `*.e2e.ts` spec is marked Required, since they all match the gate's `testMatch`.
- **Proven fail-first**: dropping an undocumented `zz-drift-probe.e2e.ts` into `e2e/specs/` turns case 1 red with the file named in the message — `expected [ 'zz-drift-probe.e2e.ts' ] to deeply equal []`. Probe removed afterwards.
- Purposes were lifted from each spec's header comment and test titles, not guessed. Where a spec had no header comment (`onboarding.e2e.ts`, `pi-audio-ownership.e2e.ts`), the purpose was read off its assertions.

**Not verified:** the Layer-3 suite itself was not run — this PR changes no spec, no fixture and no config, so the e2e CI check is the confirmation. One thing to note honestly: the *first* full `npm test` run on this branch reported a single Vitest failure; four subsequent full runs were green at 2852/2852. I chased it down rather than waving it off — it is `ChatGPTAutoReadAloud.spec.ts`'s auto-click case, which waits on a `MutationObserver` chain with a fixed 10ms `setTimeout` and loses that race under full-suite load. It reproduced on a second, unrelated branch the same day and is green 5/5 in isolation and 3/3 on a clean `origin/main` full-suite run. Filed as #642 rather than folded in here, since this PR touches a markdown file and a filesystem-reading spec — neither is anywhere near that code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
