### PR TITLE
fix(pi): adopt the reply we joined mid-write on a new conversation (#365)

### DIFF
--- a/src/chatbots/AbstractChatbots.ts
+++ b/src/chatbots/AbstractChatbots.ts
@@ -51,6 +51,11 @@ export abstract class AbstractChatbot implements Chatbot {
       return false;
     }
 
+    /** See {@link Chatbot.mountsChatHistoryMidTurn}. Only pi.ai overrides this. */
+    mountsChatHistoryMidTurn(): boolean {
+      return false;
+    }
+
     protected abstract createAssistantResponse(element: HTMLElement, includeInitialText?: boolean, isStreaming?: boolean): AssistantResponse;
 
     getAssistantResponse(element: HTMLElement, includeInitialText?: boolean, isStreaming?: boolean): AssistantResponse {

--- a/src/chatbots/Chatbot.ts
+++ b/src/chatbots/Chatbot.ts
@@ -13,6 +13,20 @@ export interface Chatbot {
   getPastChatHistorySelector(): string; // can be identical to chat history
   getRecentChatHistorySelector(): string; // can be identical to chat history
   /**
+   * Can this host's chat history come into existence in the MIDDLE of a turn —
+   * i.e. can we first attach to it while a reply is already being written?
+   *
+   * Only pi.ai does, as far as we have verified: it renders no chat history at
+   * all until a conversation exists, so the first turn of a new conversation
+   * builds the containers around a reply that is already streaming (#365).
+   * Every other host has its history on screen before a turn starts, so a
+   * message found during setup there is settled history and must be left alone.
+   *
+   * Optional, and false when omitted: a host opts IN to the mid-turn adoption
+   * in {@link ChatHistorySpeechManager.registerPresentChatHistoryListener}.
+   */
+  mountsChatHistoryMidTurn?(): boolean;
+  /**
    * Selector for the host's own in-chat voice menu container, if it has one.
    * Optional: a host with no in-chat voice surface (Pi, since 2026-07-30)
    * omits this and {@link getVoiceMenu} together, and VoiceMenuUIManager then

--- a/src/chatbots/Pi.ts
+++ b/src/chatbots/Pi.ts
@@ -130,6 +130,16 @@ class PiAIChatbot extends AbstractChatbot {
     return "div.t-body-chat";
   }
 
+  /**
+   * pi.ai renders no `div.t-body-chat` at all until a conversation exists, so
+   * the first turn of a NEW conversation builds the chat history — element,
+   * past and present containers — while Pi is already writing the answer. That
+   * is the one place a settled-looking message can still be growing (#365).
+   */
+  override mountsChatHistoryMidTurn(): boolean {
+    return true;
+  }
+
   getPastChatHistorySelector(): string {
     // Direct-child combinator (`>`): the 2nd DIRECT child of the chat history
     // container. Without `>`, the descendant combinator matches the first nested

--- a/src/dom/ChatHistory.ts
+++ b/src/dom/ChatHistory.ts
@@ -1,5 +1,6 @@
 import {
   ElementTextStream,
+  getNestedText,
   InputStreamOptions,
   LateChangeEvent,
   TextContent,
@@ -748,7 +749,7 @@ class ChatHistoryNewMessageObserver
 
   /**
    * Adopt a reply that was ALREADY on screen when this observer attached — but
-   * only if Pi is in fact still writing it.
+   * only if the host is in fact still writing it.
    *
    * pi.ai has no chat-history element at all until a conversation exists, so on
    * the FIRST turn of a NEW conversation the whole history — containers and all
@@ -760,46 +761,75 @@ class ChatHistoryNewMessageObserver
    * (#365).
    *
    * Nothing in the host's markup reliably says "still writing", so we let the
-   * message answer for itself: watch it, and take it over the moment MORE text
-   * is added. A finished message never grows, so opening a settled thread
-   * adopts nothing — which is what keeps this from re-reading, aloud, messages
-   * the user has already seen.
+   * message answer for itself: watch it, and take it over the moment more text
+   * is added. "More" is the whole safety property here — a finished message
+   * never grows — so it is measured against the text that was on screen when we
+   * started watching, and measured on the ELEMENT rather than on the emitted
+   * chunk. The chunk cannot answer the question: a host stream with no
+   * per-token deltas re-emits the entire finished message as its first (and
+   * only) chunk, and a stream that has not been told about the initial text
+   * reports its first mutation as an addition of everything it can see. Both
+   * look exactly like growth, and neither is.
+   *
+   * Only offered for a host whose chat history can be born mid-turn, and only
+   * for the first such container — see
+   * {@link ChatHistorySpeechManager.registerPresentChatHistoryListener}.
    */
   async adoptIfStillWriting(message: AssistantResponse): Promise<void> {
     const content = await message.decoratedContent();
-    // includeInitialText:false — we are asking "does MORE text arrive?", and the
-    // text already on screen is not an answer to that.
+    // The baseline: everything already written when we joined. Read it BEFORE
+    // the probe exists, so no mutation can slip in between.
+    const textOnArrival = getNestedText(content);
     const probe = message.createTextStream(content, {
       includeInitialText: false,
     });
     this.continuationProbe?.disconnect();
     this.continuationProbe = probe;
 
+    let subscription: Subscription | null = null;
+    let released = false;
     const release = () => {
+      released = true;
+      subscription?.unsubscribe();
+      subscription = null;
       probe.disconnect();
       if (this.continuationProbe === probe) {
         this.continuationProbe = null;
       }
     };
 
-    const subscription = probe.getStream().subscribe({
-      next: (text: TextContent) => {
-        // Growth only. A rewrite of text that is already there (`changed`) is
-        // how a host re-render looks, and is not evidence of a live reply.
-        if (text.changed || !text.text.trim()) return;
-        subscription.unsubscribe();
-        release();
-        // The message is live after all, so the offer to generate its audio is
-        // stale. includeInitialText:true so the user hears the whole answer,
-        // not only the part written after we joined — which also keeps the
-        // completed text's hash matching the message's, so the speech is cached
-        // (and charged) once.
-        message.clearIncompleteSpeech();
-        void this.beginStreamingSpeech(message, { includeInitialText: true });
-      },
+    const onProbeActivity = () => {
+      if (released) return;
+      const textNow = getNestedText(content);
+      const grew =
+        textNow.length > textOnArrival.length &&
+        textNow.startsWith(textOnArrival) &&
+        textNow.slice(textOnArrival.length).trim().length > 0;
+      // Not growth: a re-render, a rewrite, a lazily-attached citation, or a
+      // whole-message re-emission. The reply is settled; leave it alone.
+      if (!grew) return;
+      release();
+      // The message is live after all, so the offer to generate its audio is
+      // stale. includeInitialText:true so the user hears the whole answer,
+      // not only the part written after we joined — which also keeps the
+      // completed text's hash matching the message's, so the speech is cached
+      // (and charged) once.
+      message.clearIncompleteSpeech();
+      void this.beginStreamingSpeech(message, { includeInitialText: true });
+    };
+
+    subscription = probe.getStream().subscribe({
+      next: onProbeActivity,
       error: release,
       complete: release,
     });
+    // A block-capture stream emits and completes from inside subscribe(), i.e.
+    // before the line above has assigned `subscription`. Tidy up here instead
+    // of from a handler that could not yet see it.
+    if (released) {
+      subscription?.unsubscribe();
+      subscription = null;
+    }
   }
 
   teardown(): void {

--- a/src/dom/ChatHistory.ts
+++ b/src/dom/ChatHistory.ts
@@ -1,5 +1,6 @@
 import {
   ElementTextStream,
+  InputStreamOptions,
   LateChangeEvent,
   TextContent,
   ToolUseEvent,
@@ -671,6 +672,23 @@ class ChatHistoryNewMessageObserver
       return await this.streamSpeechFromHistory(this.speechHistory, message);
     }
 
+    return await this.beginStreamingSpeech(message);
+  }
+
+  /**
+   * Take ownership of a message that is being written RIGHT NOW: create its
+   * utterance, announce the writing to the conversation, and feed the arriving
+   * text to the synthesiser.
+   *
+   * Split out of {@link streamSpeech} so a reply that was already part-written
+   * when we attached can reach the same path without having to pass the
+   * new-arrival checks it would fail — see {@link adoptIfStillWriting}.
+   */
+  private async beginStreamingSpeech(
+    message: AssistantResponse,
+    streamOptions?: InputStreamOptions
+  ): Promise<StreamedSpeech | null> {
+    const snippet = message.text.substring(0, 10);
     const provider = await this.speechSynthesis.getActiveAudioProvider(
       this.chatbot
     );
@@ -722,9 +740,66 @@ class ChatHistoryNewMessageObserver
       },
       (lateChange) => {
         message.decorateIncompleteSpeech(true);
-      }
+      },
+      streamOptions
     );
     return new AssistantSpeech(utterance);
+  }
+
+  /**
+   * Adopt a reply that was ALREADY on screen when this observer attached — but
+   * only if Pi is in fact still writing it.
+   *
+   * pi.ai has no chat-history element at all until a conversation exists, so on
+   * the FIRST turn of a NEW conversation the whole history — containers and all
+   * — is born mid-turn, and the speech manager attaches to a reply that is
+   * already part-written. The one-shot "what is already here" pass reads it as
+   * settled history: the message gets its controls, but nothing streams it. No
+   * `saypi:piWriting` is emitted, so the prompt sits on "thinking…" until the
+   * 15s safety net, and the reply is never spoken in the user's chosen voice
+   * (#365).
+   *
+   * Nothing in the host's markup reliably says "still writing", so we let the
+   * message answer for itself: watch it, and take it over the moment MORE text
+   * is added. A finished message never grows, so opening a settled thread
+   * adopts nothing — which is what keeps this from re-reading, aloud, messages
+   * the user has already seen.
+   */
+  async adoptIfStillWriting(message: AssistantResponse): Promise<void> {
+    const content = await message.decoratedContent();
+    // includeInitialText:false — we are asking "does MORE text arrive?", and the
+    // text already on screen is not an answer to that.
+    const probe = message.createTextStream(content, {
+      includeInitialText: false,
+    });
+    this.continuationProbe?.disconnect();
+    this.continuationProbe = probe;
+
+    const release = () => {
+      probe.disconnect();
+      if (this.continuationProbe === probe) {
+        this.continuationProbe = null;
+      }
+    };
+
+    const subscription = probe.getStream().subscribe({
+      next: (text: TextContent) => {
+        // Growth only. A rewrite of text that is already there (`changed`) is
+        // how a host re-render looks, and is not evidence of a live reply.
+        if (text.changed || !text.text.trim()) return;
+        subscription.unsubscribe();
+        release();
+        // The message is live after all, so the offer to generate its audio is
+        // stale. includeInitialText:true so the user hears the whole answer,
+        // not only the part written after we joined — which also keeps the
+        // completed text's hash matching the message's, so the speech is cached
+        // (and charged) once.
+        message.clearIncompleteSpeech();
+        void this.beginStreamingSpeech(message, { includeInitialText: true });
+      },
+      error: release,
+      complete: release,
+    });
   }
 
   teardown(): void {
@@ -737,11 +812,15 @@ class ChatHistoryNewMessageObserver
     super.disconnect();
     this.toolUseSubscription?.unsubscribe();
     this.toolUseSubscription = null;
+    this.continuationProbe?.disconnect();
+    this.continuationProbe = null;
     this.clearToolUseIndicator();
     this.teardown();
   }
 
   private textStream: ElementTextStream | null = null;
+  /** The "is this reply still being written?" watch — see adoptIfStillWriting. */
+  private continuationProbe: ElementTextStream | null = null;
   private toolUseSubscription: Subscription | null = null;
   private activeToolIndicatorElement: HTMLElement | null = null;
 
@@ -751,7 +830,8 @@ class ChatHistoryNewMessageObserver
     utterance: SpeechUtterance,
     onStart: () => void,
     onEnd: (fullText: string) => void,
-    onError?: (lateChange: LateChangeEvent) => void
+    onError?: (lateChange: LateChangeEvent) => void,
+    streamOptions?: InputStreamOptions
   ): void {
     // If we're already observing an element, disconnect from it
     if (this.textStream) {
@@ -762,7 +842,7 @@ class ChatHistoryNewMessageObserver
     this.clearToolUseIndicator();
 
     // Start observing the new element
-    this.textStream = message.createTextStream(messageContent);
+    this.textStream = message.createTextStream(messageContent, streamOptions);
     let streamStartTime: number = Date.now();
     let firstChunkTime: number | null = null;
     let lastChunkTime: number | null = null;

--- a/src/dom/MessageElements.ts
+++ b/src/dom/MessageElements.ts
@@ -388,6 +388,20 @@ abstract class AssistantResponse {
     this.messageControls.decorateFailedSpeech(replace);
   }
 
+  /**
+   * Undo {@link decorateIncompleteSpeech}.
+   *
+   * A message can be judged "nothing to speak here" and then turn out to still
+   * be streaming — that is the whole of #365, where the chat history mounts
+   * mid-reply and the half-written answer is first read as settled history.
+   * Once it is adopted for streaming, the offer to generate its audio is stale
+   * and misleading, so it goes away.
+   */
+  clearIncompleteSpeech(): void {
+    this.safeRemoveClass("speech-incomplete");
+    this._element.querySelector(".saypi-regenerate-button")?.remove();
+  }
+
   async decorateIncompleteSpeech(replace: boolean = false): Promise<void> {
     this.safeAddClass("speech-incomplete");
 

--- a/src/tts/ChatHistoryManager.ts
+++ b/src/tts/ChatHistoryManager.ts
@@ -264,6 +264,17 @@ export class ChatHistorySpeechManager implements ResourceReleasable {
     });
     this.observers.push(newMessagesObserver);
     this.newMessageObserver = newMessagesObserver;
+
+    // The container does not always mount BETWEEN turns. On the first turn of a
+    // new pi.ai conversation there is no chat history to find until the turn is
+    // already under way, so the last message above may be Pi's answer caught
+    // half-written — settled-looking, but still growing. Offer it to the
+    // additions observer, which takes it over only if more text actually
+    // arrives (#365).
+    const lastInitialMessage = initialMessages[initialMessages.length - 1];
+    if (lastInitialMessage) {
+      void newMessagesObserver.adoptIfStillWriting(lastInitialMessage);
+    }
     return newMessagesObserver;
   }
 

--- a/src/tts/ChatHistoryManager.ts
+++ b/src/tts/ChatHistoryManager.ts
@@ -38,6 +38,12 @@ export class ChatHistorySpeechManager implements ResourceReleasable {
   private newMessageObserver: ChatHistoryAdditionsObserver | null = null;
   /** The present container `newMessageObserver` is bound to, for idempotence. */
   private observedPresentContainer: Element | null = null;
+  /**
+   * Whether a message has already been offered to the mid-turn adoption path
+   * (#365). Only the first populated container this manager binds can be the
+   * one it joined mid-write; every later binding is a settled thread.
+   */
+  private adoptionOffered = false;
   private static pendingSpeeches: Map<
     string,
     {
@@ -271,8 +277,25 @@ export class ChatHistorySpeechManager implements ResourceReleasable {
     // half-written — settled-looking, but still growing. Offer it to the
     // additions observer, which takes it over only if more text actually
     // arrives (#365).
+    //
+    // Narrowly, though. This method is shared by every host, and on Claude and
+    // ChatGPT the "recent" container IS the whole chat history, so without a
+    // gate the last message of any thread the user opens would be offered up —
+    // settled, already read, already paid for. Two conditions keep that from
+    // happening:
+    //   - the host must be one whose history can be born mid-turn at all, and
+    //   - it must be the FIRST populated container this manager binds, which is
+    //     the only binding that can have happened during a turn we joined late.
+    //     (A manager is built per chat-history element, and pi.ai replaces that
+    //     element per conversation, so this is once per conversation.)
+    // The growth check in adoptIfStillWriting is what makes it safe even then.
     const lastInitialMessage = initialMessages[initialMessages.length - 1];
-    if (lastInitialMessage) {
+    if (
+      lastInitialMessage &&
+      !this.adoptionOffered &&
+      this.chatbot.mountsChatHistoryMidTurn?.()
+    ) {
+      this.adoptionOffered = true;
       void newMessagesObserver.adoptIfStillWriting(lastInitialMessage);
     }
     return newMessagesObserver;

--- a/test/tts/ChatHistoryManager-newMessageStreaming.spec.ts
+++ b/test/tts/ChatHistoryManager-newMessageStreaming.spec.ts
@@ -6,6 +6,8 @@ import {
 } from "../../src/tts/SpeechSynthesisModule";
 import EventBus from "../../src/events/EventBus";
 import { PiAIChatbot } from "../../src/chatbots/Pi";
+import { ClaudeChatbot } from "../../src/chatbots/Claude";
+import ChatGPTChatbot from "../../src/chatbots/ChatGPT";
 import {
   audioProviders,
   SayPiSpeech,
@@ -326,5 +328,193 @@ describe("the first turn of a new conversation, joined mid-reply", () => {
     expect(writingEvents).toBe(0);
     expect(createSpeechStreamOrPlaceholder).not.toHaveBeenCalled();
     expect(spokenText).toEqual([]);
+  });
+
+  it("ignores a re-render of a settled reply that adds no new text", async () => {
+    // The same settled thread, but this time the host TOUCHES the message
+    // without adding to it: a paragraph node is replaced and refilled with the
+    // identical text, which is what a re-render (or a lazily-attached citation,
+    // or a highlighting pass) looks like from a MutationObserver.
+    //
+    // "Still writing" means the reply GREW. A mutation on its own means only
+    // that the host redrew something — adopting on that would re-read, aloud
+    // and at a fresh synthesis charge, a message the user has already seen.
+    const present = chatHistoryMidReply(
+      "A finished answer from an earlier session."
+    );
+    manager = new ChatHistorySpeechManager(new PiAIChatbot(), chatHistory);
+    await settle();
+
+    const reply = present.querySelector(".break-anywhere") as HTMLElement;
+    const paragraph = reply.querySelector(
+      ".whitespace-pre-wrap"
+    ) as HTMLElement;
+    const rerendered = paragraph.cloneNode(true) as HTMLElement;
+    paragraph.replaceWith(rerendered);
+    rerendered.setAttribute("data-rendered", "true");
+    await settle();
+    await settle();
+
+    expect(writingEvents).toBe(0);
+    expect(createSpeechStreamOrPlaceholder).not.toHaveBeenCalled();
+    expect(spokenText).toEqual([]);
+  });
+});
+
+/**
+ * Opening an ALREADY-SETTLED conversation on Claude and ChatGPT.
+ *
+ * The mid-reply adoption above lives in `ChatHistorySpeechManager`, which every
+ * host shares — and on Claude and ChatGPT the "recent" container IS the whole
+ * chat history (`getRecentChatHistorySelector()` returns the same selector as
+ * `getPastChatHistorySelector()`). So the last message offered to the adoption
+ * path is not a reply caught mid-write: it is the last message of whatever
+ * finished thread the user just opened, already read and already paid for.
+ *
+ * ChatGPT makes the danger concrete. Its block capture emits the finished text
+ * synchronously from the stream's constructor as soon as the turn's action bar
+ * exists, and the stream is a ReplaySubject, so a subscriber attaching
+ * afterwards still receives it. An adoption path that treats any emission as
+ * growth therefore re-synthesises and re-reads the last assistant message on
+ * every resumed conversation — the #245 regression.
+ *
+ * Neither host may synthesise anything, or announce writing, when nothing is
+ * being written.
+ */
+describe("an already-settled conversation on the other hosts", () => {
+  const mockVoice: SpeechSynthesisVoiceRemote = {
+    id: "shimmer",
+    name: "Shimmer",
+    lang: "en",
+    localService: false,
+    default: false,
+    price: 0.3,
+    price_per_thousand_chars_in_usd: 0.3,
+    price_per_thousand_chars_in_credits: 300,
+    powered_by: "OpenAI",
+    voiceURI: "",
+  };
+
+  let manager: ChatHistorySpeechManager;
+  let createSpeechStreamOrPlaceholder: ReturnType<typeof vi.fn>;
+  let spokenText: string[];
+  let writingEvents: number;
+  let textAddedListener: (event: TextAddedEvent) => void;
+  let writingListener: () => void;
+  /**
+   * Anything thrown inside an rxjs `next` handler is reported as an uncaught
+   * exception rather than surfacing at the call site, so the probe's own
+   * mishaps would otherwise be invisible to these assertions.
+   */
+  let uncaught: unknown[];
+  const captureUncaught = (error: unknown) => uncaught.push(error);
+
+  const settle = () => new Promise((r) => setTimeout(r, 50));
+
+  /** claude.ai: a finished reply — `data-is-streaming` is false, controls are up. */
+  const settledClaudeThread = (text: string): HTMLElement => {
+    const chatHistory = document.createElement("div");
+    const message = document.createElement("div");
+    message.setAttribute("data-is-streaming", "false");
+    const content = document.createElement("div");
+    content.className = "font-claude-response";
+    content.textContent = text;
+    message.appendChild(content);
+    const actionBar = document.createElement("div");
+    actionBar.className = "flex items-stretch";
+    message.appendChild(actionBar);
+    chatHistory.appendChild(message);
+    document.body.appendChild(chatHistory);
+    return chatHistory;
+  };
+
+  /** chatgpt.com: a finished turn — the copy button in its action bar says so. */
+  const settledChatGPTThread = (text: string): HTMLElement => {
+    const thread = document.createElement("div");
+    thread.id = "thread";
+    const turnList = document.createElement("div");
+    const turn = document.createElement("div");
+    turn.setAttribute("data-testid", "conversation-turn-2");
+    const assistant = document.createElement("div");
+    assistant.setAttribute("data-turn", "assistant");
+    assistant.setAttribute("data-turn-id", "turn-2");
+    const markdown = document.createElement("div");
+    markdown.className = "markdown";
+    markdown.textContent = text;
+    assistant.appendChild(markdown);
+    const actionBar = document.createElement("div");
+    const copy = document.createElement("button");
+    copy.setAttribute("data-testid", "copy-turn-action-button");
+    actionBar.appendChild(copy);
+    assistant.appendChild(actionBar);
+    turn.appendChild(assistant);
+    turnList.appendChild(turn);
+    thread.appendChild(turnList);
+    document.body.appendChild(thread);
+    return turnList;
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+
+    const utterance: SpeechUtterance = new SayPiSpeech(
+      "utterance-id",
+      "en",
+      mockVoice,
+      "https://api.saypi.ai/speak/utterance-id/stream"
+    );
+    createSpeechStreamOrPlaceholder = vi.fn(async () => utterance);
+
+    spokenText = [];
+    writingEvents = 0;
+    textAddedListener = (event: TextAddedEvent) => spokenText.push(event.text);
+    writingListener = () => (writingEvents += 1);
+    EventBus.on("saypi:tts:text:added", textAddedListener);
+    EventBus.on("saypi:piWriting", writingListener);
+    uncaught = [];
+    process.on("uncaughtException", captureUncaught);
+
+    vi.spyOn(SpeechSynthesisModule, "getInstance").mockReturnValue({
+      getActiveAudioProvider: vi.fn(async () => audioProviders.SayPi),
+      createSpeechStreamOrPlaceholder,
+      createSpeech: vi.fn(),
+      speak: vi.fn(),
+    } as unknown as SpeechSynthesisModule);
+  });
+
+  afterEach(() => {
+    EventBus.off("saypi:tts:text:added", textAddedListener);
+    EventBus.off("saypi:piWriting", writingListener);
+    process.off("uncaughtException", captureUncaught);
+    manager?.teardown();
+    vi.restoreAllMocks();
+  });
+
+  it("does not re-read the last message when a Claude thread is opened", async () => {
+    const chatHistory = settledClaudeThread("An answer from yesterday.");
+    manager = new ChatHistorySpeechManager(new ClaudeChatbot(), chatHistory);
+    await settle();
+    await settle();
+
+    expect(writingEvents).toBe(0);
+    expect(createSpeechStreamOrPlaceholder).not.toHaveBeenCalled();
+    expect(spokenText).toEqual([]);
+    expect(uncaught).toEqual([]);
+  });
+
+  it("does not re-read the last message when a ChatGPT thread is opened", async () => {
+    // ChatGPT's block capture hands its subscriber the whole finished message
+    // the moment it is constructed — synchronously, from inside subscribe(),
+    // with no mutation involved at all. Nothing here is being written, so
+    // nothing may be synthesised, announced, or thrown.
+    const chatHistory = settledChatGPTThread("An answer from yesterday.");
+    manager = new ChatHistorySpeechManager(new ChatGPTChatbot(), chatHistory);
+    await settle();
+    await settle();
+
+    expect(writingEvents).toBe(0);
+    expect(createSpeechStreamOrPlaceholder).not.toHaveBeenCalled();
+    expect(spokenText).toEqual([]);
+    expect(uncaught).toEqual([]);
   });
 });

--- a/test/tts/ChatHistoryManager-newMessageStreaming.spec.ts
+++ b/test/tts/ChatHistoryManager-newMessageStreaming.spec.ts
@@ -184,3 +184,147 @@ describe("new assistant messages on a deferred present container", () => {
     expect(createSpeechStreamOrPlaceholder).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * The FIRST turn of a BRAND-NEW pi.ai conversation (#365).
+ *
+ * pi.ai has no `div.t-body-chat` at all until a conversation exists, so on a new
+ * chat the chat-history element is born *during* the first turn — and bootstrap's
+ * progressive search can take several seconds to find it. By the time the speech
+ * manager attaches, Pi's answer is already part-written on screen.
+ *
+ * The manager's "what is already here" pass then reads that half-written reply as
+ * settled history. Nothing streams it, so `saypi:piWriting` never fires — the
+ * prompt sits on "Pi is thinking…" until the 15s safety net — and the reply is
+ * never spoken in the user's chosen voice.
+ */
+describe("the first turn of a new conversation, joined mid-reply", () => {
+  const mockVoice: SpeechSynthesisVoiceRemote = {
+    id: "shimmer",
+    name: "Shimmer",
+    lang: "en",
+    localService: false,
+    default: false,
+    price: 0.3,
+    price_per_thousand_chars_in_usd: 0.3,
+    price_per_thousand_chars_in_credits: 300,
+    powered_by: "OpenAI",
+    voiceURI: "",
+  };
+
+  let chatHistory: HTMLElement;
+  let manager: ChatHistorySpeechManager;
+  let createSpeechStreamOrPlaceholder: ReturnType<typeof vi.fn>;
+  let spokenText: string[];
+  let writingEvents: number;
+  let textAddedListener: (event: TextAddedEvent) => void;
+  let writingListener: () => void;
+
+  const settle = () => new Promise((r) => setTimeout(r, 50));
+
+  const assistantMessage = (text: string): HTMLElement => {
+    const message = document.createElement("div");
+    message.classList.add("break-anywhere");
+    const flex = document.createElement("div");
+    flex.classList.add("flex", "items-center");
+    const content = document.createElement("div");
+    content.classList.add("w-full");
+    const paragraph = document.createElement("div");
+    paragraph.classList.add("whitespace-pre-wrap");
+    paragraph.appendChild(document.createTextNode(text));
+    content.appendChild(paragraph);
+    flex.appendChild(content);
+    message.appendChild(flex);
+    return message;
+  };
+
+  /**
+   * The chat history as pi.ai renders it a beat after the first prompt is sent:
+   * containers mounted, and the reply already part-written inside the present one.
+   */
+  const chatHistoryMidReply = (partialReply: string): HTMLElement => {
+    const spacer = document.createElement("div");
+    spacer.className = "relative shrink-0 h-1 z-30";
+    chatHistory.appendChild(spacer);
+
+    const past = document.createElement("div");
+    past.className = "space-y-6";
+    chatHistory.appendChild(past);
+
+    const present = document.createElement("div");
+    present.className = "pb-6 lg:pb-8";
+    present.appendChild(assistantMessage(partialReply));
+    chatHistory.appendChild(present);
+    return present;
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    chatHistory = document.createElement("div");
+    chatHistory.classList.add("t-body-chat");
+    document.body.appendChild(chatHistory);
+
+    const utterance: SpeechUtterance = new SayPiSpeech(
+      "utterance-id",
+      "en",
+      mockVoice,
+      "https://api.saypi.ai/speak/utterance-id/stream"
+    );
+    createSpeechStreamOrPlaceholder = vi.fn(async () => utterance);
+
+    spokenText = [];
+    writingEvents = 0;
+    textAddedListener = (event: TextAddedEvent) => spokenText.push(event.text);
+    writingListener = () => (writingEvents += 1);
+    EventBus.on("saypi:tts:text:added", textAddedListener);
+    EventBus.on("saypi:piWriting", writingListener);
+
+    vi.spyOn(SpeechSynthesisModule, "getInstance").mockReturnValue({
+      getActiveAudioProvider: vi.fn(async () => audioProviders.SayPi),
+      createSpeechStreamOrPlaceholder,
+      createSpeech: vi.fn(),
+      speak: vi.fn(),
+    } as unknown as SpeechSynthesisModule);
+  });
+
+  afterEach(() => {
+    EventBus.off("saypi:tts:text:added", textAddedListener);
+    EventBus.off("saypi:piWriting", writingListener);
+    manager?.teardown();
+    vi.restoreAllMocks();
+  });
+
+  it("announces Pi is writing, and speaks the reply, when it keeps writing after we attach", async () => {
+    const present = chatHistoryMidReply("Apples are");
+    manager = new ChatHistorySpeechManager(new PiAIChatbot(), chatHistory);
+    await settle();
+
+    // Pi carries on writing the same reply.
+    const reply = present.querySelector(".break-anywhere") as HTMLElement;
+    reply.querySelector(".whitespace-pre-wrap")!.textContent =
+      "Apples are a pome fruit.";
+    await settle();
+
+    // The conversation must leave "thinking…" on Pi's own signal, not on the
+    // 15-second safety net.
+    expect(writingEvents).toBeGreaterThan(0);
+    // And the reply is read aloud, the same as every later turn in the thread.
+    expect(createSpeechStreamOrPlaceholder).toHaveBeenCalled();
+    expect(spokenText.join("")).toContain("Apples are a pome fruit.");
+    expect(reply.classList.contains("speech-incomplete")).toBe(false);
+  });
+
+  it("leaves a settled thread alone — no writing signal, no re-reading", async () => {
+    // The same shape, but the user has merely opened a finished conversation:
+    // nothing more is written. Adopting this message would re-read, aloud, a
+    // message the user has already seen.
+    chatHistoryMidReply("A finished answer from an earlier session.");
+    manager = new ChatHistorySpeechManager(new PiAIChatbot(), chatHistory);
+    await settle();
+    await settle();
+
+    expect(writingEvents).toBe(0);
+    expect(createSpeechStreamOrPlaceholder).not.toHaveBeenCalled();
+    expect(spokenText).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

On the first turn of a brand-new pi.ai conversation the prompt sits on "Pi is thinking…" for 15 seconds and then recovers via a safety-net timeout. The issue's own triage blamed a competing-observer race between the past and present observers — that race is **gone**, closed by #597's `onRecentContainer` handover (the present container now goes to the additions observer, not an old-message one). The stall survived it, so I re-derived the cause from scratch.

**pi.ai has no `div.t-body-chat` at all until a conversation exists.** On a new chat the whole chat history — element, past container, present container — is born *during* the first turn. Bootstrap's progressive search backs off to ~7.5s on its last attempt, which matches the sweep evidence on this issue ("Chat history not found on attempts 1–9, found on attempt 10, after the transcript had already been submitted"). By the time the speech manager attaches, Pi's answer is already part-written on screen.

`registerPresentChatHistoryListener`'s one-shot "what is already here" pass then reads that half-written reply as settled history. It gets its controls — which is why the turn *looks* fine and why nobody caught this earlier — but nothing streams it.

### The residual symptom is not only a 15s stall

Worth stating, because it changes the priority:

| | consequence |
|---|---|
| **No `saypi:piWriting`** | `responding.piThinking` exits only via `PI_THINKING_TIMEOUT_MS` (15s), and the prompt is frozen on "Pi is thinking…" for all of it. ~~The user cannot hang up~~ — **corrected in review**: the call button is *styled* disabled (`CallButton` greys it on `responding`), but hanging up still works. The machine's `disableCallButton` action has had its body commented out for a long time (`ConversationMachine.ts:494-496`), `CallButton.disableCallButton` deliberately keeps `disabled = false` on an `active` button so a call can always be ended, and `responding` handles `saypi:hangup` regardless of sub-state (`:1291-1307`). |
| **No streaming speech** | The message is decorated `speech-incomplete` — a Generate Audio button. With a SayPi voice selected, **the first answer of every new conversation is silent**, and only that one. Measured directly (`CLASSES: … assistant-message speech-incomplete`). Users on Pi's native voice don't see this, which is presumably why it was reported as "a stall". |
| **Poisoned endpointing data** | The 15s fallback fires `emitTurnOutcome({kind: "no-response"})` (#505) — every pi.ai new-conversation first turn is recorded as "Pi never answered" in the dataset used to calibrate auto-submit timing. |

### On #592

The triage credits #592 with part of the fix. Having read it: #592 is about **route-entry decoration** on `pi.ai` → `/redirect` → `/talk` (composer, call button, control panel). It never touches response detection, and the chat-history search it feeds is the same progressive backoff that arrives late here. It does not half-solve this, and I have not treated it as doing so.

## What

Nothing in Pi's markup reliably says "still writing", so the fix lets the message answer for itself.

When the additions observer binds a present container that **already holds messages** — on a host that can grow one mid-turn, and only the first such container this manager sees — it watches the last message (`adoptIfStillWriting`) and adopts it the moment **more text is added**, routing it into the same streaming path a normally-arriving reply gets. A finished message never grows, so a settled thread is never adopted; that self-limiting property is what keeps this from re-reading aloud what the user has already seen (the #245-shaped regression this could easily have caused). The first round of this PR asserted that property but did not actually test it — see below.

Details that matter:

- **Growth, measured against the text that was on screen when we joined.** This is the whole safety property, and the first review caught it being fake: with `includeInitialText: false`, `PiTextStream` never seeds `lastFullText`, so `full.startsWith("")` was trivially true and the *first mutation of any kind* re-emitted the entire existing message as a delta. The probe was answering "did anything mutate?", not "did more text arrive?". It now snapshots the rendered text before the probe exists and, on every emission, re-reads the **element** and requires a strict, non-blank extension of that snapshot. A re-render, a rewrite, a lazily-attached citation or a whole-message re-emission all fail that test.
- **Offered only where a chat history can be born mid-turn, and only once.** `registerPresentChatHistoryListener` is shared by all three hosts, and on Claude and ChatGPT the "recent" container *is* the whole chat history — so unscoped, the last message of every thread the user opens was being offered up. Adoption is now gated on `Chatbot.mountsChatHistoryMidTurn()` (default `false`; pi.ai is the only host that overrides it, because it is the only host that renders no history at all until a conversation exists) **and** on this being the first populated container the manager binds — the only binding that can have happened during a turn we joined late.
- **Synchronous emissions are handled.** ChatGPT's block capture emits the finished text and completes *from inside* `subscribe()`, before the subscription variable exists — which threw a TDZ `ReferenceError` out of the rxjs subscriber (see the review reply). The probe's teardown no longer depends on a binding that may not have happened yet.
- **`includeInitialText: true` on adoption**, so the user hears the whole answer rather than the tail — and so the completed text's md5 still matches `message.hash`, keeping it to one speech-cache entry and one charge.
- **`beginStreamingSpeech` extracted** from `streamSpeech` so adoption reaches the streaming path without having to fake its way past the new-arrival checks (ignore list / `isLastMessage`) it would legitimately fail. No behaviour change on the existing path.
- `clearIncompleteSpeech()` removes the now-stale Generate Audio offer when a message turns out to be live after all.
- The probe is released on first growth, on stream completion, and on observer `disconnect()`.

**Deliberately not addressed:** the issue also notes the first-turn decoration being torn down and re-applied during the route reshuffle. That is the chat-history *element* being replaced, which makes `decorateChatHistory` tear down the previous manager; it re-decorates correctly and has no user-visible cost. Left alone rather than papered over.

## Verification

**Fail-first (Layer 1, Vitest)** — `test/tts/ChatHistoryManager-newMessageStreaming.spec.ts`, in the file the issue's scenario belongs in:

- `announces Pi is writing, and speaks the reply, when it keeps writing after we attach` — containers mounted **and the reply already part-written** before the manager is constructed, then Pi keeps writing. **Failed on `490b869`** with `expected 0 to be greater than 0` (zero `saypi:piWriting`); a side probe confirmed the message was left `break-anywhere chat-message assistant-message speech-incomplete`. Passes with the fix, asserting the writing signal, `createSpeechStreamOrPlaceholder`, the words reaching the synthesiser, and no `speech-incomplete`.
- `leaves a settled thread alone — no writing signal, no re-reading` — the guard against the obvious way to get this wrong. Passed **before and after**, so it is a real control, not a co-written pass.

Added in review, each run against the pre-review head (`8e93465`) first:

- `ignores a re-render of a settled reply that adds no new text` — a settled pi.ai thread whose paragraph node is replaced and refilled with *identical* text. **Failed on `8e93465`** (`expected 1 to be +0` — one `saypi:piWriting`, i.e. the whole finished message adopted and re-read off a mutation that added nothing); passes now. This is the case the original settled-thread control could not catch, because it never mutated anything.
- `does not re-read the last message when a ChatGPT thread is opened` — a settled ChatGPT turn with its copy button present. **Failed on `8e93465`** with an uncaught `ReferenceError: Cannot access 'subscription' before initialization`: the block capture emits the finished text synchronously from the stream constructor, so the adoption fired with no mutation at all, exactly as the review said — and then crashed on its own teardown before it could re-read. Passes now, asserting no synthesis, no `saypi:piWriting`, and no uncaught error.
- `does not re-read the last message when a Claude thread is opened` — same shape on claude.ai. **This one passed before and after** (see the review reply for why: `ClaudeTextStream` emits only on a `data-is-streaming` transition, which a settled message never makes). Kept as a guard on the invariant rather than as a repro.

Both new safety mechanisms were checked to be independently sufficient: with the host gate forced open for *every* host, the growth check alone still keeps the Claude and ChatGPT cases green.

**Gate** — `tsc --noEmit` clean; Jest 2/2; **Vitest 248 files / 2852 passed, 1 skipped**.

**What I could NOT verify:** no real-host run for this one. The Layer-4 budget for this session went to #595's measurement (below), and reproducing this needs a *brand-new* pi.ai conversation whose chat history happens to mount mid-reply — timing-dependent, and a Layer-4 verify starts each run in that state but cannot be made to reliably re-hit the late-mount window. The adoption path is exercised end-to-end in JSDOM against pi.ai's real message shape and `PiTextStream`, and its dangerous direction (adopting a settled message) is pinned by the control spec. A pi.ai host sweep after merge is the natural confirmation: the signature to look for is `responding:piThinking → piWriting` on the first turn instead of `piThinking → listening`.

Fixes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
