### PR TITLE
test(chatgpt): wait for the effect, not for a fixed 10ms (#642)

### DIFF
--- a/test/chatbots/ChatGPTAutoReadAloud.spec.ts
+++ b/test/chatbots/ChatGPTAutoReadAloud.spec.ts
@@ -81,10 +81,10 @@ describe('ChatGPT auto Read Aloud', () => {
     const clickSpy = vi.spyOn(btn, 'click');
     actionBar.appendChild(btn);
 
-    // Allow mutation observer microtask to run
-    await new Promise((r) => setTimeout(r, 10));
-
-    expect(clickSpy).toHaveBeenCalledTimes(1);
+    // Poll for the effect rather than sleeping a fixed 10ms (#642): the
+    // observer callback plus the decoration chain is asynchronous, so a fixed
+    // wait is load-sensitive by construction and fails on a busy runner.
+    await vi.waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1));
   });
 
   it('does not click for older assistant turns; only newest gets auto-click', async () => {
@@ -131,12 +131,12 @@ describe('ChatGPT auto Read Aloud', () => {
     const newClickSpy = vi.spyOn(newBtn, 'click');
     newActionBar.appendChild(newBtn);
 
-    // Allow mutation observers to react
-    await new Promise((r) => setTimeout(r, 10));
-
-    // Expect only the newest message to be auto-clicked
+    // Poll for the click we DO expect (#642). That doubles as the barrier for
+    // the assertion below: once the newest message has been clicked, the
+    // observers have run, so a still-unclicked older message is a real result
+    // rather than one we simply did not wait long enough to see.
+    await vi.waitFor(() => expect(newClickSpy).toHaveBeenCalledTimes(1));
     expect(oldClickSpy).toHaveBeenCalledTimes(0);
-    expect(newClickSpy).toHaveBeenCalledTimes(1);
   });
 
   it('clicks when only a Replay-labeled button exists (no data-testid)', async () => {
@@ -162,9 +162,8 @@ describe('ChatGPT auto Read Aloud', () => {
     const clickSpy = vi.spyOn(btn, 'click');
     actionBar.appendChild(btn);
 
-    await new Promise((r) => setTimeout(r, 10));
+    await vi.waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1)); // #642
 
-    expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 
   it('does NOT auto-click for old/completed messages without isStreaming flag', async () => {
@@ -191,8 +190,10 @@ describe('ChatGPT auto Read Aloud', () => {
     const clickSpy = vi.spyOn(btn, 'click');
     actionBar.appendChild(btn);
 
-    // Allow mutation observer microtask to run
-    await new Promise((r) => setTimeout(r, 10));
+    // A negative needs elapsed time, not polling — vi.waitFor would pass at
+    // once without proving anything. Give the observers room to misbehave;
+    // 10ms was short enough that this could pass for the wrong reason (#642).
+    await new Promise((r) => setTimeout(r, 100));
 
     // Should NOT auto-click for old messages
     expect(clickSpy).toHaveBeenCalledTimes(0);
@@ -340,10 +341,8 @@ describe('ChatGPT auto Read Aloud', () => {
     const clickSpy = vi.spyOn(btn, 'click');
     actionBar.appendChild(btn);
 
-    await new Promise((r) => setTimeout(r, 10));
-
     // It must be read aloud even though it arrived via the old-message path.
-    expect(clickSpy).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1)); // #642
   });
 
   it('does NOT auto-click a message already present when the call started (#245 not regressed)', async () => {
@@ -375,7 +374,8 @@ describe('ChatGPT auto Read Aloud', () => {
     const clickSpy = vi.spyOn(btn, 'click');
     actionBar.appendChild(btn);
 
-    await new Promise((r) => setTimeout(r, 10));
+    // As above: proving silence takes elapsed time, not polling (#642).
+    await new Promise((r) => setTimeout(r, 100));
 
     // A message present at call start must stay silent.
     expect(clickSpy).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
## Why

`test/chatbots/ChatGPTAutoReadAloud.spec.ts` intermittently failed with `expected "click" to be called 1 times, but got 0 times` — observed twice on 2026-09-06, on two branches (a markdown change and a `scripts/dom-capture/` change) that cannot reach this code path. It reproduces only under full-suite load: 5/5 green in isolation, ~1 in 4 failing in a loaded run.

The cause is in the test, not the product. It waits a flat `setTimeout(…, 10)` for a `MutationObserver` callback plus an async decoration chain, then asserts. A fixed sleep is a load-sensitive wait by construction — on a busy runner 10ms is simply not enough.

This matters more than one red test: `test (22.x)` is a required check, and a flake in the merge gate teaches everyone to re-run CI instead of reading it.

## What

The six fixed waits are not all the same shape, and the fix respects that.

**Four cases assert a click DID happen.** They now poll (`vi.waitFor`) for the effect, so they take exactly as long as the chain needs and have no timing dependency left.

**One case asserts both** — the newest message is clicked, the older one is not. It polls for the click it expects, then asserts the absence of the other. That is stronger than before: the observed click is now a barrier proving the observers ran, so "the old message was not clicked" is a real result rather than one we did not wait long enough to see.

**Two cases assert that NO click happened.** Polling is the wrong tool there — `vi.waitFor` would succeed immediately without proving anything. Those keep an explicit wait, but 10ms was short enough that they could pass for the wrong reason, so they now wait 100ms. This is the one place a sleep is correct, and the comment says why.

No assertion changed. The spec still pins exactly the same behaviour, including the two opposed read-aloud regressions it guards (#245 must not re-read old messages; #200/#408 must read the new first reply).

## Verification

`npm test` run three times in full on this branch: **2850 passed / 1 skipped** each time, no failures. The spec alone: 8 passed / 1 skipped.

Being straight about the limit of that evidence: the flake was never reproducible on demand — the issue records it as load-dependent and intermittent — so three green runs cannot prove it is gone. The real argument is structural. A poll has no timing dependency to be starved of; a fixed sleep does. The change removes the mechanism rather than widening the margin.

Fixes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYdTADVdmkpPVNELAZfKbd
