### PR TITLE
voices: honour the manifest's availability, and tell the user when theirs is down (#568)

### DIFF
--- a/entrypoints/settings/tabs/voices/voices-controller.ts
+++ b/entrypoints/settings/tabs/voices/voices-controller.ts
@@ -980,6 +980,17 @@ export class VoicesController {
       scope.remove();
       current.appendChild(this.renderFallbackVoice(vm));
     }
+    // The saved voice still resolves, but its provider is hard-down (#568).
+    // Say so next to the name rather than removing the row: the user needs to
+    // know why their voice has gone quiet, and that the fix is one pick away.
+    if (selectedRemote && vm.currentUnavailable) {
+      const note = document.createElement("span");
+      note.className = "voice-current-unavailable";
+      note.setAttribute("role", "status");
+      note.dataset.i18n = "voicesSavedUnavailable";
+      note.textContent = getMessage("voicesSavedUnavailable");
+      current.appendChild(note);
+    }
     if (vm.host.hasOwnVoice && this.deps.unsetVoice && (selectedRemote || vm.unavailable)) {
       const native = document.createElement("button");
       native.type = "button";

--- a/entrypoints/settings/tabs/voices/voices-view-model.ts
+++ b/entrypoints/settings/tabs/voices/voices-view-model.ts
@@ -8,6 +8,7 @@ import {
 import {
   CLAUDE_MENU_CAP,
   curateShortlist,
+  isVoiceUnavailable,
   visibleCatalog,
 } from "../../../../src/tts/VoiceCuration";
 
@@ -102,6 +103,19 @@ export interface StudioViewModel {
    * (built-ins and grandfathered voices aren't in the catalog).
    */
   stagedCurrent: SpeechSynthesisVoiceRemote | null;
+  /**
+   * The staged voice resolves, but the server says its provider is hard-down
+   * right now (`availability: "unavailable"`, #568).
+   *
+   * Deliberately NOT folded into `unavailable` above: that one means "a saved
+   * choice exists and cannot be resolved from the catalog at all", and the two
+   * want opposite treatment. An unresolvable choice has nothing to show; this
+   * one has a voice to keep showing — grandfathered into the rail, named in the
+   * control bar, and labelled so the user knows why it has gone quiet and that
+   * they can pick another right here. Silently vanishing the voice someone is
+   * using is worse than showing it with a note.
+   */
+  currentUnavailable: boolean;
   featuredIds: string[];
   /** The resolved pin set (server defaults ⊕ user overlay). */
   pinned: Set<string>;
@@ -258,6 +272,7 @@ export function viewModel(
     catalog,
     hasBuiltins,
     unavailable: data.unavailable ?? false,
+    currentUnavailable: stagedCurrent ? isVoiceUnavailable(stagedCurrent) : false,
     currentId,
     stagedCurrent,
     featuredIds,

--- a/entrypoints/settings/tabs/voices/voices.css
+++ b/entrypoints/settings/tabs/voices/voices.css
@@ -225,6 +225,13 @@
   font-weight: 600;
   color: #2c5a42;
 }
+/* The saved voice's provider is hard-down (#568). Muted, not alarming — the
+   voice works again the moment the provider recovers, so this is a status line
+   beside the name, not an error state. Same ink as .voice-fallback. */
+.voice-current-unavailable {
+  font-size: 13px;
+  color: rgba(36, 29, 20, 0.66);
+}
 .voice-current-choice .voice-your-voice {
   font-size: 17px;
   font-weight: 600;

--- a/src/chatbots/ClaudeVoiceMenu.ts
+++ b/src/chatbots/ClaudeVoiceMenu.ts
@@ -16,6 +16,7 @@ import venusSvgContent from "../icons/lucide-venus.svg?raw";
 import { logger } from "../LoggingModule";
 import {
   curateShortlist,
+  isVoiceUnavailable,
   getVoiceTier,
   CLAUDE_MENU_CAP,
 } from "../tts/VoiceCuration";
@@ -315,8 +316,18 @@ export class ClaudeVoiceMenu extends VoiceSelector {
     description.classList.add("text-text-500", "pr-4", "text-xs", "overflow-hidden", "text-ellipsis", "max-w-[340px]");
     // Determine the appropriate description text
     if (voice) {
-      const desc = voice.description || "";
-      description.innerText = desc || getMessage("ttsVoice");
+      // Grandfathering means an unavailable voice reaches this menu only when
+      // it is the one the user has saved (#568). Say so in place of the blurb
+      // — this row is the only place they will learn their voice has gone
+      // quiet, and every other row in the menu is a working alternative.
+      if (isVoiceUnavailable(voice)) {
+        item.classList.add("saypi-voice-unavailable");
+        item.title = getMessage("voicesSavedUnavailable");
+        description.innerText = getMessage("voicesSavedUnavailable");
+      } else {
+        const desc = voice.description || "";
+        description.innerText = desc || getMessage("ttsVoice");
+      }
     } else {
       if (isSignInPrompt) {
         description.innerText = getMessage("signInForTTS");

--- a/src/styles/voices.scss
+++ b/src/styles/voices.scss
@@ -1,6 +1,11 @@
-// Signed-out state (#268): the in-chat voice selector is greyed to signal that
-// TTS requires sign-in, but stays clickable (opens the menu's sign-in item).
-// Kept dimmed on hover too, overriding the host page's hover:opacity utilities.
+// "Can't speak right now" — two causes, one look.
+//   #268: signed out, so the in-chat voice selector is greyed to signal that
+//         TTS requires sign-in, but stays clickable (opens the sign-in item).
+//   #568: the saved voice's provider is hard-down, so its grandfathered row is
+//         greyed while it stays visible and selected (the row also carries the
+//         explanation as its subtitle and title).
+// Both stay clickable and both keep the dim on hover, overriding the host
+// page's hover:opacity utilities.
 .saypi-voice-unavailable,
 .saypi-voice-unavailable:hover {
   opacity: 0.6 !important;

--- a/src/tts/SpeechModel.ts
+++ b/src/tts/SpeechModel.ts
@@ -266,6 +266,26 @@ class UtteranceFactory {
   }
 }
 
+/**
+ * Live provider health for one voice, as served by `GET /voices`
+ * (saypi-api #321, `tts/availability.py`). The server derives it per request
+ * from the TTS monitor's per-provider grade:
+ *
+ * - `"available"`  — the provider is operational, OR nothing is known about it.
+ * - `"degraded"`   — the provider is erroring but still serving. Deliberately
+ *                    NOT de-featured server-side, so the client must not hide
+ *                    it either.
+ * - `"unavailable"` — the provider is hard-down. Excluded from `featured` /
+ *                    `recommended` server-side.
+ *
+ * `null` when the health signal is unknown or switched off (the server's own
+ * kill switch) — and the field is serialized as `null`, not omitted, in that
+ * case. Absence is never read as bad news: hiding a working voice is a worse
+ * failure than briefly offering a broken one, because a user cannot route
+ * around a voice they cannot see.
+ */
+type VoiceAvailability = "available" | "degraded" | "unavailable";
+
 interface SpeechSynthesisVoiceRemote extends SpeechSynthesisVoice {
   id: string;
   price: number; // price per 1000 characters (legacy field)
@@ -280,9 +300,11 @@ interface SpeechSynthesisVoiceRemote extends SpeechSynthesisVoice {
   sample_url?: string;    // free ~2s canned preview clip; server-served when present (design §4)
   // Curation manifest (design §5; saypi-api #293). All additive and optional —
   // the client obeys them when present and falls back to local heuristics when
-  // absent. featured/section/deprecated are consumed today; recommended,
-  // sibling_id, language and chars_per_minute are preserved for later phases
-  // (defaults + rails, language shelf) but not yet acted on.
+  // absent. Consumed today: featured/section/deprecated (curation),
+  // recommended (default adoption), sample_url (the ▶ preview) and availability
+  // (#568). Still declared-but-unconsumed: sibling_id (the Downshift rescue) and
+  // chars_per_minute (absolute duration figures — the server sends null until
+  // the rate is measured), plus `language` pending the gated language shelf.
   featured?: boolean;         // in the in-host shortlist for this app
   section?: string;           // shelf key: "hd" | "everyday" | "language"
   recommended?: boolean;      // the default for this (host, locale, plan) cohort — exactly one
@@ -290,6 +312,7 @@ interface SpeechSynthesisVoiceRemote extends SpeechSynthesisVoice {
   deprecated?: boolean;       // retired: hidden from the catalog, still served to prior selectors
   language?: string;          // BCP-47 tag driving the gated language shelf (§6)
   chars_per_minute?: number;  // measured speaking rate (drives minute denominations; null until measured)
+  availability?: VoiceAvailability | null; // live provider health (see the type)
 }
 
 interface MatchableVoice {
@@ -466,6 +489,7 @@ export {
   AssistantSpeech,
   SpeechUtterance,
   SpeechSynthesisVoiceRemote,
+  VoiceAvailability,
   MatchableVoice,
   VoiceFactory,
   AIVoice,

--- a/src/tts/VoiceCuration.ts
+++ b/src/tts/VoiceCuration.ts
@@ -7,13 +7,14 @@ import { SpeechSynthesisVoiceRemote } from "./SpeechModel";
  * catalog grows; the full catalog lives one click deeper (extension settings).
  *
  * GET /voices now carries a curation manifest (saypi-api #293): `section` gives
- * the tier, `featured` marks the in-host shortlist, and `deprecated` retires a
- * voice. The client obeys those fields when present and falls back to the local
- * price/rank heuristic when they are absent, so it renders correctly against
- * both new and old server deployments (the additive-optional contract). Two
- * invariants the manifest can never override: a deprecated voice keeps
- * rendering (and working) if it is the user's current selection
- * (grandfathering), and the menu never renders empty.
+ * the tier, `featured` marks the in-host shortlist, `deprecated` retires a
+ * voice, and `availability` reports the provider's live health (#321). The
+ * client obeys those fields when present and falls back to the local price/rank
+ * heuristic when they are absent, so it renders correctly against both new and
+ * old server deployments (the additive-optional contract). Two invariants the
+ * manifest can never override: a voice that is retired OR temporarily
+ * unreachable keeps rendering (and working) if it is the user's current
+ * selection (grandfathering), and the menu never renders empty.
  */
 
 export type VoiceTier = "hd" | "everyday";
@@ -71,16 +72,45 @@ export function getVoiceTier(voice: SpeechSynthesisVoiceRemote): VoiceTier {
 }
 
 /**
- * Drop retired (deprecated) voices before a catalog is offered to new selectors
- * — EXCEPT the user's current voice, which must always keep rendering
- * (grandfathering, design §5). The server keeps synthesising TTS for prior
- * selectors; this governs only what the menus and settings catalog show.
+ * Is the server telling us this voice cannot speak right now (saypi-api #321)?
+ *
+ * Strictly `"unavailable"` — a hard-down provider. Everything else fails OPEN:
+ * absent, `null`, `"degraded"` (erroring but still serving, which the server
+ * deliberately does not de-feature), and any value a future server might send
+ * that this client doesn't recognise. The server sends `null` whenever health
+ * is unknown *on purpose*, so silence must never be read as trouble — hiding a
+ * working voice is worse than briefly offering a broken one, because a user
+ * cannot route around a voice they cannot see.
+ */
+export function isVoiceUnavailable(voice: SpeechSynthesisVoiceRemote): boolean {
+  return voice.availability === "unavailable";
+}
+
+/**
+ * Drop voices that shouldn't be offered to a NEW selector — retired
+ * (`deprecated`) ones, and ones whose provider is currently hard-down
+ * (`availability: "unavailable"`) — EXCEPT the user's current voice, which must
+ * always keep rendering (grandfathering, design §5).
+ *
+ * This is the single seam every surface goes through: the in-host shortlist
+ * (via `curateShortlist`), its fill-to-cap padding, user-pin membership, and
+ * the settings studio's full catalog. The server already drops unavailable
+ * voices from `featured`/`recommended`, so the residue this closes is
+ * client-side: padding that seats a non-featured voice when the server features
+ * fewer than the cap, a pinned voice the user chose before the outage, and the
+ * studio rail, which renders the whole catalog rather than the shortlist.
+ *
+ * The server keeps synthesising TTS for prior selectors; this governs only what
+ * the menus and settings catalog OFFER.
  */
 export function visibleCatalog(
   voices: SpeechSynthesisVoiceRemote[],
   currentVoiceId: string | null
 ): SpeechSynthesisVoiceRemote[] {
-  return voices.filter((v) => !v.deprecated || v.id === currentVoiceId);
+  return voices.filter(
+    (v) =>
+      v.id === currentVoiceId || (!v.deprecated && !isVoiceUnavailable(v))
+  );
 }
 
 export interface CuratedShortlist {

--- a/test/chatbots/ClaudeVoiceMenu-availability.spec.ts
+++ b/test/chatbots/ClaudeVoiceMenu-availability.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ConfigModule reads injected env at import time; stub it (mirrors other specs).
+vi.mock("../../src/ConfigModule", () => ({
+  config: {
+    appServerUrl: "https://app.example.com",
+    apiServerUrl: "https://api.saypi.ai",
+    GA_MEASUREMENT_ID: "x",
+    GA_API_SECRET: "x",
+    GA_ENDPOINT: "x",
+  },
+}));
+
+vi.mock("../../src/JwtManager", () => ({
+  getJwtManagerSync: () => ({
+    isAuthenticated: () => true,
+    getClaims: () => ({ ttsQuotaRemaining: 1000 }),
+  }),
+}));
+
+vi.mock("../../src/popup/popupopener", () => ({
+  openSettings: vi.fn(),
+}));
+
+vi.mock("../../src/events/EventBus.js", () => ({
+  default: { emit: vi.fn(), on: vi.fn(), off: vi.fn(), once: vi.fn() },
+}));
+
+import { ClaudeVoiceMenu } from "../../src/chatbots/ClaudeVoiceMenu";
+import { ElevenLabsVoice } from "../data/Voices";
+import { SpeechSynthesisVoiceRemote } from "../../src/tts/SpeechModel";
+
+/**
+ * `availability` in Claude's in-chat menu (#568).
+ *
+ * The other half of the client-side residue: the server already keeps a
+ * hard-down voice out of `featured`, but the menu's fill-to-cap padding and
+ * user pins could still seat one — and, for the user whose SAVED voice is the
+ * one that went down, grandfathering puts it in this menu on purpose. That row
+ * is the only place they will find out their voice has gone quiet, so it has
+ * to say so.
+ */
+
+function voice(
+  id: string,
+  name: string,
+  availability?: "available" | "degraded" | "unavailable" | null
+): SpeechSynthesisVoiceRemote {
+  const v = new ElevenLabsVoice(id, name, "F", "American", `${name} sounds nice`);
+  (v as SpeechSynthesisVoiceRemote).availability = availability ?? undefined;
+  return v;
+}
+
+// Bypass the heavy constructor (pattern from ClaudeVoiceMenu-preview.spec.ts).
+function makeMenu(): any {
+  const menu = Object.create(ClaudeVoiceMenu.prototype);
+  menu.chatbot = {} as any;
+  menu.userPreferences = {
+    getVoice: vi.fn(async () => null),
+    setVoice: vi.fn(async () => {}),
+    unsetVoice: vi.fn(async () => {}),
+  };
+  menu.element = document.createElement("div");
+  document.body.appendChild(menu.element);
+  menu.menuButton = document.createElement("button");
+  menu.menuContent = document.createElement("div");
+  menu.toggleMenu = vi.fn();
+  return menu;
+}
+
+/** Voice rows only: the "Voice off" and "More voices…" rows are menuitems too. */
+const rowNames = (menu: any): string[] =>
+  Array.from(menu.menuContent.querySelectorAll("[role='menuitem']"))
+    .map((el) => (el as HTMLElement).dataset.voiceName)
+    .filter((name): name is string => !!name && name !== "voice-off");
+
+/**
+ * The row's subtitle. The menu writes it with `innerText`, which jsdom does not
+ * implement as a live DOM property (it lands as an expando, invisible to
+ * `textContent`), so it has to be read back the same way it was written.
+ */
+const subtitleOf = (row: HTMLElement): string =>
+  ((row.querySelector("div > div.text-ellipsis") as any)?.innerText ?? "") as string;
+
+const rowFor = (menu: any, voiceName: string): HTMLElement | undefined =>
+  Array.from(menu.menuContent.querySelectorAll("[role='menuitem']")).find(
+    (el) => (el as HTMLElement).dataset.voiceName === voiceName,
+  ) as HTMLElement | undefined;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ClaudeVoiceMenu — a voice whose provider is down (#568)", () => {
+  it("does not offer a hard-down voice to a user who hasn't chosen it", () => {
+    const menu = makeMenu();
+    menu.renderMenu(
+      [voice("a", "Nova"), voice("b", "Paola", "unavailable"), voice("c", "Ash")],
+      null,
+    );
+    expect(rowNames(menu)).toEqual(["Nova", "Ash"]);
+  });
+
+  it("still offers a degraded voice — it is erroring, not down", () => {
+    const menu = makeMenu();
+    menu.renderMenu([voice("a", "Nova"), voice("b", "Ash", "degraded")], null);
+    expect(rowNames(menu)).toEqual(["Nova", "Ash"]);
+  });
+
+  it("changes nothing when the server sends no health signal", () => {
+    const menu = makeMenu();
+    menu.renderMenu([voice("a", "Nova", null), voice("b", "Ash")], null);
+    expect(rowNames(menu)).toEqual(["Nova", "Ash"]);
+  });
+
+  it("keeps the user's own down voice in the menu, and says it cannot speak", () => {
+    // Grandfathering puts it here; without the label the row is a trap — it
+    // looks selected and working, and simply produces silence.
+    const paola = voice("b", "Paola", "unavailable");
+    const menu = makeMenu();
+    menu.renderMenu([voice("a", "Nova"), paola, voice("c", "Ash")], paola);
+
+    const row = rowFor(menu, "Paola")!;
+    expect(row).toBeTruthy();
+    expect(row.classList.contains("saypi-voice-unavailable")).toBe(true);
+    expect(row.title).toBe("voicesSavedUnavailable");
+    expect(row.getAttribute("title")).toBe("voicesSavedUnavailable");
+    // The status replaces the blurb rather than sitting beside it: one row,
+    // one sentence, and the sentence that matters right now is this one.
+    expect(subtitleOf(row)).toBe("voicesSavedUnavailable");
+    expect(subtitleOf(row)).not.toContain("Paola sounds nice");
+  });
+
+  it("leaves healthy rows describing themselves as usual", () => {
+    const menu = makeMenu();
+    menu.renderMenu([voice("a", "Nova")], null);
+    const row = rowFor(menu, "Nova")!;
+    expect(row.classList.contains("saypi-voice-unavailable")).toBe(false);
+    expect(subtitleOf(row)).toBe("Nova sounds nice");
+  });
+
+  it("puts the down voice first and healthy alternatives right under it", () => {
+    // The way out has to be one click away, in the same menu.
+    const paola = voice("b", "Paola", "unavailable");
+    const menu = makeMenu();
+    menu.renderMenu([voice("a", "Nova"), paola, voice("c", "Ash")], paola);
+    expect(rowNames(menu)).toEqual(["Paola", "Nova", "Ash"]);
+  });
+});

--- a/test/settings/tabs/voices-controller.spec.tsx
+++ b/test/settings/tabs/voices-controller.spec.tsx
@@ -3645,3 +3645,72 @@ describe("adversarial release current choice", () => {
     expect(rowOf(container, "shimmer")?.getAttribute("aria-selected")).toBe("true");
   });
 });
+
+/**
+ * `availability` in the studio (#568).
+ *
+ * The studio is the surface the shortlist logic does NOT cover: it paints the
+ * whole catalog as a rail, not a capped menu, so it needs its own proof that a
+ * hard-down voice stops being offered — and, for the user whose saved voice is
+ * the one that went down, that it keeps being shown, named, and labelled.
+ */
+describe("VoicesController — a voice whose provider is down (#568)", () => {
+  const down = (id: string) => mkHdVoice(id, { availability: "unavailable" } as any);
+
+  it("stops offering a hard-down voice in the rail", async () => {
+    const { container } = await mount(
+      makeDeps({ pi: [mkVoice("nova"), down("paola"), mkVoice("ash")] })
+    );
+    expect(rowIds(container)).not.toContain("paola");
+    expect(rowIds(container)).toEqual(expect.arrayContaining(["nova", "ash"]));
+  });
+
+  it("leaves a degraded voice exactly where it was", async () => {
+    // The server deliberately keeps degraded voices featured — they are still
+    // serving. The client must not be more pessimistic than the server.
+    const { container } = await mount(
+      makeDeps({
+        pi: [mkVoice("nova"), mkVoice("ash", { availability: "degraded" } as any)],
+      })
+    );
+    expect(rowIds(container)).toEqual(expect.arrayContaining(["nova", "ash"]));
+  });
+
+  it("keeps the user's own down voice in the rail rather than vanishing it", async () => {
+    const paola = down("paola");
+    const { container } = await mount(
+      makeDeps({ pi: [mkVoice("nova"), paola], piCurrent: paola })
+    );
+    expect(rowIds(container)).toContain("paola");
+    expect(
+      rowOf(container, "paola")!.classList.contains("voice-row-current")
+    ).toBe(true);
+  });
+
+  it("names the down voice in the control bar AND says it cannot speak right now", async () => {
+    // The whole point of the issue: without this line the user's voice simply
+    // stops working, with nothing on screen to explain it or to act on.
+    const paola = down("paola");
+    const { container } = await mount(
+      makeDeps({ pi: [mkVoice("nova"), paola], piCurrent: paola })
+    );
+    expect(q(container, ".voice-your-voice")?.textContent).toBe("Paola");
+    const note = q(container, ".voice-current-unavailable");
+    expect(note?.textContent).toBe("voicesSavedUnavailable");
+    expect(note?.getAttribute("role")).toBe("status");
+  });
+
+  it("says nothing when the current voice is healthy", async () => {
+    const { container } = await mount(
+      makeDeps({ pi: [mkVoice("nova")], piCurrent: mkVoice("nova") })
+    );
+    expect(q(container, ".voice-current-unavailable")).toBeNull();
+  });
+
+  it("says nothing when the server reports no health at all (fail-open)", async () => {
+    const nova = mkVoice("nova", { availability: null } as any);
+    const { container } = await mount(makeDeps({ pi: [nova], piCurrent: nova }));
+    expect(q(container, ".voice-current-unavailable")).toBeNull();
+    expect(rowIds(container)).toContain("nova");
+  });
+});

--- a/test/tts/VoiceCuration.spec.ts
+++ b/test/tts/VoiceCuration.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getVoiceTier,
   curateShortlist,
+  isVoiceUnavailable,
   visibleCatalog,
   CLAUDE_MENU_CAP,
 } from "../../src/tts/VoiceCuration";
@@ -223,6 +224,7 @@ type Manifest = Partial<
     | "sibling_id"
     | "language"
     | "chars_per_minute"
+    | "availability"
   >
 >;
 
@@ -475,5 +477,137 @@ describe("visibleCatalog", () => {
       "b",
       "c",
     ]);
+  });
+});
+
+/**
+ * `availability` — the live provider-health field (saypi-api #321, client #568).
+ *
+ * The server already keeps a hard-down provider out of `featured`/`recommended`,
+ * so these cases pin the residue only the client can close: fill-to-cap padding,
+ * user pins, and the settings studio's full catalog — plus the case the whole
+ * issue is about, the user whose SAVED voice has gone dark.
+ */
+describe("voice availability (#568)", () => {
+  const unavailable = (id: string) =>
+    withManifest(voice(id, id.toUpperCase(), "ElevenLabs", 1000), {
+      availability: "unavailable",
+    });
+  const available = (id: string, availability?: Manifest["availability"]) =>
+    withManifest(voice(id, id.toUpperCase(), "OpenAI", 50), { availability });
+
+  describe("isVoiceUnavailable fails OPEN", () => {
+    it("is true only for a hard-down provider", () => {
+      expect(isVoiceUnavailable(unavailable("paola"))).toBe(true);
+    });
+
+    it("is false for available, degraded, null and absent", () => {
+      // The server sends null whenever health is unknown, on purpose. Silence
+      // is never bad news: a voice you cannot see is a voice you cannot route
+      // around.
+      expect(isVoiceUnavailable(available("a", "available"))).toBe(false);
+      expect(isVoiceUnavailable(available("b", "degraded"))).toBe(false);
+      expect(isVoiceUnavailable(available("c", null))).toBe(false);
+      expect(isVoiceUnavailable(voice("d", "D", "OpenAI", 50))).toBe(false);
+    });
+
+    it("is false for a value this client has never heard of", () => {
+      const future = { ...voice("e", "E", "OpenAI", 50), availability: "brand-new" };
+      expect(isVoiceUnavailable(future as SpeechSynthesisVoiceRemote)).toBe(false);
+    });
+  });
+
+  describe("visibleCatalog", () => {
+    it("stops offering an unavailable voice to new selectors", () => {
+      const catalog = [available("nova"), unavailable("paola"), available("ash")];
+      expect(visibleCatalog(catalog, null).map((v) => v.id)).toEqual([
+        "nova",
+        "ash",
+      ]);
+    });
+
+    it("keeps a degraded voice — the server does not de-feature it, nor may we", () => {
+      const catalog = [available("nova"), available("ash", "degraded")];
+      expect(visibleCatalog(catalog, null).map((v) => v.id)).toEqual([
+        "nova",
+        "ash",
+      ]);
+    });
+
+    it("changes nothing when the whole catalog reports null (today's behaviour)", () => {
+      const catalog = [available("nova", null), available("ash", null)];
+      expect(visibleCatalog(catalog, null).map((v) => v.id)).toEqual([
+        "nova",
+        "ash",
+      ]);
+    });
+  });
+
+  describe("the residue the server cannot fix", () => {
+    it("never pads the menu to its cap with an unavailable voice", () => {
+      // The server features fewer voices than the cap, so fill-to-cap runs —
+      // and used to seat whatever came next in server order, health be damned.
+      const catalog = [
+        withManifest(available("nova"), { featured: true }),
+        unavailable("paola"),
+        available("ash"),
+        available("onyx"),
+      ];
+      const result = curateShortlist(catalog, null, CLAUDE_MENU_CAP);
+      expect(result.voices.map((v) => v.id)).toEqual(["nova", "ash", "onyx"]);
+    });
+
+    it("never seats a pinned voice whose provider is down", () => {
+      // A pin is a choice the user made BEFORE the outage; honouring it here
+      // would put a mute row in a menu the user curated themselves.
+      const catalog = [available("nova"), unavailable("paola"), available("ash")];
+      const result = curateShortlist(
+        catalog,
+        null,
+        CLAUDE_MENU_CAP,
+        new Set(["paola", "ash"])
+      );
+      expect(result.voices.map((v) => v.id)).toEqual(["ash"]);
+    });
+  });
+
+  describe("the saved voice that has gone dark — the case this exists for", () => {
+    const catalog = [
+      available("nova"),
+      unavailable("paola"),
+      available("ash"),
+      available("onyx"),
+    ];
+
+    it("keeps rendering it, first, rather than silently vanishing it", () => {
+      // Grandfathering. Dropping it would leave the user staring at a menu
+      // with no indication of what happened to the voice they picked — the
+      // failure this issue calls worse than showing it with a note.
+      const result = curateShortlist(catalog, "paola", CLAUDE_MENU_CAP);
+      expect(result.voices[0].id).toBe("paola");
+    });
+
+    it("offers working alternatives alongside it, so there is a way out", () => {
+      const result = curateShortlist(catalog, "paola", CLAUDE_MENU_CAP);
+      const others = result.voices.slice(1).map((v) => v.id);
+      expect(others).toEqual(["nova", "ash", "onyx"]);
+      expect(others).not.toContain("paola");
+    });
+
+    it("never renders an empty menu, even if EVERY other voice is down too", () => {
+      const allDown = [
+        unavailable("paola"),
+        unavailable("jarnathan"),
+        unavailable("juniper"),
+      ];
+      const result = curateShortlist(allDown, "paola", CLAUDE_MENU_CAP);
+      expect(result.voices.map((v) => v.id)).toEqual(["paola"]);
+    });
+
+    it("counts the hidden voices honestly, so the door still leads somewhere", () => {
+      const result = curateShortlist(catalog, "paola", CLAUDE_MENU_CAP);
+      // 4 catalog entries, all 4 seated (paola grandfathered + 3 available).
+      expect(result.hiddenCount).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## Why

For 36 hours last July the ElevenLabs subscription sat `past_due`, every TTS call answered 401, and `/voices` went on serving Paola as `recommended`. saypi-api [#321](https://github.com/Pedal-Intelligence/saypi-api/pull/321) fixed the **steering** half server-side: the manifest now carries a live `availability` per voice and a hard-down provider is dropped from `featured`/`recommended`. A fresh install during an outage already lands on a working voice with **no client change at all** — so "the menu stops offering unavailable voices" is largely true today, and is not the headline here.

What the server cannot fix is **the user who already had that voice saved**. Their stored id still resolves, `/speak` still routes to the dead provider, and — I traced this rather than assuming — the client's own defence-in-depth (`SpeechSynthesisModule`'s catch, from #268) turns the throw at `TextToSpeechService.ts:150` into a `SpeechPlaceholder` and a `console.warn`. So their real experience is not even an error message: it is **silence, with nothing on screen to explain it and nothing to act on**. That is the case this PR is for. A filter alone would grandfather that voice and leave that user byte-identical to today — shipping the cheap half and skipping the one that matters.

## What

Scope is **`availability` only**. `sibling_id` (the Downshift rescue) and `chars_per_minute` stay declared-but-unconsumed, deliberately — see "Follow-ups".

**1. The type, verified against the server rather than a fixture.** `VoiceAvailability = "available" | "degraded" | "unavailable"`, plus `null`. I did not take this from `e2e/support/voice-catalog.ts` — that file is hand-authored, not a recording, and its only value is `"available"`, so it proves nothing about the wire format. It comes from saypi-api's own source: `tts/availability.py` maps the monitor's `operational`/`degraded`/`outage` to those three strings, `tts/models.py` declares the field `str | None`, and `app.py` sends `availability_for(voice, health) if health else None` — so the field is serialized as `null` (not omitted) whenever the health map is empty or the server's kill switch is off.

**2. One seam, three pieces of residue.** The filter lives in `visibleCatalog`, which every surface already goes through, so it closes all of the genuinely client-side gaps at once — each of which I verified:

| Residue | Where | Now |
| --- | --- | --- |
| Fill-to-cap padding can seat a non-featured (hence possibly unavailable) voice when the server features fewer than the cap | `VoiceCuration.ts:218` | filtered |
| A pinned voice — a choice made *before* the outage — is still seated | `VoiceCuration.ts:196` | filtered |
| The settings studio paints the whole catalog, not the shortlist, re-filtering independently of `curateShortlist` | `voices-view-model.ts:193` | filtered (it calls `visibleCatalog` directly) |

**3. Fails open, everywhere.** `isVoiceUnavailable` is true for the literal `"unavailable"` and nothing else — not absent, not `null`, not `"degraded"` (erroring but still serving, which the server deliberately does *not* de-feature, so the client must not be more pessimistic than the server), and not a value a future server might send. The server reads silence as good news on purpose, and the reason generalises: hiding a working voice is worse than briefly offering a broken one, because a user cannot route around a voice they cannot see.

**4. The saved-voice case — the reason for the PR.** The grandfathering clause that already kept a *deprecated* current voice rendering now covers an unreachable one too, and **both surfaces that render the current voice say what is going on**:

- **Settings studio** — the control bar keeps naming the voice and adds a muted `role="status"` line beside it. A new `currentUnavailable` on the view model, deliberately *not* folded into the existing `unavailable` flag: that one means "a saved choice exists and cannot be resolved from the catalog at all", and the two want opposite treatment — one has nothing to show, this one has a voice to keep showing.
- **Claude's in-chat menu** — the grandfathered row is dimmed (reusing the existing `.saypi-voice-unavailable`, so no new CSS) and carries the explanation as its subtitle and `title`, in place of the voice's blurb. Without that label the row is a trap: it looks selected and working, and produces silence.

Both reuse **`voicesSavedUnavailable`**, which already says exactly the right sentence in 31 locales — *"Your saved voice is unavailable right now. Try again later, or choose another voice."* No new i18n key, no `translate` run, and no risk in the 31-locale key surface the caution map warns about. Every other row in either surface is a working alternative, one click away — which is the "path out" the issue asks for.

**5. A stale comment corrected.** `SpeechModel.ts` claimed `recommended`, `sibling_id`, `language` and `chars_per_minute` were all "preserved for later phases". `recommended` (default adoption) and `sample_url` (the ▶ preview) have been consumed for a while; the comment now says what is actually consumed today and what genuinely isn't.

## Verification

- `npm test` green: **2871 Vitest passing, 1 skipped, 249 files** (this branch's `origin/main` baseline measured at 2847 — 24 new); Jest 2/2; `tsc --noEmit` clean. `gitleaks 8.30.1` clean on the branch range.
- **`test/tts/VoiceCuration.spec.ts` (+11)** — fail-open in all five shapes (`available`/`degraded`/`null`/absent/unknown-future-value); `visibleCatalog` drops an unavailable voice and keeps a degraded one; padding never seats one; pins never seat one; and the saved-voice block: it stays **first**, working alternatives follow it, `hiddenCount` stays honest, and the menu is never empty even when *every* voice is down.
- **`test/settings/tabs/voices-controller.spec.tsx` (+6)** — the studio surface end-to-end through the real controller: a down voice leaves the rail, a degraded one doesn't, the user's own down voice **stays** in the rail marked current, the control bar names it *and* renders the `role="status"` note, and nothing is said when the voice is healthy or when the server reports no health.
- **`test/chatbots/ClaudeVoiceMenu-availability.spec.ts` (new, 6)** — the same contract for the in-chat menu, driven through the real `renderMenu`: rows offered/withheld, the grandfathered row dimmed with the explanation replacing its blurb, healthy rows untouched, and the down voice first with alternatives under it.
- **Proven fail-first**, not written after the fact: neutering the `visibleCatalog` filter turns 4 curation cases and 1 studio case red; neutering the control-bar note turns the studio's "says it cannot speak right now" case red. Both reverts were restored immediately.

**Not verified:** no live `/voices` response was observed — the enum is confirmed from the server's source, which is stronger than the fixture but is still not a captured payload, and I'd rather say that than imply I watched the wire. No real-host run: the change is pure catalog-filtering plus two DOM labels, all reproducible in a controlled DOM, so Layer 1–2 is the layer that can prove it. The visual weight of the two labels (a muted 13px status line; a dimmed menu row) is unreviewed on a real host and is the one thing worth a founder's eye.

## Follow-ups (deliberately out of scope)

- **`sibling_id` — the Downshift rescue.** Left out as briefed, but flagging it so it doesn't stall silently: the open question is a **UX** one, not a technical one — auto-switch to the sibling with a toast (gets the user talking again immediately) versus prompt once and remember (respects that voice choice is personal). This PR makes the state visible and recoverable by hand; the sibling makes it automatic.
- **`chars_per_minute`** — still `null` server-side until the rate is measured, so consuming it would be a no-op.
- **The menu-cap mismatch** (`CLAUDE_MENU_CAP` 4 vs the server's pi=5/claude=6) and **`EVERYDAY_RANK` drift** (missing `cedar`/`marin`) from the issue's "pre-existing mismatches" section are untouched here — they are unrelated to `availability` and want their own decision about which side moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
