### PR TITLE
feat(endpointing): close the turn-outcome resume window at TTS start (#510)

### DIFF
--- a/doc/voice-endpointing.md
+++ b/doc/voice-endpointing.md
@@ -62,10 +62,30 @@ Tuning Knobs
   defaults absent p to 0 (maximum patience) and absent tempo to 0 (neutral).
 - `USER_STOPPED_TIMEOUT_MS` — submit regardless after prolonged silence.
 
+Turn Outcomes (the eval's ground truth)
+- The only non-circular answer to "was that really the end of the user's turn?" is whether
+  the user started speaking again right after we submitted. Each auto-submitted turn therefore
+  opens a **resume window** and reports one text-free `/turn-outcome` event when it closes
+  (`src/TurnOutcomeModule.ts`, wired in `ConversationMachine`; issues #505/#510).
+- The window OPENS at auto-submit (`converting.submitting`, action `openTurnOutcome`) and
+  CLOSES when the assistant becomes **audible** — TTS start (`saypi:piSpeaking`) — so a resume
+  is measured against what the user could actually hear, not against text they had merely seen.
+- Closing cases, exactly one per turn:
+  - TTS starts → `response_started_at` = TTS start.
+  - Response completes unspoken (`piWriting` → `saypi:piStoppedWriting`, i.e. voice-out off) →
+    `response_started_at` = when the reply text appeared.
+  - The user resumes first, in `piThinking` **or** `piWriting` → `user_resumed`, `resumed_at`,
+    and a null `response_started_at` (nothing was ever spoken).
+  - `PI_THINKING_TIMEOUT_MS` elapses with no response at all → both timestamps null.
+- Known gaps: a hangup mid-response, and a turn stuck in `piWriting` (host DOM drift, TTS off,
+  `piStoppedWriting` never fires), emit nothing and fall through to the server-side fallback.
+  Maintenance messages (suppressed buffer flushes) are excluded by design.
+
 Tests
 - test/timers/calculateDelay.spec.ts — verifies timing math.
 - test/TranscriptionModule.tempo-forwarding.spec.ts — ensures server `tempo`/`pFinishedSpeaking` propagate.
 - test/state-machines/ConversationMachine-submissionDelay.spec.ts — proves that accumulating holds until the delay elapses and that merges don’t preempt the timer.
+- test/state-machines/ConversationMachine-turnOutcome.spec.ts — pins when the resume window closes and what each closing case reports.
 
 Practical Guidance
 - If you see premature submits, check logs for `noStopYet: true` (guard blocked) or `finalDelay: 0` with a high `pFinished` (the elapsed transcription time consumed the wait).

--- a/src/state-machines/ConversationMachine.ts
+++ b/src/state-machines/ConversationMachine.ts
@@ -107,6 +107,8 @@ interface PendingTurnOutcome {
   lastSpeechEndedAt: number;      // when the user stopped speaking (timeUserStoppedSpeaking)
   app?: string;                   // pi / claude / chatgpt
   isMaintenance: boolean;         // suppressed buffer flush — excluded from the eval
+  writingStartedAt?: number;      // when the reply text first appeared — the response-start
+                                  // fallback for a turn that is never spoken (#510)
 }
 
 interface ConversationContext {
@@ -539,25 +541,52 @@ const machine = setup({
       };
       return { pendingTurnOutcome: pending };
     }),
-    // Close the resume window and report the outcome (#505). Fired on the single
-    // transition that leaves `responding.piThinking`, so exactly once per turn.
-    // Maintenance messages (suppressed buffer flushes) are excluded from the eval.
+    // The reply text has appeared but nothing is audible yet, so the resume window
+    // stays OPEN (#510). Record when the text appeared: it is the response-start
+    // we report if this turn is never spoken (voice-out off, or TTS unavailable).
+    markResponseWriting: assign(({ context }) => {
+      const pending = context.pendingTurnOutcome;
+      if (!pending) return {};
+      return {
+        pendingTurnOutcome: { ...pending, writingStartedAt: Date.now() },
+      };
+    }),
+    // Close the resume window and report the outcome (#505, #510).
+    //
+    // Window close = the assistant became AUDIBLE (`response-started`, at TTS
+    // start), or the turn ended without ever becoming audible: completed unspoken
+    // (`response-written`, timed from when the text appeared), the user resumed
+    // first (`resumed`), or no response was ever detected (`no-response`).
+    //
+    // Exactly one of those transitions is traversed per turn: piThinking is
+    // entered once per turn and leaves by exactly one edge, and the only edge
+    // that does NOT close the window (-> piWriting) leads to a state whose own
+    // edges all close it. Maintenance messages (suppressed buffer flushes) are
+    // excluded from the eval.
     emitTurnOutcome: (
       { context },
-      params: { kind: "response-started" | "resumed" | "no-response" }
+      params: {
+        kind: "response-started" | "response-written" | "resumed" | "no-response";
+      }
     ) => {
       const pending = context.pendingTurnOutcome;
       if (!pending || pending.isMaintenance) {
         return;
       }
       const now = Date.now();
+      const responseStartedAt =
+        params.kind === "response-started"
+          ? now
+          : params.kind === "response-written"
+          ? pending.writingStartedAt ?? now
+          : null;
       postTurnOutcome({
         sessionId: pending.sessionId,
         lastSequenceNumber: pending.lastSequenceNumber,
         trigger: "auto",
         userResumed: params.kind === "resumed",
         submittedAt: pending.submittedAt,
-        responseStartedAt: params.kind === "response-started" ? now : null,
+        responseStartedAt,
         resumedAt: params.kind === "resumed" ? now : null,
         lastSpeechEndedAt: pending.lastSpeechEndedAt,
         pFinishedSpeaking: pending.pFinishedSpeaking ?? null,
@@ -1333,14 +1362,11 @@ const machine = setup({
         states: {
           piThinking: {
             on: {
-              // Resume-window CLOSE (#505). v1 closes on the FIRST response signal
-              // to leave piThinking — piWriting (text) or piSpeaking (TTS). With
-              // TTS on the order is piThinking->piWriting->piSpeaking, so v1 closes
-              // at text-appear rather than the spec's preferred TTS-start; this
-              // slightly under-counts resumes in the text-shown-not-yet-spoken gap.
-              // Deliberate v1 simplification (founder-approved) — spec-fidelity is
-              // tracked in #510. Emitting on the single piThinking exit keeps it to
-              // exactly one event per turn.
+              // Resume-window CLOSE (#505, #510). The window closes when the
+              // assistant becomes AUDIBLE, so a resume is measured against what the
+              // user could actually hear. With TTS on the order is
+              // piThinking->piWriting->piSpeaking, so this edge is only taken when
+              // speech starts with no writing signal at all.
               "saypi:piSpeaking": {
                 target: "piSpeaking",
                 actions: {
@@ -1348,11 +1374,15 @@ const machine = setup({
                   params: { kind: "response-started" },
                 },
               },
+              // Text on screen is not yet something the user has heard, so this
+              // edge does NOT close the window (#510) — it only records the
+              // text-appear time as the fallback response-start for a turn that
+              // never gets spoken. piWriting closes the window on every one of its
+              // own edges, so the one-event-per-turn invariant survives.
               "saypi:piWriting": {
                 target: "piWriting",
                 actions: {
-                  type: "emitTurnOutcome",
-                  params: { kind: "response-started" },
+                  type: "markResponseWriting",
                 },
               },
               // The user resumed speaking before the response started — a
@@ -1513,13 +1543,44 @@ const machine = setup({
           },
           piWriting: {
             on: {
+              // Resume-window CLOSE: the response is now audible (#510).
               "saypi:piSpeaking": {
                 target: "piSpeaking",
+                actions: {
+                  type: "emitTurnOutcome",
+                  params: { kind: "response-started" },
+                },
               },
+              // Resume-window CLOSE: the response finished without ever being
+              // spoken (voice-out off, or TTS unavailable), so the response-start
+              // we report is when the text appeared (#510).
               "saypi:piStoppedWriting": {
                 target: "#conversation.listening",
+                actions: [
+                  {
+                    type: "suppressWrittenResponseWhenMaintainance",
+                  },
+                  {
+                    type: "emitTurnOutcome",
+                    params: { kind: "response-written" },
+                  },
+                ],
+              },
+              // Resume-window CLOSE: the user has SEEN the reply but HEARD nothing
+              // and started talking again — a plausible false finish, which v1
+              // mis-filed as an out-of-scope barge-in (#510). Same target and guard
+              // as the parent `responding` region's transition (which would
+              // otherwise handle this event identically — v5 transitions are
+              // internal by default, so neither re-enters `responding`); restated
+              // here only to attach the outcome emit, as piThinking does.
+              "saypi:userSpeaking": {
+                target: "#conversation.responding.userInterrupting",
+                guard: {
+                  type: "interruptionsAllowed",
+                },
                 actions: {
-                  type: "suppressWrittenResponseWhenMaintainance",
+                  type: "emitTurnOutcome",
+                  params: { kind: "resumed" },
                 },
               },
             },

--- a/test/state-machines/ConversationMachine-turnOutcome.spec.ts
+++ b/test/state-machines/ConversationMachine-turnOutcome.spec.ts
@@ -2,15 +2,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTestActor } from './support/testActor';
 
 // ---------------------------------------------------------------------------
-// Turn-outcome emission wiring (issue #505).
+// Turn-outcome emission wiring (issues #505, #510).
 //
 // The resume window lives entirely in ConversationMachine: it OPENS when the
-// endpointing auto-submit fires (converting.submitting) and CLOSES on the single
-// transition that leaves responding.piThinking:
-//   - piThinking -> piWriting / piSpeaking : the response started (response_started_at = now)
-//   - piThinking -> userInterrupting        : the user resumed first (user_resumed, resumed_at)
-//   - PI_THINKING_TIMEOUT_MS fallback         : response never started (response_started_at = null)
-// piThinking is entered/left exactly once per turn, so exactly one event fires.
+// endpointing auto-submit fires (converting.submitting) and CLOSES when the
+// assistant becomes AUDIBLE, or when the turn ends without ever becoming audible:
+//   - piThinking -> piSpeaking              : TTS start (response_started_at = now)
+//   - piWriting  -> piSpeaking              : TTS start (response_started_at = now)
+//   - piWriting  -> listening (stopped writing) : completed unspoken
+//                                             (response_started_at = text-appear)
+//   - piThinking/piWriting -> userInterrupting : the user resumed first
+//                                             (user_resumed, resumed_at)
+//   - PI_THINKING_TIMEOUT_MS fallback       : response never started (null)
+// piThinking -> piWriting only ARMS the fallback timestamp; it does not close the
+// window (#510). Each turn traverses exactly one of the closing transitions above,
+// so exactly one event fires per turn.
 //
 // These tests assert the machine hands the right observation to postTurnOutcome
 // (mocked). The correlation data (session id, last sequence number, score,
@@ -159,18 +165,28 @@ describe('ConversationMachine: turn-outcome emission', () => {
     vi.useRealTimers();
   });
 
-  it('emits response-started with the turn snapshot when the reply text appears (piWriting)', () => {
+  it('holds the window open while the reply text streams, closing it at TTS start (#510)', () => {
     driveToPiThinking(service);
     expect(service.state.matches({ responding: 'piThinking' })).toBe(true);
 
     service.send('saypi:piWriting');
+    const textAppearedAt = Date.now();
+
+    // Text on screen is not yet a response the user can hear: window still open.
+    expect(postTurnOutcomeMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1_200); // TTS synthesis lag
+    service.send('saypi:piSpeaking');
+    const ttsStartedAt = Date.now();
 
     expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
     const arg = postTurnOutcomeMock.mock.calls[0][0];
     expect(arg.trigger).toBe('auto');
     expect(arg.userResumed).toBe(false);
     expect(arg.resumedAt).toBeNull();
-    expect(typeof arg.responseStartedAt).toBe('number');
+    // The window closes at TTS start, not at text-appear.
+    expect(arg.responseStartedAt).toBe(ttsStartedAt);
+    expect(arg.responseStartedAt).toBeGreaterThan(textAppearedAt);
     // correlation snapshot from context
     expect(arg.sessionId).toBe('sess-1');
     expect(arg.lastSequenceNumber).toBe(1);
@@ -180,14 +196,79 @@ describe('ConversationMachine: turn-outcome emission', () => {
     expect(arg.lastSpeechEndedAt).toBeGreaterThan(0);
   });
 
-  it('emits response-started when TTS begins (piSpeaking)', () => {
+  it('emits response-started when TTS begins without a writing signal (piThinking -> piSpeaking)', () => {
     driveToPiThinking(service);
     service.send('saypi:piSpeaking');
 
     expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
     const arg = postTurnOutcomeMock.mock.calls[0][0];
     expect(arg.userResumed).toBe(false);
-    expect(typeof arg.responseStartedAt).toBe('number');
+    expect(arg.responseStartedAt).toBe(Date.now());
+  });
+
+  it('emits exactly once for a spoken turn, not again when the speech ends', () => {
+    driveToPiThinking(service);
+    service.send('saypi:piWriting');
+    expect(postTurnOutcomeMock).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(500);
+    service.send('saypi:piSpeaking');
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+
+    service.send('saypi:piStoppedSpeaking');
+
+    expect(service.state.matches('listening')).toBe(true);
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to text-appear time when the response completes unspoken (TTS off)', () => {
+    driveToPiThinking(service);
+
+    service.send('saypi:piWriting');
+    const textAppearedAt = Date.now();
+    expect(postTurnOutcomeMock).not.toHaveBeenCalled(); // window still open
+    vi.advanceTimersByTime(3_000); // the reply streams to the page, no TTS ever starts
+    service.send('saypi:piStoppedWriting');
+
+    expect(service.state.matches('listening')).toBe(true);
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+    const arg = postTurnOutcomeMock.mock.calls[0][0];
+    expect(arg.userResumed).toBe(false);
+    expect(arg.resumedAt).toBeNull();
+    // Nothing was ever audible, so the response start is when the text appeared —
+    // NOT when the response finished.
+    expect(arg.responseStartedAt).toBe(textAppearedAt);
+  });
+
+  it('counts a resume while the reply is still only on screen as a resume (#510)', () => {
+    driveToPiThinking(service);
+    service.send('saypi:piWriting');
+    vi.advanceTimersByTime(400);
+
+    // The user has SEEN the reply but HEARD nothing, and starts talking again:
+    // a plausible false finish, which v1 mis-filed as an out-of-scope barge-in.
+    service.send('saypi:userSpeaking');
+
+    expect(service.state.matches({ responding: 'userInterrupting' })).toBe(true);
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+    const arg = postTurnOutcomeMock.mock.calls[0][0];
+    expect(arg.userResumed).toBe(true);
+    expect(arg.resumedAt).toBe(Date.now());
+    // Nothing was ever spoken, so there is no response-start to report.
+    expect(arg.responseStartedAt).toBeNull();
+
+    // And the resumed turn does not emit a second time when TTS later starts.
+    service.send({ type: 'saypi:userStoppedSpeaking', duration: 100 });
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit when the call is hung up mid-writing (window abandoned)', () => {
+    driveToPiThinking(service);
+    service.send('saypi:piWriting');
+
+    service.send('saypi:hangup');
+
+    expect(service.state.matches('inactive')).toBe(true);
+    expect(postTurnOutcomeMock).not.toHaveBeenCalled();
   });
 
   it('emits a resume (false-finish) when the user speaks again before the response starts', () => {
@@ -220,20 +301,23 @@ describe('ConversationMachine: turn-outcome emission', () => {
   });
 
   it('does NOT re-emit a stale snapshot when piThinking is entered outside the auto-submit path', () => {
-    // Turn 1: a real auto-submit -> response starts -> one emit, then back to listening.
+    // Turn 1: a real auto-submit -> response completes -> one emit, then back to listening.
     driveToPiThinking(service);
     service.send('saypi:piWriting');
-    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
     service.send('saypi:piStoppedWriting');
+    expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1);
     expect(service.state.matches('listening')).toBe(true);
 
     // A later, non-SayPi-submit thinking episode (e.g. the assistant starts
     // responding to a manually-typed message) enters responding.piThinking via
     // the listening `saypi:piThinking` handler — NOT via converting.submitting, so
-    // no fresh snapshot is taken. The prior turn's snapshot must not be re-emitted.
+    // no fresh snapshot is taken. The prior turn's snapshot must not be re-emitted,
+    // at any of the window-closing transitions.
     service.send('saypi:piThinking');
     expect(service.state.matches({ responding: 'piThinking' })).toBe(true);
     service.send('saypi:piWriting');
+    service.send('saypi:piSpeaking');
+    service.send('saypi:piStoppedSpeaking');
 
     expect(postTurnOutcomeMock).toHaveBeenCalledTimes(1); // still only turn 1's emit
   });
@@ -248,6 +332,7 @@ describe('ConversationMachine: turn-outcome emission', () => {
     expect(service.state.matches({ responding: 'piThinking' })).toBe(true);
 
     service.send('saypi:piWriting');
+    service.send('saypi:piSpeaking');
 
     expect(postTurnOutcomeMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Why

The `turn-outcome` event is the ground truth behind saypi-api's endpointing eval: for each auto-submitted turn it records whether the user started speaking again before the assistant responded — the only non-circular way to ask "did we cut them off?". That answer is only as good as where we draw the end of the window.

v1 (#505) closed the resume window on the **first** response signal to leave `piThinking`: `saypi:piWriting` (reply text appears) or `saypi:piSpeaking` (TTS start), whichever came first. With voice-out on, text always streams before audio synthesises, so in practice the window closed at **text-appear**. That measures a resume against something the user may never have looked at. Someone who has *seen* a reply but *heard* nothing and starts talking again is a plausible false finish; v1 filed them as an out-of-scope barge-in instead, biasing the eval's resume count optimistically. #510 is the spec-fidelity follow-up.

## What

The window now closes when the assistant becomes **audible**.

- `piThinking → piWriting` no longer closes the window. It records when the text appeared (`markResponseWriting`), which becomes the reported `response_started_at` for a turn that is never spoken.
- `piWriting → piSpeaking` **closes** the window: `response_started_at` = TTS start. (`piThinking → piSpeaking` still closes it the same way, for the case where speech starts with no writing signal.)
- `piWriting → listening` on `saypi:piStoppedWriting` **closes** it: the reply completed unspoken (voice-out off), so `response_started_at` = text-appear time, not completion time.
- `piWriting → userInterrupting` **closes** it as a **resume** — the gap #510 was filed to close — with `response_started_at: null`, since nothing was ever audible. (The issue floated null as the likely choice; it is also the only option that keeps the field's meaning "when the response became audible" intact, and the payload shape can't change.)
- `piThinking`'s resume and timeout paths are untouched.

**Exactly one event per turn still holds**, by the same structural argument as v1: `piThinking` is entered once per turn and leaves by exactly one edge, and its single *non*-closing edge (`→ piWriting`) leads to a state whose own edges all close the window. `piWriting` is unreachable except from `piThinking`, so no second close can follow a first.

**Nothing in the control plane moved.** No transition target, guard, or timeout changed; the diff is actions, emit placement, and one new context field. The one new transition — `piWriting`'s `saypi:userSpeaking` — restates the parent `responding` region's transition verbatim (same target, same guard) purely to attach the emit, exactly as `piThinking` already does. I checked the semantic that makes that safe rather than assuming it: XState v5 transitions are **internal by default**, so neither the parent form nor the child form re-enters `responding` (probed against the installed xstate 5.32.1 — a parent→descendant transition logs only the descendant's entry). The `ConversationMachine` characterization suite (59 tests) is green and unmodified.

**Deliberately not done:** the `piWriting` timeout fallback the issue suggests. That is new transition topology and a new timeout in a reserve-zone machine, which this change was scoped to stay out of. The cost is documented below and in `doc/voice-endpointing.md`.

## Verification

Fail-first. I started by inverting the existing `piWriting` assertion in `test/state-machines/ConversationMachine-turnOutcome.spec.ts` — it emitted where the new behaviour must stay silent — and watched it fail before writing any implementation. Against the pre-change machine, **5 of the 10 tests failed** and the 5 `piThinking`-path tests (which must not change) passed.

What the suite pins now:

1. **TTS on** — `piWriting` emits nothing; `piSpeaking` 1.2s later emits exactly one event whose `responseStartedAt` equals *TTS start*, strictly greater than text-appear. Full correlation snapshot (session id, sequence number, `pFinishedSpeaking`, `submittedAt`, `lastSpeechEndedAt`) still checked here.
2. **TTS off / completed unspoken** — no emit at text-appear; one emit at `piStoppedWriting`, with `responseStartedAt` equal to the *text-appear* time, not the 3s-later completion.
3. **Resume during `piWriting`** (interruptions enabled) — exactly one event, `userResumed: true`, `resumedAt` = now, `responseStartedAt: null`, and the machine still lands in `responding.userInterrupting`; a following `userStoppedSpeaking` does not emit again.
4. **Unchanged paths** — `piThinking → piSpeaking` direct, `piThinking → userInterrupting` resume, the `PI_THINKING_TIMEOUT_MS` no-response fallback, the stale-snapshot guard (now driven through *all* the closing edges), and the maintenance-message exclusion (now driven through to TTS start, since it would otherwise pass trivially).
5. **Emit-once** — a spoken turn does not emit again when the speech ends.
6. **Hangup mid-writing** emits nothing — pinning the known gap rather than pretending it is covered.

- `npm test`: exit 0 — `tsc --noEmit` clean, Jest 2/2, **Vitest 2851 passed / 1 skipped** across 248 files (baseline on `main` 2847; the turn-outcome spec goes 6 → 10 tests).
- `npx vitest run test/state-machines/`: 422/422 across 26 files.

**Unverified / known gaps.** No real-host run — this is telemetry-only and fully determined by machine topology, so it proves out at Layer 1; nothing here changes what the user sees or hears. Two turns still emit nothing and fall through to the server-side fallback: a hangup mid-response (pre-existing in v1, for `piThinking` too), and a turn stuck in `piWriting` because TTS is off and `piStoppedWriting` never fires (host DOM drift) — new in this change, and the case the deferred `piWriting` timeout would cover. Both are now documented in `doc/voice-endpointing.md`.

**For saypi-api:** the payload shape is unchanged, so no server change is required. But `response_started_at` now means "when the assistant became audible" rather than "first response signal", and resumes during `piWriting` now arrive as resumes rather than not at all — so eval results should be **segmented by extension version** across this release boundary rather than pooled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
