### PR TITLE
fix(prompt): submit the voice turn when the tab is in the background (#101)

### DIFF
--- a/src/chatbots/AbstractChatbots.ts
+++ b/src/chatbots/AbstractChatbots.ts
@@ -5,6 +5,41 @@ import { shortenTranscript } from "../TextModule";
 import { ImmersionStateChecker } from "../ImmersionServiceLite";
 import { AssistantResponse, UserMessage } from "../dom/MessageElements";
 
+/** True when the tab is in the background, where animation frames are suspended. */
+function isDocumentHidden(): boolean {
+  return typeof document !== "undefined" && document.hidden === true;
+}
+
+/**
+ * Schedules the next step of the prompt-typing animation (issue #101).
+ *
+ * Browsers do not run `requestAnimationFrame` callbacks in a hidden tab, so a
+ * chain of frames stalls the moment the user switches away — and with it the
+ * `saypi:autoSubmit` that ends the chain, stranding the transcript unsent in
+ * the composer. While a frame is pending we therefore also watch for the tab
+ * going hidden and hand over to `onHidden`, which finishes the turn in one step
+ * (nobody is watching an animation they cannot see).
+ *
+ * Whichever path fires first wins and the other becomes a no-op, so exactly one
+ * of them runs — including when the browser flushes the parked frame on the
+ * user's return. In a visible tab the frame always wins, leaving foreground
+ * behaviour unchanged.
+ */
+function scheduleTypingStep(onFrame: () => void, onHidden: () => void): void {
+  let settled = false;
+  const settle = (step: () => void) => {
+    if (settled) return;
+    settled = true;
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    step();
+  };
+  function onVisibilityChange() {
+    if (isDocumentHidden()) settle(onHidden);
+  }
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  requestAnimationFrame(() => settle(onFrame));
+}
+
 export abstract class AbstractChatbot implements Chatbot {
     protected readonly preferences = UserPreferenceModule.getInstance();
     private assistantResponseCache = new WeakMap<HTMLElement, AssistantResponse>();
@@ -231,6 +266,15 @@ ${internalMonologueInstruction}
       }
       // Avoid reading from the live DOM each frame; build locally to prevent duplication
       let typedSoFar = "";
+      // The tab went into the background mid-animation: type the remainder in
+      // one step so the turn still completes (issue #101).
+      const finishWithoutAnimation = () => {
+        if (sentences.length > 0) {
+          sentences.length = 0;
+          this.setText(text);
+        }
+        if (submit) EventBus.emit("saypi:autoSubmit");
+      };
       const typeNextSentenceOrSubmit = () => {
         if (sentences.length === 0) {
           if (submit) EventBus.emit("saypi:autoSubmit");
@@ -240,9 +284,10 @@ ${internalMonologueInstruction}
         typedSoFar += nextSentence;
         // Replace all content with the accumulated text to avoid racing with external edits
         this.setText(typedSoFar);
-        requestAnimationFrame(typeNextSentenceOrSubmit);
+        scheduleTypingStep(typeNextSentenceOrSubmit, finishWithoutAnimation);
       };
-      if (sentences.length === 0) {
+      if (sentences.length === 0 || isDocumentHidden()) {
+        // Nothing to animate, or no one to see it: type and submit in one step.
         this.enterTextAndSubmit(text, submit);
       } else {
         typeNextSentenceOrSubmit();

--- a/test/chatbots/AbstractUserPrompt.hiddenTab.spec.ts
+++ b/test/chatbots/AbstractUserPrompt.hiddenTab.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AbstractUserPrompt } from '../../src/chatbots/AbstractChatbots';
+import EventBus from '../../src/events/EventBus.js';
+
+/**
+ * Issue #101: browsers suspend requestAnimationFrame in a hidden tab, so the
+ * sentence-by-sentence typing animation in `typeText` never advances and the
+ * `saypi:autoSubmit` that ends it never fires. The user switches tabs mid-turn,
+ * comes back, and finds their transcript sitting unsent in the composer.
+ *
+ * These specs model a hidden tab the only honest way: rAF is stubbed to *never*
+ * call back, exactly as a real browser behaves while the tab is in the
+ * background.
+ */
+
+class FakePrompt extends AbstractUserPrompt {
+  PROMPT_CHARACTER_LIMIT = 100000;
+  constructor(el: HTMLElement) { super(el as any); }
+  setText(text: string): void { (this.element as any).textContent = text; }
+  getText(): string { return (this.element as any).textContent || ''; }
+  setPlaceholderText(_text: string): void {}
+  getPlaceholderText(): string { return ''; }
+  getDefaultPlaceholderText(): string { return ''; }
+}
+
+describe('AbstractUserPrompt.typeText in a background tab', () => {
+  let el: HTMLElement;
+  let prompt: FakePrompt;
+  let rafOrig: any;
+  let pendingFrames: FrameRequestCallback[];
+  let hidden: boolean;
+  let emitSpy: ReturnType<typeof vi.spyOn>;
+
+  const autoSubmitCount = () =>
+    emitSpy.mock.calls.filter((call) => call[0] === 'saypi:autoSubmit').length;
+
+  const setHidden = (value: boolean) => {
+    hidden = value;
+    document.dispatchEvent(new Event('visibilitychange'));
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    el = document.createElement('div');
+    el.contentEditable = 'true';
+    document.body.appendChild(el);
+    prompt = new FakePrompt(el);
+
+    hidden = false;
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    });
+
+    // A hidden tab queues animation frames and never runs them.
+    pendingFrames = [];
+    rafOrig = globalThis.requestAnimationFrame;
+    // @ts-ignore
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      pendingFrames.push(cb);
+      return pendingFrames.length as any;
+    };
+
+    emitSpy = vi.spyOn(EventBus, 'emit');
+  });
+
+  afterEach(() => {
+    // @ts-ignore
+    globalThis.requestAnimationFrame = rafOrig;
+    // @ts-ignore
+    delete (document as any).hidden;
+    emitSpy.mockRestore();
+  });
+
+  it('types the whole transcript and submits once when the tab is already hidden', () => {
+    hidden = true;
+
+    (prompt as any).typeText('Hello world. How are you? ', true);
+
+    expect(el.textContent).toBe('Hello world. How are you? ');
+    expect(autoSubmitCount()).toBe(1);
+  });
+
+  it('does not submit a hidden-tab draft when submit is false', () => {
+    hidden = true;
+
+    (prompt as any).typeText('Just a draft. Nothing more. ', false);
+
+    expect(el.textContent).toBe('Just a draft. Nothing more. ');
+    expect(autoSubmitCount()).toBe(0);
+  });
+
+  it('finishes the turn when the tab is hidden mid-animation', () => {
+    (prompt as any).typeText('One. Two. Three. ', true);
+
+    // Foreground start: the first sentence is typed, the rest awaits a frame.
+    expect(el.textContent).toBe('One.');
+    expect(autoSubmitCount()).toBe(0);
+
+    setHidden(true);
+
+    expect(el.textContent).toBe('One. Two. Three. ');
+    expect(autoSubmitCount()).toBe(1);
+  });
+
+  it('does not submit twice if a suspended frame runs after the takeover', () => {
+    (prompt as any).typeText('One. Two. ', true);
+    setHidden(true);
+    expect(autoSubmitCount()).toBe(1);
+
+    // Returning to the foreground flushes the frames the browser had parked.
+    hidden = false;
+    pendingFrames.splice(0).forEach((cb) => cb(0 as any));
+
+    expect(el.textContent).toBe('One. Two. ');
+    expect(autoSubmitCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why

#101 is a 2024 "investigate background functionality" ticket, but it contains one very concrete, reproducible extension-side defect, described in its own words: Say, Pi "continues to record and transcribe speech in the background" but "gets stuck at the point of submitting the transcription".

That stall has a single cause. `AbstractUserPrompt.typeText()` animates the transcript into the composer one sentence at a time by chaining `requestAnimationFrame` calls, and `saypi:autoSubmit` — the event that actually sends the turn — is emitted from the *last* link of that chain. Browsers do not run animation frames in a hidden tab, so the moment the user switches away the chain stops after the first sentence: text in the composer, no submit, no error, no retry. The turn just never completes, and the user comes back to an unsent message.

I verified this is the *only* thing gating the emit on the transcript → submit path: `saypi:autoSubmit` has exactly one producer (this function) and one consumer (`ButtonModule.handleAutoSubmit`), nothing between `ConversationMachine.mergeAndSubmitTranscript` and `setFinal` is visibility-gated, and `typeText` holds the only `requestAnimationFrame` in that path (the other four in `src/` are tooltip/auth-prompt/mic-meter UI).

## What

The animation exists for the person watching it, so when nobody is watching, we skip it.

- **Already hidden when typing starts** → `enterTextAndSubmit(text, submit)`: full text in, one submit, no animation. This is the same one-step path the immersive view has always taken.
- **Hidden mid-animation** → the pending frame is already lost, so each scheduled step now *also* listens for `visibilitychange` and hands over to a one-step finish (`finishWithoutAnimation`) that types the remainder and submits.
- Frame and hand-over race; the first to fire settles the step and the loser becomes a no-op. So the turn submits **exactly once** even when the browser flushes the parked frame as the user returns to the tab.

**Foreground behaviour is unchanged by construction.** In a visible tab the frame always wins — `visibilitychange` cannot fire without the tab going hidden — so the visible typing animation and the single trailing `saypi:autoSubmit` are byte-for-byte what they were. That was the constraint to respect here: `AbstractChatbots` is shared by all three hosts, and Claude's submit-race gate (#488/#241, `claude/submitGate.ts`) hangs off this emit.

Two notes on the emit becoming synchronous on the hidden path. It is not a new pattern — the immersive branch and the no-sentence-punctuation branch already emit synchronously. And it stays safe with respect to `setFinal`'s `textarea.readOnly` juggling, because the consumer `handleAutoSubmit` awaits `getAutoSubmit()` before submitting, so `readOnly` is restored in the same synchronous run before any submit is attempted.

## Verification

Fail-first, per the TDD protocol. New spec `test/chatbots/AbstractUserPrompt.hiddenTab.spec.ts` models a hidden tab honestly: `requestAnimationFrame` is stubbed to queue callbacks and *never* run them, exactly as a background tab behaves.

Before the fix, all 4 new tests failed for the right reason (`expected 'One.' to be 'One. Two. Three. '`, `expected +0 to be 1`) while the 3 pre-existing `typeText` specs passed. The pins:

1. tab already hidden → whole transcript in the composer, `saypi:autoSubmit` emitted exactly once;
2. tab hidden, `submit=false` (the draft path) → whole transcript, **zero** submits;
3. tab hidden mid-animation → first sentence typed in the foreground, then the remainder completes and submits once on `visibilitychange`;
4. parked frames flushed after the hand-over → still exactly one submit and no re-typing.

`test/chatbots/AbstractUserPrompt.typeText.spec.ts` is untouched and still green — it is the foreground-behaviour guard.

- `npm test`: exit 0 — `tsc --noEmit` clean, Jest 2/2, **Vitest 2851 passed / 1 skipped** (baseline on `main` is 2847; +4 are the new specs).

**Unverified:** no real-host (Layer 4) run. The behaviour is a JS scheduling property, fully reproducible against a controlled DOM, so per the test-layer guide it belongs at Layer 1 — but the end-to-end claim ("background tab, speak, the message actually sends on the live host") has not been exercised in a real browser, and a real background tab additionally throttles the *consumer* side in ways JSDOM cannot show.

**Out of scope, deliberately:** #101 also covers iOS/Android/screen-off background operation, native-app alternatives, and background-audio research. Those are separate problems; I have re-scoped the issue in a comment rather than growing this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
